### PR TITLE
develop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,9 @@ export type { IconButtonProps, IconButtonVariant, IconButtonSize } from "./ui/ic
 export { LinearProgress } from "./ui/linear-progress";
 export type { LinearProgressProps } from "./ui/linear-progress";
 export { ListItem } from "./ui/list-item";
+export type { ListItemProps } from "./ui/list-item";
 export { OtpInput } from "./ui/otp-input";
 export type { OtpInputProps } from "./ui/otp-input";
-export type { ListItemProps } from "./ui/list-item";
 export { Modal } from "./ui/modal";
 export type { ModalProps } from "./ui/modal";
 export { Pagination } from "./ui/pagination";

--- a/src/ui/otp-input/OtpInput.test.tsx
+++ b/src/ui/otp-input/OtpInput.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import type * as React from "react";
+import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { OtpInput } from "./index";
 
@@ -62,6 +62,23 @@ describe("OtpInput", () => {
 			clipboardData: { getData: () => "12-34-56" },
 		});
 		expect(onChange).toHaveBeenCalledWith("123456");
+	});
+
+	it("handles paste on non-first input", () => {
+		const onChange = vi.fn();
+		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		fireEvent.paste(inputs[3], {
+			clipboardData: { getData: () => "123456" },
+		});
+		expect(onChange).toHaveBeenCalledWith("123456");
+	});
+
+	it("redirects focus to first empty box on focus", () => {
+		render(<ControlledOtp length={6} value="12" ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+		fireEvent.focus(inputs[5]);
+		expect(document.activeElement).toBe(inputs[2]);
 	});
 
 	it("renders supporting text", () => {

--- a/src/ui/otp-input/index.tsx
+++ b/src/ui/otp-input/index.tsx
@@ -71,6 +71,13 @@ export const OtpInput = ({
 		}
 	};
 
+	const handleFocus = (index: number) => {
+		const firstEmpty = digits.findIndex((d) => d === "");
+		if (firstEmpty !== -1 && firstEmpty < index) {
+			focusInput(firstEmpty);
+		}
+	};
+
 	const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Backspace") {
 			if (digits[index]) {
@@ -126,8 +133,9 @@ export const OtpInput = ({
 						maxLength={1}
 						value={digit}
 						onChange={(e) => handleChange(i, e)}
+						onFocus={() => handleFocus(i)}
 						onKeyDown={(e) => handleKeyDown(i, e)}
-						onPaste={i === 0 ? handlePaste : undefined}
+						onPaste={handlePaste}
 						disabled={disabled}
 						autoFocus={autoFocus && i === 0}
 						aria-label={`${i + 1}번째 자리`}

--- a/src/ui/select/index.tsx
+++ b/src/ui/select/index.tsx
@@ -218,7 +218,7 @@ export const Select = ({
 		setDropUp(spaceBelow < listHeight && spaceAbove > spaceBelow);
 	}, [isOpen, options.length]);
 
-	const rootClassName = cn("select", className);
+	const rootClassName = cn("select", { select_has_label: !!label }, className);
 
 	const controlClassName = cn(
 		"select_control",

--- a/src/ui/select/style.scss
+++ b/src/ui/select/style.scss
@@ -6,13 +6,22 @@
   display: inline-flex;
   flex-direction: column;
   width: 100%;
-  gap: token.$spacing_4;
   font-family: token.$font_family_primary;
 
   &_label {
-    @include token.label_small;
-    font-weight: token.$font_weight_medium;
+    position: absolute;
+    top: -8px;
+    left: token.$spacing_16;
+    padding: 0 token.$spacing_4;
+    background: var(--select-surface, #{token.$color_bg_solid});
+    font-family: token.$font_family_primary;
+    font-size: token.$font_size_12;
+    font-weight: token.$font_weight_regular;
+    line-height: token.$line_height_16;
+    letter-spacing: 0.32px;
     color: token.$color_text_heading;
+    white-space: nowrap;
+    pointer-events: none;
   }
 
   &_control {
@@ -23,8 +32,8 @@
     gap: token.$spacing_8;
     cursor: pointer;
     color: token.$color_text_heading;
-    background: token.$color_bg_solid;
-    border-radius: token.$radius_md;
+    background: var(--select-surface, #{token.$color_bg_solid});
+    border-radius: token.$radius_lg;
     transition:
             border-color token.$transition_base,
             box-shadow token.$transition_base,
@@ -66,7 +75,7 @@
     }
 
     &.is_open {
-      background: token.$color_bg_solid;
+      background: var(--select-surface, #{token.$color_bg_solid});
       border-color: token.$color_brand_primary;
       box-shadow: token.$focus_ring;
     }
@@ -81,23 +90,26 @@
     }
 
     &.is_open {
-      background: token.$color_bg_solid;
+      background: var(--select-surface, #{token.$color_bg_solid});
       border-color: token.$color_brand_primary;
       box-shadow: token.$focus_ring;
     }
   }
 
   &_size_sm {
+    min-height: 40px;
     padding: token.$spacing_8 token.$spacing_16;
     @include token.label_small;
   }
 
   &_size_md {
+    min-height: 52px;
     padding: token.$spacing_12 token.$spacing_20;
     @include token.body_medium;
   }
 
   &_size_lg {
+    min-height: 52px;
     padding: token.$spacing_16 token.$spacing_24;
     @include token.body_large;
   }
@@ -192,5 +204,12 @@
       cursor: not-allowed;
       color: token.$color_text_caption;
     }
+  }
+
+  // ── Label states ─────────────────────────────────────────────────────────
+
+  &:has(.select_control:disabled) .select_label,
+  &:has(.select_control.is_disabled) .select_label {
+    color: token.$color_text_disabled;
   }
 }

--- a/src/ui/textfield/index.tsx
+++ b/src/ui/textfield/index.tsx
@@ -5,11 +5,15 @@ import { cn } from "../../utils";
 import { Icon } from "../icon";
 import "./style.scss";
 
+export type TextFieldSize = "sm" | "md";
+
 export interface TextFieldProps
 	extends Omit<
 		React.InputHTMLAttributes<HTMLInputElement>,
 		"size" | "onChange" | "value" | "defaultValue"
 	> {
+	/** 입력 필드 크기 (기본값: "md") */
+	size?: TextFieldSize;
 	/** 입력 필드 위에 표시할 라벨 텍스트 */
 	label?: string;
 	/** 라벨 표시 여부 (기본값: true) */
@@ -57,6 +61,7 @@ export const TextField = ({
 	trailingIcon,
 	clearable,
 	fullWidth,
+	size = "md",
 	className,
 	onChangeAction,
 	value,
@@ -92,6 +97,7 @@ export const TextField = ({
 
 	const rootClassName = cn(
 		"text_field",
+		size === "sm" && "text_field_size_sm",
 		fullWidth && "text_field_full_width",
 		error && "text_field_error",
 		props.disabled && "text_field_disabled",

--- a/src/ui/textfield/style.scss
+++ b/src/ui/textfield/style.scss
@@ -21,12 +21,27 @@
     padding: token.$spacing_4 0;
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_lg;
-    background: token.$color_bg_solid;
+    background: inherit;
     transition: border-color token.$transition_base;
 
     &:hover {
       border-color: token.$color_border_hover;
     }
+  }
+
+  // ── Size variants ──────────────────────────────────────────────────────
+
+  &_size_sm &_container {
+    min-height: 40px;
+  }
+
+  &_size_sm &_input_wrap {
+    padding: token.$spacing_8 token.$spacing_16;
+  }
+
+  &_size_sm &_input {
+    font-size: token.$font_size_14;
+    line-height: token.$line_height_20;
   }
 
   &_container:focus-within {
@@ -40,7 +55,7 @@
     top: -8px;
     left: token.$spacing_16;
     padding: 0 token.$spacing_4;
-    background: token.$color_bg_solid;
+    background: var(--text-field-surface, #{token.$color_bg_solid});
     font-family: token.$font_family_primary;
     font-size: token.$font_size_12;
     font-weight: token.$font_weight_regular;


### PR DESCRIPTION
## 작업 개요

TextField 배경색 대응 및 Select 컴포넌트 UI 개선

## 작업한 내용

### TextField
- [x] `size` prop 추가 (`sm` | `md`)
- [x] 라벨 배경에 `--text-field-surface` CSS 변수 적용 — 흰색이 아닌 배경에서도 자연스럽게 표시
- [x] 컨테이너 배경 `background: inherit`으로 변경

### Select
- [x] 라벨을 TextField와 동일한 floating label 형태로 재디자인 (`top: -8px`, border 위에 걸침)
- [x] `--select-surface` CSS 변수 적용 — 비흰색 배경 대응
- [x] `min-height` 추가로 TextField와 높이 통일 (sm: 40px, md/lg: 52px)
- [x] `border-radius` → `radius_lg`로 TextField와 통일
- [x] disabled 상태 라벨 색상 처리 (`:has()` 선택자)

### OtpInput (코드 리뷰 반영)
- [x] `export` 순서 정리 — ListItemProps를 ListItem 바로 아래로 이동
- [x] 모든 칸에서 붙여넣기 동작하도록 수정

## 전달할 추가 이슈
- 없음