### PR TITLE
fix: reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
       "style": "./dist/vanilla/bigtablet.min.css",
       "default": "./dist/vanilla/bigtablet.min.js"
     },
-    "./vanilla/style.css": "./dist/vanilla/bigtablet.css",
     "./vanilla/style.min.css": "./dist/vanilla/bigtablet.min.css",
-    "./vanilla/bigtablet.js": "./dist/vanilla/bigtablet.js",
     "./vanilla/bigtablet.min.js": "./dist/vanilla/bigtablet.min.js"
   },
   "files": [
     "dist",
-    "src/styles/scss",
+    "!dist/vanilla/bigtablet.css",
+    "!dist/vanilla/bigtablet.js",
+    "!dist/vanilla/examples",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## 변경 내용

### NPM 패키지 크기 최적화
- `src/styles/scss` 제외 (이미 `dist/styles/scss`에 복사됨)
- Vanilla 비압축 버전 제외 (`bigtablet.css`, `bigtablet.js`)
- Vanilla examples 폴더 제외
- 비압축 버전 exports 제거

### 결과
- **패키지 크기: 205KB → 128KB** (~37% 감소)

### CDN 사용법 (변경 없음)
```html
<link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
<script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
```