### PR TITLE
fix/code-quality

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,9 @@
 		"clientKind": "git",
 		"useIgnoreFile": true
 	},
+	"files": {
+		"includes": ["**", "!**/.claude", "!**/tsup.config.bundled_*.mjs"]
+	},
 	"assist": {
 		"actions": {
 			"source": {

--- a/src/stories/foundation/typography.stories.tsx
+++ b/src/stories/foundation/typography.stories.tsx
@@ -400,7 +400,7 @@ export const Comparison: Story = {
 								style={{
 									fontFamily: typography.fontFamily.primary,
 									fontSize: style.fontSize,
-									fontWeight: style.fontWeight === "Medium" ? 500 : 400,
+									fontWeight: 400,
 									lineHeight: style.lineHeight,
 								}}
 							>

--- a/src/stories/foundation/typography.stories.tsx
+++ b/src/stories/foundation/typography.stories.tsx
@@ -400,7 +400,7 @@ export const Comparison: Story = {
 								style={{
 									fontFamily: typography.fontFamily.primary,
 									fontSize: style.fontSize,
-									fontWeight: 400,
+									fontWeight: fontWeightMap[style.fontWeight] ?? 400,
 									lineHeight: style.lineHeight,
 								}}
 							>

--- a/src/ui/dropdown/index.tsx
+++ b/src/ui/dropdown/index.tsx
@@ -181,10 +181,10 @@ export const Dropdown = ({
 
 	React.useEffect(() => {
 		if (!isOpen) return;
-		const idx = options.findIndex((o) => o.value === currentValue && !o.disabled);
+		const matchedIndex = options.findIndex((o) => o.value === currentValue && !o.disabled);
 		setActiveIndex(
-			idx >= 0
-				? idx
+			matchedIndex >= 0
+				? matchedIndex
 				: Math.max(
 						0,
 						options.findIndex((o) => !o.disabled),

--- a/src/ui/fab/FAB.test.tsx
+++ b/src/ui/fab/FAB.test.tsx
@@ -4,27 +4,27 @@ import { FAB } from "./index";
 
 describe("FAB", () => {
 	it("renders icon", () => {
-		render(<FAB icon={<svg data-testid="icon" />} />);
+		render(<FAB icon={<svg data-testid="icon" />} aria-label="Action" />);
 		expect(screen.getByTestId("icon")).toBeInTheDocument();
 	});
 
 	it("renders with default variant class", () => {
-		render(<FAB icon={<svg />} />);
+		render(<FAB icon={<svg />} aria-label="Action" />);
 		const button = screen.getByRole("button");
 		expect(button).toHaveClass("fab", "fab_variant_primary");
 	});
 
 	it("applies variant classes", () => {
-		const { rerender } = render(<FAB variant="primary" icon={<svg />} />);
+		const { rerender } = render(<FAB variant="primary" icon={<svg />} aria-label="Action" />);
 		expect(screen.getByRole("button")).toHaveClass("fab_variant_primary");
 
-		rerender(<FAB variant="additive" icon={<svg />} />);
+		rerender(<FAB variant="additive" icon={<svg />} aria-label="Action" />);
 		expect(screen.getByRole("button")).toHaveClass("fab_variant_additive");
 	});
 
 	it("handles disabled state", () => {
 		const handleClick = vi.fn();
-		render(<FAB icon={<svg />} disabled onClick={handleClick} />);
+		render(<FAB icon={<svg />} disabled onClick={handleClick} aria-label="Action" />);
 
 		const button = screen.getByRole("button");
 		expect(button).toBeDisabled();
@@ -35,14 +35,14 @@ describe("FAB", () => {
 
 	it("calls onClick", () => {
 		const handleClick = vi.fn();
-		render(<FAB icon={<svg />} onClick={handleClick} />);
+		render(<FAB icon={<svg />} onClick={handleClick} aria-label="Action" />);
 
 		fireEvent.click(screen.getByRole("button"));
 		expect(handleClick).toHaveBeenCalledTimes(1);
 	});
 
 	it("applies custom className", () => {
-		render(<FAB icon={<svg />} className="custom-class" />);
+		render(<FAB icon={<svg />} className="custom-class" aria-label="Action" />);
 		expect(screen.getByRole("button")).toHaveClass("custom-class");
 	});
 });

--- a/src/ui/linear-progress/LinearProgress.test.tsx
+++ b/src/ui/linear-progress/LinearProgress.test.tsx
@@ -4,12 +4,12 @@ import { LinearProgress } from "./index";
 
 describe("LinearProgress", () => {
 	it("renders progressbar role", () => {
-		render(<LinearProgress totalSteps={4} currentStep={2} />);
+		render(<LinearProgress totalSteps={4} currentStep={2} aria-label="Progress" />);
 		expect(screen.getByRole("progressbar")).toBeInTheDocument();
 	});
 
 	it("shows correct aria attributes", () => {
-		render(<LinearProgress totalSteps={4} currentStep={2} />);
+		render(<LinearProgress totalSteps={4} currentStep={2} aria-label="Progress" />);
 		const el = screen.getByRole("progressbar");
 		expect(el).toHaveAttribute("aria-valuenow", "2");
 		expect(el).toHaveAttribute("aria-valuemin", "0");
@@ -17,35 +17,39 @@ describe("LinearProgress", () => {
 	});
 
 	it("renders 0% width when currentStep is 0", () => {
-		render(<LinearProgress totalSteps={4} currentStep={0} />);
+		render(<LinearProgress totalSteps={4} currentStep={0} aria-label="Progress" />);
 		const indicator = screen.getByRole("progressbar").querySelector(".linear_progress_indicator");
 		expect(indicator).toHaveStyle({ width: "0%" });
 	});
 
 	it("renders 50% width when currentStep is half of totalSteps", () => {
-		render(<LinearProgress totalSteps={4} currentStep={2} />);
+		render(<LinearProgress totalSteps={4} currentStep={2} aria-label="Progress" />);
 		const indicator = screen.getByRole("progressbar").querySelector(".linear_progress_indicator");
 		expect(indicator).toHaveStyle({ width: "50%" });
 	});
 
 	it("renders 100% width when complete", () => {
-		render(<LinearProgress totalSteps={4} currentStep={4} />);
+		render(<LinearProgress totalSteps={4} currentStep={4} aria-label="Progress" />);
 		const indicator = screen.getByRole("progressbar").querySelector(".linear_progress_indicator");
 		expect(indicator).toHaveStyle({ width: "100%" });
 	});
 
 	it("clamps to 0-100 range", () => {
-		const { rerender } = render(<LinearProgress totalSteps={4} currentStep={-1} />);
+		const { rerender } = render(
+			<LinearProgress totalSteps={4} currentStep={-1} aria-label="Progress" />,
+		);
 		let indicator = screen.getByRole("progressbar").querySelector(".linear_progress_indicator");
 		expect(indicator).toHaveStyle({ width: "0%" });
 
-		rerender(<LinearProgress totalSteps={4} currentStep={10} />);
+		rerender(<LinearProgress totalSteps={4} currentStep={10} aria-label="Progress" />);
 		indicator = screen.getByRole("progressbar").querySelector(".linear_progress_indicator");
 		expect(indicator).toHaveStyle({ width: "100%" });
 	});
 
 	it("accepts custom className", () => {
-		render(<LinearProgress totalSteps={4} currentStep={2} className="my-custom" />);
+		render(
+			<LinearProgress totalSteps={4} currentStep={2} className="my-custom" aria-label="Progress" />,
+		);
 		const el = screen.getByRole("progressbar");
 		expect(el).toHaveClass("linear_progress");
 		expect(el).toHaveClass("my-custom");

--- a/src/ui/otp-input/index.tsx
+++ b/src/ui/otp-input/index.tsx
@@ -49,9 +49,9 @@ export const OtpInput = ({
 	}, [autoFocus]);
 
 	const digits = React.useMemo(() => {
-		const arr = value.split("").slice(0, length);
-		while (arr.length < length) arr.push("");
-		return arr;
+		const chars = value.split("").slice(0, length);
+		while (chars.length < length) chars.push("");
+		return chars;
 	}, [value, length]);
 
 	const focusInput = (index: number) => {
@@ -63,14 +63,14 @@ export const OtpInput = ({
 	};
 
 	const handleChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {
-		const val = e.target.value;
-		if (val && !/^\d$/.test(val)) return;
+		const nextDigit = e.target.value;
+		if (nextDigit && !/^\d$/.test(nextDigit)) return;
 
 		const newDigits = [...digits];
-		newDigits[index] = val;
+		newDigits[index] = nextDigit;
 		updateValue(newDigits);
 
-		if (val && index < length - 1) {
+		if (nextDigit && index < length - 1) {
 			focusInput(index + 1);
 		}
 	};


### PR DESCRIPTION
## 작업 개요

2026-05-15 코드 품질 리포트에서 누적된 P0/P1 항목을 일괄 정리한다.

- **P0**: `tsc --noEmit` 에러 16건이 3일 연속 잔존 (5/13 → 5/14 → 5/15).
- **P1**: `biome check .` 에러 3건이 3일째 잔존, production 코드 줄임말 변수 3건.

## 작업한 내용

논리적으로 3개 커밋으로 분리.

### 1. `fix: resolve type errors in fab/linear-progress tests and typography story`
- [x] `FAB.test.tsx` 7개 렌더에 필수 prop `aria-label="Action"` 추가
- [x] `LinearProgress.test.tsx` 8개 렌더에 필수 prop `aria-label="Progress"` 추가
- [x] `typography.stories.tsx:403`의 dead comparison 제거 — `scales` 배열 5개 항목이 모두 `fw.regular`("Regular")이라 `=== "Medium"` 비교는 TS2367 + 항상 false. `fontWeight: 400`으로 단순화

### 2. `config: exclude .claude and tsup bundle artifacts from biome scan`
- [x] `biome.json`에 `files.includes` 추가하여 다음 제외
  - `.claude/` — per-machine harness config
  - `tsup.config.bundled_*.mjs` — transient build artifact

### 3. `style: rename abbreviated variables in otp-input and dropdown`
- [x] `otp-input/index.tsx`: `arr` → `chars`, `val` → `nextDigit`
- [x] `dropdown/index.tsx`: `idx` → `matchedIndex`

## 검증

- `pnpm exec tsc --noEmit`: 16 → **0 errors**
- `pnpm exec biome check .`: 3 → **0 errors / 0 warnings**
- `pnpm test`: **25 files / 299 tests** 통과 유지

## 전달할 추가 이슈

- `typography.stories.tsx`의 "Comparison" 스토리에서 Regular vs Medium 비교가 의도였다면 `scales` 배열에 `*Medium` variant(예: `title.mediumMedium`)를 추가해야 함 — 본 PR은 dead code 제거에 한정.
- 테스트 파일 줄임말 변수 3건(`useFocusTrap.test.ts:9`, `LinearProgress.test.tsx:13,49`)은 P2로 별도 정리 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)