### PR TITLE
fix/chromatic-esm-warning

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,6 +2,7 @@ name: Chromatic
 
 on:
   pull_request:
+    branches: [ develop ]
   push:
     branches: [ main ]
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -86,5 +86,12 @@ export default defineConfig([
     sourcemap: false,
     minify: true,
     outExtension: () => ({ js: ".min.js" }),
+    esbuildOptions(options) {
+      // bigtablet.js uses UMD pattern (module.exports) for browser compatibility.
+      // Since package.json has "type": "module", esbuild treats it as ESM and warns
+      // about the CommonJS `module` variable. Suppress this — the IIFE format handles
+      // the global export and the UMD check is irrelevant at runtime.
+      options.logOverride = { "commonjs-variable-in-esm": "silent" };
+    },
   },
 ]);


### PR DESCRIPTION
## Chromatic 불필요 실행 제거 및 ESM 빌드 경고 수정

## 작업한 내용
- [x] `storybook.yml`: `pull_request` 트리거를 `develop` 브랜치 대상 PR에만 실행하도록 제한
  - 기존: 모든 PR에서 Chromatic 실행 → develop → main PR에서도 불필요하게 실행됨
  - 수정: `branches: [develop]` 필터 추가
- [x] `tsup.config.ts`: vanilla 번들 빌드 시 발생하는 ESM 경고 억제
  - 원인: `package.json`의 `"type": "module"` 설정으로 esbuild가 `bigtablet.js`를 ESM으로 인식, UMD 패턴의 `module.exports` 사용에 경고 발생
  - 수정: `esbuildOptions`에 `logOverride: { "commonjs-variable-in-esm": "silent" }` 추가 (IIFE 포맷이 런타임 글로벌 export를 처리하므로 경고는 무의미)

## 전달할 추가 이슈
- 없음