### PR TITLE
fix: remove source map from vanilla build

### DIFF
--- a/scripts/build-vanilla.mjs
+++ b/scripts/build-vanilla.mjs
@@ -9,16 +9,16 @@ const outDir = path.join(root, "dist/vanilla");
 // Create output directory
 fs.mkdirSync(outDir, { recursive: true });
 
-// Compile SCSS to CSS using sass-embedded
+// Compile SCSS to CSS using sass-embedded (--no-source-map to exclude source maps)
 try {
   execSync(
-    `npx sass --load-path=. --load-path=src ${srcDir}/bigtablet.scss ${outDir}/bigtablet.css`,
+    `npx sass --no-source-map --load-path=. --load-path=src ${srcDir}/bigtablet.scss ${outDir}/bigtablet.css`,
     { stdio: "inherit" }
   );
 
   // Also create minified version
   execSync(
-    `npx sass --load-path=. --load-path=src --style=compressed ${srcDir}/bigtablet.scss ${outDir}/bigtablet.min.css`,
+    `npx sass --no-source-map --load-path=. --load-path=src --style=compressed ${srcDir}/bigtablet.scss ${outDir}/bigtablet.min.css`,
     { stdio: "inherit" }
   );
 


### PR DESCRIPTION
## 변경 내용

### Source Map 제외
- Vanilla CSS 빌드에서 source map 파일 제거
- 패키지 크기 절감: 120KB → 104KB (~16KB 감소)

### 변경 파일
- `scripts/build-vanilla.mjs`: `--no-source-map` 옵션 추가

### 비고
- source map은 디버깅용으로, 프로덕션 배포에는 불필요
- 비압축 버전(`bigtablet.css`, `bigtablet.js`)으로 디버깅 가능