### PR TITLE
fix/security-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,9 +117,9 @@
   },
   "pnpm": {
     "overrides": {
-      "rollup": ">=4.59.0",
-      "lodash": ">=4.17.23",
-      "lodash-es": ">=4.17.23"
+      "rollup": "^4.59.0",
+      "lodash": "^4.17.23",
+      "lodash-es": "^4.17.23"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  rollup: '>=4.59.0'
-  lodash: '>=4.17.23'
-  lodash-es: '>=4.17.23'
+  rollup: ^4.59.0
+  lodash: ^4.17.23
+  lodash-es: ^4.17.23
 
 importers:
 
@@ -945,7 +945,7 @@ packages:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: '>=4.59.0'
+      rollup: ^4.59.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -1166,7 +1166,7 @@ packages:
     resolution: {integrity: sha512-Ant0NhgqHKzQsseeVTSetZCuDHHs0W2HRkHt51Kg/sUl0T/sDtfVA+fWZT8nGzGZqYSFkxqYPWjauPmIhPtaRw==}
     peerDependencies:
       esbuild: '*'
-      rollup: '>=4.59.0'
+      rollup: ^4.59.0
       storybook: ^10.1.11
       vite: '*'
       webpack: '*'


### PR DESCRIPTION
## 제목
fix/security-patch

## 작업한 내용
- [x] rollup 보안 취약점 패치 (4.55.1 → ≥4.59.0, Arbitrary File Write via Path Traversal)
- [x] lodash 보안 취약점 패치 (4.17.21 → ≥4.17.23, Prototype Pollution)
- [x] lodash-es 보안 취약점 패치 (4.17.22 → ≥4.17.23, Prototype Pollution)
- [x] pnpm.overrides로 transitive 의존성 안전 버전 강제 지정

## 전달할 추가 이슈
- esbuild 취약점(#1)은 vite@5가 `esbuild ^0.21.3`을 요구하여 override 불가 — 프로덕션 영향 없는 개발 서버 전용 리스크, vite 메이저 업그레이드 시 해소 예정

closes #26
closes #15
closes #14