### PR TITLE
fix/chip-spinner-improvements

### DIFF
--- a/src/ui/chip/chip.stories.tsx
+++ b/src/ui/chip/chip.stories.tsx
@@ -122,6 +122,39 @@ export const LongText: Story = {
 	),
 };
 
+export const InputRemovableInteractive: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+
+	name: "Input 삭제 (인터랙티브)",
+	render: () => {
+		const [items, setItems] = React.useState(["디자인", "개발", "기획", "마케팅"]);
+		const remove = (label: string) => setItems((prev) => prev.filter((v) => v !== label));
+		return (
+			<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+				<p style={{ margin: 0, fontSize: 13, color: "#666" }}>
+					X 버튼을 눌러 칩을 삭제해보세요.
+				</p>
+				<div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+					{items.map((label) => (
+						<Chip
+							key={label}
+							type="input"
+							label={label}
+							removable
+							onRemove={() => remove(label)}
+						/>
+					))}
+					{items.length === 0 && (
+						<p style={{ margin: 0, fontSize: 13, color: "#999" }}>
+							모든 칩이 삭제되었습니다.
+						</p>
+					)}
+				</div>
+			</div>
+		);
+	},
+};
+
 export const Interactive: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 

--- a/src/ui/chip/chip.stories.tsx
+++ b/src/ui/chip/chip.stories.tsx
@@ -28,8 +28,8 @@ const meta: Meta<typeof Chip> = {
 			control: "boolean",
 			description: "비활성화 상태입니다.",
 		},
-		onClick: { action: "clicked" },
-		onRemove: { action: "removed" },
+		onClick: { action: "onClick", control: false },
+		onRemove: { action: "onRemove", control: false },
 	},
 	args: {
 		type: "basic",

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -65,6 +65,7 @@
 	}
 
 	// ── Trailing button ─────────────────────────────────────────────────────
+	// X 버튼: 아이콘 자체에만 circular hover 적용 (전체 state layer 없음)
 
 	&_trailing {
 		display: inline-flex;
@@ -75,28 +76,12 @@
 		cursor: pointer;
 		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
 		color: token.$color_text_heading;
-		position: relative;
-		overflow: hidden;
 
-		// State layer overlay
-		&::before {
-			content: "";
-			position: absolute;
-			top: 0; right: 0; bottom: 0; left: 0;
-			border-radius: inherit;
-			transition: background token.$transition_base;
-			pointer-events: none;
-		}
-
-		&:hover:not(:disabled)::before {
-			background: token.$color_state_hover_on_light;
-		}
-
-		&:focus-visible:not(:disabled)::before {
+		&:focus-visible:not(:disabled) .chip_icon {
 			background: token.$color_state_focus_on_light;
 		}
 
-		&:active:not(:disabled)::before {
+		&:active:not(:disabled) .chip_icon {
 			background: token.$color_state_pressed_on_light;
 		}
 
@@ -123,7 +108,7 @@
 		}
 	}
 
-	&_content:hover:not(:disabled) .chip_icon,
+	// chip_trailing의 X 아이콘만 circular hover (chip_content는 전체 state layer 사용)
 	&_trailing:hover:not(:disabled) .chip_icon {
 		background: token.$color_state_hover_on_light;
 	}

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -19,7 +19,7 @@
 		border: none;
 		background: transparent;
 		cursor: pointer;
-		padding: token.$spacing_6 token.$spacing_12;
+		padding: token.$spacing_6 token.$spacing_12 token.$spacing_6 token.$spacing_16;
 		@include token.body_small_medium;
 		color: token.$color_text_heading;
 		position: relative;
@@ -86,6 +86,10 @@
 			border-radius: inherit;
 			transition: background token.$transition_base;
 			pointer-events: none;
+		}
+
+		&:hover:not(:disabled)::before {
+			background: token.$color_state_hover_on_light;
 		}
 
 		&:focus-visible:not(:disabled)::before {

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -109,14 +109,23 @@
 
 	&_icon {
 		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 		width: 20px;
 		height: 20px;
 		flex-shrink: 0;
+		border-radius: token.$radius_full;
+		transition: background token.$transition_base;
 
 		svg {
 			width: 100%;
 			height: 100%;
 		}
+	}
+
+	&_content:hover:not(:disabled) .chip_icon,
+	&_trailing:hover:not(:disabled) .chip_icon {
+		background: token.$color_state_hover_on_light;
 	}
 
 	// ── Label ───────────────────────────────────────────────────────────────

--- a/src/ui/spinner/style.scss
+++ b/src/ui/spinner/style.scss
@@ -14,5 +14,5 @@
   border: token.$border_width_indicator solid token.$color_border_default;
   border-top-color: token.$color_brand_primary;
 
-  animation: spinner_spin token.$transition_dramatic linear infinite;
+  animation: spinner_spin 0.8s linear infinite;
 }


### PR DESCRIPTION
## 작업 개요
Chip UX 개선, Spinner 애니메이션 버그 수정

## 작업한 내용
- [x] Chip trailing(X) 버튼 호버 복구
- [x] Chip 왼쪽 패딩 확대 (spacing_12 → spacing_16)
- [x] Chip Input removable 인터랙티브 스토리 추가 (X 클릭 시 실제 삭제)
- [x] Spinner 애니메이션 버그 수정 — token.$transition_dramatic 잘못된 토큰 참조로 animation이 none이었던 문제 해결
- [x] chip_icon에 circular 호버 추가
- [x] Chip 더블 액션 버그 수정 — argTypes action 중복 등록 문제
- [x] Chip 더블 호버 버그 수정 — chip_content는 전체 state layer, chip_trailing X 아이콘만 circular hover로 분리

## 전달할 추가 이슈
없음