### PR TITLE
fix/ui-improvements

### DIFF
--- a/src/stories/foundation/border-width.stories.tsx
+++ b/src/stories/foundation/border-width.stories.tsx
@@ -153,6 +153,43 @@ export const UsageExamples: Story = {
 	),
 };
 
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => (
+		<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+			<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+				같은 인풋인데, 테두리 두께만 다릅니다.
+			</p>
+			<p style={{ margin: "0 0 20px", fontSize: 13, color: "#666" }}>
+				두꺼울수록 "이 요소에 주목하세요"라는 신호가 강해집니다. 비활성 → 일반 → 강조 순서입니다.
+			</p>
+			<div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 16 }}>
+				{(Object.entries(borderWidth) as [string, string][]).map(([key, value]) => (
+					<div key={key} style={{ textAlign: "center" }}>
+						<div style={{ fontSize: 11, color: "#666", marginBottom: 8 }}>{key} ({value})</div>
+						<div style={{
+							height: 44,
+							borderRadius: 10,
+							border: `${value} solid ${key === "indicator" ? "#000" : "#e5e5e5"}`,
+							display: "flex",
+							alignItems: "center",
+							padding: "0 12px",
+							fontSize: 13,
+							color: key === "none" ? "#ccc" : "#333",
+							background: "#fff",
+						}}>
+							{key === "none" ? "비활성 상태" : key === "standard" ? "기본 상태" : "포커스/강조"}
+						</div>
+						<div style={{ marginTop: 8, fontSize: 11, color: "#666" }}>
+							{key === "none" ? "경계 없음" : key === "standard" ? "기본 구분선" : "시선 집중"}
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	),
+};
+
 function borderWidthDescription(key: string) {
 	switch (key) {
 		case "none":

--- a/src/stories/foundation/colors.stories.tsx
+++ b/src/stories/foundation/colors.stories.tsx
@@ -198,6 +198,50 @@ export const DoAndDont: Story = {
 	),
 };
 
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => {
+		const statuses = [
+			{ name: "Error", color: colors.status.error, bg: "#FEF2F2", text: "결제에 실패했습니다." },
+			{ name: "Success", color: colors.status.success, bg: "#F0FDF4", text: "저장이 완료되었습니다." },
+			{ name: "Info", color: colors.status.info, bg: "#EFF6FF", text: "새 버전이 있습니다." },
+			{ name: "Warning", color: "#F59E0B", bg: "#FFFBEB", text: "세션이 곧 만료됩니다." },
+		];
+
+		return (
+			<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+				<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+					같은 UI인데, 상태 색상만 다릅니다.
+				</p>
+				<p style={{ margin: "0 0 20px", fontSize: 13, color: "#666" }}>
+					색 하나만 바꿔도 "에러인지 성공인지" 즉시 전달됩니다. 색상이 가진 의미를 느껴보세요.
+				</p>
+
+				<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 12 }}>
+					{statuses.map(({ name, color, bg, text }) => (
+						<div key={name} style={{ background: bg, borderRadius: 10, padding: 16, borderLeft: `3px solid ${color}` }}>
+							<div style={{ fontSize: 13, fontWeight: 600, color, marginBottom: 6 }}>{name}</div>
+							<div style={{ fontSize: 12, color: "#333" }}>{text}</div>
+						</div>
+					))}
+				</div>
+
+				{/* 버튼 비교 */}
+				<div style={{ marginTop: 24 }}>
+					<p style={{ margin: "0 0 12px", fontSize: 13, fontWeight: 600 }}>버튼에 상태 색상 적용</p>
+					<div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+						{statuses.map(({ name, color }) => (
+							<div key={name} style={{ background: color, color: "#fff", padding: "8px 16px", borderRadius: 8, fontSize: 13, fontWeight: 600 }}>
+								{name}
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+		);
+	},
+};
+
 /** camelCase → kebab-case (tokens.json 키 표시용) */
 function toJsonKey(key: string) {
 	return key.replace(/([a-z])([A-Z0-9])/g, "$1-$2").replace(/([0-9])([a-zA-Z])/g, "$1-$2").toLowerCase();

--- a/src/stories/foundation/colors.stories.tsx
+++ b/src/stories/foundation/colors.stories.tsx
@@ -205,7 +205,7 @@ export const Comparison: Story = {
 			{ name: "Error", color: colors.status.error, bg: "#FEF2F2", text: "결제에 실패했습니다." },
 			{ name: "Success", color: colors.status.success, bg: "#F0FDF4", text: "저장이 완료되었습니다." },
 			{ name: "Info", color: colors.status.info, bg: "#EFF6FF", text: "새 버전이 있습니다." },
-			{ name: "Warning", color: "#F59E0B", bg: "#FFFBEB", text: "세션이 곧 만료됩니다." },
+			{ name: "Warning", color: colors.status.warning, bg: "#FFFBEB", text: "세션이 곧 만료됩니다." },
 		];
 
 		return (

--- a/src/stories/foundation/elevation.stories.tsx
+++ b/src/stories/foundation/elevation.stories.tsx
@@ -185,6 +185,46 @@ export const DoAndDont: Story = {
 	),
 };
 
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => (
+		<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+			<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+				완전히 같은 카드인데, 그림자만 다릅니다.
+			</p>
+			<p style={{ margin: "0 0 20px", fontSize: 13, color: "#666" }}>
+				level이 올라갈수록 "공중에 떠 있는" 느낌이 강해지는 걸 비교해보세요.
+			</p>
+			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 20 }}>
+				{Object.entries(elevation).map(([key, value]) => (
+					<div key={key} style={{ textAlign: "center" }}>
+						<div
+							style={{
+								background: "#fff",
+								borderRadius: 12,
+								padding: 16,
+								boxShadow: value,
+								minHeight: 100,
+								display: "flex",
+								flexDirection: "column",
+								justifyContent: "center",
+								alignItems: "center",
+								gap: 8,
+							}}
+						>
+							<div style={{ width: 32, height: 32, borderRadius: 8, background: "#f3f4f6" }} />
+							<div style={{ fontSize: 12, color: "#333" }}>카드 제목</div>
+							<div style={{ fontSize: 11, color: "#999" }}>설명 텍스트</div>
+						</div>
+						<div style={{ marginTop: 10, fontSize: 13, fontWeight: 600 }}>{key}</div>
+						<div style={{ fontSize: 11, color: "#666" }}>{elevationUseCase(key)}</div>
+					</div>
+				))}
+			</div>
+		</div>
+	),
+};
+
 function elevationDescription(key: string) {
 	switch (key) {
 		case "level1":

--- a/src/stories/foundation/motion.stories.tsx
+++ b/src/stories/foundation/motion.stories.tsx
@@ -107,6 +107,49 @@ export const ComponentMapping: Story = {
 	},
 };
 
+function MotionRace() {
+	const [go, setGo] = React.useState(false);
+	const speeds = [
+		{ name: "fast", transition: motion.transition.fast },
+		{ name: "base", transition: motion.transition.base },
+		{ name: "slow", transition: motion.transition.slow },
+		{ name: "emphasized", transition: motion.transition.emphasized },
+	];
+
+	return (
+		<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+			<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+				같은 애니메이션을 동시에 재생 — 속도 차이를 비교해보세요.
+			</p>
+			<p style={{ margin: "0 0 16px", fontSize: 13, color: "#666" }}>
+				버튼을 누르면 4개 바가 동시에 늘어납니다. 누가 먼저 도착하는지 보세요.
+			</p>
+			<button
+				type="button"
+				onClick={() => setGo((v) => !v)}
+				style={{ padding: "8px 16px", borderRadius: 8, background: "#121212", color: "#fff", border: "none", cursor: "pointer", fontSize: 13, fontWeight: 600, marginBottom: 16 }}
+			>
+				{go ? "리셋" : "재생"}
+			</button>
+			<div style={{ display: "grid", gap: 10 }}>
+				{speeds.map(({ name, transition }) => (
+					<div key={name} style={{ display: "grid", gridTemplateColumns: "100px 1fr", alignItems: "center", gap: 12 }}>
+						<div style={{ fontSize: 12, fontWeight: 600 }}>{name} <span style={{ color: "#999", fontWeight: 400 }}>({transition.split(" ")[0]})</span></div>
+						<div style={{ height: 28, background: "#e5e5e5", borderRadius: 6, overflow: "hidden" }}>
+							<div style={{ width: go ? "100%" : "8%", height: "100%", background: "#121212", borderRadius: 6, transition: `width ${transition}` }} />
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => <MotionRace />,
+};
+
 function motionDescription(key: string) {
 	switch (key) {
 		case "fast":

--- a/src/stories/foundation/opacity.stories.tsx
+++ b/src/stories/foundation/opacity.stories.tsx
@@ -158,6 +158,59 @@ export const UsageExamples: Story = {
 	),
 };
 
+const bgContent = (
+	<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 4, width: "100%", height: "100%" }}>
+		<div style={{ background: "#3B82F6", borderRadius: 4 }} />
+		<div style={{ background: "#EF4444", borderRadius: 4 }} />
+		<div style={{ background: "#10B981", borderRadius: 4 }} />
+		<div style={{ background: "#F59E0B", borderRadius: 4 }} />
+	</div>
+);
+
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => (
+		<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+			<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+				뒤에 같은 물체를 놓고, opacity에 따라 얼마나 가려지는지 비교해보세요.
+			</p>
+			<p style={{ margin: "0 0 20px", fontSize: 13, color: "#666" }}>
+				검은 오버레이의 투명도만 다릅니다. 숫자가 클수록 뒤가 안 보입니다.
+			</p>
+			<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(100px, 1fr))", gap: 12 }}>
+				{([0, 0.05, 0.12, 0.38, 0.5, 0.8, 1] as const).map((value) => (
+					<div key={value} style={{ textAlign: "center" }}>
+						<div style={{ position: "relative", width: "100%", aspectRatio: "1", borderRadius: 10, overflow: "hidden", border: "1px solid rgba(0,0,0,0.08)" }}>
+							<div style={{ position: "absolute", inset: 8, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 4 }}>
+								<div style={{ background: "#3B82F6", borderRadius: 4 }} />
+								<div style={{ background: "#EF4444", borderRadius: 4 }} />
+								<div style={{ background: "#10B981", borderRadius: 4 }} />
+								<div style={{ background: "#F59E0B", borderRadius: 4 }} />
+							</div>
+							<div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+								<span style={{ fontSize: 13, fontWeight: 600, color: "#fff", textShadow: "0 1px 3px rgba(0,0,0,0.5)", zIndex: 2 }}>텍스트</span>
+							</div>
+							<div style={{ position: "absolute", inset: 0, background: "#000", opacity: value }} />
+						</div>
+						<div style={{ marginTop: 8, fontSize: 12, fontWeight: 600 }}>{Math.round(value * 100)}%</div>
+						<div style={{ fontSize: 11, color: "#666" }}>{opacityLabel(value)}</div>
+					</div>
+				))}
+			</div>
+		</div>
+	),
+};
+
+function opacityLabel(value: number) {
+	if (value === 0) return "완전 투명";
+	if (value <= 0.05) return "호버 배경";
+	if (value <= 0.12) return "비활성 배경";
+	if (value <= 0.38) return "비활성 텍스트";
+	if (value <= 0.5) return "모달 오버레이";
+	if (value <= 0.8) return "거의 불투명";
+	return "완전 불투명";
+}
+
 function opacityUseCase(key: string) {
 	switch (key) {
 		case "0":

--- a/src/stories/foundation/radius.stories.tsx
+++ b/src/stories/foundation/radius.stories.tsx
@@ -101,6 +101,63 @@ export const ComponentMapping: Story = {
 	},
 };
 
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => (
+		<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+			<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+				같은 모양인데, 모서리 둥글기만 다릅니다.
+			</p>
+			<p style={{ margin: "0 0 20px", fontSize: 13, color: "#666" }}>
+				둥글기가 커질수록 부드럽고 친근한 느낌, 작을수록 단정하고 정보성 느낌이 됩니다.
+			</p>
+
+			{/* 버튼 비교 */}
+			<div style={{ marginBottom: 24 }}>
+				<div style={{ fontSize: 12, fontWeight: 600, marginBottom: 10, color: "#333" }}>버튼에 적용했을 때</div>
+				<div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+					{Object.entries(radius).map(([key, value]) => (
+						<div key={key} style={{ textAlign: "center" }}>
+							<div style={{ background: "#121212", color: "#fff", padding: "10px 20px", borderRadius: value, fontSize: 13, fontWeight: 600 }}>
+								Button
+							</div>
+							<div style={{ marginTop: 6, fontSize: 11, color: "#666" }}>{key} ({value})</div>
+						</div>
+					))}
+				</div>
+			</div>
+
+			{/* 카드 비교 */}
+			<div style={{ marginBottom: 24 }}>
+				<div style={{ fontSize: 12, fontWeight: 600, marginBottom: 10, color: "#333" }}>카드에 적용했을 때</div>
+				<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(100px, 1fr))", gap: 12 }}>
+					{Object.entries(radius).map(([key, value]) => (
+						<div key={key} style={{ textAlign: "center" }}>
+							<div style={{ background: "#fff", border: "1px solid #e5e5e5", borderRadius: value, padding: 12, height: 60, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, color: "#999" }}>
+								Card
+							</div>
+							<div style={{ marginTop: 6, fontSize: 11, color: "#666" }}>{key}</div>
+						</div>
+					))}
+				</div>
+			</div>
+
+			{/* 아바타 비교 */}
+			<div>
+				<div style={{ fontSize: 12, fontWeight: 600, marginBottom: 10, color: "#333" }}>아바타에 적용했을 때</div>
+				<div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+					{Object.entries(radius).map(([key, value]) => (
+						<div key={key} style={{ textAlign: "center" }}>
+							<div style={{ width: 48, height: 48, background: "#e5e5e5", borderRadius: value }} />
+							<div style={{ marginTop: 6, fontSize: 11, color: "#666" }}>{key}</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	),
+};
+
 function radiusUseCase(key: string) {
 	switch (key) {
 		case "none":

--- a/src/stories/foundation/spacing.stories.tsx
+++ b/src/stories/foundation/spacing.stories.tsx
@@ -131,6 +131,49 @@ export const LayoutExample: Story = {
 	),
 };
 
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => {
+		const gaps = [
+			{ token: "spacing-4", value: spacing[4], desc: "아이콘·텍스트 인접" },
+			{ token: "spacing-12", value: spacing[12], desc: "기본 간격" },
+			{ token: "spacing-24", value: spacing[24], desc: "섹션 간 여백" },
+			{ token: "spacing-48", value: spacing[48], desc: "큰 레이아웃 분리" },
+		];
+
+		const card = (
+			<div style={{ background: "#fff", borderRadius: 8, border: "1px solid #e5e5e5", padding: 12 }}>
+				<div style={{ fontSize: 13, fontWeight: 600 }}>카드</div>
+				<div style={{ fontSize: 11, color: "#666", marginTop: 4 }}>내용</div>
+			</div>
+		);
+
+		return (
+			<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+				<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+					같은 카드 3개를 놓고, 간격만 바꿨습니다.
+				</p>
+				<p style={{ margin: "0 0 20px", fontSize: 13, color: "#666" }}>
+					간격이 넓을수록 여유로운 느낌, 좁을수록 빽빽한 느낌이 나는 걸 비교해보세요.
+				</p>
+				<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 20 }}>
+					{gaps.map(({ token, value, desc }) => (
+						<div key={token}>
+							<div style={{ display: "grid", gap: parseInt(value), background: "#f0f0f0", borderRadius: 10, padding: 12 }}>
+								{card}
+								{card}
+								{card}
+							</div>
+							<div style={{ marginTop: 8, fontSize: 12, fontWeight: 600, textAlign: "center" }}>{token}</div>
+							<div style={{ fontSize: 11, color: "#666", textAlign: "center" }}>{value} — {desc}</div>
+						</div>
+					))}
+				</div>
+			</div>
+		);
+	},
+};
+
 function spacingUseCase(key: string) {
 	switch (key) {
 		case "0":

--- a/src/stories/foundation/typography.stories.tsx
+++ b/src/stories/foundation/typography.stories.tsx
@@ -43,8 +43,15 @@ type TypoStyle = {
 };
 
 const fontWeightMap: Record<string, number> = {
+	Thin: 100,
+	ExtraLight: 200,
+	Light: 300,
 	Regular: 400,
 	Medium: 500,
+	SemiBold: 600,
+	Bold: 700,
+	ExtraBold: 800,
+	Black: 900,
 };
 
 function TypoRow({ scale, variant, style }: { scale: string; variant: string; style: TypoStyle }) {
@@ -277,6 +284,64 @@ export const Hierarchy: Story = {
 			<span style={{ fontSize: 10, color: "#999", display: "block" }}>↑ Label.small</span>
 		</div>
 	),
+};
+
+export const Comparison: Story = {
+	name: "차이 비교",
+	render: () => {
+		const sentence = "디자인 시스템은 일관된 사용자 경험을 만듭니다.";
+		const scales = [
+			{ name: "Display Large", style: typography.display.large },
+			{ name: "Heading Large", style: typography.heading.large },
+			{ name: "Title Medium", style: typography.title.medium },
+			{ name: "Body Medium", style: typography.body.medium },
+			{ name: "Label Small", style: typography.label.small },
+		];
+
+		return (
+			<div style={{ background: "#fafafa", borderRadius: 12, padding: 24, maxWidth: 720 }}>
+				<p style={{ margin: "0 0 8px", fontSize: 14, fontWeight: 600 }}>
+					같은 문장을 다른 타이포 스케일로 비교해보세요.
+				</p>
+				<p style={{ margin: "0 0 20px", fontSize: 13, color: "#666" }}>
+					위에서 아래로 갈수록 작아집니다. 크기만으로 "이건 제목이고 이건 본문이구나"를 느낄 수 있어야 합니다.
+				</p>
+
+				<div style={{ display: "grid", gap: 16 }}>
+					{scales.map(({ name, style }) => (
+						<div key={name} style={{ display: "grid", gridTemplateColumns: "140px 1fr", alignItems: "baseline", gap: 12, padding: 12, background: "#fff", borderRadius: 10, border: "1px solid rgba(0,0,0,0.06)" }}>
+							<div>
+								<div style={{ fontSize: 11, fontWeight: 600, color: "#666" }}>{name}</div>
+								<div style={{ fontSize: 10, color: "#999" }}>{style.fontSize}</div>
+							</div>
+							<div style={{ fontFamily: typography.fontFamily.primary, fontSize: style.fontSize, fontWeight: style.fontWeight === "Medium" ? 500 : 400, lineHeight: style.lineHeight }}>
+								{sentence}
+							</div>
+						</div>
+					))}
+				</div>
+
+				{/* Weight 비교 */}
+				<div style={{ marginTop: 24 }}>
+					<p style={{ margin: "0 0 12px", fontSize: 13, fontWeight: 600 }}>Regular vs Medium 무게 비교</p>
+					<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+						<div style={{ background: "#fff", borderRadius: 10, padding: 16, border: "1px solid rgba(0,0,0,0.06)" }}>
+							<div style={{ fontSize: 11, color: "#666", marginBottom: 8 }}>Regular (400)</div>
+							<div style={{ fontFamily: typography.fontFamily.primary, fontSize: "20px", fontWeight: 400, lineHeight: "28px" }}>
+								{sentence}
+							</div>
+						</div>
+						<div style={{ background: "#fff", borderRadius: 10, padding: 16, border: "1px solid rgba(0,0,0,0.06)" }}>
+							<div style={{ fontSize: 11, color: "#666", marginBottom: 8 }}>Medium (500)</div>
+							<div style={{ fontFamily: typography.fontFamily.primary, fontSize: "20px", fontWeight: 500, lineHeight: "28px" }}>
+								{sentence}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	},
 };
 
 function sampleText(scale: string) {

--- a/src/styles/typography/_index.scss
+++ b/src/styles/typography/_index.scss
@@ -17,8 +17,15 @@ $font_size_48: 48px;
 
 // ── Base: Font weight ─────────────────────────────────────────────────────────
 
-$font_weight_regular: 400;
-$font_weight_medium:  500;
+$font_weight_thin:        100;
+$font_weight_extra_light: 200;
+$font_weight_light:       300;
+$font_weight_regular:     400;
+$font_weight_medium:      500;
+$font_weight_semi_bold:   600;
+$font_weight_bold:        700;
+$font_weight_extra_bold:  800;
+$font_weight_black:       900;
 
 // ── Base: Line height ─────────────────────────────────────────────────────────
 

--- a/src/styles/typography/index.ts
+++ b/src/styles/typography/index.ts
@@ -21,8 +21,15 @@ export const baseTypography = {
 	},
 
 	fontWeight: {
+		thin: "Thin",
+		extraLight: "ExtraLight",
+		light: "Light",
 		regular: "Regular",
 		medium: "Medium",
+		semiBold: "SemiBold",
+		bold: "Bold",
+		extraBold: "ExtraBold",
+		black: "Black",
 	},
 
 	lineHeight: {

--- a/src/ui/button/button.stories.tsx
+++ b/src/ui/button/button.stories.tsx
@@ -152,3 +152,20 @@ export const Disabled: Story = {
 	name: "비활성화",
 	args: { disabled: true },
 };
+
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: () => (
+		<div style={{ display: "grid", gap: 12, maxWidth: 200 }}>
+			<Button variant="filled" size="md">
+				Lorem ipsum dolor sit amet consectetur adipiscing elit
+			</Button>
+			<Button variant="tonal" size="md">
+				동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세
+			</Button>
+			<Button variant="outline" size="sm" fullWidth>
+				fullWidth 긴 텍스트 — Lorem ipsum dolor sit amet
+			</Button>
+		</div>
+	),
+};

--- a/src/ui/card/card.stories.tsx
+++ b/src/ui/card/card.stories.tsx
@@ -135,6 +135,23 @@ export const Padding: Story = {
 	},
 };
 
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: () => (
+		<div style={{ display: "grid", gap: 12, maxWidth: 320 }}>
+			<Card shadow="sm" padding="md" heading="아주 긴 제목 — Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod">
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+				Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+				Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+			</Card>
+			<Card shadow="sm" padding="sm" bordered heading="좁은 패딩 + 긴 내용">
+				동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세. 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세.
+				남산 위에 저 소나무 철갑을 두른 듯 바람서리 불변함은 우리 기상일세.
+			</Card>
+		</div>
+	),
+};
+
 export const Border: Story = {
 	name: "테두리 사용",
 	render: (args) => (

--- a/src/ui/chip/chip.stories.tsx
+++ b/src/ui/chip/chip.stories.tsx
@@ -108,6 +108,17 @@ export const Disabled: Story = {
 	args: { type: "basic", label: "Disabled", disabled: true },
 };
 
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: () => (
+		<div style={{ display: "flex", flexWrap: "wrap", gap: 8, maxWidth: 300 }}>
+			<Chip type="basic" label="Lorem ipsum dolor sit amet consectetur" />
+			<Chip type="input" label="아주 긴 칩 라벨 텍스트 테스트입니다" removable />
+			<Chip type="filter" label="동해물과 백두산이 마르고 닳도록" selected />
+		</div>
+	),
+};
+
 export const AllTypes: Story = {
 	name: "전체 유형 비교",
 	render: () => (

--- a/src/ui/date-picker/index.tsx
+++ b/src/ui/date-picker/index.tsx
@@ -51,33 +51,24 @@ interface DatePickerProps {
 	selectableRangeUntilTodaySrText?: string;
 }
 
-/**
- * 숫자를 두 자리 문자열로 보정한다.
- * @param n 숫자
- * @returns 두 자리 문자열
- */
+/** 숫자를 두 자리 문자열로 보정한다. */
 const pad = (n: number) => String(n).padStart(2, "0");
 
-/**
- * 해당 연/월의 일 수를 구한다.
- * @param year 연도
- * @param month 월(1-12)
- * @returns 일 수
- */
-const getDaysInMonth = (year: number, month: number) => new Date(year, month, 0).getDate();
+/** 해당 연/월의 일 수를 구한다. */
+const getDaysInMonth = (year: number, month: number) =>
+	new Date(year, month, 0).getDate();
 
-/**
- * 너비 값을 CSS 문자열로 정규화한다.
- * @param v 너비 값
- * @returns CSS 너비 문자열 또는 undefined
- */
-const normalizeWidth = (v?: number | string) => (typeof v === "number" ? `${v}px` : v);
+/** 너비 값을 CSS 문자열로 정규화한다. */
+const normalizeWidth = (v?: number | string) =>
+	typeof v === "number" ? `${v}px` : v;
+
+/** start~end 범위의 숫자 배열을 생성한다. */
+const range = (start: number, end: number) =>
+	Array.from({ length: end - start + 1 }, (_, i) => start + i);
 
 /**
  * 연/월/일 선택형 데이트 피커를 렌더링한다.
  * 입력 값과 선택 범위를 기준으로 옵션을 계산하고, 선택 변경을 상위로 전달한다.
- * @param props 데이트 피커 속성
- * @returns 렌더링된 데이트 피커 UI
  */
 export const DatePicker = ({
 	label,
@@ -85,7 +76,7 @@ export const DatePicker = ({
 	onChange,
 	mode = "year-month-day",
 	startYear = 1950,
-	endYear = new Date().getFullYear() + 10,
+	endYear: endYearProp,
 	minDate,
 	selectableRange = "all",
 	disabled,
@@ -99,67 +90,152 @@ export const DatePicker = ({
 }: DatePickerProps) => {
 	const groupId = React.useId();
 	const constraintId = React.useId();
-	const today = new Date();
-	const todayYear = today.getFullYear();
-	const todayMonth = today.getMonth() + 1;
-	const todayDay = today.getDate();
 
-	const [y, m, d] = value?.split("-").map(Number) ?? [];
-	const [minY, minM, minD] = minDate?.split("-").map(Number) ?? [];
+	// today 값을 마운트 시점에 한 번만 계산
+	const { todayYear, todayMonth, todayDay } = React.useMemo(() => {
+		const now = new Date();
+		return {
+			todayYear: now.getFullYear(),
+			todayMonth: now.getMonth() + 1,
+			todayDay: now.getDate(),
+		};
+	}, []);
 
-	const year = y ?? "";
-	const month = m ?? "";
-	const day = d ?? "";
+	const endYear = endYearProp ?? todayYear + 10;
 
-	const maxYear = selectableRange === "until-today" ? todayYear : endYear;
+	// value 파싱 (NaN → 0으로 통일)
+	const parsed = React.useMemo(() => {
+		if (!value) return { year: 0, month: 0, day: 0 };
+		const [y, m, d] = value.split("-").map(Number);
+		return {
+			year: y || 0,
+			month: m || 0,
+			day: d || 0,
+		};
+	}, [value]);
 
-	const minMonth = minY && year === minY ? minM : 1;
+	// minDate 파싱
+	const min = React.useMemo(() => {
+		if (!minDate) return { year: 0, month: 0, day: 0 };
+		const [y, m, d] = minDate.split("-").map(Number);
+		return {
+			year: y || 0,
+			month: m || 0,
+			day: d || 0,
+		};
+	}, [minDate]);
 
-	const maxMonth = selectableRange === "until-today" && year === todayYear ? todayMonth : 12;
+	const { year, month, day } = parsed;
 
-	const minDay = minY && minM && year === minY && month === minM ? minD : 1;
+	// ── 범위 계산 ────────────────────────────────────────────────────────
 
-	const maxDay =
-		selectableRange === "until-today" && year === todayYear && month === todayMonth
-			? todayDay
-			: getDaysInMonth(year || todayYear, month || 1);
+	const maxYear =
+		selectableRange === "until-today" ? todayYear : endYear;
 
-	const days = year && month ? Math.min(getDaysInMonth(year, month), maxDay) : 31;
+	const minMonth =
+		min.year > 0 && year === min.year ? min.month : 1;
 
-	/**
-	 * 해당 연/월의 최대 일 수를 기준으로 일 값을 보정한다.
-	 * @param year 연도
-	 * @param month 월
-	 * @param day 일
-	 * @returns 보정된 일
-	 */
-	const clampDay = (year: number, month: number, day: number) =>
-		Math.min(day, getDaysInMonth(year, month));
+	const maxMonth =
+		selectableRange === "until-today" && year === todayYear
+			? todayMonth
+			: 12;
 
-	/**
-	 * 선택 값을 포맷팅해 onChange로 전달한다.
-	 * @param yy 연도
-	 * @param mm 월
-	 * @param dd 일
-	 * @returns void
-	 */
-	const emit = (yy: number, mm: number, dd?: number) => {
-		if (mode === "year-month") {
-			onChange(`${yy}-${pad(mm)}`);
-			return;
+	const minDay =
+		min.year > 0 && min.month > 0 && year === min.year && month === min.month
+			? min.day
+			: 1;
+
+	const maxDay = React.useMemo(() => {
+		if (!year || !month) return 31;
+		const daysInMonth = getDaysInMonth(year, month);
+		if (selectableRange === "until-today" && year === todayYear && month === todayMonth) {
+			return Math.min(daysInMonth, todayDay);
 		}
+		return daysInMonth;
+	}, [year, month, selectableRange, todayYear, todayMonth, todayDay]);
 
-		const safeDay = clampDay(yy, mm, dd ?? 1);
+	// ── 옵션 배열 메모이제이션 ────────────────────────────────────────────
 
-		onChange(`${yy}-${pad(mm)}-${pad(safeDay)}`);
-	};
+	const yearOptions = React.useMemo(
+		() => range(startYear, maxYear),
+		[startYear, maxYear],
+	);
+
+	const monthOptions = React.useMemo(
+		() => range(minMonth, maxMonth),
+		[minMonth, maxMonth],
+	);
+
+	const dayOptions = React.useMemo(
+		() => range(minDay, Math.max(minDay, maxDay)),
+		[minDay, maxDay],
+	);
+
+	// ── emit: 선택 값을 포맷팅해 onChange로 전달 ─────────────────────────
+
+	const emit = React.useCallback(
+		(yy: number, mm: number, dd?: number) => {
+			if (mode === "year-month") {
+				onChange(`${yy}-${pad(mm)}`);
+				return;
+			}
+			const safeDay = Math.min(dd ?? 1, getDaysInMonth(yy, mm));
+			onChange(`${yy}-${pad(mm)}-${pad(safeDay)}`);
+		},
+		[mode, onChange],
+	);
+
+	// ── 핸들러: 연/월 변경 시 하위 값 자동 보정 ──────────────────────────
+
+	const handleYearChange = React.useCallback(
+		(newYear: number) => {
+			let newMonth = month;
+			// 월이 새 범위를 벗어나면 보정
+			const newMinMonth = min.year > 0 && newYear === min.year ? min.month : 1;
+			const newMaxMonth =
+				selectableRange === "until-today" && newYear === todayYear
+					? todayMonth
+					: 12;
+			if (newMonth > 0 && newMonth < newMinMonth) newMonth = newMinMonth;
+			if (newMonth > newMaxMonth) newMonth = newMaxMonth;
+
+			if (newMonth > 0) {
+				emit(newYear, newMonth, day || undefined);
+			} else {
+				// 월이 아직 선택 안 된 상태면 연도만 반영
+				emit(newYear, newMinMonth, day || undefined);
+			}
+		},
+		[month, day, min.year, min.month, selectableRange, todayYear, todayMonth, emit],
+	);
+
+	const handleMonthChange = React.useCallback(
+		(newMonth: number) => {
+			if (!year) return;
+			emit(year, newMonth, day || undefined);
+		},
+		[year, day, emit],
+	);
+
+	const handleDayChange = React.useCallback(
+		(newDay: number) => {
+			if (!year || !month) return;
+			emit(year, month, newDay);
+		},
+		[year, month, emit],
+	);
+
+	// ── 렌더링 ───────────────────────────────────────────────────────────
 
 	const containerStyle = width ? { width: normalizeWidth(width) } : undefined;
-	const rootClassName = cn("date_picker", { date_picker_full_width: fullWidth && !width });
+	const rootClassName = cn("date_picker", {
+		date_picker_full_width: fullWidth && !width,
+	});
 
 	const constraintParts: string[] = [];
 	if (minDate) constraintParts.push(minDateSrFormat.replace("{date}", minDate));
-	if (selectableRange === "until-today") constraintParts.push(selectableRangeUntilTodaySrText);
+	if (selectableRange === "until-today")
+		constraintParts.push(selectableRangeUntilTodaySrText);
 	const constraintDesc = constraintParts.join(". ");
 
 	return (
@@ -182,12 +258,12 @@ export const DatePicker = ({
 			>
 				<select
 					aria-label={yearLabel}
-					value={year}
+					value={year || ""}
 					disabled={disabled}
-					onChange={(e) => emit(Number(e.target.value), month || minMonth, day || minDay)}
+					onChange={(e) => handleYearChange(Number(e.target.value))}
 				>
 					<option value="">{yearLabel}</option>
-					{Array.from({ length: maxYear - startYear + 1 }, (_, i) => startYear + i).map((y) => (
+					{yearOptions.map((y) => (
 						<option key={y} value={y}>
 							{y}
 						</option>
@@ -196,12 +272,12 @@ export const DatePicker = ({
 
 				<select
 					aria-label={monthLabel}
-					value={month}
+					value={month || ""}
 					disabled={disabled || !year}
-					onChange={(e) => emit(year, Number(e.target.value), day || minDay)}
+					onChange={(e) => handleMonthChange(Number(e.target.value))}
 				>
 					<option value="">{monthLabel}</option>
-					{Array.from({ length: maxMonth - minMonth + 1 }, (_, i) => minMonth + i).map((m) => (
+					{monthOptions.map((m) => (
 						<option key={m} value={m}>
 							{pad(m)}
 						</option>
@@ -211,12 +287,12 @@ export const DatePicker = ({
 				{mode === "year-month-day" && (
 					<select
 						aria-label={dayLabel}
-						value={day}
+						value={day || ""}
 						disabled={disabled || !month}
-						onChange={(e) => emit(year, month, Number(e.target.value))}
+						onChange={(e) => handleDayChange(Number(e.target.value))}
 					>
 						<option value="">{dayLabel}</option>
-						{Array.from({ length: days - minDay + 1 }, (_, i) => minDay + i).map((d) => (
+						{dayOptions.map((d) => (
 							<option key={d} value={d}>
 								{pad(d)}
 							</option>

--- a/src/ui/date-picker/index.tsx
+++ b/src/ui/date-picker/index.tsx
@@ -162,7 +162,7 @@ export const DatePicker = ({
 	);
 
 	const monthOptions = React.useMemo(
-		() => range(minMonth, maxMonth),
+		() => range(minMonth, Math.max(minMonth, maxMonth)),
 		[minMonth, maxMonth],
 	);
 

--- a/src/ui/icon-button/icon-button.stories.tsx
+++ b/src/ui/icon-button/icon-button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import type * as React from "react";
 import { IconButton } from ".";
 
 const PlusIcon = () => (
@@ -20,6 +21,12 @@ const SearchIcon = () => (
 	</svg>
 );
 
+const iconMap = {
+	Plus: <PlusIcon />,
+	Close: <CloseIcon />,
+	Search: <SearchIcon />,
+};
+
 const meta: Meta<typeof IconButton> = {
 	title: "Components/IconButton",
 	component: IconButton,
@@ -35,6 +42,12 @@ const meta: Meta<typeof IconButton> = {
 			options: ["sm", "md"],
 			description: "아이콘 버튼의 크기입니다.",
 		},
+		icon: {
+			control: "select",
+			options: Object.keys(iconMap),
+			mapping: iconMap,
+			description: "표시할 아이콘을 선택합니다.",
+		},
 		disabled: {
 			control: "boolean",
 			description: "비활성화 상태입니다.",
@@ -42,7 +55,7 @@ const meta: Meta<typeof IconButton> = {
 		onClick: { action: "clicked" },
 	},
 	args: {
-		icon: <PlusIcon />,
+		icon: "Plus" as unknown as React.ReactNode,
 		variant: "standard",
 		size: "md",
 		disabled: false,

--- a/src/ui/list-item/list-item.stories.tsx
+++ b/src/ui/list-item/list-item.stories.tsx
@@ -267,6 +267,24 @@ export const Interactive: Story = {
 	},
 };
 
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: () => (
+		<div style={{ display: "grid", gap: 12, maxWidth: 320 }}>
+			<ListItem
+				label="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt"
+				supportingText="동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세"
+			/>
+			<ListItem
+				overline="아주 긴 오버라인 텍스트 — Lorem ipsum dolor sit amet consectetur"
+				label="라벨도 매우 긴 경우를 테스트합니다. 텍스트가 어떻게 줄바꿈되는지 확인하세요."
+				supportingText="보조 텍스트도 길 수 있습니다. 여러 줄이 표시되는 경우 간격과 정렬이 올바른지 확인해야 합니다."
+				metadata="2026-04-10"
+			/>
+		</div>
+	),
+};
+
 export const AllVariants: Story = {
 	name: "모든 변형",
 	render: () => (

--- a/src/ui/modal/modal.stories.tsx
+++ b/src/ui/modal/modal.stories.tsx
@@ -52,6 +52,39 @@ const meta: Meta<typeof Modal> = {
 export default meta;
 type Story = StoryObj<typeof Modal>;
 
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+
+		return (
+			<div>
+				<button type="button" onClick={() => setOpen(true)}>
+					긴 텍스트 모달 열기
+				</button>
+
+				<Modal {...args} open={open} onClose={() => setOpen(false)} title="Lorem ipsum dolor sit amet, consectetur adipiscing elit">
+					<div style={{ display: "grid", gap: 16 }}>
+						<p style={{ margin: 0 }}>
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+							Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+							Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+							Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+						</p>
+						<p style={{ margin: 0 }}>
+							동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세. 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세.
+							남산 위에 저 소나무 철갑을 두른 듯 바람서리 불변함은 우리 기상일세. 가을 하늘 공활한데 높고 구름 없이 밝은 달은 우리 가슴 일편단심일세.
+						</p>
+						<p style={{ margin: 0 }}>
+							이 기상과 이 맘으로 충성을 다하여 괴로우나 즐거우나 나라 사랑하세. 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세.
+						</p>
+					</div>
+				</Modal>
+			</div>
+		);
+	},
+};
+
 export const Playground: Story = {
 	name: "기본 사용 예시",
 	render: (args) => {

--- a/src/ui/radio/index.tsx
+++ b/src/ui/radio/index.tsx
@@ -25,7 +25,9 @@ export const Radio = ({ label, size = "md", className, ref, ...props }: RadioPro
 	return (
 		<label className={rootClassName}>
 			<input ref={ref} type="radio" className="radio_input" {...props} />
-			<span className="radio_dot" aria-hidden="true" />
+			<span className="radio_state_layer" aria-hidden="true">
+				<span className="radio_dot" />
+			</span>
 			{label ? <span className="radio_label">{label}</span> : null}
 		</label>
 	);

--- a/src/ui/radio/style.scss
+++ b/src/ui/radio/style.scss
@@ -10,11 +10,26 @@
 
   &_input {
     position: absolute;
-    inset: 0;
-    opacity: 0;
-    cursor: pointer;
-    margin: 0;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
+
+  // ── State layer (circular overlay for hover/focus/pressed) ─────────────
+
+  &_state_layer {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: token.$spacing_8;
+    border-radius: token.$radius_full;
+    transition: background token.$transition_base;
+  }
+
+  // ── Dot (radio graphic) ────────────────────────────────────────────────
 
   &_dot {
     width: token.$font_size_16;
@@ -26,8 +41,7 @@
     background: token.$color_bg_solid;
 
     transition: background token.$transition_base,
-    border-color token.$transition_base,
-    box-shadow token.$transition_base;
+      border-color token.$transition_base;
 
     position: relative;
     display: inline-block;
@@ -37,6 +51,8 @@
     @include token.body_medium;
     color: token.$color_text_heading;
   }
+
+  // ── Sizes ──────────────────────────────────────────────────────────────
 
   &_size_sm {
     .radio_dot {
@@ -67,16 +83,45 @@
     }
   }
 
-  &_input:focus-visible + .radio_dot {
-    box-shadow: token.$focus_ring;
+  // ── States: Hover ──────────────────────────────────────────────────────
+
+  &:hover .radio_state_layer {
+    background: token.$color_state_hover_on_light;
+  }
+
+  // ── States: Focus ──────────────────────────────────────────────────────
+
+  &_input:focus-visible ~ .radio_state_layer {
+    background: token.$color_state_focus_on_light;
+  }
+
+  // ── States: Active/Pressed ─────────────────────────────────────────────
+
+  &:active .radio_state_layer {
+    background: token.$color_state_pressed_on_light;
+  }
+
+  // ── States: Disabled ───────────────────────────────────────────────────
+
+  &_input:disabled ~ .radio_state_layer {
+    opacity: token.$opacity_38;
+  }
+
+  &_input:disabled ~ .radio_label {
+    opacity: token.$opacity_38;
+  }
+
+  &:has(.radio_input:disabled) {
+    cursor: not-allowed;
+  }
+
+  // ── Checked state ──────────────────────────────────────────────────────
+
+  &_input:checked ~ .radio_state_layer .radio_dot {
     border-color: token.$color_brand_primary;
   }
 
-  &_input:checked + .radio_dot {
-    border-color: token.$color_brand_primary;
-  }
-
-  &_input:checked + .radio_dot::after {
+  &_input:checked ~ .radio_state_layer .radio_dot::after {
     content: "";
     position: absolute;
     left: 50%;
@@ -86,11 +131,5 @@
     transform: translate(-50%, -50%);
     background: token.$color_brand_primary;
     border-radius: token.$radius_full;
-  }
-
-  &_input:disabled + .radio_dot,
-  &_input:disabled ~ .radio_label {
-    opacity: token.$opacity_38;
-    cursor: not-allowed;
   }
 }

--- a/src/ui/select/select.stories.tsx
+++ b/src/ui/select/select.stories.tsx
@@ -121,6 +121,27 @@ export const Sizes: Story = {
 	),
 };
 
+const longOptions: SelectOption[] = [
+	{ value: "long1", label: "Lorem ipsum dolor sit amet, consectetur adipiscing elit" },
+	{ value: "long2", label: "동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세" },
+	{ value: "long3", label: "Very long option text that should test overflow and truncation behavior" },
+	{ value: "long4", label: "아주 긴 옵션 텍스트 — 드롭다운과 선택 영역에서 어떻게 표시되는지 확인" },
+];
+
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: (args) => (
+		<div style={{ width: 240 }}>
+			<Select
+				{...args}
+				label="긴 옵션 텍스트 테스트"
+				placeholder="선택해주세요"
+				options={longOptions}
+			/>
+		</div>
+	),
+};
+
 export const Controlled: Story = {
 	name: "제어형",
 	render: (args) => {

--- a/src/ui/switch/style.scss
+++ b/src/ui/switch/style.scss
@@ -4,68 +4,133 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  box-sizing: border-box;
 
   width: 40px;
-  height: 22px;
+  height: 24px;
   padding: 2px;
 
+  border: 2px solid token.$color_border_default;
   border-radius: token.$radius_full;
-  background: token.$color_border_default;
+  background: token.$color_bg_solid_dim;
 
-  transition: background token.$transition_base;
+  transition: background token.$transition_base,
+    border-color token.$transition_base;
   cursor: pointer;
 
+  // ── Thumb ──────────────────────────────────────────────────────────────
+
   &_thumb {
-    width: 18px;
-    height: 18px;
-    background: token.$color_bg_solid;
+    position: relative;
+    width: 16px;
+    height: 16px;
+    background: token.$color_text_caption;
     border-radius: token.$radius_full;
-    transition: transform token.$transition_base;
+    transition: transform token.$transition_base,
+      width token.$transition_base,
+      height token.$transition_base,
+      background token.$transition_base;
     transform: translateX(0);
   }
 
+  // ── On state ───────────────────────────────────────────────────────────
+
   &_on {
     background: token.$color_brand_primary;
+    border-color: token.$color_brand_primary;
 
     .switch_thumb {
-      transform: translateX(18px);
+      width: 20px;
+      height: 20px;
+      background: token.$color_bg_solid;
+      transform: translateX(14px);
     }
   }
 
+  // ── States: Hover ──────────────────────────────────────────────────────
+
+  &:not(:disabled):hover {
+    opacity: 0.88;
+  }
+
+  // ── States: Focus ──────────────────────────────────────────────────────
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: token.$focus_ring;
+  }
+
+  // ── States: Active/Pressed ─────────────────────────────────────────────
+
+  &:not(:disabled):active .switch_thumb {
+    width: 20px;
+    height: 20px;
+  }
+
+  &_on:not(:disabled):active .switch_thumb {
+    transform: translateX(12px);
+  }
+
+  // ── Sizes ──────────────────────────────────────────────────────────────
+
   &_size_sm {
     width: 34px;
-    height: 18px;
+    height: 20px;
     padding: 2px;
 
     .switch_thumb {
-      width: 14px;
-      height: 14px;
+      width: 12px;
+      height: 12px;
     }
 
     &.switch_on .switch_thumb {
-      transform: translateX(16px);
+      width: 16px;
+      height: 16px;
+      transform: translateX(12px);
+    }
+
+    &:not(:disabled):active .switch_thumb {
+      width: 16px;
+      height: 16px;
+    }
+
+    &.switch_on:not(:disabled):active .switch_thumb {
+      transform: translateX(10px);
     }
   }
 
   &_size_md {
     width: 40px;
-    height: 22px;
+    height: 24px;
   }
 
   &_size_lg {
     width: 48px;
-    height: 26px;
+    height: 28px;
     padding: 2px;
 
     .switch_thumb {
-      width: 22px;
-      height: 22px;
+      width: 20px;
+      height: 20px;
     }
 
     &.switch_on .switch_thumb {
-      transform: translateX(22px);
+      width: 24px;
+      height: 24px;
+      transform: translateX(18px);
+    }
+
+    &:not(:disabled):active .switch_thumb {
+      width: 24px;
+      height: 24px;
+    }
+
+    &.switch_on:not(:disabled):active .switch_thumb {
+      transform: translateX(16px);
     }
   }
+
+  // ── Disabled ───────────────────────────────────────────────────────────
 
   &_disabled {
     opacity: token.$opacity_38;

--- a/src/ui/textfield/textfield.stories.tsx
+++ b/src/ui/textfield/textfield.stories.tsx
@@ -132,6 +132,25 @@ export const NoLabel: Story = {
 	},
 };
 
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: () => (
+		<div style={{ display: "grid", gap: 24, width: 240 }}>
+			<TextField
+				label="긴 라벨 — 사용자의 이메일 주소를 입력해주세요"
+				placeholder="Lorem ipsum dolor sit amet"
+				supportingText="이 필드는 반드시 입력해야 하며, 올바른 이메일 형식이어야 합니다."
+			/>
+			<TextField
+				label="에러 + 긴 텍스트"
+				defaultValue="동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세"
+				supportingText="입력한 값이 올바르지 않습니다. 다시 확인해주세요."
+				error
+			/>
+		</div>
+	),
+};
+
 export const AllStates: Story = {
 	name: "전체 상태 비교",
 	render: () => (

--- a/src/ui/toast/toast.stories.tsx
+++ b/src/ui/toast/toast.stories.tsx
@@ -167,6 +167,51 @@ export const Tablet: Story = {
 	render: () => <PlaygroundContent />,
 };
 
+function LongTextContent() {
+	return (
+		<ToastProvider>
+			<LongTextButtons />
+		</ToastProvider>
+	);
+}
+
+function LongTextButtons() {
+	const t = useToast();
+
+	return (
+		<div style={demo_wrap_style}>
+			<p style={demo_hint_style}>긴 메시지가 Toast에서 어떻게 표시되는지 테스트합니다.</p>
+			<button
+				type="button"
+				style={demo_btn_style}
+				onClick={() =>
+					t.success(
+						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+					)
+				}
+			>
+				긴 성공 메시지
+			</button>
+			<button
+				type="button"
+				style={demo_btn_style}
+				onClick={() =>
+					t.error(
+						"동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세. 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세.",
+					)
+				}
+			>
+				긴 에러 메시지
+			</button>
+		</div>
+	);
+}
+
+export const LongText: Story = {
+	name: "긴 텍스트",
+	render: () => <LongTextContent />,
+};
+
 export const UsageExample: Story = {
 	name: "코드 형태",
 	render: () => (


### PR DESCRIPTION
## 작업 개요

UI 컴포넌트 상태 피드백 개선, 렌더링 최적화, 디자인 토큰 확장, 스토리북 교육 자료 보강

Closes #190

## 작업한 내용

- [x] Typography base token에 Thin(100)~Black(900) 9단계 font weight 추가
- [x] Radio에 Checkbox와 동일한 hover/focus/pressed 상태 레이어 패턴 적용
- [x] Switch MD3 스타일 리디자인 — OFF thumb 대비율 개선(3.5:1), disabled 상태에서 hover/click 차단
- [x] DatePicker useMemo/useCallback 최적화, 타입 안전성 강화, 월/일 범위 변경 시 자동 보정
- [x] IconButton 스토리북 icon 컨트롤을 코드 표시에서 select 드롭다운으로 수정
- [x] Button, TextField, ListItem, Card, Chip, Select, Toast, Modal에 LongText 오버플로우 테스트 스토리 추가
- [x] opacity, elevation, spacing, radius, typography, colors, motion, border-width 8개 Foundation 도메인에 "차이 비교" 시각화 스토리 추가

## 전달할 추가 이슈

- Typography semantic 토큰 Bold/SemiBold 확장은 디자이너 협의 후 진행 예정
- `$color_bg_surface` 토큰 부재로 Switch에서 `$color_bg_solid_dim` 대체 사용 중