### PR TITLE
develop

### DIFF
--- a/src/ui/select/Select.test.tsx
+++ b/src/ui/select/Select.test.tsx
@@ -80,8 +80,8 @@ describe("Select", () => {
 
 	it("applies fullWidth style", () => {
 		render(<Select options={options} fullWidth />);
-		// button → fieldset → div.select (fullWidth style은 최상위 래퍼에 적용)
-		const wrapper = screen.getByRole("button").parentElement?.parentElement;
+		// button → select_inner → fieldset → div.select (fullWidth style은 최상위 래퍼에 적용)
+		const wrapper = screen.getByRole("button").parentElement?.parentElement?.parentElement;
 		expect(wrapper).toHaveStyle({ width: "100%" });
 	});
 

--- a/src/ui/select/index.tsx
+++ b/src/ui/select/index.tsx
@@ -242,28 +242,31 @@ export const Select = ({
 					</legend>
 				)}
 
-				<button
-					ref={controlRef}
-					id={selectId}
-					type="button"
-					className={cn("select_control", { is_disabled: disabled })}
-					aria-haspopup="listbox"
-					aria-expanded={isOpen}
-					aria-controls={`${selectId}_listbox`}
-					onClick={() => !disabled && setIsOpen((o) => !o)}
-					onKeyDown={onKeyDown}
-					disabled={disabled}
-				>
-				<span
-					className={currentOption ? "select_value" : "select_placeholder"}
-					style={textAlign === "left" ? { textAlign: "start" } : undefined}
-				>
-					{currentOption ? currentOption.label : placeholder}
-				</span>
-				<span className="select_icon" aria-hidden="true">
-					<ChevronDown size={16} />
-				</span>
-			</button>
+				{/* select_inner: legend가 layout 공간 차지하므로 TextField의 text_field_inner 패턴 적용 */}
+				<div className="select_inner">
+					<button
+						ref={controlRef}
+						id={selectId}
+						type="button"
+						className={cn("select_control", { is_disabled: disabled })}
+						aria-haspopup="listbox"
+						aria-expanded={isOpen}
+						aria-controls={`${selectId}_listbox`}
+						onClick={() => !disabled && setIsOpen((o) => !o)}
+						onKeyDown={onKeyDown}
+						disabled={disabled}
+					>
+						<span
+							className={currentOption ? "select_value" : "select_placeholder"}
+							style={textAlign === "left" ? { textAlign: "start" } : undefined}
+						>
+							{currentOption ? currentOption.label : placeholder}
+						</span>
+						<span className="select_icon" aria-hidden="true">
+							<ChevronDown size={16} />
+						</span>
+					</button>
+				</div>
 			</fieldset>
 
 			{isOpen && (

--- a/src/ui/select/style.scss
+++ b/src/ui/select/style.scss
@@ -78,17 +78,24 @@
     background-color: token.$color_bg_solid_dim;
   }
 
-  // ── Size 클래스 (fieldset으로 이동) ───────────────────────────────────────
+  // ── Inner row (legend이 layout 공간 차지하므로 TextField의 inner 패턴 적용) ──
 
-  &_size_sm {
+  &_inner {
+    display: flex;
+    align-items: stretch;
+  }
+
+  // ── Size 클래스 (inner에 min-height 적용) ─────────────────────────────────
+
+  &_size_sm &_inner {
     min-height: 40px;
   }
 
-  &_size_md {
+  &_size_md &_inner {
     min-height: 52px;
   }
 
-  &_size_lg {
+  &_size_lg &_inner {
     min-height: 52px;
   }
 
@@ -121,8 +128,7 @@
   // ── Control (button) ──────────────────────────────────────────────────────
 
   &_control {
-    width: 100%;
-    min-height: inherit;
+    flex: 1;
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
@@ -130,6 +136,7 @@
     cursor: pointer;
     background: transparent;
     border: none;
+    outline: none; // 클릭 시 브라우저 기본 focus ring 제거
     color: token.$color_text_heading;
 
     &:disabled,


### PR DESCRIPTION
## 작업 개요

Select 컴포넌트 밀림 및 클릭 시 테두리 강조 버그 수정

## 작업한 내용

### Select
- [x] `select_inner` wrapper 추가 — fieldset+legend 구조에서 legend가 layout 공간을 차지해 button이 밀리는 문제 수정 (TextField의 `text_field_inner` 패턴 적용)
- [x] size별 `min-height`를 fieldset → `select_inner`로 이동
- [x] `select_control`에 `outline: none` 추가 — 클릭 시 브라우저 기본 focus ring 제거
- [x] `Select.test.tsx` fullWidth 선택자 depth 수정 (select_inner 추가 반영)

## 전달할 추가 이슈
- 없음