### PR TITLE
develop

### DIFF
--- a/src/ui/select/Select.test.tsx
+++ b/src/ui/select/Select.test.tsx
@@ -80,7 +80,8 @@ describe("Select", () => {
 
 	it("applies fullWidth style", () => {
 		render(<Select options={options} fullWidth />);
-		const wrapper = screen.getByRole("button").parentElement;
+		// button → fieldset → div.select (fullWidth style은 최상위 래퍼에 적용)
+		const wrapper = screen.getByRole("button").parentElement?.parentElement;
 		expect(wrapper).toHaveStyle({ width: "100%" });
 	});
 

--- a/src/ui/select/index.tsx
+++ b/src/ui/select/index.tsx
@@ -220,8 +220,8 @@ export const Select = ({
 
 	const rootClassName = cn("select", { select_has_label: !!label }, className);
 
-	const controlClassName = cn(
-		"select_control",
+	const fieldsetClassName = cn(
+		"select_fieldset",
 		`select_variant_${variant}`,
 		`select_size_${size}`,
 		{ is_open: isOpen, is_disabled: disabled },
@@ -235,24 +235,25 @@ export const Select = ({
 			className={rootClassName}
 			style={fullWidth ? { width: "100%" } : undefined}
 		>
-			{label && (
-				<label htmlFor={selectId} className="select_label">
-					{label}
-				</label>
-			)}
+			<fieldset className={fieldsetClassName}>
+				{label && (
+					<legend className="select_label">
+						<label htmlFor={selectId}>{label}</label>
+					</legend>
+				)}
 
-			<button
-				ref={controlRef}
-				id={selectId}
-				type="button"
-				className={controlClassName}
-				aria-haspopup="listbox"
-				aria-expanded={isOpen}
-				aria-controls={`${selectId}_listbox`}
-				onClick={() => !disabled && setIsOpen((o) => !o)}
-				onKeyDown={onKeyDown}
-				disabled={disabled}
-			>
+				<button
+					ref={controlRef}
+					id={selectId}
+					type="button"
+					className={cn("select_control", { is_disabled: disabled })}
+					aria-haspopup="listbox"
+					aria-expanded={isOpen}
+					aria-controls={`${selectId}_listbox`}
+					onClick={() => !disabled && setIsOpen((o) => !o)}
+					onKeyDown={onKeyDown}
+					disabled={disabled}
+				>
 				<span
 					className={currentOption ? "select_value" : "select_placeholder"}
 					style={textAlign === "left" ? { textAlign: "start" } : undefined}
@@ -263,6 +264,7 @@ export const Select = ({
 					<ChevronDown size={16} />
 				</span>
 			</button>
+			</fieldset>
 
 			{isOpen && (
 				<div id={`${selectId}_listbox`} role="listbox" className={listClassName}>

--- a/src/ui/select/style.scss
+++ b/src/ui/select/style.scss
@@ -8,46 +8,22 @@
   width: 100%;
   font-family: token.$font_family_primary;
 
-  &_label {
-    position: absolute;
-    top: -8px;
-    left: token.$spacing_16;
-    padding: 0 token.$spacing_4;
-    background: var(--select-surface, #{token.$color_bg_solid});
-    font-family: token.$font_family_primary;
-    font-size: token.$font_size_12;
-    font-weight: token.$font_weight_regular;
-    line-height: token.$line_height_16;
-    letter-spacing: 0.32px;
-    color: token.$color_text_heading;
-    white-space: nowrap;
-    pointer-events: none;
-  }
+  // ── Fieldset (border + border-radius) ─────────────────────────────────────
 
-  &_control {
-    width: 100%;
-    display: inline-flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: token.$spacing_8;
-    cursor: pointer;
-    color: token.$color_text_heading;
-    background: var(--select-surface, #{token.$color_bg_solid});
+  &_fieldset {
+    // fieldset UA 스타일 reset
+    padding: 0;
+    margin: 0;
+    min-inline-size: 0;
+
     border-radius: token.$radius_lg;
+    background-color: token.$color_bg_solid;
     transition:
-            border-color token.$transition_base,
-            box-shadow token.$transition_base,
-            background token.$transition_base;
-    @include token.body_medium;
-
-    &:disabled,
-    &.is_disabled {
-      cursor: not-allowed;
-      opacity: token.$opacity_38;
-      background: token.$color_bg_solid_dim;
-      color: token.$color_text_caption;
-    }
+      border-color token.$transition_base,
+      background-color token.$transition_base;
   }
+
+  // ── Variant 클래스 (fieldset으로 이동) ────────────────────────────────────
 
   &_variant_outline {
     border: token.$border_width_standard solid token.$color_border_default;
@@ -68,14 +44,14 @@
 
     &:hover:not(.is_disabled) {
       background: color.mix(
-                      token.$color_bg_solid,
-                      token.$color_bg_solid_dim,
-                      70%
+        token.$color_bg_solid,
+        token.$color_bg_solid_dim,
+        70%
       );
     }
 
     &.is_open {
-      background: var(--select-surface, #{token.$color_bg_solid});
+      background: token.$color_bg_solid;
       border-color: token.$color_brand_primary;
       box-shadow: token.$focus_ring;
     }
@@ -90,29 +66,98 @@
     }
 
     &.is_open {
-      background: var(--select-surface, #{token.$color_bg_solid});
+      background: token.$color_bg_solid;
       border-color: token.$color_brand_primary;
       box-shadow: token.$focus_ring;
     }
   }
 
+  // ── Disabled 상태 (fieldset) ──────────────────────────────────────────────
+
+  &_fieldset.is_disabled {
+    background-color: token.$color_bg_solid_dim;
+  }
+
+  // ── Size 클래스 (fieldset으로 이동) ───────────────────────────────────────
+
   &_size_sm {
     min-height: 40px;
-    padding: token.$spacing_8 token.$spacing_16;
-    @include token.label_small;
   }
 
   &_size_md {
     min-height: 52px;
-    padding: token.$spacing_12 token.$spacing_20;
-    @include token.body_medium;
   }
 
   &_size_lg {
     min-height: 52px;
+  }
+
+  // ── Label (legend) ────────────────────────────────────────────────────────
+
+  &_label {
+    margin-inline-start: token.$spacing_12; // 16px 정렬 (16px - 4px padding)
+    padding: 0 token.$spacing_4;
+    color: token.$color_text_heading;
+    transition: color token.$transition_base;
+
+    > label {
+      display: block;
+      font-family: token.$font_family_primary;
+      font-size: token.$font_size_12;
+      font-weight: token.$font_weight_regular;
+      line-height: token.$line_height_16;
+      letter-spacing: 0.32px;
+      color: inherit;
+      pointer-events: none;
+      cursor: default;
+    }
+  }
+
+  // disabled label 색상
+  &_fieldset.is_disabled .select_label {
+    color: token.$color_text_disabled;
+  }
+
+  // ── Control (button) ──────────────────────────────────────────────────────
+
+  &_control {
+    width: 100%;
+    min-height: inherit;
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: token.$spacing_8;
+    cursor: pointer;
+    background: transparent;
+    border: none;
+    color: token.$color_text_heading;
+
+    &:disabled,
+    &.is_disabled {
+      cursor: not-allowed;
+      opacity: token.$opacity_38;
+      color: token.$color_text_caption;
+    }
+  }
+
+  // ── Padding은 control에 (descendant selector) ─────────────────────────────
+
+  &_size_sm &_control {
+    padding: token.$spacing_8 token.$spacing_16;
+    @include token.label_small;
+  }
+
+  &_size_md &_control {
+    padding: token.$spacing_12 token.$spacing_20;
+    @include token.body_medium;
+  }
+
+  &_size_lg &_control {
     padding: token.$spacing_16 token.$spacing_24;
     @include token.body_large;
   }
+
+  // ── Value / Placeholder ───────────────────────────────────────────────────
 
   &_value {
     flex: 1 1 auto;
@@ -135,12 +180,16 @@
     color: token.$color_text_caption;
   }
 
+  // ── Icon ──────────────────────────────────────────────────────────────────
+
   &_icon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     color: token.$color_text_body;
   }
+
+  // ── List (dropdown) ───────────────────────────────────────────────────────
 
   &_list {
     position: absolute;
@@ -170,6 +219,8 @@
       margin-bottom: token.$spacing_4;
     }
   }
+
+  // ── Option ────────────────────────────────────────────────────────────────
 
   &_option {
     width: 100%;
@@ -204,12 +255,5 @@
       cursor: not-allowed;
       color: token.$color_text_caption;
     }
-  }
-
-  // ── Label states ─────────────────────────────────────────────────────────
-
-  &:has(.select_control:disabled) .select_label,
-  &:has(.select_control.is_disabled) .select_label {
-    color: token.$color_text_disabled;
   }
 }


### PR DESCRIPTION
## 작업 개요

Select 컴포넌트에 fieldset/legend 구조 적용. TextField와 동일한 방식으로 floating label 배경색 의존성 제거.

## 작업한 내용

### Select
- [x] `fieldset`이 border 담당 — variant/size 클래스 fieldset으로 이동
- [x] label: absolute-positioned `label` → `legend > label` 구조로 전환
- [x] `--select-surface` CSS variable 및 label `background` 완전 제거
- [x] control(button): border 없음, fieldset 크기 상속 (`min-height: inherit`)
- [x] disabled: fieldset `background-color: color_bg_solid_dim`
- [x] `Select.test.tsx`: fullWidth 테스트 선택자 수정 (fieldset 구조 반영)

## 전달할 추가 이슈
- 없음