### PR TITLE
feat/toast-mobile

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -5,9 +5,9 @@ const preview: Preview = {
 	parameters: {
 		viewport: {
 			viewports: {
-				compact: { name: "Compact (Mobile)", styles: { width: "375px", height: "812px" } },
-				medium: { name: "Medium (Tablet)", styles: { width: "768px", height: "1024px" } },
-				expanded: { name: "Expanded", styles: { width: "1024px", height: "768px" } },
+				compact: { name: "Compact (Mobile)", styles: { width: "375px", height: "667px" } },
+				medium: { name: "Medium (Tablet)", styles: { width: "768px", height: "600px" } },
+				expanded: { name: "Expanded", styles: { width: "1024px", height: "600px" } },
 			},
 		},
 		controls: { expanded: true },

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,13 @@ import type { Preview } from "@storybook/react";
 const preview: Preview = {
 	tags: ["autodocs"],
 	parameters: {
+		viewport: {
+			viewports: {
+				compact: { name: "Compact (Mobile)", styles: { width: "375px", height: "812px" } },
+				medium: { name: "Medium (Tablet)", styles: { width: "768px", height: "1024px" } },
+				expanded: { name: "Expanded", styles: { width: "1024px", height: "768px" } },
+			},
+		},
 		controls: { expanded: true },
 		nextjs: {
 			appDirectory: true,

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,12 +2,15 @@ import type { Preview } from "@storybook/react";
 
 const preview: Preview = {
 	tags: ["autodocs"],
+	initialGlobals: {
+		viewport: { value: "responsive" },
+	},
 	parameters: {
 		viewport: {
-			viewports: {
-				compact: { name: "Compact (Mobile)", styles: { width: "375px", height: "667px" } },
-				medium: { name: "Medium (Tablet)", styles: { width: "768px", height: "600px" } },
-				expanded: { name: "Expanded", styles: { width: "1024px", height: "600px" } },
+			options: {
+				compact: { name: "Compact (Mobile)", styles: { width: "375px", height: "812px" } },
+				medium: { name: "Medium (Tablet)", styles: { width: "768px", height: "1024px" } },
+				expanded: { name: "Expanded", styles: { width: "1024px", height: "768px" } },
 			},
 		},
 		controls: { expanded: true },

--- a/src/stories/components/toast.stories.tsx
+++ b/src/stories/components/toast.stories.tsx
@@ -155,13 +155,15 @@ export const Playground: Story = {
 
 export const Mobile: Story = {
 	name: "Mobile (Compact)",
-	parameters: { viewport: { defaultViewport: "compact" } },
+	globals: { viewport: { value: "compact" } },
+	parameters: { layout: "fullscreen" },
 	render: () => <PlaygroundContent />,
 };
 
 export const Tablet: Story = {
 	name: "Tablet (Medium)",
-	parameters: { viewport: { defaultViewport: "medium" } },
+	globals: { viewport: { value: "medium" } },
+	parameters: { layout: "fullscreen" },
 	render: () => <PlaygroundContent />,
 };
 

--- a/src/stories/components/toast.stories.tsx
+++ b/src/stories/components/toast.stories.tsx
@@ -140,13 +140,29 @@ t.success("저장 완료", 5000);
 export default meta;
 type Story = StoryObj;
 
-export const Playground: Story = {
-	name: "Playground",
-	render: () => (
+function PlaygroundContent() {
+	return (
 		<ToastProvider>
 			<ToastDemoButtons />
 		</ToastProvider>
-	),
+	);
+}
+
+export const Playground: Story = {
+	name: "Playground",
+	render: () => <PlaygroundContent />,
+};
+
+export const Mobile: Story = {
+	name: "Mobile (Compact)",
+	parameters: { viewport: { defaultViewport: "compact" } },
+	render: () => <PlaygroundContent />,
+};
+
+export const Tablet: Story = {
+	name: "Tablet (Medium)",
+	parameters: { viewport: { defaultViewport: "medium" } },
+	render: () => <PlaygroundContent />,
 };
 
 export const UsageExample: Story = {

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -104,6 +104,11 @@
   }
 
   @include breakpoint.compact {
+    padding: token.$spacing_8 token.$spacing_12 token.$spacing_12;
+    font-size: 13px;
+    line-height: token.$line_height_20;
+    border-radius: token.$radius_md;
+    box-shadow: token.$shadow_level1;
     animation-name: toast_slide_in_mobile;
 
     &_exiting {
@@ -124,6 +129,12 @@
   &_warning { color: token.$color_status_warning; }
   &_info    { color: token.$color_status_info; }
   &_default { color: token.$color_text_body; }
+
+  @include breakpoint.compact {
+    margin-top: 0;
+
+    svg { width: 16px; height: 16px; }
+  }
 }
 
 // ── Message ───────────────────────────────────────────────────────────────────
@@ -161,6 +172,12 @@
   &:focus-visible {
     outline: none;
     box-shadow: token.$focus_ring;
+  }
+
+  @include breakpoint.compact {
+    width: 18px;
+    height: 18px;
+    margin-top: 0;
   }
 }
 

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -1,4 +1,5 @@
 @use "src/styles/scss/token" as token;
+@use "src/styles/scss/_breakpoints" as breakpoint;
 
 // ── Animations ───────────────────────────────────────────────────────────────
 
@@ -24,6 +25,28 @@
   }
 }
 
+@keyframes toast_slide_in_mobile {
+  from {
+    opacity: 0;
+    transform: translateY(calc(100% + 16px));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes toast_slide_out_mobile {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(calc(100% + 16px));
+  }
+}
+
 @keyframes toast_progress {
   from { width: 100%; }
   to   { width: 0%; }
@@ -42,6 +65,14 @@
   pointer-events: none;
   width: 360px;
   max-width: calc(100vw - 32px);
+
+  @include breakpoint.compact {
+    top: auto;
+    bottom: token.$spacing_16;
+    left: token.$spacing_16;
+    right: token.$spacing_16;
+    width: auto;
+  }
 }
 
 // ── Item ─────────────────────────────────────────────────────────────────────
@@ -70,6 +101,14 @@
 
   &_exiting {
     animation: toast_slide_out 0.26s ease-in forwards;
+  }
+
+  @include breakpoint.compact {
+    animation-name: toast_slide_in_mobile;
+
+    &_exiting {
+      animation-name: toast_slide_out_mobile;
+    }
   }
 }
 


### PR DESCRIPTION
## 작업 개요

Toast 컴포넌트 모바일 반응형 대응 추가

## 작업한 내용

- [x] `style.scss` — compact breakpoint (≤599px) 추가
  - 컨테이너: 우상단 → 하단 풀폭으로 변경
  - 애니메이션: 우→좌 슬라이드 → 아래→위 슬라이드로 변경
- [x] `.storybook/preview.ts` — 커스텀 뷰포트 프리셋 등록 (Compact/Medium/Expanded)
- [x] `toast.stories.tsx` — Mobile, Tablet 뷰포트 스토리 추가

## 전달할 추가 이슈

- 데스크톱 동작 변경 없음
- ToastProvider, useToast 로직 변경 없음