### PR TITLE
merge: develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,28 +52,37 @@ src/
   ```
   src/ui/{category}/{ComponentName}/
   ├── index.tsx            # Component implementation
-  ├── style.module.scss    # CSS Module styles
+  ├── style.scss           # Global SCSS styles
   └── *.stories.tsx        # Storybook stories (optional)
   ```
 
-### Styling (CSS Modules)
-- **CSS Modules**: All styles use `style.module.scss` files
-- Import pattern: `import styles from "./style.module.scss";`
-- Class usage: `className={styles.button}` or `className={styles[`variant_${variant}`]}`
+### Styling (Global SCSS)
+- **Global SCSS**: All styles use `style.scss` files (not CSS Modules)
+- Import pattern: `import "./style.scss";`
+- Class usage: `className="button"` or `` className={`button_variant_${variant}`} ``
 - SCSS tokens: `@use "src/styles/scss/token" as token;`
 - Never use hardcoded values - always use tokens
 
 ### className Pattern
 ```tsx
 const buttonClassName = [
-    styles.button,
-    styles[`size_${size}`],
-    styles[`variant_${variant}`],
-    isActive && styles.active,
+    "button",
+    `button_size_${size}`,
+    `button_variant_${variant}`,
+    isActive && "button_active",
     className ?? "",
 ]
     .filter(Boolean)
     .join(" ");
+
+// cn() utility also supported:
+const buttonClassName = cn(
+    "button",
+    `button_size_${size}`,
+    `button_variant_${variant}`,
+    isActive && "button_active",
+    className,
+);
 ```
 
 ### Design Tokens

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@
 [![npm version](https://img.shields.io/npm/v/@bigtablet/design-system.svg)](https://www.npmjs.com/package/@bigtablet/design-system)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Test Coverage](https://img.shields.io/badge/coverage-86%25-brightgreen.svg)](https://github.com/Bigtablet/bigtablet-design-system/actions)
+[![CI](https://github.com/Bigtablet/bigtablet-design-system/actions/workflows/ci.yml/badge.svg)](https://github.com/Bigtablet/bigtablet-design-system/actions/workflows/ci.yml)
+[![Storybook](https://img.shields.io/badge/Storybook-FF4785?logo=storybook&logoColor=white)](https://bigtablet.github.io/bigtablet-design-system)
 
 [🇰🇷 한국어](./README_KR.md) · 🇺🇸 English
 
 The official design system of Bigtablet — a unified UI library composed of Foundation (design tokens) and UI Components.
+
+> **Note**: This is Bigtablet's in-house design system, open-sourced for community reference.
+> External use is welcome, but minor versions may include breaking changes without prior notice.
 
 [GitHub](https://github.com/Bigtablet/bigtablet-design-system) · [NPM](https://www.npmjs.com/package/@bigtablet/design-system) · [Storybook](https://bigtablet.github.io/bigtablet-design-system)
 
@@ -30,6 +35,7 @@ The official design system of Bigtablet — a unified UI library composed of Fou
 | ♿ **Accessibility** | Keyboard navigation, screen reader support, full ARIA attributes |
 | 🧪 **86% Coverage** | Stable test coverage powered by Vitest |
 | 🎭 **Storybook** | Interactive documentation for all components |
+| 🎯 **Zero Dependencies** | No bundled runtime dependencies — peer deps only |
 
 ---
 
@@ -49,14 +55,16 @@ pnpm add @bigtablet/design-system
 **Peer Dependencies**
 
 ```bash
-npm install react react-dom lucide-react
+npm install react@^19 react-dom@^19 "lucide-react@>=0.552.0"
 ```
 
-> Recommended for use with **React 18+** and **Next.js 13+**.
+> Requires **React 19** and **lucide-react ≥ 0.552.0**. Compatible with **Next.js 13+**.
 
 ---
 
 ## Quick Start
+
+> ⚠️ **Alert** and **Toast** require Providers at the root of your app — see [Provider Setup](#provider-setup) below.
 
 ### Pure React
 

--- a/src/styles/scss/_colors.scss
+++ b/src/styles/scss/_colors.scss
@@ -40,6 +40,10 @@ $color_accent: #3B82F6;
 $color_accent_light: #60A5FA;
 $color_accent_dark: #2563EB;
 
+/* Hover */
+$color_hover_subtle: rgba(0, 0, 0, 0.03);
+$color_hover_light:  rgba(0, 0, 0, 0.05);
+
 /* Overlay */
 $color_overlay: rgba(0, 0, 0, 0.5);
 $color_overlay_light: rgba(0, 0, 0, 0.3);

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import {createContext, useContext, useState, useCallback} from "react";
 import {createPortal} from "react-dom";
+import { useFocusTrap } from "../../../utils";
 import "./style.scss";
 
 export type AlertVariant = "info" | "success" | "warning" | "error";
@@ -142,6 +143,9 @@ const AlertModal: React.FC<AlertModalProps> = ({
                                                    onCancel,
                                                    onClose,
                                                }) => {
+    const panelRef = React.useRef<HTMLDivElement>(null);
+    useFocusTrap(panelRef, true);
+
     const modalClassName = [
         "alert_modal",
         `alert_variant_${variant}`,
@@ -157,8 +161,13 @@ const AlertModal: React.FC<AlertModalProps> = ({
         .join(" ");
 
     return (
-        <div className="alert_overlay" onClick={onClose}>
+        <div
+            className="alert_overlay"
+            onClick={onClose}
+            onKeyDown={(e) => e.key === "Escape" && onClose()}
+        >
             <div
+                ref={panelRef}
                 className={modalClassName}
                 onClick={(e) => e.stopPropagation()}
                 role="alertdialog"

--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -82,7 +82,7 @@ describe("Toast display", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByRole("status")).toBeInTheDocument();
         expect(screen.getByText("저장 완료")).toBeInTheDocument();
     });
 
@@ -108,7 +108,7 @@ describe("Toast display", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByRole("status")).toBeInTheDocument();
         expect(screen.getByText("경고 메시지")).toBeInTheDocument();
     });
 
@@ -121,7 +121,7 @@ describe("Toast display", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByRole("status")).toBeInTheDocument();
         expect(screen.getByText("정보 메시지")).toBeInTheDocument();
     });
 
@@ -134,7 +134,7 @@ describe("Toast display", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByRole("status")).toBeInTheDocument();
         expect(screen.getByText("기본 메시지")).toBeInTheDocument();
     });
 
@@ -158,8 +158,9 @@ describe("Toast display", () => {
         fireEvent.click(screen.getByRole("button", { name: "first" }));
         fireEvent.click(screen.getByRole("button", { name: "second" }));
 
-        const alerts = screen.getAllByRole("alert");
-        expect(alerts).toHaveLength(2);
+        // 첫 번째는 success(role="status"), 두 번째는 error(role="alert")
+        expect(screen.getByRole("status")).toBeInTheDocument();
+        expect(screen.getByRole("alert")).toBeInTheDocument();
         expect(screen.getByText("첫 번째")).toBeInTheDocument();
         expect(screen.getByText("두 번째")).toBeInTheDocument();
     });
@@ -189,9 +190,9 @@ describe("Toast display", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "spam" }));
 
-        // maxCount=3 이므로 최대 3개만 표시됨
-        const alerts = screen.getAllByRole("alert");
-        expect(alerts.length).toBeLessThanOrEqual(3);
+        // maxCount=3 이므로 최대 3개만 표시됨 (success는 role="status")
+        const statuses = screen.getAllByRole("status");
+        expect(statuses.length).toBeLessThanOrEqual(3);
     });
 });
 
@@ -210,7 +211,7 @@ describe("Toast close", () => {
         fireEvent.click(screen.getByRole("button", { name: "trigger" }));
         expect(screen.getByText("닫기 테스트")).toBeInTheDocument();
 
-        fireEvent.click(screen.getByRole("button", { name: "닫기" }));
+        fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
         // 슬라이드 아웃 setTimeout(260ms) 완료 대기
         await act(async () => {
@@ -235,7 +236,7 @@ describe("Toast close", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-        const closeBtn = screen.getByRole("button", { name: "닫기" });
+        const closeBtn = screen.getByRole("button", { name: "Close" });
 
         // 빠르게 두 번 클릭
         fireEvent.click(closeBtn);

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -25,6 +25,8 @@ export interface ToastProviderProps {
     children: React.ReactNode;
     /** 최대 동시 표시 토스트 수 (기본값: 5) */
     maxCount?: number;
+    /** 토스트 닫기 버튼의 aria-label (기본값: "Close") */
+    closeAriaLabel?: string;
 }
 
 const VARIANT_ICONS: Record<ToastVariant, React.ReactElement> = {
@@ -40,6 +42,7 @@ const VARIANT_ICONS: Record<ToastVariant, React.ReactElement> = {
 interface ToastItemComponentProps {
     item: ToastItem;
     onRemove: (id: string) => void;
+    closeAriaLabel: string;
 }
 
 /**
@@ -48,7 +51,7 @@ interface ToastItemComponentProps {
  * @param props 토스트 아이템 속성
  * @returns 렌더링된 토스트 아이템
  */
-const ToastItemComponent = ({ item, onRemove }: ToastItemComponentProps) => {
+const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemComponentProps) => {
     const [exiting, setExiting] = React.useState(false);
     const closingRef = React.useRef(false);
 
@@ -73,7 +76,7 @@ const ToastItemComponent = ({ item, onRemove }: ToastItemComponentProps) => {
     return (
         <div
             className={itemClassName}
-            role="alert"
+            role={item.variant === "error" ? "alert" : "status"}
         >
             <span className={`toast_icon toast_icon_${item.variant}`} aria-hidden="true">
                 {VARIANT_ICONS[item.variant]}
@@ -85,7 +88,7 @@ const ToastItemComponent = ({ item, onRemove }: ToastItemComponentProps) => {
                 type="button"
                 className="toast_close"
                 onClick={close}
-                aria-label="닫기"
+                aria-label={closeAriaLabel}
             >
                 <X size={14} />
             </button>
@@ -108,7 +111,7 @@ const ToastItemComponent = ({ item, onRemove }: ToastItemComponentProps) => {
  * @param props Provider 속성
  * @returns 렌더링된 Provider와 토스트 컨테이너
  */
-export const ToastProvider = ({ children, maxCount = 5 }: ToastProviderProps) => {
+export const ToastProvider = ({ children, maxCount = 5, closeAriaLabel = "Close" }: ToastProviderProps) => {
     const [toasts, setToasts] = React.useState<ToastItem[]>([]);
     const [isMounted, setIsMounted] = React.useState(false);
 
@@ -145,12 +148,18 @@ export const ToastProvider = ({ children, maxCount = 5 }: ToastProviderProps) =>
             {children}
             {isMounted &&
                 createPortal(
-                    <div className="toast_container">
+                    <div
+                        className="toast_container"
+                        aria-live="polite"
+                        aria-atomic="false"
+                        aria-label="Notifications"
+                    >
                         {toasts.map(item => (
                             <ToastItemComponent
                                 key={item.id}
                                 item={item}
                                 onRemove={removeToast}
+                                closeAriaLabel={closeAriaLabel}
                             />
                         ))}
                     </div>,

--- a/src/ui/form/date-picker/DatePicker.test.tsx
+++ b/src/ui/form/date-picker/DatePicker.test.tsx
@@ -10,22 +10,22 @@ describe("DatePicker", () => {
 
     it("renders year select with placeholder", () => {
         render(<DatePicker onChange={() => {}} />);
-        expect(screen.getByText("연도")).toBeInTheDocument();
+        expect(screen.getByText("Year")).toBeInTheDocument();
     });
 
     it("renders month select with placeholder", () => {
         render(<DatePicker onChange={() => {}} />);
-        expect(screen.getByText("월")).toBeInTheDocument();
+        expect(screen.getByText("Month")).toBeInTheDocument();
     });
 
     it("renders day select in year-month-day mode", () => {
         render(<DatePicker mode="year-month-day" onChange={() => {}} />);
-        expect(screen.getByText("일")).toBeInTheDocument();
+        expect(screen.getByText("Day")).toBeInTheDocument();
     });
 
     it("does not render day select in year-month mode", () => {
         render(<DatePicker mode="year-month" onChange={() => {}} />);
-        expect(screen.queryByText("일")).not.toBeInTheDocument();
+        expect(screen.queryByText("Day")).not.toBeInTheDocument();
     });
 
     it("calls onChange when year is selected", () => {

--- a/src/ui/form/date-picker/index.tsx
+++ b/src/ui/form/date-picker/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -32,6 +33,12 @@ interface DatePickerProps {
      * @deprecated `fullWidth` 사용 또는 CSS로 처리
      */
     width?: number | string;
+    /** 연도 select의 aria-label 및 빈 옵션 텍스트 (기본값: "Year") */
+    yearLabel?: string;
+    /** 월 select의 aria-label 및 빈 옵션 텍스트 (기본값: "Month") */
+    monthLabel?: string;
+    /** 일 select의 aria-label 및 빈 옵션 텍스트 (기본값: "Day") */
+    dayLabel?: string;
 }
 
 /**
@@ -76,7 +83,11 @@ export const DatePicker = ({
     disabled,
     fullWidth = true,
     width,
+    yearLabel = "Year",
+    monthLabel = "Month",
+    dayLabel = "Day",
 }: DatePickerProps) => {
+    const groupId = React.useId();
     const today = new Date();
     const todayYear = today.getFullYear();
     const todayMonth = today.getMonth() + 1;
@@ -153,18 +164,22 @@ export const DatePicker = ({
     return (
         <div className={rootClassName} style={containerStyle}>
             {label && (
-                <label className="date_picker_label">{label}</label>
+                <label className="date_picker_label" id={groupId}>{label}</label>
             )}
-            <div className="date_picker_fields">
+            <div
+                className="date_picker_fields"
+                role="group"
+                aria-labelledby={label ? groupId : undefined}
+            >
                 <select
-                    aria-label="연도"
+                    aria-label={yearLabel}
                     value={year}
                     disabled={disabled}
                     onChange={(e) =>
                         emit(Number(e.target.value), month || minMonth, day || minDay)
                     }
                 >
-                    <option value="">연도</option>
+                    <option value="">{yearLabel}</option>
                     {Array.from(
                         {length: maxYear - startYear + 1},
                         (_, i) => startYear + i,
@@ -176,14 +191,14 @@ export const DatePicker = ({
                 </select>
 
                 <select
-                    aria-label="월"
+                    aria-label={monthLabel}
                     value={month}
                     disabled={disabled || !year}
                     onChange={(e) =>
                         emit(year, Number(e.target.value), day || minDay)
                     }
                 >
-                    <option value="">월</option>
+                    <option value="">{monthLabel}</option>
                     {Array.from({length: maxMonth - minMonth + 1}, (_, i) => minMonth + i).map(
                         (m) => (
                             <option key={m} value={m}>
@@ -195,14 +210,14 @@ export const DatePicker = ({
 
                 {mode === "year-month-day" && (
                     <select
-                        aria-label="일"
+                        aria-label={dayLabel}
                         value={day}
                         disabled={disabled || !month}
                         onChange={(e) =>
                             emit(year, month, Number(e.target.value))
                         }
                     >
-                        <option value="">일</option>
+                        <option value="">{dayLabel}</option>
                         {Array.from(
                             {length: days - minDay + 1},
                             (_, i) => minDay + i,

--- a/src/ui/form/file/FileInput.test.tsx
+++ b/src/ui/form/file/FileInput.test.tsx
@@ -5,7 +5,7 @@ import { FileInput } from "./index";
 describe("FileInput", () => {
     it("renders with default label", () => {
         render(<FileInput />);
-        expect(screen.getByText("파일 선택")).toBeInTheDocument();
+        expect(screen.getByText("Choose file")).toBeInTheDocument();
     });
 
     it("renders with custom label", () => {
@@ -22,7 +22,7 @@ describe("FileInput", () => {
     it("associates label with input", () => {
         render(<FileInput />);
         const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-        const label = screen.getByText("파일 선택");
+        const label = screen.getByText("Choose file");
 
         expect(label).toHaveAttribute("for", input.id);
     });
@@ -79,7 +79,7 @@ describe("FileInput", () => {
 
     it("has file_input_label class on label", () => {
         render(<FileInput />);
-        const label = screen.getByText("파일 선택");
+        const label = screen.getByText("Choose file");
         expect(label).toHaveClass("file_input_label");
     });
 });

--- a/src/ui/form/file/index.tsx
+++ b/src/ui/form/file/index.tsx
@@ -18,7 +18,7 @@ export interface FileInputProps
  * @returns 렌더링된 파일 입력 UI
  */
 export const FileInput = ({
-                              label = "파일 선택",
+                              label = "Choose file",
                               onFiles,
                               className,
                               disabled,
@@ -35,7 +35,7 @@ export const FileInput = ({
         .join(" ");
 
     return (
-        <div style={{cursor: "pointer"}} className={rootClassName}>
+        <div className={rootClassName}>
             <input
                 id={inputId}
                 type="file"

--- a/src/ui/form/textfield/style.scss
+++ b/src/ui/form/textfield/style.scss
@@ -111,7 +111,7 @@
     border: 1px solid transparent;
 
     &:hover:not(:disabled) {
-      background: rgba(0, 0, 0, 0.03);
+      background: token.$color_hover_subtle;
     }
 
     &:focus-visible {

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -69,7 +69,7 @@
     color: token.$color_text_primary;
 
     &:hover:not(:disabled) {
-      background: rgba(0, 0, 0, 0.05);
+      background: token.$color_hover_light;
     }
 
     &:active:not(:disabled) {

--- a/src/ui/general/select/style.scss
+++ b/src/ui/general/select/style.scss
@@ -77,7 +77,7 @@
     border: 1px solid transparent;
 
     &:hover:not(.is_disabled) {
-      background: rgba(0, 0, 0, 0.03);
+      background: token.$color_hover_subtle;
     }
 
     &.is_open {

--- a/src/ui/navigation/pagination/index.tsx
+++ b/src/ui/navigation/pagination/index.tsx
@@ -11,6 +11,10 @@ export interface PaginationProps {
     totalPages: number;
     /** 페이지 변경 시 호출되는 콜백 */
     onChange: (page: number) => void;
+    /** 이전 페이지 버튼 aria-label (기본값: "Previous page") */
+    prevLabel?: string;
+    /** 다음 페이지 버튼 aria-label (기본값: "Next page") */
+    nextLabel?: string;
 }
 
 /**
@@ -70,7 +74,7 @@ const getPaginationItems = (page: number, totalPages: number) => {
  * @param props 페이지네이션 속성
  * @returns 렌더링된 페이지네이션 UI
  */
-export const Pagination = ({ page, totalPages, onChange }: PaginationProps) => {
+export const Pagination = ({ page, totalPages, onChange, prevLabel = "Previous page", nextLabel = "Next page" }: PaginationProps) => {
     const prevDisabled = page <= 1;
     const nextDisabled = page >= totalPages;
 
@@ -85,7 +89,7 @@ export const Pagination = ({ page, totalPages, onChange }: PaginationProps) => {
                 className="pagination_item"
                 onClick={() => onChange(page - 1)}
                 disabled={prevDisabled}
-                aria-label="Previous page"
+                aria-label={prevLabel}
             >
                 ‹
             </button>
@@ -125,7 +129,7 @@ export const Pagination = ({ page, totalPages, onChange }: PaginationProps) => {
                 className="pagination_item"
                 onClick={() => onChange(page + 1)}
                 disabled={nextDisabled}
-                aria-label="Next page"
+                aria-label={nextLabel}
             >
                 ›
             </button>

--- a/src/ui/navigation/sidebar/Sidebar.test.tsx
+++ b/src/ui/navigation/sidebar/Sidebar.test.tsx
@@ -159,7 +159,7 @@ describe("Sidebar", () => {
         expect(screen.getByRole("navigation")).toBeInTheDocument();
 
         // 닫기 버튼 클릭
-        fireEvent.click(screen.getByAltText("Close"));
+        fireEvent.click(screen.getByAltText("사이드바 닫기"));
 
         // 사이드바가 닫혀야 한다(nav 숨김)
         expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
@@ -169,18 +169,18 @@ describe("Sidebar", () => {
         render(<Sidebar items={basicItems} />);
 
         // 먼저 사이드바를 닫는다
-        fireEvent.click(screen.getByAltText("Close"));
+        fireEvent.click(screen.getByAltText("사이드바 닫기"));
         expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
 
         // 메뉴 버튼 클릭으로 다시 연다
-        fireEvent.click(screen.getByAltText("Open"));
+        fireEvent.click(screen.getByAltText("사이드바 열기"));
         expect(screen.getByRole("navigation")).toBeInTheDocument();
     });
 
     it("saves sidebar state to localStorage", () => {
         render(<Sidebar items={basicItems} />);
 
-        fireEvent.click(screen.getByAltText("Close"));
+        fireEvent.click(screen.getByAltText("사이드바 닫기"));
         expect(localStorageMock.setItem).toHaveBeenCalledWith("isOpen", "false");
     });
 

--- a/src/ui/navigation/sidebar/index.tsx
+++ b/src/ui/navigation/sidebar/index.tsx
@@ -154,14 +154,14 @@ export const Sidebar = ({
                         >
                             <Image
                                 src="/images/sidebar/arrow-close.svg"
-                                alt="Close"
+                                alt="사이드바 닫기"
                                 width={24}
                                 height={24}
                             />
                         </button>
                     </div>
 
-                    <nav className="sidebar_nav">
+                    <nav className="sidebar_nav" aria-label="메인 메뉴">
                         {items.map((item) => {
                             if (item.type === "group") {
                                 const open = openGroups.includes(item.id);
@@ -227,6 +227,7 @@ export const Sidebar = ({
                                                         key={child.href}
                                                         href={child.href}
                                                         className={subItemClassName}
+                                                        aria-current={active ? "page" : undefined}
                                                         onClick={() =>
                                                             onItemSelect?.(
                                                                 child.href
@@ -263,6 +264,7 @@ export const Sidebar = ({
                                     key={item.href}
                                     href={item.href}
                                     className={itemClassName}
+                                    aria-current={active ? "page" : undefined}
                                     onClick={() =>
                                         onItemSelect?.(item.href)
                                     }
@@ -290,7 +292,7 @@ export const Sidebar = ({
                 >
                     <Image
                         src="/images/sidebar/menu.svg"
-                        alt="Open"
+                        alt="사이드바 열기"
                         width={24}
                         height={24}
                     />


### PR DESCRIPTION
## A11y, i18n, 컨벤션 개선 및 README 업데이트

## 작업한 내용
- [x] A11y 개선: Alert 포커스 트랩 + Escape 키, Toast aria-live 컨테이너, Sidebar nav aria-label + aria-current, DatePicker role="group"
- [x] i18n 개선: DatePicker yearLabel/monthLabel/dayLabel props, Toast closeAriaLabel prop, Pagination prevLabel/nextLabel props, FileInput 기본값 영어화
- [x] 컨벤션 개선: SCSS hover 토큰 추가, 하드코딩 rgba 값 토큰화, FileInput 인라인 스타일 제거
- [x] README: CI 배지, Storybook 배지, Zero Dependencies, Peer deps 버전, Provider ⚠️ callout, 사내 라이브러리 안내 추가
- [x] tokens/design-tokens.json 중복 파일 삭제

## 전달할 추가 이슈
- 없음