### PR TITLE
develop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ export type { IconButtonProps, IconButtonVariant, IconButtonSize } from "./ui/ic
 export { LinearProgress } from "./ui/linear-progress";
 export type { LinearProgressProps } from "./ui/linear-progress";
 export { ListItem } from "./ui/list-item";
+export { OtpInput } from "./ui/otp-input";
+export type { OtpInputProps } from "./ui/otp-input";
 export type { ListItemProps } from "./ui/list-item";
 export { Modal } from "./ui/modal";
 export type { ModalProps } from "./ui/modal";

--- a/src/ui/otp-input/OtpInput.test.tsx
+++ b/src/ui/otp-input/OtpInput.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { OtpInput } from "./index";
+
+function ControlledOtp(props: Partial<React.ComponentProps<typeof OtpInput>>) {
+	const [val, setVal] = React.useState(props.value ?? "");
+	return <OtpInput length={6} {...props} value={val} onChange={setVal} />;
+}
+
+describe("OtpInput", () => {
+	it("renders correct number of inputs for length=6", () => {
+		render(<OtpInput length={6} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		expect(inputs.length).toBe(6);
+	});
+
+	it("renders correct number of inputs for length=4", () => {
+		render(<OtpInput length={4} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		expect(inputs.length).toBe(4);
+	});
+
+	it("displays value across inputs", () => {
+		render(<OtpInput length={6} value="123456" ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+		expect(inputs[0].value).toBe("1");
+		expect(inputs[5].value).toBe("6");
+	});
+
+	it("calls onChange when digit is entered", () => {
+		const onChange = vi.fn();
+		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		fireEvent.change(inputs[0], { target: { value: "5" } });
+		expect(onChange).toHaveBeenCalledWith("5");
+	});
+
+	it("rejects non-numeric input", () => {
+		const onChange = vi.fn();
+		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		fireEvent.change(inputs[0], { target: { value: "a" } });
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("handles paste", () => {
+		const onChange = vi.fn();
+		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		fireEvent.paste(inputs[0], {
+			clipboardData: { getData: () => "123456" },
+		});
+		expect(onChange).toHaveBeenCalledWith("123456");
+	});
+
+	it("handles paste with non-numeric characters", () => {
+		const onChange = vi.fn();
+		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		fireEvent.paste(inputs[0], {
+			clipboardData: { getData: () => "12-34-56" },
+		});
+		expect(onChange).toHaveBeenCalledWith("123456");
+	});
+
+	it("renders supporting text", () => {
+		render(<OtpInput length={6} supportingText="인증 코드를 입력하세요" ariaLabel="OTP" />);
+		expect(screen.getByText("인증 코드를 입력하세요")).toBeDefined();
+	});
+
+	it("applies error class when error is true", () => {
+		render(<OtpInput length={6} error ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		expect(inputs[0].className).toContain("otp_input_box_error");
+	});
+
+	it("applies disabled attribute when disabled", () => {
+		render(<OtpInput length={6} disabled ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+		expect(inputs[0].disabled).toBe(true);
+	});
+
+	it("has correct aria-label on group", () => {
+		render(<OtpInput length={6} ariaLabel="인증 코드" />);
+		expect(screen.getByRole("group")).toBeDefined();
+		expect(screen.getByRole("group").getAttribute("aria-label")).toBe("인증 코드");
+	});
+});

--- a/src/ui/otp-input/index.tsx
+++ b/src/ui/otp-input/index.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "../../utils";
+import "./style.scss";
+
+export interface OtpInputProps {
+	/** OTP 자릿수 (기본값: 6) */
+	length?: 4 | 6;
+	/** 제어형 값 */
+	value?: string;
+	/** 값 변경 콜백 */
+	onChange?: (value: string) => void;
+	/** 에러 상태 */
+	error?: boolean;
+	/** 비활성화 */
+	disabled?: boolean;
+	/** 하단 도움말 텍스트 */
+	supportingText?: string;
+	/** 첫 번째 입력에 자동 포커스 */
+	autoFocus?: boolean;
+	/** 접근성 레이블 */
+	ariaLabel?: string;
+	/** 추가 className */
+	className?: string;
+}
+
+/**
+ * OTP 입력 컴포넌트를 렌더링한다.
+ * 각 자리를 개별 입력으로 분리하고, 자동 포커스 이동·붙여넣기를 지원한다.
+ * @param props OTP 입력 속성
+ * @returns 렌더링된 OTP 입력 요소
+ */
+export const OtpInput = ({
+	length = 6,
+	value = "",
+	onChange,
+	error = false,
+	disabled = false,
+	supportingText,
+	autoFocus = false,
+	ariaLabel = "OTP 입력",
+	className,
+}: OtpInputProps) => {
+	const inputsRef = React.useRef<(HTMLInputElement | null)[]>([]);
+
+	const digits = React.useMemo(() => {
+		const arr = value.split("").slice(0, length);
+		while (arr.length < length) arr.push("");
+		return arr;
+	}, [value, length]);
+
+	const focusInput = (index: number) => {
+		inputsRef.current[index]?.focus();
+	};
+
+	const updateValue = (newDigits: string[]) => {
+		onChange?.(newDigits.join(""));
+	};
+
+	const handleChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {
+		const val = e.target.value;
+		if (val && !/^\d$/.test(val)) return;
+
+		const newDigits = [...digits];
+		newDigits[index] = val;
+		updateValue(newDigits);
+
+		if (val && index < length - 1) {
+			focusInput(index + 1);
+		}
+	};
+
+	const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Backspace") {
+			if (digits[index]) {
+				const newDigits = [...digits];
+				newDigits[index] = "";
+				updateValue(newDigits);
+			} else if (index > 0) {
+				focusInput(index - 1);
+				const newDigits = [...digits];
+				newDigits[index - 1] = "";
+				updateValue(newDigits);
+			}
+			e.preventDefault();
+		}
+
+		if (e.key === "ArrowLeft" && index > 0) {
+			focusInput(index - 1);
+			e.preventDefault();
+		}
+		if (e.key === "ArrowRight" && index < length - 1) {
+			focusInput(index + 1);
+			e.preventDefault();
+		}
+	};
+
+	const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+		e.preventDefault();
+		const pasted = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, length);
+		if (!pasted) return;
+
+		const newDigits = [...digits];
+		for (let i = 0; i < pasted.length; i++) {
+			newDigits[i] = pasted[i];
+		}
+		updateValue(newDigits);
+
+		const nextIndex = Math.min(pasted.length, length - 1);
+		focusInput(nextIndex);
+	};
+
+	const rootClassName = cn("otp_input", className);
+
+	return (
+		<div className={rootClassName} role="group" aria-label={ariaLabel}>
+			<div className="otp_input_boxes">
+				{digits.map((digit, i) => (
+					<input
+						key={i}
+						ref={(el) => { inputsRef.current[i] = el; }}
+						type="text"
+						inputMode="numeric"
+						pattern="\d*"
+						maxLength={1}
+						value={digit}
+						onChange={(e) => handleChange(i, e)}
+						onKeyDown={(e) => handleKeyDown(i, e)}
+						onPaste={i === 0 ? handlePaste : undefined}
+						disabled={disabled}
+						autoFocus={autoFocus && i === 0}
+						aria-label={`${i + 1}번째 자리`}
+						className={cn(
+							"otp_input_box",
+							error && "otp_input_box_error",
+							disabled && "otp_input_box_disabled",
+						)}
+					/>
+				))}
+			</div>
+			{supportingText && (
+				<span className={cn("otp_input_supporting", error && "otp_input_supporting_error")}>
+					{supportingText}
+				</span>
+			)}
+		</div>
+	);
+};
+
+OtpInput.displayName = "OtpInput";

--- a/src/ui/otp-input/otp-input.stories.tsx
+++ b/src/ui/otp-input/otp-input.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import { OtpInput } from ".";
+
+const meta: Meta<typeof OtpInput> = {
+	title: "Components/OtpInput",
+	component: OtpInput,
+	tags: ["autodocs"],
+	argTypes: {
+		length: {
+			control: "select",
+			options: [4, 6],
+			description: "OTP 자릿수입니다.",
+		},
+		error: {
+			control: "boolean",
+			description: "에러 상태입니다.",
+		},
+		disabled: {
+			control: "boolean",
+			description: "비활성화 상태입니다.",
+		},
+		supportingText: {
+			control: "text",
+			description: "하단 도움말 텍스트입니다.",
+		},
+	},
+	args: {
+		length: 6,
+		error: false,
+		disabled: false,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: `
+**OtpInput**은 일회용 비밀번호(OTP) 입력을 위한 컴포넌트입니다.
+
+### 언제 사용하나요?
+- 이메일/SMS 인증 코드 입력
+- 2단계 인증(2FA) 코드 입력
+- 결제 인증 번호 입력
+
+### 주요 기능
+- **자동 포커스 이동**: 숫자 입력 시 다음 칸으로 자동 이동
+- **백스페이스**: 현재 칸 삭제 후 이전 칸으로 이동
+- **붙여넣기**: 복사한 코드를 한 번에 붙여넣기
+- **화살표 키**: 좌/우 키로 칸 간 이동
+
+### 사용 방법
+\`\`\`tsx
+const [otp, setOtp] = React.useState("");
+
+<OtpInput
+  length={6}
+  value={otp}
+  onChange={setOtp}
+  supportingText="인증 코드를 입력하세요"
+/>
+
+// 에러 상태
+<OtpInput
+  length={6}
+  value={otp}
+  onChange={setOtp}
+  error
+  supportingText="인증 코드가 올바르지 않습니다"
+/>
+\`\`\`
+        `,
+			},
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof OtpInput>;
+
+// ── Controlled ───────────────────────────────────────────────────────────────
+
+export const Controlled: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	name: "제어형",
+	render: ({ length, error, disabled }) => {
+		const [val, setVal] = React.useState("");
+
+		return (
+			<div style={{ display: "grid", gap: 12, padding: 20 }}>
+				<OtpInput
+					length={length}
+					value={val}
+					onChange={setVal}
+					error={error}
+					disabled={disabled}
+					supportingText="인증 코드를 입력하세요"
+					autoFocus
+				/>
+				<p style={{ margin: 0, fontSize: 13, color: "#666" }}>입력된 값: "{val}"</p>
+			</div>
+		);
+	},
+};
+
+// ── Lengths ──────────────────────────────────────────────────────────────────
+
+export const Lengths: Story = {
+	name: "자릿수 비교",
+	render: () => {
+		const [val4, setVal4] = React.useState("");
+		const [val6, setVal6] = React.useState("");
+
+		return (
+			<div style={{ display: "grid", gap: 24, padding: 20 }}>
+				<div>
+					<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>4자리</p>
+					<OtpInput length={4} value={val4} onChange={setVal4} supportingText="4자리 코드" />
+				</div>
+				<div>
+					<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>6자리</p>
+					<OtpInput length={6} value={val6} onChange={setVal6} supportingText="6자리 코드" />
+				</div>
+			</div>
+		);
+	},
+};
+
+// ── States ───────────────────────────────────────────────────────────────────
+
+export const States: Story = {
+	name: "상태별 비교",
+	render: () => (
+		<div style={{ display: "grid", gap: 24, padding: 20 }}>
+			<div>
+				<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>기본</p>
+				<OtpInput length={6} value="123456" supportingText="Supporting text" />
+			</div>
+			<div>
+				<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>에러</p>
+				<OtpInput length={6} value="123456" error supportingText="인증 코드가 올바르지 않습니다" />
+			</div>
+			<div>
+				<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>비활성화</p>
+				<OtpInput length={6} disabled supportingText="Supporting text" />
+			</div>
+		</div>
+	),
+};

--- a/src/ui/otp-input/style.scss
+++ b/src/ui/otp-input/style.scss
@@ -1,0 +1,86 @@
+@use "src/styles/token" as token;
+
+// ── Root ─────────────────────────────────────────────────────────────────────
+
+.otp_input {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+// ── Boxes container ──────────────────────────────────────────────────────────
+
+.otp_input_boxes {
+  display: flex;
+  gap: token.$spacing_6;
+}
+
+// ── Individual box ───────────────────────────────────────────────────────────
+
+.otp_input_box {
+  width: 48px;
+  min-height: 56px;
+  padding: token.$spacing_4;
+
+  border: token.$border_width_standard solid token.$color_border_default;
+  border-radius: token.$radius_lg;
+  background: none;
+
+  font-family: token.$font_family_primary;
+  font-size: token.$font_size_14;
+  font-weight: token.$font_weight_regular;
+  line-height: token.$line_height_20;
+  color: token.$color_text_heading;
+  text-align: center;
+
+  outline: none;
+  transition:
+    border-color token.$transition_fast,
+    box-shadow token.$transition_fast;
+
+  // ── Hover ──────────────────────────────────────────────────────────────
+
+  &:hover:not(:disabled):not(:focus) {
+    border-color: token.$color_border_hover;
+  }
+
+  // ── Focus ──────────────────────────────────────────────────────────────
+
+  &:focus {
+    border-color: token.$color_border_focus;
+    border-width: 2px;
+    padding: calc(#{token.$spacing_4} - 1px);
+  }
+
+  // ── Disabled ───────────────────────────────────────────────────────────
+
+  &_disabled {
+    opacity: token.$opacity_38;
+    cursor: not-allowed;
+  }
+
+  // ── Error ──────────────────────────────────────────────────────────────
+
+  &_error {
+    border-color: token.$color_status_error;
+
+    &:focus {
+      border-color: token.$color_status_error;
+    }
+  }
+}
+
+// ── Supporting text ──────────────────────────────────────────────────────────
+
+.otp_input_supporting {
+  padding-top: token.$spacing_4;
+  font-family: token.$font_family_primary;
+  font-size: token.$font_size_12;
+  font-weight: token.$font_weight_regular;
+  line-height: token.$line_height_16;
+  color: token.$color_text_body;
+
+  &_error {
+    color: token.$color_status_error;
+  }
+}

--- a/src/ui/otp-input/style.scss
+++ b/src/ui/otp-input/style.scss
@@ -56,7 +56,7 @@
 
   &_disabled {
     cursor: not-allowed;
-    color: token.$color_text_disabled;
+    color: token.$color_text_body;
   }
 
   // ── Error ──────────────────────────────────────────────────────────────

--- a/src/ui/otp-input/style.scss
+++ b/src/ui/otp-input/style.scss
@@ -55,8 +55,8 @@
   // ── Disabled ───────────────────────────────────────────────────────────
 
   &_disabled {
-    opacity: token.$opacity_38;
     cursor: not-allowed;
+    color: token.$color_text_disabled;
   }
 
   // ── Error ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 작업 개요

Figma 스펙 기반 OTP 입력 컴포넌트 신규 추가

## 작업한 내용
- [x] OtpInput 컴포넌트 구현 (4자리/6자리, 자동 포커스 이동, 백스페이스 내비게이션)
- [x] 붙여넣기 모든 칸에서 동작하도록 수정 (코드 리뷰 반영)
- [x] 빈 칸 건너뛰기 방지 — focus 시 첫 번째 빈 칸으로 리다이렉트 (코드 리뷰 반영)
- [x] 비활성화 텍스트 색상 Figma 스펙(`semantic/color/text/body`) 적용
- [x] `src/index.ts`에 `OtpInput`, `OtpInputProps` export 추가

## 전달할 추가 이슈
- 없음