### PR TITLE
fix/select-position-flicker

### DIFF
--- a/src/ui/general/select/style.scss
+++ b/src/ui/general/select/style.scss
@@ -157,12 +157,6 @@
       margin-top: 0;
       margin-bottom: token.$spacing_xs;
     }
-
-    &_portal {
-      position: fixed;
-      margin-top: 0;
-      margin-bottom: 0;
-    }
   }
 
   &_option {


### PR DESCRIPTION
## Select 드롭다운 초기 렌더링 위치 깜빡임 수정

## 작업한 내용
- [x] listPosition 초기값을 null로 설정
- [x] 위치 계산 전에는 Portal 내용을 렌더링하지 않음
- [x] 드롭다운 닫힐 때 listPosition을 null로 리셋

## 문제 원인
- listPosition 초기값이 `{ top: 0, left: 0, width: 0 }`이어서 Portal이 위치 계산 전에 (0, 0) 좌표에 렌더링됨

## 전달할 추가 이슈
- 없음