### PR TITLE
refactor/textfield-fieldset-legend

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -6,6 +6,14 @@ const preview: Preview = {
 		viewport: { value: "responsive" },
 	},
 	parameters: {
+		backgrounds: {
+			default: "white",
+			values: [
+				{ name: "white", value: "#FFFFFF" },
+				{ name: "dim (color_bg_solid_dim)", value: "#F4F4F4" },
+				{ name: "dark", value: "#1A1A1A" },
+			],
+		},
 		options: {
 			storySort: {
 				method: "alphabetical",

--- a/src/ui/textfield/index.tsx
+++ b/src/ui/textfield/index.tsx
@@ -48,6 +48,7 @@ const ClearIcon = () => <Icon name="close" size={20} />;
 /**
  * 텍스트 필드를 렌더링한다.
  * Figma DS 기준 outlined 스타일 + floating label을 지원한다.
+ * fieldset + legend 구조로 배경색 없이 border notch를 자연스럽게 처리한다.
  * @param props 텍스트 필드 속성
  * @returns 렌더링된 텍스트 필드 UI
  */
@@ -122,54 +123,57 @@ export const TextField = ({
 
 	return (
 		<div className={rootClassName}>
-			<div className="text_field_container">
-				{leadingIcon && (
-					<span className="text_field_icon" aria-hidden="true">
-						{leadingIcon}
-					</span>
-				)}
-
-				<div className={cn("text_field_input_wrap", (resolvedTrailing) && "text_field_input_wrap_no_pad_right")}>
-					<input
-						id={inputId}
-						ref={ref}
-						className="text_field_input"
-						aria-invalid={!!error}
-						aria-describedby={helperId}
-						aria-label={!showLabel ? label : undefined}
-						{...props}
-						value={innerValue}
-						onCompositionStart={() => {
-							isComposingRef.current = true;
-						}}
-						onCompositionEnd={(event) => {
-							isComposingRef.current = false;
-							const rawValue = event.currentTarget.value;
-							const nextValue = applyTransform(rawValue);
-							setInnerValue(nextValue);
-							onChangeAction?.(nextValue);
-						}}
-						onChange={(event) => {
-							const rawValue = event.target.value;
-							if (isComposingRef.current) {
-								setInnerValue(rawValue);
-								return;
-							}
-							const nextValue = applyTransform(rawValue);
-							setInnerValue(nextValue);
-							onChangeAction?.(nextValue);
-						}}
-					/>
-				</div>
-
-				{resolvedTrailing}
-
+			{/* fieldset + legend: 배경색 없이 border notch를 브라우저가 자동 처리 */}
+			<fieldset className="text_field_container">
 				{label && showLabel && (
-					<label className="text_field_label" htmlFor={inputId}>
-						{label}
-					</label>
+					<legend className="text_field_label">
+						<label htmlFor={inputId}>{label}</label>
+					</legend>
 				)}
-			</div>
+
+				<div className="text_field_inner">
+					{leadingIcon && (
+						<span className="text_field_icon" aria-hidden="true">
+							{leadingIcon}
+						</span>
+					)}
+
+					<div className={cn("text_field_input_wrap", resolvedTrailing && "text_field_input_wrap_no_pad_right")}>
+						<input
+							id={inputId}
+							ref={ref}
+							className="text_field_input"
+							aria-invalid={!!error}
+							aria-describedby={helperId}
+							aria-label={!showLabel ? label : undefined}
+							{...props}
+							value={innerValue}
+							onCompositionStart={() => {
+								isComposingRef.current = true;
+							}}
+							onCompositionEnd={(event) => {
+								isComposingRef.current = false;
+								const rawValue = event.currentTarget.value;
+								const nextValue = applyTransform(rawValue);
+								setInnerValue(nextValue);
+								onChangeAction?.(nextValue);
+							}}
+							onChange={(event) => {
+								const rawValue = event.target.value;
+								if (isComposingRef.current) {
+									setInnerValue(rawValue);
+									return;
+								}
+								const nextValue = applyTransform(rawValue);
+								setInnerValue(nextValue);
+								onChangeAction?.(nextValue);
+							}}
+						/>
+					</div>
+
+					{resolvedTrailing}
+				</div>
+			</fieldset>
 
 			{supportingText && (
 				<div id={helperId} className="text_field_helper">

--- a/src/ui/textfield/style.scss
+++ b/src/ui/textfield/style.scss
@@ -9,19 +9,16 @@
     width: 100%;
   }
 
-  // ── Container (border + border-radius) ─────────────────────────────────
+  // ── Container (fieldset: border + border-radius) ────────────────────────
 
   &_container {
-    position: relative;
-    display: flex;
-    align-items: center;
-    gap: token.$spacing_4;
-    width: 100%;
-    min-height: 52px;
-    padding: token.$spacing_4 0;
+    // fieldset UA 스타일 reset
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_lg;
-    background: inherit;
+    padding: 0;
+    margin: 0;
+    min-inline-size: 0; // fieldset 기본값 min-content 제거
+    width: 100%;
     transition: border-color token.$transition_base;
 
     &:hover {
@@ -29,9 +26,23 @@
     }
   }
 
+  &_container:focus-within {
+    border-color: token.$color_border_focus;
+  }
+
+  // ── Inner row (아이콘 + input + trailing 감싸는 flex row) ───────────────
+
+  &_inner {
+    display: flex;
+    align-items: center;
+    gap: token.$spacing_4;
+    min-height: 52px;
+    padding: token.$spacing_4 0;
+  }
+
   // ── Size variants ──────────────────────────────────────────────────────
 
-  &_size_sm &_container {
+  &_size_sm &_inner {
     min-height: 40px;
   }
 
@@ -44,27 +55,28 @@
     line-height: token.$line_height_20;
   }
 
-  &_container:focus-within {
-    border-color: token.$color_border_focus;
-  }
-
-  // ── Floating label ─────────────────────────────────────────────────────
+  // ── Floating label (legend) ────────────────────────────────────────────
+  // fieldset + legend 구조: 브라우저가 border를 legend 주변에서 자동으로 끊어줌.
+  // 배경색 불필요.
 
   &_label {
-    position: absolute;
-    top: -8px;
-    left: token.$spacing_16;
+    margin-inline-start: token.$spacing_12; // 16px 정렬 (16px - 4px padding)
     padding: 0 token.$spacing_4;
-    background: var(--text-field-surface, #{token.$color_bg_solid});
-    font-family: token.$font_family_primary;
-    font-size: token.$font_size_12;
-    font-weight: token.$font_weight_regular;
-    line-height: token.$line_height_16;
-    letter-spacing: 0.32px;
     color: token.$color_text_heading;
-    white-space: nowrap;
-    pointer-events: none;
     transition: color token.$transition_base;
+
+    > label {
+      display: block;
+      font-family: token.$font_family_primary;
+      font-size: token.$font_size_12;
+      font-weight: token.$font_weight_regular;
+      line-height: token.$line_height_16;
+      letter-spacing: 0.32px;
+      color: inherit;
+      white-space: nowrap;
+      pointer-events: none;
+      cursor: default;
+    }
   }
 
   // ── Input ──────────────────────────────────────────────────────────────
@@ -153,8 +165,6 @@
     }
   }
 
-  // clear 버튼이 있으면 input_wrap 오른쪽 패딩 제거 (_no_pad_right 클래스로 처리)
-
   // ── Helper text ────────────────────────────────────────────────────────
 
   &_helper {
@@ -198,7 +208,7 @@
         border-color: token.$color_bg_disabled;
       }
 
-      // 내부 콘텐츠 전체 opacity 0.38
+      // legend 제외한 내부 콘텐츠 전체 opacity 0.38
       > *:not(.text_field_label) {
         opacity: token.$opacity_38;
       }

--- a/src/ui/textfield/textfield.stories.tsx
+++ b/src/ui/textfield/textfield.stories.tsx
@@ -176,3 +176,42 @@ export const AllStates: Story = {
 		</div>
 	),
 };
+
+export const OnDimBackground: Story = {
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		backgrounds: { default: "dim (color_bg_solid_dim)" },
+	},
+
+	name: "Dim 배경 테스트 (fieldset/legend border notch)",
+	render: () => (
+		<div
+			style={{
+				display: "grid",
+				gap: 24,
+				width: 320,
+				padding: 32,
+				backgroundColor: "#F4F4F4",
+				// fieldset+legend 구조: 배경색 CSS variable 불필요
+			}}
+		>
+			<TextField label="기본" placeholder="Input" />
+			<TextField label="에러 상태" placeholder="Input" supportingText="에러 메시지" error />
+			<TextField label="비활성화" placeholder="Input" disabled />
+			<TextField label="아이콘 포함" placeholder="Search" leadingIcon={<SearchIcon />} />
+		</div>
+	),
+};
+
+export const SizeComparison: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+
+	name: "크기 비교 (sm / md)",
+	render: () => (
+		<div style={{ display: "grid", gap: 24, width: 320 }}>
+			<TextField label="Size md (기본)" placeholder="Input" size="md" supportingText="min-height 52px" />
+			<TextField label="Size sm" placeholder="Input" size="sm" supportingText="min-height 40px" />
+			<TextField label="Size sm + 아이콘" placeholder="Search" size="sm" leadingIcon={<SearchIcon />} />
+		</div>
+	),
+};


### PR DESCRIPTION
## 작업 개요

TextField의 floating label이 어떤 배경색 위에서도 자연스럽게 border를 끊도록 구조를 개선합니다.

기존 `div` + absolute-positioned `label` 구조는 label 뒤에 배경색이 있어야 border가 끊겨 보였습니다. `fieldset` + `legend` 구조로 전환하면 브라우저가 legend 주변 border를 자동으로 처리하므로 배경색이 완전히 불필요합니다.

## 작업한 내용

- [x] Container: `div.text_field_container` → `fieldset` (UA 스타일 reset)
- [x] Label: absolute-positioned `label` → `legend > label` 구조
- [x] Inner row: 아이콘 + input + trailing을 `div.text_field_inner` flex row로 감쌈
- [x] `--text-field-surface` CSS variable 및 label `background` 제거
- [x] size_sm: `_container` → `_inner` min-height 40px 적용
- [x] Storybook: 전역 배경색 옵션 추가 (white / dim / dark), dim 배경 테스트 story, size 비교 story 추가

## 전달할 추가 이슈

- 없음