### PR TITLE
fix/select-datepicker

### DIFF
--- a/src/ui/date-picker/index.tsx
+++ b/src/ui/date-picker/index.tsx
@@ -173,7 +173,7 @@ export const DatePicker = ({
 
 	const dayOptions = React.useMemo<SelectOption[]>(
 		() =>
-			range(minDay, Math.max(minDay, maxDay)).map((d) => ({
+			range(Math.min(31, Math.max(1, minDay)), Math.max(minDay, maxDay)).map((d) => ({
 				value: String(d),
 				label: pad(d),
 			})),

--- a/src/ui/date-picker/index.tsx
+++ b/src/ui/date-picker/index.tsx
@@ -137,10 +137,11 @@ export const DatePicker = ({
 	const maxMonth =
 		selectableRange === "until-today" && year === todayYear ? todayMonth : 12;
 
-	const minDay =
+	const minDay = Math.min(31, Math.max(1,
 		min.year > 0 && min.month > 0 && year === min.year && month === min.month
 			? min.day
-			: 1;
+			: 1,
+	));
 
 	const maxDay = React.useMemo(() => {
 		if (!year || !month) return 31;
@@ -173,7 +174,7 @@ export const DatePicker = ({
 
 	const dayOptions = React.useMemo<SelectOption[]>(
 		() =>
-			range(Math.min(31, Math.max(1, minDay)), Math.max(minDay, maxDay)).map((d) => ({
+			range(minDay, Math.max(minDay, maxDay)).map((d) => ({
 				value: String(d),
 				label: pad(d),
 			})),


### PR DESCRIPTION
## 작업 개요

DatePicker minDay 유효하지 않은 입력 방어 처리

## 작업한 내용

- [x] `minDay` 범위를 `1–31`로 클램핑 (`Math.min(31, Math.max(1, minDay))`) — minMonth 방어 로직과 동일한 패턴 적용

## 전달할 추가 이슈

- 없음