### PR TITLE
fix/chip-hover

### DIFF
--- a/src/ui/chip/Chip.test.tsx
+++ b/src/ui/chip/Chip.test.tsx
@@ -33,7 +33,7 @@ describe("Chip", () => {
 	it("shows chevron for filter type", () => {
 		const { container } = render(<Chip label="Tag" type="filter" />);
 		expect(container.firstChild).toHaveClass("chip_has_trailing");
-		expect(container.querySelector(".chip_icon_btn .chip_icon svg")).toBeInTheDocument();
+		expect(container.querySelector(".chip_content .chip_icon svg")).toBeInTheDocument();
 	});
 
 	it("handles disabled state", () => {

--- a/src/ui/chip/Chip.test.tsx
+++ b/src/ui/chip/Chip.test.tsx
@@ -33,7 +33,7 @@ describe("Chip", () => {
 	it("shows chevron for filter type", () => {
 		const { container } = render(<Chip label="Tag" type="filter" />);
 		expect(container.firstChild).toHaveClass("chip_has_trailing");
-		expect(container.querySelector(".chip_content .chip_icon svg")).toBeInTheDocument();
+		expect(container.querySelector(".chip_icon_btn .chip_icon svg")).toBeInTheDocument();
 	});
 
 	it("handles disabled state", () => {

--- a/src/ui/chip/index.tsx
+++ b/src/ui/chip/index.tsx
@@ -58,12 +58,15 @@ export const Chip = ({
 	className,
 	...props
 }: ChipProps) => {
-	// chip_content 내부 아이콘 hover 시 전체 state layer를 끄기 위한 상태
-	const [contentIconHovered, setContentIconHovered] = useState(false);
+	// 아이콘 직접 hover 시 칩 전체 state layer를 끄기 위한 상태
+	const [iconHovered, setIconHovered] = useState(false);
 
 	const hasLeading = selected;
 	const hasTrailingButton = type === "input" && removable;
 	const hasTrailingIcon = hasTrailingButton || type === "filter";
+
+	const enterIcon = () => setIconHovered(true);
+	const leaveIcon = () => setIconHovered(false);
 
 	const chipClassName = cn(
 		"chip",
@@ -72,17 +75,15 @@ export const Chip = ({
 		hasLeading && "chip_has_leading",
 		hasTrailingIcon && "chip_has_trailing",
 		disabled && "chip_disabled",
+		iconHovered && "chip_icon_hovered",
 		className,
 	);
-
-	const enterContentIcon = () => setContentIconHovered(true);
-	const leaveContentIcon = () => setContentIconHovered(false);
 
 	return (
 		<div className={chipClassName} {...props}>
 			<button
 				type="button"
-				className={cn("chip_content", contentIconHovered && "chip_icon_hovered")}
+				className="chip_content"
 				disabled={disabled}
 				onClick={onClick}
 				{...(type === "filter" ? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open } : {})}
@@ -91,8 +92,8 @@ export const Chip = ({
 					<span
 						className="chip_icon"
 						aria-hidden="true"
-						onPointerEnter={enterContentIcon}
-						onPointerLeave={leaveContentIcon}
+						onPointerEnter={enterIcon}
+						onPointerLeave={leaveIcon}
 					>
 						<CheckIcon />
 					</span>
@@ -102,8 +103,8 @@ export const Chip = ({
 					<span
 						className="chip_icon"
 						aria-hidden="true"
-						onPointerEnter={enterContentIcon}
-						onPointerLeave={leaveContentIcon}
+						onPointerEnter={enterIcon}
+						onPointerLeave={leaveIcon}
 					>
 						<ChevronDownIcon />
 					</span>
@@ -117,7 +118,12 @@ export const Chip = ({
 					onClick={onRemove}
 					aria-label="Remove"
 				>
-					<span className="chip_icon" aria-hidden="true">
+					<span
+						className="chip_icon"
+						aria-hidden="true"
+						onPointerEnter={enterIcon}
+						onPointerLeave={leaveIcon}
+					>
 						<CloseIcon />
 					</span>
 				</button>

--- a/src/ui/chip/index.tsx
+++ b/src/ui/chip/index.tsx
@@ -58,9 +58,8 @@ export const Chip = ({
 	className,
 	...props
 }: ChipProps) => {
-	// 아이콘에 직접 hover 시 해당 버튼의 전체 state layer를 끄기 위한 상태
+	// chip_content 내부 아이콘 hover 시 전체 state layer를 끄기 위한 상태
 	const [contentIconHovered, setContentIconHovered] = useState(false);
-	const [trailingIconHovered, setTrailingIconHovered] = useState(false);
 
 	const hasLeading = selected;
 	const hasTrailingButton = type === "input" && removable;
@@ -78,8 +77,6 @@ export const Chip = ({
 
 	const enterContentIcon = () => setContentIconHovered(true);
 	const leaveContentIcon = () => setContentIconHovered(false);
-	const enterTrailingIcon = () => setTrailingIconHovered(true);
-	const leaveTrailingIcon = () => setTrailingIconHovered(false);
 
 	return (
 		<div className={chipClassName} {...props}>
@@ -115,17 +112,12 @@ export const Chip = ({
 			{hasTrailingButton && (
 				<button
 					type="button"
-					className={cn("chip_trailing", trailingIconHovered && "chip_icon_hovered")}
+					className="chip_trailing"
 					disabled={disabled}
 					onClick={onRemove}
 					aria-label="Remove"
 				>
-					<span
-						className="chip_icon"
-						aria-hidden="true"
-						onPointerEnter={enterTrailingIcon}
-						onPointerLeave={leaveTrailingIcon}
-					>
+					<span className="chip_icon" aria-hidden="true">
 						<CloseIcon />
 					</span>
 				</button>

--- a/src/ui/chip/index.tsx
+++ b/src/ui/chip/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import type * as React from "react";
 import { cn } from "../../utils";
 import "./style.scss";
 
@@ -46,8 +46,6 @@ const ChevronDownIcon = () => (
 	</svg>
 );
 
-type HoverZone = "leading" | "label" | "trailing-icon" | null;
-
 export const Chip = ({
 	type = "basic",
 	label,
@@ -60,12 +58,8 @@ export const Chip = ({
 	className,
 	...props
 }: ChipProps) => {
-	const [hoverZone, setHoverZone] = useState<HoverZone>(null);
-
 	const hasLeading = selected;
-	// removable input chip만 별도 trailing 버튼 유지 (두 가지 다른 액션 필요)
 	const hasTrailingButton = type === "input" && removable;
-	// filter/removable input 모두 trailing 아이콘 패딩 적용
 	const hasTrailingIcon = hasTrailingButton || type === "filter";
 
 	const chipClassName = cn(
@@ -78,41 +72,52 @@ export const Chip = ({
 		className,
 	);
 
-	const handleMouseLeave = () => setHoverZone(null);
-
 	return (
 		<div className={chipClassName} {...props}>
-			<button
-				type="button"
-				className={cn("chip_content", !disabled && hoverZone === "label" && "chip_content_hover")}
-				disabled={disabled}
-				onClick={onClick}
-				onMouseOver={() => setHoverZone("label")}
-				onMouseLeave={handleMouseLeave}
-				{...(type === "filter" ? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open } : {})}
-			>
-				{hasLeading && (
-					<span
-						className={cn("chip_icon", !disabled && hoverZone === "leading" && "chip_icon_hover")}
-						aria-hidden="true"
-						onMouseOver={(e) => { e.stopPropagation(); setHoverZone("leading"); }}
-						onMouseLeave={handleMouseLeave}
-					>
+			{/* Leading icon — 독립 버튼 (원형 hover) */}
+			{hasLeading && (
+				<button
+					type="button"
+					className="chip_icon_btn chip_icon_btn_leading"
+					disabled={disabled}
+					onClick={onClick}
+					tabIndex={-1}
+					aria-hidden="true"
+				>
+					<span className="chip_icon">
 						<CheckIcon />
 					</span>
-				)}
+				</button>
+			)}
+
+			{/* Label — 메인 버튼 (전체 영역 hover) */}
+			<button
+				type="button"
+				className="chip_label_btn"
+				disabled={disabled}
+				onClick={onClick}
+				{...(type === "filter" ? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open } : {})}
+			>
 				<span className="chip_label">{label}</span>
-				{type === "filter" && (
-					<span
-						className={cn("chip_icon", !disabled && hoverZone === "trailing-icon" && "chip_icon_hover")}
-						aria-hidden="true"
-						onMouseOver={(e) => { e.stopPropagation(); setHoverZone("trailing-icon"); }}
-						onMouseLeave={handleMouseLeave}
-					>
+			</button>
+
+			{/* Filter trailing icon — 독립 버튼 (원형 hover) */}
+			{type === "filter" && (
+				<button
+					type="button"
+					className="chip_icon_btn chip_icon_btn_trailing"
+					disabled={disabled}
+					onClick={onClick}
+					tabIndex={-1}
+					aria-hidden="true"
+				>
+					<span className="chip_icon">
 						<ChevronDownIcon />
 					</span>
-				)}
-			</button>
+				</button>
+			)}
+
+			{/* Remove button — 독립 버튼 (원형 hover) */}
 			{hasTrailingButton && (
 				<button
 					type="button"

--- a/src/ui/chip/index.tsx
+++ b/src/ui/chip/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import React, { useState } from "react";
 import { cn } from "../../utils";
 import "./style.scss";
 
@@ -46,6 +46,8 @@ const ChevronDownIcon = () => (
 	</svg>
 );
 
+type HoverZone = "leading" | "label" | "trailing-icon" | null;
+
 export const Chip = ({
 	type = "basic",
 	label,
@@ -58,6 +60,8 @@ export const Chip = ({
 	className,
 	...props
 }: ChipProps) => {
+	const [hoverZone, setHoverZone] = useState<HoverZone>(null);
+
 	const hasLeading = selected;
 	// removable input chip만 별도 trailing 버튼 유지 (두 가지 다른 액션 필요)
 	const hasTrailingButton = type === "input" && removable;
@@ -74,23 +78,37 @@ export const Chip = ({
 		className,
 	);
 
+	const handleMouseLeave = () => setHoverZone(null);
+
 	return (
 		<div className={chipClassName} {...props}>
 			<button
 				type="button"
-				className="chip_content"
+				className={cn("chip_content", !disabled && hoverZone === "label" && "chip_content_hover")}
 				disabled={disabled}
 				onClick={onClick}
+				onMouseOver={() => setHoverZone("label")}
+				onMouseLeave={handleMouseLeave}
 				{...(type === "filter" ? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open } : {})}
 			>
 				{hasLeading && (
-					<span className="chip_icon" aria-hidden="true">
+					<span
+						className={cn("chip_icon", !disabled && hoverZone === "leading" && "chip_icon_hover")}
+						aria-hidden="true"
+						onMouseOver={(e) => { e.stopPropagation(); setHoverZone("leading"); }}
+						onMouseLeave={handleMouseLeave}
+					>
 						<CheckIcon />
 					</span>
 				)}
 				<span className="chip_label">{label}</span>
 				{type === "filter" && (
-					<span className="chip_icon" aria-hidden="true">
+					<span
+						className={cn("chip_icon", !disabled && hoverZone === "trailing-icon" && "chip_icon_hover")}
+						aria-hidden="true"
+						onMouseOver={(e) => { e.stopPropagation(); setHoverZone("trailing-icon"); }}
+						onMouseLeave={handleMouseLeave}
+					>
 						<ChevronDownIcon />
 					</span>
 				)}

--- a/src/ui/chip/index.tsx
+++ b/src/ui/chip/index.tsx
@@ -58,8 +58,9 @@ export const Chip = ({
 	className,
 	...props
 }: ChipProps) => {
-	// 아이콘에 직접 hover 시 전체 state layer를 끄기 위한 상태
-	const [iconHovered, setIconHovered] = useState(false);
+	// 아이콘에 직접 hover 시 해당 버튼의 전체 state layer를 끄기 위한 상태
+	const [contentIconHovered, setContentIconHovered] = useState(false);
+	const [trailingIconHovered, setTrailingIconHovered] = useState(false);
 
 	const hasLeading = selected;
 	const hasTrailingButton = type === "input" && removable;
@@ -75,14 +76,16 @@ export const Chip = ({
 		className,
 	);
 
-	const enterIcon = () => setIconHovered(true);
-	const leaveIcon = () => setIconHovered(false);
+	const enterContentIcon = () => setContentIconHovered(true);
+	const leaveContentIcon = () => setContentIconHovered(false);
+	const enterTrailingIcon = () => setTrailingIconHovered(true);
+	const leaveTrailingIcon = () => setTrailingIconHovered(false);
 
 	return (
 		<div className={chipClassName} {...props}>
 			<button
 				type="button"
-				className={cn("chip_content", iconHovered && "chip_icon_hovered")}
+				className={cn("chip_content", contentIconHovered && "chip_icon_hovered")}
 				disabled={disabled}
 				onClick={onClick}
 				{...(type === "filter" ? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open } : {})}
@@ -91,8 +94,8 @@ export const Chip = ({
 					<span
 						className="chip_icon"
 						aria-hidden="true"
-						onPointerEnter={enterIcon}
-						onPointerLeave={leaveIcon}
+						onPointerEnter={enterContentIcon}
+						onPointerLeave={leaveContentIcon}
 					>
 						<CheckIcon />
 					</span>
@@ -102,8 +105,8 @@ export const Chip = ({
 					<span
 						className="chip_icon"
 						aria-hidden="true"
-						onPointerEnter={enterIcon}
-						onPointerLeave={leaveIcon}
+						onPointerEnter={enterContentIcon}
+						onPointerLeave={leaveContentIcon}
 					>
 						<ChevronDownIcon />
 					</span>
@@ -112,12 +115,17 @@ export const Chip = ({
 			{hasTrailingButton && (
 				<button
 					type="button"
-					className="chip_trailing"
+					className={cn("chip_trailing", trailingIconHovered && "chip_icon_hovered")}
 					disabled={disabled}
 					onClick={onRemove}
 					aria-label="Remove"
 				>
-					<span className="chip_icon" aria-hidden="true">
+					<span
+						className="chip_icon"
+						aria-hidden="true"
+						onPointerEnter={enterTrailingIcon}
+						onPointerLeave={leaveTrailingIcon}
+					>
 						<CloseIcon />
 					</span>
 				</button>

--- a/src/ui/chip/index.tsx
+++ b/src/ui/chip/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import React, { useState } from "react";
 import { cn } from "../../utils";
 import "./style.scss";
 
@@ -58,6 +58,9 @@ export const Chip = ({
 	className,
 	...props
 }: ChipProps) => {
+	// 아이콘에 직접 hover 시 전체 state layer를 끄기 위한 상태
+	const [iconHovered, setIconHovered] = useState(false);
+
 	const hasLeading = selected;
 	const hasTrailingButton = type === "input" && removable;
 	const hasTrailingIcon = hasTrailingButton || type === "filter";
@@ -72,52 +75,40 @@ export const Chip = ({
 		className,
 	);
 
+	const enterIcon = () => setIconHovered(true);
+	const leaveIcon = () => setIconHovered(false);
+
 	return (
 		<div className={chipClassName} {...props}>
-			{/* Leading icon — 독립 버튼 (원형 hover) */}
-			{hasLeading && (
-				<button
-					type="button"
-					className="chip_icon_btn chip_icon_btn_leading"
-					disabled={disabled}
-					onClick={onClick}
-					tabIndex={-1}
-					aria-hidden="true"
-				>
-					<span className="chip_icon">
-						<CheckIcon />
-					</span>
-				</button>
-			)}
-
-			{/* Label — 메인 버튼 (전체 영역 hover) */}
 			<button
 				type="button"
-				className="chip_label_btn"
+				className={cn("chip_content", iconHovered && "chip_icon_hovered")}
 				disabled={disabled}
 				onClick={onClick}
 				{...(type === "filter" ? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open } : {})}
 			>
+				{hasLeading && (
+					<span
+						className="chip_icon"
+						aria-hidden="true"
+						onPointerEnter={enterIcon}
+						onPointerLeave={leaveIcon}
+					>
+						<CheckIcon />
+					</span>
+				)}
 				<span className="chip_label">{label}</span>
-			</button>
-
-			{/* Filter trailing icon — 독립 버튼 (원형 hover) */}
-			{type === "filter" && (
-				<button
-					type="button"
-					className="chip_icon_btn chip_icon_btn_trailing"
-					disabled={disabled}
-					onClick={onClick}
-					tabIndex={-1}
-					aria-hidden="true"
-				>
-					<span className="chip_icon">
+				{type === "filter" && (
+					<span
+						className="chip_icon"
+						aria-hidden="true"
+						onPointerEnter={enterIcon}
+						onPointerLeave={leaveIcon}
+					>
 						<ChevronDownIcon />
 					</span>
-				</button>
-			)}
-
-			{/* Remove button — 독립 버튼 (원형 hover) */}
+				)}
+			</button>
 			{hasTrailingButton && (
 				<button
 					type="button"

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -8,6 +8,32 @@
 	border: token.$border_width_standard solid token.$color_border_default;
 	overflow: hidden;
 	transition: border-color token.$transition_base;
+	position: relative;
+
+	// ── Hover state layer (칩 전체 커버) ────────────────────────────────────
+
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0; right: 0; bottom: 0; left: 0;
+		border-radius: inherit;
+		transition: background token.$transition_base;
+		pointer-events: none;
+	}
+
+	&:hover::before {
+		background: token.$color_state_hover_on_light;
+	}
+
+	// 아이콘 직접 hover 시 전체 state layer 숨김
+	&.chip_icon_hovered:hover::before {
+		background: transparent;
+	}
+
+	// 모든 아이콘 공통 원형 hover (chip_content/chip_trailing 무관)
+	.chip_icon:hover {
+		background: token.$color_state_hover_on_light;
+	}
 
 	// ── Content button ──────────────────────────────────────────────────────
 
@@ -25,7 +51,7 @@
 		position: relative;
 		overflow: hidden;
 
-		// State layer overlay (전체 영역)
+		// State layer overlay (focus/active 전용)
 		&::before {
 			content: "";
 			position: absolute;
@@ -33,16 +59,6 @@
 			border-radius: inherit;
 			transition: background token.$transition_base;
 			pointer-events: none;
-		}
-
-		// 기본 hover: 전체 state layer
-		&:hover:not(:disabled)::before {
-			background: token.$color_state_hover_on_light;
-		}
-
-		// 아이콘에 직접 hover 중이면 전체 state layer 숨김
-		&.chip_icon_hovered:hover:not(:disabled)::before {
-			background: transparent;
 		}
 
 		&:focus-visible:not(:disabled)::before {
@@ -55,11 +71,6 @@
 
 		&:disabled {
 			cursor: not-allowed;
-		}
-
-		// chip_content 내부 아이콘: 직접 hover 시 원형 highlight
-		.chip_icon:hover {
-			background: token.$color_state_hover_on_light;
 		}
 	}
 
@@ -76,7 +87,6 @@
 	}
 
 	// ── Trailing button (X) ─────────────────────────────────────────────────
-	// chip_content 내부 아이콘과 동일하게 원형 hover만 적용
 
 	&_trailing {
 		display: inline-flex;
@@ -87,10 +97,6 @@
 		cursor: pointer;
 		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
 		color: token.$color_text_heading;
-
-		&:hover:not(:disabled) .chip_icon {
-			background: token.$color_state_hover_on_light;
-		}
 
 		&:focus-visible:not(:disabled) .chip_icon {
 			background: token.$color_state_focus_on_light;
@@ -116,7 +122,7 @@
 		flex-shrink: 0;
 		border-radius: token.$radius_full;
 		transition: background token.$transition_base;
-		position: relative; // ::before state layer 위에 렌더링되도록
+		position: relative; // chip ::before 위에 렌더링되도록
 
 		svg {
 			width: 100%;

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -9,34 +9,32 @@
 	overflow: hidden;
 	transition: border-color token.$transition_base;
 
-	// ── Content button ──────────────────────────────────────────────────────
+	// ── Label button (메인 클릭 영역, 전체 state layer) ─────────────────────
 
-	&_content {
+	&_label_btn {
 		flex: 1;
 		display: inline-flex;
 		align-items: center;
-		gap: token.$spacing_4;
 		border: none;
 		background: transparent;
 		cursor: pointer;
-		padding: token.$spacing_6 token.$spacing_12 token.$spacing_6 token.$spacing_16;
+		padding: token.$spacing_6 token.$spacing_12;
 		@include token.body_small_medium;
 		color: token.$color_text_heading;
 		position: relative;
 		overflow: hidden;
+		white-space: nowrap;
 
-		// State layer overlay
+		// State layer overlay (전체 영역)
 		&::before {
 			content: "";
 			position: absolute;
 			top: 0; right: 0; bottom: 0; left: 0;
-			border-radius: inherit;
 			transition: background token.$transition_base;
 			pointer-events: none;
 		}
 
-		// Hover: React-controlled class (label zone only)
-		&.chip_content_hover:not(:disabled)::before {
+		&:hover:not(:disabled)::before {
 			background: token.$color_state_hover_on_light;
 		}
 
@@ -53,30 +51,29 @@
 		}
 	}
 
-	// ── Leading icon padding adjustment ─────────────────────────────────────
+	// ── Icon buttons (leading / filter trailing, 원형 hover) ──────────────
 
-	&_has_leading .chip_content {
-		padding-left: token.$spacing_8;
-	}
-
-	// ── Trailing icon padding adjustment ────────────────────────────────────
-
-	&_has_trailing .chip_content {
-		padding-right: token.$spacing_8;
-	}
-
-	// ── Trailing button ─────────────────────────────────────────────────────
-	// X 버튼: 아이콘 자체에만 circular hover 적용 (다른 아이콘과 동일 방식)
-
-	&_trailing {
+	&_icon_btn {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
 		border: none;
 		background: transparent;
 		cursor: pointer;
-		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
+		padding: 0;
 		color: token.$color_text_heading;
+
+		&_leading {
+			padding-left: token.$spacing_8;
+		}
+
+		&_trailing {
+			padding-right: token.$spacing_8;
+		}
+
+		&:hover:not(:disabled) .chip_icon {
+			background: token.$color_state_hover_on_light;
+		}
 
 		&:focus-visible:not(:disabled) .chip_icon {
 			background: token.$color_state_focus_on_light;
@@ -91,7 +88,36 @@
 		}
 	}
 
-	// ── Icon ────────────────────────────────────────────────────────────────
+	// ── Remove button (X, 원형 hover) ──────────────────────────────────────
+
+	&_trailing {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
+		color: token.$color_text_heading;
+
+		&:hover:not(:disabled) .chip_icon {
+			background: token.$color_state_hover_on_light;
+		}
+
+		&:focus-visible:not(:disabled) .chip_icon {
+			background: token.$color_state_focus_on_light;
+		}
+
+		&:active:not(:disabled) .chip_icon {
+			background: token.$color_state_pressed_on_light;
+		}
+
+		&:disabled {
+			cursor: not-allowed;
+		}
+	}
+
+	// ── Icon ───────────────────────────────────────────────────────────────
 
 	&_icon {
 		display: inline-flex;
@@ -109,28 +135,16 @@
 		}
 	}
 
-	// Circular icon hover — 모든 아이콘 공통 (원형)
-	// chip_content 내부: React-controlled class
-	// chip_trailing X: CSS :hover
-	&_icon_hover,
-	&_trailing:hover:not(:disabled) .chip_icon {
-		background: token.$color_state_hover_on_light;
-	}
-
-	// ── Label ───────────────────────────────────────────────────────────────
+	// ── Label ──────────────────────────────────────────────────────────────
 
 	&_label {
 		white-space: nowrap;
 	}
 
-	// ── Disabled ────────────────────────────────────────────────────────────
+	// ── Disabled ───────────────────────────────────────────────────────────
 
 	&_disabled {
 		opacity: token.$opacity_38;
 		pointer-events: none;
-
-		button {
-			cursor: not-allowed;
-		}
 	}
 }

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -76,7 +76,7 @@
 	}
 
 	// ── Trailing button (X) ─────────────────────────────────────────────────
-	// chip_content와 동일한 패턴: 전체 state layer + 아이콘 원형 hover 토글
+	// 아이콘만 있는 단일 버튼 — 전체 state layer만 적용 (아이콘 토글 불필요)
 
 	&_trailing {
 		display: inline-flex;
@@ -90,7 +90,6 @@
 		position: relative;
 		overflow: hidden;
 
-		// State layer overlay (전체 영역)
 		&::before {
 			content: "";
 			position: absolute;
@@ -99,14 +98,8 @@
 			pointer-events: none;
 		}
 
-		// 기본 hover: 전체 state layer
 		&:hover:not(:disabled)::before {
 			background: token.$color_state_hover_on_light;
-		}
-
-		// 아이콘에 직접 hover 중이면 전체 state layer 숨김
-		&.chip_icon_hovered:hover:not(:disabled)::before {
-			background: transparent;
 		}
 
 		&:focus-visible:not(:disabled)::before {
@@ -119,11 +112,6 @@
 
 		&:disabled {
 			cursor: not-allowed;
-		}
-
-		// 아이콘 직접 hover 시 원형 highlight
-		.chip_icon:hover {
-			background: token.$color_state_hover_on_light;
 		}
 	}
 

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -76,7 +76,7 @@
 	}
 
 	// ── Trailing button (X) ─────────────────────────────────────────────────
-	// 아이콘만 있는 단일 버튼 — 전체 state layer만 적용 (아이콘 토글 불필요)
+	// chip_content 내부 아이콘과 동일하게 원형 hover만 적용
 
 	&_trailing {
 		display: inline-flex;
@@ -87,26 +87,16 @@
 		cursor: pointer;
 		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
 		color: token.$color_text_heading;
-		position: relative;
-		overflow: hidden;
 
-		&::before {
-			content: "";
-			position: absolute;
-			top: 0; right: 0; bottom: 0; left: 0;
-			transition: background token.$transition_base;
-			pointer-events: none;
-		}
-
-		&:hover:not(:disabled)::before {
+		&:hover:not(:disabled) .chip_icon {
 			background: token.$color_state_hover_on_light;
 		}
 
-		&:focus-visible:not(:disabled)::before {
+		&:focus-visible:not(:disabled) .chip_icon {
 			background: token.$color_state_focus_on_light;
 		}
 
-		&:active:not(:disabled)::before {
+		&:active:not(:disabled) .chip_icon {
 			background: token.$color_state_pressed_on_light;
 		}
 

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -76,6 +76,7 @@
 	}
 
 	// ── Trailing button (X) ─────────────────────────────────────────────────
+	// chip_content와 동일한 패턴: 전체 state layer + 아이콘 원형 hover 토글
 
 	&_trailing {
 		display: inline-flex;
@@ -86,21 +87,43 @@
 		cursor: pointer;
 		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
 		color: token.$color_text_heading;
+		position: relative;
+		overflow: hidden;
 
-		&:hover:not(:disabled) .chip_icon {
+		// State layer overlay (전체 영역)
+		&::before {
+			content: "";
+			position: absolute;
+			top: 0; right: 0; bottom: 0; left: 0;
+			transition: background token.$transition_base;
+			pointer-events: none;
+		}
+
+		// 기본 hover: 전체 state layer
+		&:hover:not(:disabled)::before {
 			background: token.$color_state_hover_on_light;
 		}
 
-		&:focus-visible:not(:disabled) .chip_icon {
+		// 아이콘에 직접 hover 중이면 전체 state layer 숨김
+		&.chip_icon_hovered:hover:not(:disabled)::before {
+			background: transparent;
+		}
+
+		&:focus-visible:not(:disabled)::before {
 			background: token.$color_state_focus_on_light;
 		}
 
-		&:active:not(:disabled) .chip_icon {
+		&:active:not(:disabled)::before {
 			background: token.$color_state_pressed_on_light;
 		}
 
 		&:disabled {
 			cursor: not-allowed;
+		}
+
+		// 아이콘 직접 hover 시 원형 highlight
+		.chip_icon:hover {
+			background: token.$color_state_hover_on_light;
 		}
 	}
 

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -10,8 +10,6 @@
 	transition: border-color token.$transition_base;
 	position: relative;
 
-	// ── Hover state layer (칩 전체 커버) ────────────────────────────────────
-
 	&::before {
 		content: "";
 		position: absolute;
@@ -25,17 +23,22 @@
 		background: token.$color_state_hover_on_light;
 	}
 
-	// 아이콘 직접 hover 시 전체 state layer 숨김
-	&.chip_icon_hovered:hover::before {
+	&:active::before {
+		background: token.$color_state_pressed_on_light;
+	}
+
+	&.chip_icon_hovered:hover::before,
+	&.chip_icon_hovered:active::before {
 		background: transparent;
 	}
 
-	// 모든 아이콘 공통 원형 hover (chip_content/chip_trailing 무관)
 	.chip_icon:hover {
 		background: token.$color_state_hover_on_light;
 	}
 
-	// ── Content button ──────────────────────────────────────────────────────
+	.chip_icon:active {
+		background: token.$color_state_pressed_on_light;
+	}
 
 	&_content {
 		flex: 1;
@@ -51,7 +54,6 @@
 		position: relative;
 		overflow: hidden;
 
-		// State layer overlay (focus/active 전용)
 		&::before {
 			content: "";
 			position: absolute;
@@ -65,28 +67,18 @@
 			background: token.$color_state_focus_on_light;
 		}
 
-		&:active:not(:disabled)::before {
-			background: token.$color_state_pressed_on_light;
-		}
-
 		&:disabled {
 			cursor: not-allowed;
 		}
 	}
 
-	// ── Leading icon padding adjustment ─────────────────────────────────────
-
 	&_has_leading .chip_content {
 		padding-left: token.$spacing_8;
 	}
 
-	// ── Trailing icon padding adjustment ────────────────────────────────────
-
 	&_has_trailing .chip_content {
 		padding-right: token.$spacing_8;
 	}
-
-	// ── Trailing button (X) ─────────────────────────────────────────────────
 
 	&_trailing {
 		display: inline-flex;
@@ -102,16 +94,10 @@
 			background: token.$color_state_focus_on_light;
 		}
 
-		&:active:not(:disabled) .chip_icon {
-			background: token.$color_state_pressed_on_light;
-		}
-
 		&:disabled {
 			cursor: not-allowed;
 		}
 	}
-
-	// ── Icon ────────────────────────────────────────────────────────────────
 
 	&_icon {
 		display: inline-flex;
@@ -122,7 +108,7 @@
 		flex-shrink: 0;
 		border-radius: token.$radius_full;
 		transition: background token.$transition_base;
-		position: relative; // chip ::before 위에 렌더링되도록
+		position: relative;
 
 		svg {
 			width: 100%;
@@ -130,13 +116,9 @@
 		}
 	}
 
-	// ── Label ───────────────────────────────────────────────────────────────
-
 	&_label {
 		white-space: nowrap;
 	}
-
-	// ── Disabled ────────────────────────────────────────────────────────────
 
 	&_disabled {
 		opacity: token.$opacity_38;

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -66,7 +66,7 @@
 	}
 
 	// ── Trailing button ─────────────────────────────────────────────────────
-	// X 버튼: 아이콘 자체에만 circular hover 적용 (전체 state layer 없음)
+	// X 버튼: 버튼 전체 영역에 state layer 적용
 
 	&_trailing {
 		display: inline-flex;
@@ -77,12 +77,27 @@
 		cursor: pointer;
 		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
 		color: token.$color_text_heading;
+		position: relative;
+		overflow: hidden;
 
-		&:focus-visible:not(:disabled) .chip_icon {
+		// State layer overlay
+		&::before {
+			content: "";
+			position: absolute;
+			top: 0; right: 0; bottom: 0; left: 0;
+			transition: background token.$transition_base;
+			pointer-events: none;
+		}
+
+		&:hover:not(:disabled)::before {
+			background: token.$color_state_hover_on_light;
+		}
+
+		&:focus-visible:not(:disabled)::before {
 			background: token.$color_state_focus_on_light;
 		}
 
-		&:active:not(:disabled) .chip_icon {
+		&:active:not(:disabled)::before {
 			background: token.$color_state_pressed_on_light;
 		}
 
@@ -110,9 +125,7 @@
 	}
 
 	// Circular icon hover — React-controlled (chip_content 내부 아이콘)
-	// CSS-controlled (chip_trailing X 버튼)
-	&_icon_hover,
-	&_trailing:hover:not(:disabled) .chip_icon {
+	&_icon_hover {
 		background: token.$color_state_hover_on_light;
 	}
 

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -35,7 +35,8 @@
 			pointer-events: none;
 		}
 
-		&:hover:not(:disabled)::before {
+		// Hover: React-controlled class (label zone only)
+		&.chip_content_hover:not(:disabled)::before {
 			background: token.$color_state_hover_on_light;
 		}
 
@@ -108,7 +109,9 @@
 		}
 	}
 
-	// chip_trailing의 X 아이콘만 circular hover (chip_content는 전체 state layer 사용)
+	// Circular icon hover — React-controlled (chip_content 내부 아이콘)
+	// CSS-controlled (chip_trailing X 버튼)
+	&_icon_hover,
 	&_trailing:hover:not(:disabled) .chip_icon {
 		background: token.$color_state_hover_on_light;
 	}

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -9,33 +9,40 @@
 	overflow: hidden;
 	transition: border-color token.$transition_base;
 
-	// ── Label button (메인 클릭 영역, 전체 state layer) ─────────────────────
+	// ── Content button ──────────────────────────────────────────────────────
 
-	&_label_btn {
+	&_content {
 		flex: 1;
 		display: inline-flex;
 		align-items: center;
+		gap: token.$spacing_4;
 		border: none;
 		background: transparent;
 		cursor: pointer;
-		padding: token.$spacing_6 token.$spacing_12;
+		padding: token.$spacing_6 token.$spacing_12 token.$spacing_6 token.$spacing_16;
 		@include token.body_small_medium;
 		color: token.$color_text_heading;
 		position: relative;
 		overflow: hidden;
-		white-space: nowrap;
 
 		// State layer overlay (전체 영역)
 		&::before {
 			content: "";
 			position: absolute;
 			top: 0; right: 0; bottom: 0; left: 0;
+			border-radius: inherit;
 			transition: background token.$transition_base;
 			pointer-events: none;
 		}
 
+		// 기본 hover: 전체 state layer
 		&:hover:not(:disabled)::before {
 			background: token.$color_state_hover_on_light;
+		}
+
+		// 아이콘에 직접 hover 중이면 전체 state layer 숨김
+		&.chip_icon_hovered:hover:not(:disabled)::before {
+			background: transparent;
 		}
 
 		&:focus-visible:not(:disabled)::before {
@@ -49,46 +56,26 @@
 		&:disabled {
 			cursor: not-allowed;
 		}
-	}
 
-	// ── Icon buttons (leading / filter trailing, 원형 hover) ──────────────
-
-	&_icon_btn {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		border: none;
-		background: transparent;
-		cursor: pointer;
-		padding: 0;
-		color: token.$color_text_heading;
-
-		&_leading {
-			padding-left: token.$spacing_8;
-		}
-
-		&_trailing {
-			padding-right: token.$spacing_8;
-		}
-
-		&:hover:not(:disabled) .chip_icon {
+		// chip_content 내부 아이콘: 직접 hover 시 원형 highlight
+		.chip_icon:hover {
 			background: token.$color_state_hover_on_light;
 		}
-
-		&:focus-visible:not(:disabled) .chip_icon {
-			background: token.$color_state_focus_on_light;
-		}
-
-		&:active:not(:disabled) .chip_icon {
-			background: token.$color_state_pressed_on_light;
-		}
-
-		&:disabled {
-			cursor: not-allowed;
-		}
 	}
 
-	// ── Remove button (X, 원형 hover) ──────────────────────────────────────
+	// ── Leading icon padding adjustment ─────────────────────────────────────
+
+	&_has_leading .chip_content {
+		padding-left: token.$spacing_8;
+	}
+
+	// ── Trailing icon padding adjustment ────────────────────────────────────
+
+	&_has_trailing .chip_content {
+		padding-right: token.$spacing_8;
+	}
+
+	// ── Trailing button (X) ─────────────────────────────────────────────────
 
 	&_trailing {
 		display: inline-flex;
@@ -117,7 +104,7 @@
 		}
 	}
 
-	// ── Icon ───────────────────────────────────────────────────────────────
+	// ── Icon ────────────────────────────────────────────────────────────────
 
 	&_icon {
 		display: inline-flex;
@@ -128,6 +115,7 @@
 		flex-shrink: 0;
 		border-radius: token.$radius_full;
 		transition: background token.$transition_base;
+		position: relative; // ::before state layer 위에 렌더링되도록
 
 		svg {
 			width: 100%;
@@ -135,16 +123,20 @@
 		}
 	}
 
-	// ── Label ──────────────────────────────────────────────────────────────
+	// ── Label ───────────────────────────────────────────────────────────────
 
 	&_label {
 		white-space: nowrap;
 	}
 
-	// ── Disabled ───────────────────────────────────────────────────────────
+	// ── Disabled ────────────────────────────────────────────────────────────
 
 	&_disabled {
 		opacity: token.$opacity_38;
 		pointer-events: none;
+
+		button {
+			cursor: not-allowed;
+		}
 	}
 }

--- a/src/ui/chip/style.scss
+++ b/src/ui/chip/style.scss
@@ -66,7 +66,7 @@
 	}
 
 	// ── Trailing button ─────────────────────────────────────────────────────
-	// X 버튼: 버튼 전체 영역에 state layer 적용
+	// X 버튼: 아이콘 자체에만 circular hover 적용 (다른 아이콘과 동일 방식)
 
 	&_trailing {
 		display: inline-flex;
@@ -77,27 +77,12 @@
 		cursor: pointer;
 		padding: token.$spacing_6 token.$spacing_8 token.$spacing_6 0;
 		color: token.$color_text_heading;
-		position: relative;
-		overflow: hidden;
 
-		// State layer overlay
-		&::before {
-			content: "";
-			position: absolute;
-			top: 0; right: 0; bottom: 0; left: 0;
-			transition: background token.$transition_base;
-			pointer-events: none;
-		}
-
-		&:hover:not(:disabled)::before {
-			background: token.$color_state_hover_on_light;
-		}
-
-		&:focus-visible:not(:disabled)::before {
+		&:focus-visible:not(:disabled) .chip_icon {
 			background: token.$color_state_focus_on_light;
 		}
 
-		&:active:not(:disabled)::before {
+		&:active:not(:disabled) .chip_icon {
 			background: token.$color_state_pressed_on_light;
 		}
 
@@ -124,8 +109,11 @@
 		}
 	}
 
-	// Circular icon hover — React-controlled (chip_content 내부 아이콘)
-	&_icon_hover {
+	// Circular icon hover — 모든 아이콘 공통 (원형)
+	// chip_content 내부: React-controlled class
+	// chip_trailing X: CSS :hover
+	&_icon_hover,
+	&_trailing:hover:not(:disabled) .chip_icon {
 		background: token.$color_state_hover_on_light;
 	}
 


### PR DESCRIPTION
## 작업 개요
Chip 컴포넌트의 hover/active state layer를 개선하여, 모든 영역(라벨, 아이콘, X 버튼)이 일관되게 동작하도록 수정

## 작업한 내용
- [x] hover state layer를 chip_content에서 chip 컨테이너 레벨로 이동 → 라벨 hover 시 X 영역 포함 칩 전체 하이라이트
- [x] 아이콘 직접 hover 시 칩 전체 state layer 숨기고 원형 highlight만 표시 (onPointerEnter/Leave)
- [x] active/pressed state도 chip 레벨로 통합 → 두 레이어 겹침(더 진해지는 현상) 제거
- [x] 모든 아이콘(체크, chevron, X) 동일한 원형 hover/active 동작
- [x] focus-visible은 개별 버튼 레벨 유지 (키보드 접근성)
- [x] 불필요한 주석 정리

## 전달할 추가 이슈
- chip_content와 chip_trailing이 형제 버튼이라 state layer 공유가 안 되는 구조적 한계를 chip 컨테이너 레벨 ::before로 해결