### PR TITLE
feat/vanilla-parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,9 @@ dist/vanilla/
 
 <div id="my-modal" class="bt-modal" data-bt-modal>
   <div class="bt-modal__panel" style="width: 480px;">
+    <button class="bt-modal__close" data-modal-close aria-label="Close">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+    </button>
     <div class="bt-modal__header">Title</div>
     <div class="bt-modal__body">Content</div>
     <div class="bt-modal__footer">

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -368,6 +368,9 @@ npm install @bigtablet/design-system
 <!-- 모달 -->
 <div id="my-modal" class="bt-modal" data-bt-modal>
   <div class="bt-modal__panel" style="width: 480px;">
+    <button class="bt-modal__close" data-modal-close aria-label="닫기">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+    </button>
     <div class="bt-modal__header">모달 제목</div>
     <div class="bt-modal__body">
       <p>모달 내용을 여기에 작성합니다.</p>

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -196,7 +196,7 @@
     color: var(--bt-color-text-primary);
 
     &:hover:not(:disabled) {
-      background: rgba(0, 0, 0, 0.05);
+      background: var(--bt-color-hover);
     }
 
     &:active:not(:disabled) {
@@ -282,7 +282,7 @@
       &:focus-visible {
         outline: none;
         border-color: var(--bt-color-accent);
-        box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 0 0 3px var(--bt-color-border-light);
       }
     }
 
@@ -294,7 +294,7 @@
         outline: none;
         border-color: var(--bt-color-accent);
         background: var(--bt-color-background);
-        box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 0 0 3px var(--bt-color-border-light);
       }
     }
 
@@ -663,7 +663,7 @@
 
       &.is-open {
         border-color: var(--bt-color-accent);
-        box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 0 0 3px var(--bt-color-border-light);
       }
     }
 
@@ -674,7 +674,7 @@
       &.is-open {
         background: var(--bt-color-background);
         border-color: var(--bt-color-accent);
-        box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 0 0 3px var(--bt-color-border-light);
       }
     }
 
@@ -1105,7 +1105,7 @@
     &:focus-visible {
       outline: none;
       border-color: var(--bt-color-accent);
-      box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+      box-shadow: 0 0 0 3px var(--bt-color-border-light);
     }
 
     &:disabled {

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -9,9 +9,13 @@
    CSS Custom Properties (Design Tokens)
    ======================================== */
 :root {
-  /* Colors - Brand */
+  /* Colors - Brand (양 테마 검정/흰 고정 — Button --primary 등 의도된 다크 fill) */
   --bt-color-primary: #{token.$color_brand_primary};
   --bt-color-on-primary: #{token.$color_brand_on_primary};
+
+  /* Colors - Accent (light=검정/dark=흰 자동 반전 — indicator/checked/focus 강조) */
+  --bt-color-accent: #{token.$color_accent_default};
+  --bt-color-accent-on-surface: #{token.$color_accent_on_surface};
 
   /* Colors - Background */
   --bt-color-background: #{token.$color_bg_solid};
@@ -277,7 +281,7 @@
 
       &:focus-visible {
         outline: none;
-        border-color: var(--bt-color-primary);
+        border-color: var(--bt-color-accent);
         box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
       }
     }
@@ -288,7 +292,7 @@
 
       &:focus-visible {
         outline: none;
-        border-color: var(--bt-color-primary);
+        border-color: var(--bt-color-accent);
         background: var(--bt-color-background);
         box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
       }
@@ -421,7 +425,7 @@
   /* States */
   &__input:focus-visible + .bt-checkbox__box {
     box-shadow: 0 0 0 3px var(--bt-color-border-light);
-    border-color: var(--bt-color-primary);
+    border-color: var(--bt-color-accent);
   }
 
   &__input:disabled + .bt-checkbox__box,
@@ -431,8 +435,8 @@
   }
 
   &__input:checked + .bt-checkbox__box {
-    background: var(--bt-color-primary);
-    border-color: var(--bt-color-primary);
+    background: var(--bt-color-accent);
+    border-color: var(--bt-color-accent);
   }
 
   &__input:checked + .bt-checkbox__box::after {
@@ -442,7 +446,7 @@
     top: 50%;
     width: 0.28rem;
     height: 0.55rem;
-    border: 2px solid var(--bt-color-background);
+    border: 2px solid var(--bt-color-accent-on-surface);
     border-top: 0;
     border-left: 0;
     transform: translate(-50%, -58%) rotate(45deg);
@@ -513,11 +517,12 @@
   /* States */
   &__input:focus-visible + .bt-radio__dot {
     box-shadow: 0 0 0 3px var(--bt-color-border-light);
-    border-color: var(--bt-color-primary);
+    border-color: var(--bt-color-accent);
   }
 
   &__input:checked + .bt-radio__dot {
-    border-color: var(--bt-color-primary);
+    border-color: var(--bt-color-accent);
+    border-width: 2px;
   }
 
   &__input:checked + .bt-radio__dot::after {
@@ -528,7 +533,7 @@
     width: 60%;
     height: 60%;
     transform: translate(-50%, -50%);
-    background: var(--bt-color-primary);
+    background: var(--bt-color-accent);
     border-radius: 9999px;
   }
 
@@ -567,11 +572,12 @@
   }
 
   &--on {
-    background: var(--bt-color-primary);
+    background: var(--bt-color-accent);
 
     .bt-toggle__thumb {
       width: 20px;
       height: 20px;
+      background: var(--bt-color-accent-on-surface);
       transform: translateX(16px);
     }
   }
@@ -656,7 +662,7 @@
       }
 
       &.is-open {
-        border-color: var(--bt-color-primary);
+        border-color: var(--bt-color-accent);
         box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
       }
     }
@@ -667,7 +673,7 @@
 
       &.is-open {
         background: var(--bt-color-background);
-        border-color: var(--bt-color-primary);
+        border-color: var(--bt-color-accent);
         box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
       }
     }
@@ -793,6 +799,7 @@
   }
 
   &__panel {
+    position: relative; // close button 의 absolute 기준
     background: var(--bt-color-background);
     border-radius: var(--bt-radius-lg);
     box-shadow: var(--bt-elevation-3);
@@ -802,11 +809,40 @@
 
   &__header {
     padding: var(--bt-spacing-lg);
+    padding-right: calc(var(--bt-spacing-lg) + 32px); // close 버튼 겹침 방지
     border-bottom: 1px solid var(--bt-color-border);
     color: var(--bt-color-text-primary);
     font-size: var(--bt-font-size-xl);
     font-weight: var(--bt-font-weight-semibold);
     line-height: 1.3;
+  }
+
+  &__close {
+    position: absolute;
+    top: var(--bt-spacing-md);
+    right: var(--bt-spacing-md);
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--bt-color-text-tertiary);
+    border-radius: var(--bt-radius-md);
+    cursor: pointer;
+    transition: background var(--bt-transition-fast),
+                color var(--bt-transition-fast);
+
+    &:hover {
+      background: var(--bt-color-hover);
+      color: var(--bt-color-text-primary);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px var(--bt-color-border-light);
+    }
   }
 
   &__body {
@@ -931,7 +967,7 @@
   box-sizing: border-box;
   border-radius: 50%;
   border: 2px solid var(--bt-color-border);
-  border-top-color: var(--bt-color-primary);
+  border-top-color: var(--bt-color-accent);
   animation: bt-spinner-spin 0.8s linear infinite;
 
   &--sm { width: 16px; height: 16px; }
@@ -1062,13 +1098,13 @@
     background-repeat: no-repeat;
 
     &:hover:not(:disabled) {
-      border-color: var(--bt-color-primary);
+      border-color: var(--bt-color-accent);
       background-color: var(--bt-color-background-secondary);
     }
 
     &:focus-visible {
       outline: none;
-      border-color: var(--bt-color-primary);
+      border-color: var(--bt-color-accent);
       box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
     }
 
@@ -1128,7 +1164,7 @@
 
   &__control:focus-visible + .bt-file-input__label {
     box-shadow: 0 0 0 3px var(--bt-color-border-light);
-    border-color: var(--bt-color-primary);
+    border-color: var(--bt-color-accent);
   }
 
   &--disabled {


### PR DESCRIPTION
## 작업 개요

직전 머지된 PR #259 (fix/code-quality) 에서 Vanilla 번들 일부 parity 가 빠짐. React 와 다크 모드 동작 일치 + 신규 Modal X close 아이콘 반영.

## 작업한 내용

### 다크 모드 parity
- [x] Vanilla 가 `--bt-color-primary` (brand_primary 양 테마 검정 고정) 를 모든 indicator (checkbox checked, radio dot, toggle on, focus ring, spinner) 에 사용 → 다크에서 검정-on-네이비 안 보이는 문제
- [x] `--bt-color-accent` + `--bt-color-accent-on-surface` 추가 (`accent_default` / `accent_on_surface` 토큰 매핑 — 양쪽 다 다크에서 자동 반전)
- [x] indicator 들 swap: checkbox checked bg+border, checkbox checkmark → `accent-on-surface`, radio outline-ring + 2px border + inner dot, toggle --on track + thumb → `accent-on-surface`, spinner border-top, 모든 focus/is-open/hover border-color
- [x] Button --primary 배경은 의도된 검정 fill 이라 `--bt-color-primary` 유지 (React Button filled variant 와 일치)

### Modal X close 아이콘
- [x] `.bt-modal__close` 클래스 추가 — 우상단 32×32 X 버튼
- [x] `.bt-modal__panel` `position: relative` 추가 (close 의 absolute 기준)
- [x] `.bt-modal__header` 의 padding-right 확보 (title 이 X 와 겹치지 않게)
- [x] 기존 `data-modal-close` 자동 바인딩 활용 → JS 변경 불필요
- [x] CLAUDE.md, docs/VANILLA.md 의 Modal HTML 예시에 X 아이콘 사용 패턴 반영

## 전달할 추가 이슈

- **FileInput preview variant** — React 만 있음. Vanilla 추가는 JS (blob URL 생성/해제) + SCSS 필요. 별도 PR
- **Spinner Vercel 12-bar 스타일** — Vanilla 는 classic border-spin 유지 (HTML 구조 변경 부담 vs 시각 개선 trade-off)
- **LinearProgress 컴포넌트** — Vanilla 에 미구현. 별도 PR