### PR TITLE
feat/select-auto-flip

### DIFF
--- a/src/ui/general/select/index.tsx
+++ b/src/ui/general/select/index.tsx
@@ -54,8 +54,10 @@ export const Select = ({
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [activeIndex, setActiveIndex] = React.useState(-1);
+  const [dropUp, setDropUp] = React.useState(false);
 
   const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const controlRef = React.useRef<HTMLButtonElement>(null);
 
   const currentOption = React.useMemo(
       () => options.find((o) => o.value === currentValue) ?? null,
@@ -167,6 +169,17 @@ export const Select = ({
     );
   }, [isOpen, options, currentValue]);
 
+  React.useLayoutEffect(() => {
+    if (!isOpen || !controlRef.current) return;
+
+    const rect = controlRef.current.getBoundingClientRect();
+    const listHeight = Math.min(options.length * 40, 288);
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+
+    setDropUp(spaceBelow < listHeight && spaceAbove > spaceBelow);
+  }, [isOpen, options.length]);
+
   const rootClassName = ["select", className ?? ""]
       .filter(Boolean)
       .join(" ");
@@ -197,6 +210,7 @@ export const Select = ({
         )}
 
         <button
+            ref={controlRef}
             id={selectId}
             type="button"
             className={controlClassName}
@@ -230,7 +244,7 @@ export const Select = ({
             <ul
                 id={`${selectId}_listbox`}
                 role="listbox"
-                className="select_list"
+                className={`select_list${dropUp ? " select_list_up" : ""}`}
             >
               {options.map((opt, i) => {
                 const selected =

--- a/src/ui/general/select/style.scss
+++ b/src/ui/general/select/style.scss
@@ -150,6 +150,13 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding: token.$spacing_xs 0;
+
+    &_up {
+      top: auto;
+      bottom: 100%;
+      margin-top: 0;
+      margin-bottom: token.$spacing_xs;
+    }
   }
 
   &_option {


### PR DESCRIPTION
## Select 드롭다운 자동 방향 전환 기능 추가

## 작업한 내용
- [x] 드롭다운 열릴 때 하단/상단 공간 계산 로직 추가
- [x] 하단 공간 부족 시 드롭다운을 위로 표시 (auto-flip)
- [x] `select_list_up` 스타일 추가

## 동작 방식
- `useLayoutEffect`로 드롭다운 열릴 때 공간 계산
- `spaceBelow < listHeight && spaceAbove > spaceBelow` 조건 시 위로 전환
- 리스트 최대 높이(288px)와 옵션 개수 기반 높이 중 작은 값 사용

## 관련 이슈
- Closes #63