### PR TITLE
develop

### DIFF
--- a/src/ui/textfield/index.tsx
+++ b/src/ui/textfield/index.tsx
@@ -123,7 +123,7 @@ export const TextField = ({
 
 	return (
 		<div className={rootClassName}>
-			{/* fieldset + legend: 배경색 없이 border notch를 브라우저가 자동 처리 */}
+			{/* fieldset + legend: 브라우저가 legend 주변 border를 자동으로 끊어줌 */}
 			<fieldset className="text_field_container">
 				{label && showLabel && (
 					<legend className="text_field_label">

--- a/src/ui/textfield/style.scss
+++ b/src/ui/textfield/style.scss
@@ -19,8 +19,8 @@
     margin: 0;
     min-inline-size: 0; // fieldset 기본값 min-content 제거
     width: 100%;
-    background: token.$color_bg_solid;
-    transition: border-color token.$transition_base;
+    background-color: token.$color_bg_solid;
+    transition: border-color token.$transition_base, background-color token.$transition_base;
 
     &:hover {
       border-color: token.$color_border_hover;
@@ -204,6 +204,7 @@
   &_disabled {
     .text_field_container {
       border-color: token.$color_bg_disabled;
+      background-color: token.$color_bg_solid_dim;
 
       &:hover {
         border-color: token.$color_bg_disabled;

--- a/src/ui/textfield/style.scss
+++ b/src/ui/textfield/style.scss
@@ -19,6 +19,7 @@
     margin: 0;
     min-inline-size: 0; // fieldset 기본값 min-content 제거
     width: 100%;
+    background: token.$color_bg_solid;
     transition: border-color token.$transition_base;
 
     &:hover {


### PR DESCRIPTION
## 작업 개요

TextField fieldset/legend 구조 전환 및 흰색 배경 복구

## 작업한 내용

### TextField
- [x] Container: `div` → `fieldset` (UA 스타일 reset: margin/padding/min-inline-size)
- [x] Label: absolute-positioned `label` → `legend > label` 구조로 전환
- [x] 아이콘 + input + trailing: `div.text_field_inner` flex row로 감쌈
- [x] `--text-field-surface` CSS variable 및 label `background` 완전 제거
- [x] size_sm: `_inner` min-height 40px 적용
- [x] fieldset `background: color_bg_solid` 복구 (입력 영역 흰색 보장)

### Storybook
- [x] 전역 배경색 옵션 추가 (white / dim / dark)
- [x] dim 배경 테스트 story 추가
- [x] size sm / md 비교 story 추가

## 전달할 추가 이슈
- 없음