### PR TITLE
fix/xss-vanilla-html-injection

### DIFF
--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -27,6 +27,18 @@
   }
 
   /**
+   * Escape HTML special characters to prevent XSS
+   */
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  /**
    * Add event listener with cleanup
    */
   function on(element, event, handler, options) {
@@ -428,8 +440,8 @@
 
     overlay.innerHTML = `
       <div class="bt-alert__modal">
-        ${config.title ? `<div class="bt-alert__title">${config.title}</div>` : ""}
-        <div class="bt-alert__message">${config.message}</div>
+        ${config.title ? `<div class="bt-alert__title">${escapeHtml(config.title)}</div>` : ""}
+        <div class="bt-alert__message">${escapeHtml(config.message)}</div>
         <div class="bt-alert__actions" style="justify-content: ${
           config.actionsAlign === "left"
             ? "flex-start"
@@ -439,10 +451,10 @@
         }">
           ${
             config.showCancel
-              ? `<button class="bt-button bt-button--md bt-button--secondary" data-alert-cancel>${config.cancelText}</button>`
+              ? `<button class="bt-button bt-button--md bt-button--secondary" data-alert-cancel>${escapeHtml(config.cancelText)}</button>`
               : ""
           }
-          <button class="bt-button bt-button--md bt-button--primary" data-alert-confirm>${config.confirmText}</button>
+          <button class="bt-button bt-button--md bt-button--primary" data-alert-confirm>${escapeHtml(config.confirmText)}</button>
         </div>
       </div>
     `;
@@ -629,10 +641,10 @@
           html += `
             <button
               class="bt-pagination__page${isActive ? " bt-pagination__page--active" : ""}"
-              data-page="${item}"
+              data-page="${escapeHtml(item)}"
               ${isActive ? 'aria-current="page"' : ""}
             >
-              ${item}
+              ${escapeHtml(item)}
             </button>
           `;
         }


### PR DESCRIPTION
## XSS 취약점 수정 (CodeQL js/html-constructed-from-input)

## 원인
`src/vanilla/bigtablet.js`의 Alert, Pagination 컴포넌트에서 라이브러리 입력값을 `innerHTML`에 직접 삽입하여 XSS 가능성 존재

## 작업한 내용
- [x] `escapeHtml()` 유틸 함수 추가 (`&`, `<`, `>`, `"`, `'` 이스케이프)
- [x] Alert: `title`, `message`, `cancelText`, `confirmText` → `escapeHtml()` 적용
- [x] Pagination: 페이지 번호 `item` → `escapeHtml()` 적용

## 참고
- CodeQL Rule: `js/html-constructed-from-input`
- 영향 범위: Vanilla JS 패키지 전용 (`src/vanilla/bigtablet.js`), React 컴포넌트는 JSX가 자동 이스케이프하므로 해당 없음