### PR TITLE
feat/dark-mode-polish

### DIFF
--- a/src/stories/cookbook/data.stories.tsx
+++ b/src/stories/cookbook/data.stories.tsx
@@ -94,7 +94,7 @@ export const UserList: Story = {
 								margin: 0,
 								fontSize: 16,
 								fontWeight: 700,
-								color: "#121212",
+								color: "var(--bt-color-text-heading)",
 							}}
 						>
 							팀 멤버
@@ -126,24 +126,24 @@ export const UserList: Story = {
 												borderRadius: "50%",
 												background:
 													user.status === "online"
-														? "#16A34A"
+														? "var(--bt-color-status-success)"
 														: user.status === "away"
-															? "#F59E0B"
-															: "#94A3B8",
-												border: "2px solid #fff",
+															? "var(--bt-color-status-warning)"
+															: "var(--bt-color-text-caption)",
+												border: "2px solid var(--bt-color-bg-solid)",
 											}}
 										/>
 									</span>
 									<Stack gap={2}>
 										<Stack direction="horizontal" gap={8} align="center">
-											<span style={{ fontSize: 14, fontWeight: 600, color: "#121212" }}>
+											<span style={{ fontSize: 14, fontWeight: 600, color: "var(--bt-color-text-heading)" }}>
 												{user.name}
 											</span>
 											<Badge variant={STATUS_VARIANT[user.status]} shape="label">
 												{STATUS_LABEL[user.status]}
 											</Badge>
 										</Stack>
-										<span style={{ fontSize: 12, color: "#888" }}>
+										<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 											{user.role} · {user.email}
 										</span>
 									</Stack>
@@ -191,7 +191,7 @@ export const StatusBadgesRow: Story = {
 						style={{
 							fontSize: 12,
 							fontWeight: 600,
-							color: "#888",
+							color: "var(--bt-color-text-caption)",
 							textTransform: "uppercase",
 							letterSpacing: "0.04em",
 						}}
@@ -213,7 +213,7 @@ export const StatusBadgesRow: Story = {
 						style={{
 							fontSize: 12,
 							fontWeight: 600,
-							color: "#888",
+							color: "var(--bt-color-text-caption)",
 							textTransform: "uppercase",
 							letterSpacing: "0.04em",
 						}}
@@ -233,7 +233,7 @@ export const StatusBadgesRow: Story = {
 						style={{
 							fontSize: 12,
 							fontWeight: 600,
-							color: "#888",
+							color: "var(--bt-color-text-caption)",
 							textTransform: "uppercase",
 							letterSpacing: "0.04em",
 						}}
@@ -297,7 +297,7 @@ export const StatCards: Story = {
 				<Card key={stat.label} bordered padding="lg" shadow="sm">
 					<Stack gap={12}>
 						<Stack direction="horizontal" justify="between" align="center">
-							<span style={{ fontSize: 13, color: "#888", fontWeight: 500 }}>
+							<span style={{ fontSize: 13, color: "var(--bt-color-text-caption)", fontWeight: 500 }}>
 								{stat.label}
 							</span>
 							<span
@@ -308,8 +308,8 @@ export const StatCards: Story = {
 									width: 36,
 									height: 36,
 									borderRadius: 10,
-									background: "#F2F5F8",
-									color: "#47555E",
+									background: "var(--bt-color-bg-solid-dim)",
+									color: "var(--bt-color-text-body)",
 								}}
 							>
 								{stat.icon}
@@ -319,7 +319,7 @@ export const StatCards: Story = {
 							style={{
 								fontSize: 28,
 								fontWeight: 700,
-								color: "#121212",
+								color: "var(--bt-color-text-heading)",
 								letterSpacing: "-0.02em",
 							}}
 						>
@@ -335,14 +335,18 @@ export const StatCards: Story = {
 									fontWeight: 700,
 									padding: "2px 8px",
 									borderRadius: 999,
-									background: stat.positive ? "#DCFCE7" : "#FEE2E2",
-									color: stat.positive ? "#047857" : "#B91C1C",
+									background: stat.positive
+										? "color-mix(in srgb, var(--bt-color-status-success) 18%, transparent)"
+										: "color-mix(in srgb, var(--bt-color-status-error) 18%, transparent)",
+									color: stat.positive
+										? "var(--bt-color-status-success)"
+										: "var(--bt-color-status-error)",
 								}}
 							>
 								{stat.positive ? <TrendingUp size={12} /> : <TrendingDown size={12} />}
 								{stat.delta}
 							</span>
-							<span style={{ fontSize: 12, color: "#888" }}>{stat.caption}</span>
+							<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>{stat.caption}</span>
 						</Stack>
 					</Stack>
 				</Card>
@@ -408,12 +412,12 @@ export const OrderTimeline: Story = {
 								margin: 0,
 								fontSize: 16,
 								fontWeight: 700,
-								color: "#121212",
+								color: "var(--bt-color-text-heading)",
 							}}
 						>
 							주문 #1024
 						</h3>
-						<span style={{ fontSize: 12, color: "#888" }}>
+						<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 							2026.05.20 · 김민준 고객
 						</span>
 					</Stack>
@@ -437,16 +441,16 @@ export const OrderTimeline: Story = {
 											borderRadius: "50%",
 											background:
 												item.status === "active"
-													? "#303841"
+													? "var(--bt-color-accent-default)"
 													: item.status === "done"
-														? "#DCFCE7"
-														: "#F2F5F8",
+														? "color-mix(in srgb, var(--bt-color-status-success) 18%, transparent)"
+														: "var(--bt-color-bg-solid-dim)",
 											color:
 												item.status === "active"
-													? "#fff"
+													? "var(--bt-color-accent-on-surface)"
 													: item.status === "done"
-														? "#047857"
-														: "#94A3B8",
+														? "var(--bt-color-status-success)"
+														: "var(--bt-color-text-caption)",
 											display: "inline-flex",
 											alignItems: "center",
 											justifyContent: "center",
@@ -460,7 +464,9 @@ export const OrderTimeline: Story = {
 												width: 2,
 												flex: 1,
 												minHeight: 32,
-												background: isPending ? "#E5E7EB" : "#CBD5E1",
+												background: isPending
+													? "var(--bt-color-border-default)"
+													: "var(--bt-color-border-hover)",
 												marginTop: 4,
 												marginBottom: 4,
 											}}
@@ -474,19 +480,23 @@ export const OrderTimeline: Story = {
 											style={{
 												fontSize: 14,
 												fontWeight: 600,
-												color: isPending ? "#888" : "#121212",
+												color: isPending
+													? "var(--bt-color-text-caption)"
+													: "var(--bt-color-text-heading)",
 											}}
 										>
 											{item.title}
 										</span>
 										<Chip type="static" size="sm" tone={item.statusTone} label={item.statusLabel} />
 									</Stack>
-									<span style={{ fontSize: 12, color: "#888" }}>{item.time}</span>
+									<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>{item.time}</span>
 									<p
 										style={{
 											margin: 0,
 											fontSize: 13,
-											color: isPending ? "#94A3B8" : "#444",
+											color: isPending
+												? "var(--bt-color-text-caption)"
+												: "var(--bt-color-text-body)",
 											lineHeight: 1.55,
 										}}
 									>

--- a/src/stories/cookbook/feedback.stories.tsx
+++ b/src/stories/cookbook/feedback.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Inbox, Search, Trash2 } from "lucide-react";
+import { Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "../../ui/general/button";
 import { Card } from "../../ui/display/card";
@@ -42,7 +42,7 @@ export const LoadingSkeleton: Story = {
 							margin: 0,
 							fontSize: 16,
 							fontWeight: 700,
-							color: "#121212",
+							color: "var(--bt-color-text-heading)",
 						}}
 					>
 						게시물 목록
@@ -102,17 +102,17 @@ export const LoadingSkeleton: Story = {
 											{post.name.charAt(0)}
 										</div>
 										<Stack gap={4} style={{ flex: 1 }}>
-											<span style={{ fontSize: 13, color: "#888", fontWeight: 500 }}>
+											<span style={{ fontSize: 13, color: "var(--bt-color-text-caption)", fontWeight: 500 }}>
 												{post.name}
 											</span>
-											<span style={{ fontSize: 15, fontWeight: 700, color: "#121212" }}>
+											<span style={{ fontSize: 15, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 												{post.title}
 											</span>
 											<p
 												style={{
 													margin: 0,
 													fontSize: 13,
-													color: "#666",
+													color: "var(--bt-color-text-body)",
 													lineHeight: 1.55,
 												}}
 											>
@@ -133,29 +133,30 @@ export const LoadingSkeleton: Story = {
 export const EmptyStatePattern: Story = {
 	name: "빈 상태 + CTA",
 	render: () => (
-		<Grid cols={2} gap={24} style={{ width: 760 }}>
-			<Card bordered padding="lg" shadow="sm">
-				<EmptyState
-					illustration={<Inbox size={56} strokeWidth={1.5} color="#94A3B8" />}
-					title="받은 메일이 없습니다"
-					description="새 메일이 오면 여기에서 바로 확인할 수 있어요."
-					action={<Button variant="filled">새 메일 작성</Button>}
-				/>
-			</Card>
-			<Card bordered padding="lg" shadow="sm">
-				<EmptyState
-					illustration={<Search size={56} strokeWidth={1.5} color="#94A3B8" />}
-					title="검색 결과가 없습니다"
-					description='"비건 디저트"에 대한 결과를 찾지 못했어요. 검색어를 바꿔 다시 시도해 보세요.'
-					action={
-						<Stack direction="horizontal" gap={8} justify="center">
-							<Button variant="outline">검색어 지우기</Button>
-							<Button variant="filled">필터 재설정</Button>
-						</Stack>
-					}
-				/>
-			</Card>
-		</Grid>
+		<div
+			style={{
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				minHeight: 480,
+				padding: 48,
+				background: "var(--bt-color-bg-solid)",
+			}}
+		>
+			<EmptyState
+				size="lg"
+				illustration={<Search size={56} strokeWidth={1.5} />}
+				title="검색 결과가 없습니다"
+				description={
+					<>
+						<span>{'"비건 디저트"에 대한 결과를 찾지 못했어요.'}</span>
+						<br />
+						<span>검색어를 바꾸거나 필터를 재설정해 다시 시도해 보세요.</span>
+					</>
+				}
+				action={<Button variant="filled">필터 재설정</Button>}
+			/>
+		</div>
 	),
 };
 
@@ -177,13 +178,16 @@ export const ConfirmationModal: Story = {
 						setCompleted(false);
 						setOpen(true);
 					}}
-					style={{ color: "#B91C1C", borderColor: "#FCA5A5" }}
+					style={{
+						color: "var(--bt-color-status-error)",
+						borderColor: "color-mix(in srgb, var(--bt-color-status-error) 45%, transparent)",
+					}}
 				>
 					계정 삭제
 				</Button>
 
 				{completed && (
-					<span style={{ fontSize: 13, color: "#047857", fontWeight: 600 }}>
+					<span style={{ fontSize: 13, color: "var(--bt-color-status-success)", fontWeight: 600 }}>
 						삭제 요청이 접수되었습니다.
 					</span>
 				)}
@@ -195,7 +199,7 @@ export const ConfirmationModal: Story = {
 					width={440}
 				>
 					<Stack gap={20}>
-						<p style={{ margin: 0, fontSize: 14, color: "#444", lineHeight: 1.6 }}>
+						<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)", lineHeight: 1.6 }}>
 							계정을 삭제하면 모든 매장 데이터·정산 기록·연동 정보가 영구적으로
 							제거되며, 이 작업은 되돌릴 수 없습니다.
 						</p>
@@ -203,10 +207,10 @@ export const ConfirmationModal: Story = {
 							style={{
 								padding: 12,
 								borderRadius: 8,
-								background: "#FEF2F2",
-								border: "1px solid #FECACA",
+								background: "color-mix(in srgb, var(--bt-color-status-error) 12%, transparent)",
+								border: "1px solid color-mix(in srgb, var(--bt-color-status-error) 35%, transparent)",
 								fontSize: 13,
-								color: "#B91C1C",
+								color: "var(--bt-color-status-error)",
 							}}
 						>
 							삭제 후 7일 동안은 동일 이메일로 신규 가입이 제한됩니다.
@@ -221,7 +225,7 @@ export const ConfirmationModal: Story = {
 									setCompleted(true);
 									setOpen(false);
 								}}
-								style={{ background: "#B91C1C", color: "#fff" }}
+								style={{ background: "var(--bt-color-status-error)", color: "#fff" }}
 							>
 								삭제하기
 							</Button>
@@ -242,10 +246,10 @@ const ToastDemo = () => {
 		<Card bordered padding="lg" shadow="sm">
 			<Stack gap={16} style={{ width: 360 }}>
 				<Stack gap={4}>
-					<h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "#121212" }}>
+					<h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 						토스트 메시지
 					</h3>
-					<p style={{ margin: 0, fontSize: 13, color: "#666" }}>
+					<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>
 						짧고 일시적인 시스템 피드백에 사용하세요.
 					</p>
 				</Stack>

--- a/src/stories/cookbook/form.stories.tsx
+++ b/src/stories/cookbook/form.stories.tsx
@@ -40,9 +40,9 @@ const FormCard = ({
 	<div
 		style={{
 			width,
-			background: "#fff",
+			background: "var(--bt-color-bg-solid)",
 			borderRadius: 16,
-			border: "1px solid #E5E5E5",
+			border: "1px solid var(--bt-color-border-default)",
 			padding: "28px 24px",
 			boxShadow: "0 1px 3px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.04)",
 		}}
@@ -52,7 +52,7 @@ const FormCard = ({
 				margin: "0 0 20px",
 				fontSize: 18,
 				fontWeight: 700,
-				color: "#121212",
+				color: "var(--bt-color-text-heading)",
 				letterSpacing: "-0.01em",
 			}}
 		>
@@ -105,7 +105,7 @@ export const LoginForm: Story = {
 								background: "none",
 								border: "none",
 								padding: 0,
-								color: "#47555E",
+								color: "var(--bt-color-text-body)",
 								fontSize: 13,
 								fontWeight: 500,
 								cursor: "pointer",
@@ -123,14 +123,14 @@ export const LoginForm: Story = {
 					<Divider />
 
 					<Stack direction="horizontal" justify="center" gap={4} align="center">
-						<span style={{ fontSize: 13, color: "#666" }}>아직 계정이 없으신가요?</span>
+						<span style={{ fontSize: 13, color: "var(--bt-color-text-body)" }}>아직 계정이 없으신가요?</span>
 						<button
 							type="button"
 							style={{
 								background: "none",
 								border: "none",
 								padding: 0,
-								color: "#303841",
+								color: "var(--bt-color-text-heading)",
 								fontSize: 13,
 								fontWeight: 600,
 								cursor: "pointer",
@@ -212,14 +212,14 @@ export const SignUpForm: Story = {
 							<span style={{ fontSize: 13 }}>
 								<a
 									href="#terms"
-									style={{ color: "#303841", textDecoration: "underline" }}
+									style={{ color: "var(--bt-color-text-heading)", textDecoration: "underline" }}
 								>
 									이용약관
 								</a>{" "}
 								및{" "}
 								<a
 									href="#privacy"
-									style={{ color: "#303841", textDecoration: "underline" }}
+									style={{ color: "var(--bt-color-text-heading)", textDecoration: "underline" }}
 								>
 									개인정보처리방침
 								</a>
@@ -263,9 +263,9 @@ export const SearchWithFilter: Story = {
 			<div
 				style={{
 					width: 600,
-					background: "#fff",
+					background: "var(--bt-color-bg-solid)",
 					borderRadius: 16,
-					border: "1px solid #E5E5E5",
+					border: "1px solid var(--bt-color-border-default)",
 					padding: "24px",
 					boxShadow:
 						"0 1px 3px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.04)",
@@ -327,7 +327,7 @@ export const SearchWithFilter: Story = {
 									border: "none",
 									padding: 0,
 									marginLeft: 4,
-									color: "#666",
+									color: "var(--bt-color-text-body)",
 									fontSize: 12,
 									fontWeight: 500,
 									cursor: "pointer",
@@ -366,7 +366,7 @@ export const SettingsSection: Story = {
 								margin: 0,
 								fontSize: 13,
 								fontWeight: 600,
-								color: "#888",
+								color: "var(--bt-color-text-caption)",
 								textTransform: "uppercase",
 								letterSpacing: "0.04em",
 							}}
@@ -397,7 +397,7 @@ export const SettingsSection: Story = {
 								margin: 0,
 								fontSize: 13,
 								fontWeight: 600,
-								color: "#888",
+								color: "var(--bt-color-text-caption)",
 								textTransform: "uppercase",
 								letterSpacing: "0.04em",
 							}}
@@ -406,10 +406,10 @@ export const SettingsSection: Story = {
 						</p>
 						<Stack direction="horizontal" justify="between" align="center">
 							<Stack gap={2}>
-								<span style={{ fontSize: 14, fontWeight: 500, color: "#121212" }}>
+								<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 									이메일 알림
 								</span>
-								<span style={{ fontSize: 12, color: "#888" }}>
+								<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 									주문·정산 등 주요 활동을 이메일로 받아보기
 								</span>
 							</Stack>
@@ -422,10 +422,10 @@ export const SettingsSection: Story = {
 						</Stack>
 						<Stack direction="horizontal" justify="between" align="center">
 							<Stack gap={2}>
-								<span style={{ fontSize: 14, fontWeight: 500, color: "#121212" }}>
+								<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 									푸시 알림
 								</span>
-								<span style={{ fontSize: 12, color: "#888" }}>
+								<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 									앱에서 실시간 푸시 알림 수신
 								</span>
 							</Stack>
@@ -438,10 +438,10 @@ export const SettingsSection: Story = {
 						</Stack>
 						<Stack direction="horizontal" justify="between" align="center">
 							<Stack gap={2}>
-								<span style={{ fontSize: 14, fontWeight: 500, color: "#121212" }}>
+								<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 									SMS 알림
 								</span>
-								<span style={{ fontSize: 12, color: "#888" }}>
+								<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 									긴급 알림만 SMS로 발송
 								</span>
 							</Stack>
@@ -463,7 +463,7 @@ export const SettingsSection: Story = {
 								margin: 0,
 								fontSize: 13,
 								fontWeight: 600,
-								color: "#888",
+								color: "var(--bt-color-text-caption)",
 								textTransform: "uppercase",
 								letterSpacing: "0.04em",
 							}}

--- a/src/stories/cookbook/layout.stories.tsx
+++ b/src/stories/cookbook/layout.stories.tsx
@@ -48,7 +48,7 @@ type Story = StoryObj;
 export const MarketingHeroFeatureGrid: Story = {
 	name: "마케팅: 히어로 + 기능 그리드",
 	render: () => (
-		<div style={{ minHeight: "100vh", background: "#fff" }}>
+		<div style={{ minHeight: "100vh", background: "var(--bt-color-bg-solid)" }}>
 			<Hero
 				eyebrow="신규 출시"
 				title="더 빠르게, 더 단순하게"
@@ -70,7 +70,7 @@ export const MarketingHeroFeatureGrid: Story = {
 									margin: 0,
 									fontSize: 32,
 									fontWeight: 700,
-									color: "#121212",
+									color: "var(--bt-color-text-heading)",
 									textAlign: "center",
 									letterSpacing: "-0.02em",
 								}}
@@ -81,7 +81,7 @@ export const MarketingHeroFeatureGrid: Story = {
 								style={{
 									margin: 0,
 									fontSize: 16,
-									color: "#666",
+									color: "var(--bt-color-text-body)",
 									textAlign: "center",
 									maxWidth: 520,
 								}}
@@ -145,12 +145,12 @@ export const MarketingHeroFeatureGrid: Story = {
 												margin: 0,
 												fontSize: 16,
 												fontWeight: 700,
-												color: "#121212",
+												color: "var(--bt-color-text-heading)",
 											}}
 										>
 											{feature.title}
 										</h3>
-										<p style={{ margin: 0, fontSize: 14, color: "#666", lineHeight: 1.55 }}>
+										<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)", lineHeight: 1.55 }}>
 											{feature.desc}
 										</p>
 									</Stack>
@@ -169,11 +169,56 @@ export const MarketingHeroFeatureGrid: Story = {
 export const SidebarLayout: Story = {
 	name: "사이드바 레이아웃",
 	render: () => (
-		<div style={{ display: "flex", minHeight: "100vh", background: "#F2F5F8" }}>
+		<div style={{ display: "flex", minHeight: "100vh", background: "var(--bt-color-bg-solid-dim)" }}>
 			<Sidebar
 				header={
-					<div style={{ color: "#fff", fontWeight: 800, fontSize: 18, letterSpacing: "-0.02em" }}>
-						Bigtablet
+					<img
+						src="/images/logo/bigtablet.png"
+						alt="Bigtablet"
+						height={28}
+						style={{ display: "block" }}
+					/>
+				}
+				headerCollapsed={
+					<img
+						src="/images/logo/favicon.png"
+						alt="Bigtablet"
+						width={28}
+						height={28}
+						style={{ display: "block", borderRadius: 6 }}
+					/>
+				}
+				footer={
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 8,
+							padding: "8px 12px",
+						}}
+					>
+						<div
+							style={{
+								width: 32,
+								height: 32,
+								borderRadius: 999,
+								background: "var(--bt-color-bg-solid-dim)",
+								color: "var(--bt-color-text-heading)",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								fontWeight: 600,
+								flexShrink: 0,
+							}}
+						>
+							S
+						</div>
+						<div style={{ display: "grid", gap: 2, fontSize: 13, minWidth: 0 }}>
+							<strong style={{ color: "var(--bt-color-text-heading)" }}>sangmin</strong>
+							<span style={{ color: "var(--bt-color-text-body)", fontSize: 11 }}>
+								sangmin@bigtablet.com
+							</span>
+						</div>
 					</div>
 				}
 			>
@@ -203,13 +248,13 @@ export const SidebarLayout: Story = {
 								margin: 0,
 								fontSize: 24,
 								fontWeight: 700,
-								color: "#121212",
+								color: "var(--bt-color-text-heading)",
 								letterSpacing: "-0.02em",
 							}}
 						>
 							홈
 						</h1>
-						<p style={{ margin: 0, fontSize: 14, color: "#666" }}>
+						<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)" }}>
 							오늘 매장의 흐름을 빠르게 확인하세요.
 						</p>
 					</Stack>
@@ -217,14 +262,14 @@ export const SidebarLayout: Story = {
 					<Card bordered padding="lg" shadow="sm">
 						<Stack gap={12}>
 							<Stack direction="horizontal" justify="between" align="center">
-								<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "#121212" }}>
+								<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 									최근 활동
 								</h2>
 								<Button variant="text" size="sm">
 									모두 보기
 								</Button>
 							</Stack>
-							<p style={{ margin: 0, fontSize: 14, color: "#666", lineHeight: 1.6 }}>
+							<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)", lineHeight: 1.6 }}>
 								사이드바 + main content 영역의 기본 골격입니다. Sidebar 컴포넌트와 우측 Stack
 								기반 레이아웃을 조합해 어드민·관리자 페이지를 빠르게 시작할 수 있습니다.
 							</p>
@@ -272,7 +317,7 @@ const STAT_CARDS = [
 export const TwoColumnDashboard: Story = {
 	name: "투-컬럼 대시보드",
 	render: () => (
-		<div style={{ padding: 32, background: "#F2F5F8", minHeight: "100vh" }}>
+		<div style={{ padding: 32, background: "var(--bt-color-bg-solid-dim)", minHeight: "100vh" }}>
 			<Container size="xl">
 				<Stack gap={24}>
 					<Stack direction="horizontal" justify="between" align="center">
@@ -282,13 +327,13 @@ export const TwoColumnDashboard: Story = {
 									margin: 0,
 									fontSize: 24,
 									fontWeight: 700,
-									color: "#121212",
+									color: "var(--bt-color-text-heading)",
 									letterSpacing: "-0.02em",
 								}}
 							>
 								오늘의 매출
 							</h1>
-							<p style={{ margin: 0, fontSize: 14, color: "#666" }}>
+							<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)" }}>
 								2026년 5월 20일 화요일 · 영업 중
 							</p>
 						</Stack>
@@ -308,10 +353,10 @@ export const TwoColumnDashboard: Story = {
 							<Card key={stat.label} bordered padding="md" shadow="sm">
 								<Stack gap={12}>
 									<Stack direction="horizontal" justify="between" align="center">
-										<span style={{ fontSize: 13, color: "#888" }}>{stat.label}</span>
-										<span style={{ color: "#47555E" }}>{stat.icon}</span>
+										<span style={{ fontSize: 13, color: "var(--bt-color-text-caption)" }}>{stat.label}</span>
+										<span style={{ color: "var(--bt-color-text-body)" }}>{stat.icon}</span>
 									</Stack>
-									<span style={{ fontSize: 24, fontWeight: 700, color: "#121212" }}>
+									<span style={{ fontSize: 24, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 										{stat.value}
 									</span>
 									<span
@@ -334,7 +379,7 @@ export const TwoColumnDashboard: Story = {
 							<Card bordered padding="lg" shadow="sm">
 								<Stack gap={16}>
 									<Stack direction="horizontal" justify="between" align="center">
-										<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "#121212" }}>
+										<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 											시간대별 매출
 										</h2>
 										<Chip type="static" size="sm" tone="success" label="실시간" />
@@ -350,7 +395,7 @@ export const TwoColumnDashboard: Story = {
 											display: "flex",
 											alignItems: "center",
 											justifyContent: "center",
-											color: "#94A3B8",
+											color: "var(--bt-color-text-caption)",
 											fontSize: 13,
 										}}
 									>
@@ -361,7 +406,7 @@ export const TwoColumnDashboard: Story = {
 						</div>
 						<Card bordered padding="lg" shadow="sm">
 							<Stack gap={16}>
-								<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "#121212" }}>
+								<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 									Best 메뉴
 								</h2>
 								<Stack gap={12}>
@@ -394,11 +439,11 @@ export const TwoColumnDashboard: Story = {
 												>
 													{idx + 1}
 												</span>
-												<span style={{ fontSize: 14, fontWeight: 500, color: "#121212" }}>
+												<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 													{item.name}
 												</span>
 											</Stack>
-											<span style={{ fontSize: 13, color: "#666", fontWeight: 600 }}>
+											<span style={{ fontSize: 13, color: "var(--bt-color-text-body)", fontWeight: 600 }}>
 												{item.count}건
 											</span>
 										</Stack>
@@ -463,7 +508,7 @@ const STATUS_LABELS: Record<string, { label: string; tone: "success" | "accent" 
 export const ListPage: Story = {
 	name: "리스트 페이지",
 	render: () => (
-		<div style={{ padding: 32, background: "#F2F5F8", minHeight: "100vh" }}>
+		<div style={{ padding: 32, background: "var(--bt-color-bg-solid-dim)", minHeight: "100vh" }}>
 			<Container size="xl">
 				<Stack gap={20}>
 					<Breadcrumb
@@ -481,13 +526,13 @@ export const ListPage: Story = {
 									margin: 0,
 									fontSize: 24,
 									fontWeight: 700,
-									color: "#121212",
+									color: "var(--bt-color-text-heading)",
 									letterSpacing: "-0.02em",
 								}}
 							>
 								주문 목록
 							</h1>
-							<p style={{ margin: 0, fontSize: 14, color: "#666" }}>
+							<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)" }}>
 								오늘 들어온 모든 주문을 한 곳에서 확인하세요.
 							</p>
 						</Stack>

--- a/src/stories/examples/page-composition.stories.tsx
+++ b/src/stories/examples/page-composition.stories.tsx
@@ -332,10 +332,43 @@ export const AdminDashboard: Story = {
 			{/* Sidebar */}
 			<Sidebar
 				header={
-					<img src="/images/logo/bigtablet.png" alt="Bigtablet" height={20} style={{ display: "block" }} />
+					<img src="/images/logo/bigtablet.png" alt="Bigtablet" height={28} style={{ display: "block" }} />
 				}
 				headerCollapsed={
-					<img src="/images/logo/favicon.png" alt="" width={28} height={28} style={{ display: "block", borderRadius: 6 }} />
+					<img src="/images/logo/favicon.png" alt="Bigtablet" width={28} height={28} style={{ display: "block", borderRadius: 6 }} />
+				}
+				footer={
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 8,
+							padding: "8px 12px",
+						}}
+					>
+						<div
+							style={{
+								width: 32,
+								height: 32,
+								borderRadius: 999,
+								background: "var(--bt-color-bg-solid-dim)",
+								color: "var(--bt-color-text-heading)",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								fontWeight: 600,
+								flexShrink: 0,
+							}}
+						>
+							S
+						</div>
+						<div style={{ display: "grid", gap: 2, fontSize: 13, minWidth: 0 }}>
+							<strong style={{ color: "var(--bt-color-text-heading)" }}>sangmin</strong>
+							<span style={{ color: "var(--bt-color-text-body)", fontSize: 11 }}>
+								sangmin@bigtablet.com
+							</span>
+						</div>
+					</div>
 				}
 			>
 				<SidebarSection label="메인">

--- a/src/stories/foundation/dark-mode.stories.tsx
+++ b/src/stories/foundation/dark-mode.stories.tsx
@@ -110,7 +110,7 @@ function btnStyle(active: boolean): React.CSSProperties {
 		borderRadius: 6,
 		border: "1px solid var(--bt-color-border-default)",
 		background: active ? "var(--bt-color-accent-default)" : "var(--bt-color-bg-solid)",
-		color: active ? "#fff" : "var(--bt-color-text-heading)",
+		color: active ? "var(--bt-color-accent-on-surface)" : "var(--bt-color-text-heading)",
 		cursor: "pointer",
 		fontSize: 13,
 	};

--- a/src/stories/getting-started/introduction.stories.tsx
+++ b/src/stories/getting-started/introduction.stories.tsx
@@ -57,9 +57,9 @@ export const Overview: Story = {
 			<section
 				style={{
 					padding: 24,
-					background: "#f8f9fa",
+					background: "var(--bt-color-bg-solid-dim)",
 					borderRadius: 12,
-					border: "1px solid #e5e5e5",
+					border: "1px solid var(--bt-color-border-default)",
 				}}
 			>
 				<h3 style={{ margin: "0 0 16px", fontSize: 16 }}>빠른 시작</h3>
@@ -85,9 +85,9 @@ export const Overview: Story = {
 			<section
 				style={{
 					padding: 24,
-					background: "#f8f9fa",
+					background: "var(--bt-color-bg-solid-dim)",
 					borderRadius: 12,
-					border: "1px solid #e5e5e5",
+					border: "1px solid var(--bt-color-border-default)",
 				}}
 			>
 				<h3 style={{ margin: "0 0 12px", fontSize: 16 }}>버전 정보</h3>
@@ -118,8 +118,8 @@ function Step({
 					width: 28,
 					height: 28,
 					borderRadius: "50%",
-					background: "#121212",
-					color: "#fff",
+					background: "var(--bt-color-accent-default)",
+					color: "var(--bt-color-accent-on-surface)",
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "center",
@@ -145,9 +145,9 @@ function InfoCard({ label, value }: { label: string; value: string }) {
 		<div
 			style={{
 				padding: "12px 16px",
-				background: "#fff",
+				background: "var(--bt-color-bg-solid)",
 				borderRadius: 8,
-				border: "1px solid #e5e5e5",
+				border: "1px solid var(--bt-color-border-default)",
 			}}
 		>
 			<div style={{ fontSize: 11, opacity: 0.55, marginBottom: 4 }}>{label}</div>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom";
+import { Globals } from "@react-spring/web";
+
+// jsdom 환경에서 react-spring 애니메이션 즉시 완료 (onRest 트리거 보장)
+// — 진입/퇴출 unmount 타이밍 의존 테스트가 RAF 없이 동작
+Globals.assign({ skipAnimation: true });

--- a/src/ui/display/divider/divider.stories.tsx
+++ b/src/ui/display/divider/divider.stories.tsx
@@ -51,14 +51,14 @@ export const AllWeights: Story = {
 	render: () => (
 		<div style={{ display: "grid", gap: 24 }}>
 			<div>
-				<p style={{ margin: "0 0 8px", fontSize: 14, color: "#737373" }}>
+				<p style={{ margin: "0 0 8px", fontSize: 14, color: "var(--bt-color-text-body)" }}>
 					Standard (1px) — 일반적인 콘텐츠 구분
 				</p>
 				<Divider weight="standard" />
 			</div>
 
 			<div>
-				<p style={{ margin: "0 0 8px", fontSize: 14, color: "#737373" }}>
+				<p style={{ margin: "0 0 8px", fontSize: 14, color: "var(--bt-color-text-body)" }}>
 					Heavy (2px) — 섹션 간 강조 구분
 				</p>
 				<Divider weight="heavy" />

--- a/src/ui/display/icon/icon.stories.tsx
+++ b/src/ui/display/icon/icon.stories.tsx
@@ -58,7 +58,7 @@ export const Sizes: Story = {
 					style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}
 				>
 					<Icon icon={Search} size={size} />
-					<code style={{ fontSize: 11, color: "#888" }}>{size}px</code>
+					<code style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>{size}px</code>
 				</div>
 			))}
 		</div>
@@ -75,7 +75,7 @@ export const StrokeWidths: Story = {
 					style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}
 				>
 					<Icon icon={Settings} size={32} strokeWidth={sw} />
-					<code style={{ fontSize: 11, color: "#888" }}>{sw}</code>
+					<code style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>{sw}</code>
 				</div>
 			))}
 		</div>

--- a/src/ui/display/list-item/list-item.stories.tsx
+++ b/src/ui/display/list-item/list-item.stories.tsx
@@ -63,12 +63,12 @@ const Thumb = (
 			width: 56,
 			height: 56,
 			borderRadius: 8,
-			background: "#E5E5E5",
+			background: "var(--bt-color-bg-solid-dim)",
 			display: "flex",
 			alignItems: "center",
 			justifyContent: "center",
 			fontSize: 12,
-			color: "#444",
+			color: "var(--bt-color-text-body)",
 		}}
 	>
 		56×56

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -39,7 +39,7 @@ const columns: TableColumn<User>[] = [
 		header: "관리",
 		width: "15%",
 		align: "right",
-		render: () => <span style={{ color: "#0369A1", cursor: "pointer" }}>편집</span>,
+		render: () => <span style={{ color: "var(--bt-color-status-info)", cursor: "pointer" }}>편집</span>,
 	},
 ];
 
@@ -108,7 +108,7 @@ export const Sizes: Story = {
 		<div style={{ display: "grid", gap: 24 }}>
 			{(["sm", "md", "lg"] as const).map((size) => (
 				<div key={size}>
-					<div style={{ fontSize: 12, color: "#666", marginBottom: 6 }}>size={size}</div>
+					<div style={{ fontSize: 12, color: "var(--bt-color-text-body)", marginBottom: 6 }}>size={size}</div>
 					<Table<User>
 						columns={columns.slice(0, 3)}
 						data={sampleUsers.slice(0, 3)}

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -104,9 +104,8 @@ describe("Alert", () => {
 		expect(screen.getByText("Test")).toBeInTheDocument();
 
 		fireEvent.click(screen.getByText("확인"));
-		// Exit animation in progress — overlay still rendered with exiting class
-		const overlay = screen.getByRole("alertdialog").parentElement;
-		expect(overlay).toHaveClass("alert_exiting");
+		// Exit animation in progress (spring) — overlay still mounted with role="presentation"
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 	});
 
 	it("starts exit animation when cancel is clicked", () => {
@@ -116,8 +115,7 @@ describe("Alert", () => {
 		expect(screen.getByText("Test")).toBeInTheDocument();
 
 		fireEvent.click(screen.getByText("취소"));
-		const overlay = screen.getByRole("alertdialog").parentElement;
-		expect(overlay).toHaveClass("alert_exiting");
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 	});
 
 	it("starts exit animation when overlay is clicked", () => {
@@ -128,7 +126,7 @@ describe("Alert", () => {
 
 		const overlay = screen.getByRole("alertdialog").parentElement;
 		if (overlay) fireEvent.click(overlay);
-		expect(overlay).toHaveClass("alert_exiting");
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 	});
 
 	it("has correct accessibility attributes", () => {

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { animated, useSpring } from "@react-spring/web";
 import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
 import * as React from "react";
 import { createContext, useCallback, useContext, useState } from "react";
@@ -131,20 +132,26 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	const messageId = React.useId();
 
 	const [shouldRender, setShouldRender] = useState(isOpen);
-	const [isExiting, setIsExiting] = useState(false);
-	const wasOpenRef = React.useRef(isOpen);
 
 	useFocusTrap(panelRef, isOpen);
 
 	React.useEffect(() => {
-		if (isOpen) {
-			setShouldRender(true);
-			setIsExiting(false);
-		} else if (wasOpenRef.current) {
-			setIsExiting(true);
-		}
-		wasOpenRef.current = isOpen;
+		if (isOpen) setShouldRender(true);
 	}, [isOpen]);
+
+	const overlayStyle = useSpring({
+		opacity: isOpen ? 1 : 0,
+		config: { tension: 280, friction: 28, clamp: !isOpen },
+		onRest: (result) => {
+			if (!isOpen && result.finished) setShouldRender(false);
+		},
+	});
+
+	const panelStyle = useSpring({
+		opacity: isOpen ? 1 : 0,
+		transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		config: { tension: 280, friction: 28, clamp: !isOpen },
+	});
 
 	if (!shouldRender) return null;
 
@@ -153,29 +160,24 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	const confirmVariant: ButtonVariant = "filled";
 	const cancelVariant: ButtonVariant = "outline";
 
-	const overlayClassName = cn("alert_overlay", isExiting && "alert_exiting");
 	const modalClassName = cn("alert_modal", `alert_variant_${variant}`);
 
 	return createPortal(
 		// biome-ignore lint/a11y/noStaticElementInteractions: modal overlay pattern
-		<div
-			className={overlayClassName}
+		<animated.div
+			className="alert_overlay"
+			style={overlayStyle}
 			role="presentation"
 			onClick={onClose}
 			onKeyDown={(e) => e.key === "Escape" && onClose()}
 		>
-			<div
+			<animated.div
 				ref={panelRef}
 				className={modalClassName}
+				style={panelStyle}
 				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
-				}}
-				onAnimationEnd={(e) => {
-					if (isExiting && e.target === e.currentTarget) {
-						setShouldRender(false);
-						setIsExiting(false);
-					}
 				}}
 				role="alertdialog"
 				aria-modal="true"
@@ -219,8 +221,8 @@ const AlertModal: React.FC<AlertModalProps> = ({
 						{confirmText}
 					</Button>
 				</div>
-			</div>
-		</div>,
+			</animated.div>
+		</animated.div>,
 		document.body,
 	);
 };

--- a/src/ui/feedback/alert/style.scss
+++ b/src/ui/feedback/alert/style.scss
@@ -1,25 +1,5 @@
 @use "src/styles/token" as token;
 
-@keyframes alert_overlay_in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-@keyframes alert_overlay_out {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-
-@keyframes alert_panel_in {
-  from { opacity: 0; transform: translateY(8px) scale(0.98); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-@keyframes alert_panel_out {
-  from { opacity: 1; transform: translateY(0) scale(1); }
-  to   { opacity: 0; transform: translateY(4px) scale(0.98); }
-}
-
 .alert {
   &_overlay {
     position: fixed;
@@ -29,7 +9,7 @@
     align-items: center;
     justify-content: center;
     z-index: token.$z_level5;
-    animation: alert_overlay_in token.$transition_enter_base forwards;
+    will-change: opacity;
   }
 
   &_modal {
@@ -38,17 +18,8 @@
     min-width: 320px;
     max-width: 480px;
     box-shadow: token.$elevation_level4;
-    animation: alert_panel_in token.$transition_enter_base forwards;
     will-change: transform, opacity;
     overflow: hidden;
-  }
-
-  &_exiting {
-    animation: alert_overlay_out token.$transition_exit_fast forwards;
-
-    .alert_modal {
-      animation: alert_panel_out token.$transition_exit_fast forwards;
-    }
   }
 
   &_header {

--- a/src/ui/feedback/linear-progress/linear-progress.stories.tsx
+++ b/src/ui/feedback/linear-progress/linear-progress.stories.tsx
@@ -36,7 +36,7 @@ export const AllSteps: Story = {
 		<div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
 			{[0, 1, 2, 3, 4].map((step) => (
 				<div key={step}>
-					<p style={{ margin: "0 0 8px", fontSize: 14, color: "#666" }}>
+					<p style={{ margin: "0 0 8px", fontSize: 14, color: "var(--bt-color-text-body)" }}>
 						{step}/4 ({Math.round((step / 4) * 100)}%)
 					</p>
 					<LinearProgress totalSteps={4} currentStep={step} aria-label={`진행률 ${step}/4`} />

--- a/src/ui/feedback/spinner/spinner.stories.tsx
+++ b/src/ui/feedback/spinner/spinner.stories.tsx
@@ -63,8 +63,8 @@ export const InButton: Story = {
 				padding: "8px 16px",
 				borderRadius: 8,
 				border: "1px solid #e5e5e5",
-				background: "#fafafa",
-				color: "#666",
+				background: "var(--bt-color-bg-solid-dim)",
+				color: "var(--bt-color-text-body)",
 				cursor: "not-allowed",
 			}}
 		>

--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import type * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ToastProvider } from "./index";
@@ -203,9 +203,7 @@ describe("Toast display", () => {
 // ── Toast close ───────────────────────────────────────────────────────────────
 
 describe("Toast close", () => {
-	it("removes toast after close button click and animation delay", async () => {
-		vi.useFakeTimers();
-
+	it("removes toast after close button click (spring exit)", async () => {
 		render(
 			<ToastProvider>
 				<ToastTrigger fn={(t) => t.success("닫기 테스트")} />
@@ -217,21 +215,16 @@ describe("Toast close", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
-		// 슬라이드 아웃 setTimeout(260ms) 완료 대기
-		await act(async () => {
-			vi.advanceTimersByTime(300);
-		});
-
-		expect(screen.queryByText("닫기 테스트")).not.toBeInTheDocument();
-
-		vi.useRealTimers();
+		// spring exit 완료 후 unmount (실제 RAF 진행 대기)
+		await waitFor(
+			() => {
+				expect(screen.queryByText("닫기 테스트")).not.toBeInTheDocument();
+			},
+			{ timeout: 1500 },
+		);
 	});
 
 	it("does not double-close when close is called twice rapidly", async () => {
-		vi.useFakeTimers();
-
-		const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-
 		render(
 			<ToastProvider>
 				<ToastTrigger fn={(t) => t.success("중복 닫기")} />
@@ -241,23 +234,17 @@ describe("Toast close", () => {
 		fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
 		const closeBtn = screen.getByRole("button", { name: "Close" });
-
-		// 빠르게 두 번 클릭
+		// 빠르게 두 번 클릭 — closingRef 가 두 번째 호출 무시
 		fireEvent.click(closeBtn);
 		fireEvent.click(closeBtn);
 
-		// 260ms 지연 setTimeout은 closingRef 덕분에 한 번만 호출되어야 함
-		const removalTimeouts = timeoutSpy.mock.calls.filter(([, ms]) => ms === 260);
-		expect(removalTimeouts).toHaveLength(1);
-
-		await act(async () => {
-			vi.advanceTimersByTime(300);
-		});
-
-		expect(screen.queryByText("중복 닫기")).not.toBeInTheDocument();
-
-		timeoutSpy.mockRestore();
-		vi.useRealTimers();
+		// 결국 단 한 번만 unmount 되고 토스트 사라짐
+		await waitFor(
+			() => {
+				expect(screen.queryByText("중복 닫기")).not.toBeInTheDocument();
+			},
+			{ timeout: 1500 },
+		);
 	});
 });
 
@@ -482,9 +469,7 @@ describe("Toast auto-dismiss", () => {
 		vi.useRealTimers();
 	});
 
-	it("adds toast_item_exiting class during slide-out animation", async () => {
-		vi.useFakeTimers();
-
+	it("toast remains in DOM during spring exit then unmounts", async () => {
 		render(
 			<ToastProvider>
 				<ToastTrigger fn={(t) => t.success("exiting 상태")} />
@@ -492,26 +477,21 @@ describe("Toast auto-dismiss", () => {
 		);
 
 		fireEvent.click(screen.getByRole("button", { name: "trigger" }));
+		const item = document.querySelector(".toast_item");
+		expect(item).not.toBeNull();
 
-		const item = document.querySelector(".toast_item") as HTMLElement;
-		expect(item.className).not.toContain("toast_item_exiting");
+		fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
-		await act(async () => {
-			fireEvent.click(screen.getByRole("button", { name: "Close" }));
-		});
+		// spring exit 진행 중 — 잠시 DOM 유지
+		expect(document.querySelector(".toast_item")).not.toBeNull();
 
-		// 아직 setTimeout(260ms) 완료 전 — DOM은 유지되고 exiting 클래스만 부여됨
-		const exitingItem = document.querySelector(".toast_item") as HTMLElement | null;
-		expect(exitingItem).not.toBeNull();
-		expect(exitingItem?.className).toContain("toast_item_exiting");
-
-		await act(async () => {
-			vi.advanceTimersByTime(300);
-		});
-
-		expect(document.querySelector(".toast_item")).toBeNull();
-
-		vi.useRealTimers();
+		// spring 완료 후 unmount
+		await waitFor(
+			() => {
+				expect(document.querySelector(".toast_item")).toBeNull();
+			},
+			{ timeout: 1500 },
+		);
 	});
 });
 

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { animated } from "@react-spring/web";
 import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
-import { cn } from "../../../utils";
+import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info" | "default";
@@ -53,24 +54,31 @@ interface ToastItemComponentProps {
  * @returns 렌더링된 토스트 아이템
  */
 const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemComponentProps) => {
-	const [exiting, setExiting] = React.useState(false);
+	const [visible, setVisible] = React.useState(true);
 	const closingRef = React.useRef(false);
 
+	const style = useSpringPresence({
+		visible,
+		from: "translateX(20px)", // 우측에서 슬라이드 인
+		onExitComplete: () => onRemove(item.id),
+	});
+
 	/**
-	 * 슬라이드 아웃 애니메이션 후 토스트를 제거한다.
+	 * 슬라이드 아웃 모션 후 토스트를 제거한다 (onExitComplete 가 onRemove 호출).
 	 * @returns void
 	 */
 	const close = React.useCallback(() => {
 		if (closingRef.current) return;
 		closingRef.current = true;
-		setExiting(true);
-		setTimeout(() => onRemove(item.id), 260);
-	}, [item.id, onRemove]);
-
-	const itemClassName = cn("toast_item", exiting && "toast_item_exiting");
+		setVisible(false);
+	}, []);
 
 	return (
-		<div className={itemClassName} role={item.variant === "error" ? "alert" : "status"}>
+		<animated.div
+			className="toast_item"
+			style={style}
+			role={item.variant === "error" ? "alert" : "status"}
+		>
 			<span className={`toast_icon toast_icon_${item.variant}`} aria-hidden="true">
 				{VARIANT_ICONS[item.variant]}
 			</span>
@@ -87,7 +95,7 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 				onAnimationEnd={close}
 				aria-hidden="true"
 			/>
-		</div>
+		</animated.div>
 	);
 };
 

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -2,50 +2,8 @@
 @use "src/styles/breakpoints" as breakpoint;
 
 // ── Animations ───────────────────────────────────────────────────────────────
-
-@keyframes toast_slide_in {
-  from {
-    opacity: 0;
-    transform: translateX(calc(100% + 16px));
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-@keyframes toast_slide_out {
-  from {
-    opacity: 1;
-    transform: translateX(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateX(calc(100% + 16px));
-  }
-}
-
-@keyframes toast_slide_in_mobile {
-  from {
-    opacity: 0;
-    transform: translateY(calc(100% + 16px));
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes toast_slide_out_mobile {
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(calc(100% + 16px));
-  }
-}
+// Toast item 진입/퇴출 모션은 react-spring (useSpringPresence) 가 처리.
+// progress bar 는 CSS keyframes 로.
 
 @keyframes toast_progress {
   from { width: 100%; }
@@ -97,12 +55,7 @@
   color: token.$color_text_heading;
   line-height: token.$line_height_24;
 
-  animation: toast_slide_in token.$transition_enter_base forwards;
   will-change: transform, opacity;
-
-  &_exiting {
-    animation: toast_slide_out token.$transition_exit_base forwards;
-  }
 
   @include breakpoint.compact {
     padding: token.$spacing_8 token.$spacing_12 token.$spacing_12;
@@ -110,11 +63,6 @@
     line-height: token.$line_height_20;
     border-radius: token.$radius_md;
     box-shadow: token.$elevation_level1;
-    animation-name: toast_slide_in_mobile;
-
-    &_exiting {
-      animation-name: toast_slide_out_mobile;
-    }
   }
 }
 

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -89,7 +89,7 @@ export const Controlled: Story = {
 		return (
 			<div style={{ width: 320 }}>
 				<Dropdown {...args} value={value} onChange={setValue} />
-				<div style={{ marginTop: 8, fontSize: 12, color: "#888" }}>
+				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 					선택: <strong>{String(value)}</strong>
 				</div>
 			</div>

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -216,7 +216,10 @@ export const Dropdown = ({
 	const fieldsetClassName = cn("dropdown_fieldset", { is_open: isOpen, is_disabled: disabled });
 	const listClassName = cn("dropdown_list", { dropdown_list_up: dropUp });
 
-	// Spring presence — list 진입 모션 (Menu/Tooltip 과 동일 패턴)
+	// Spring presence — list 진입 모션 (Menu/Tooltip 과 동일 패턴, 퇴출은 즉시 unmount)
+	// Dropdown 은 빠른 선택 popup 이라 외부 클릭/Esc 가 즉시 닫혀야 자연. Modal 처럼
+	// shouldRender + onExitComplete 패턴은 spring onRest 가 sync 동작 보장 안 해
+	// 키보드 네비/선택 unit test (Esc/Enter 후 즉시 listbox 사라짐 기대) 깨짐.
 	const listStyle = useSpringPresence({
 		visible: isOpen,
 		from: dropUp ? "translateY(4px)" : "translateY(-4px)",

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -206,11 +206,13 @@ export const Dropdown = ({
 	useLayoutEffect(() => {
 		if (!isOpen || !controlRef.current) return;
 		const rect = controlRef.current.getBoundingClientRect();
-		const listHeight = Math.min(options.length * 56, 288);
 		const spaceBelow = window.innerHeight - rect.bottom;
 		const spaceAbove = rect.top;
-		setDropUp(spaceBelow < listHeight && spaceAbove > spaceBelow);
-	}, [isOpen, options.length]);
+		// dropUp 보수적 — 아래 최소 공간 (120px) 부족하고 위가 더 넓을 때만.
+		// 작은 viewport (Storybook Docs iframe 등) 에서 무분별한 dropUp 방지.
+		const MIN_BELOW = 120;
+		setDropUp(spaceBelow < MIN_BELOW && spaceAbove > spaceBelow);
+	}, [isOpen]);
 
 	const rootClassName = cn("dropdown", `dropdown_size_${size}`, className);
 	const fieldsetClassName = cn("dropdown_fieldset", { is_open: isOpen, is_disabled: disabled });

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { animated } from "@react-spring/web";
 import * as React from "react";
 import {
 	Fragment,
@@ -11,7 +12,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { cn } from "../../../utils";
+import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
 import { Check, ChevronDown } from "lucide-react";
 
@@ -215,6 +216,12 @@ export const Dropdown = ({
 	const fieldsetClassName = cn("dropdown_fieldset", { is_open: isOpen, is_disabled: disabled });
 	const listClassName = cn("dropdown_list", { dropdown_list_up: dropUp });
 
+	// Spring presence — list 진입 모션 (Menu/Tooltip 과 동일 패턴)
+	const listStyle = useSpringPresence({
+		visible: isOpen,
+		from: dropUp ? "translateY(4px)" : "translateY(-4px)",
+	});
+
 	return (
 		<div
 			ref={wrapperRef}
@@ -252,7 +259,12 @@ export const Dropdown = ({
 			</div>
 
 			{isOpen && (
-				<div id={`${dropdownId}_listbox`} role="listbox" className={listClassName}>
+				<animated.div
+					id={`${dropdownId}_listbox`}
+					role="listbox"
+					className={listClassName}
+					style={listStyle}
+				>
 					{options.map((opt, i) => {
 						const selected = currentValue === opt.value;
 						const active = i === activeIndex;
@@ -296,7 +308,7 @@ export const Dropdown = ({
 							</Fragment>
 						);
 					})}
-				</div>
+				</animated.div>
 			)}
 		</div>
 	);

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -1,15 +1,5 @@
 @use "src/styles/token" as token;
 
-@keyframes dropdown_pop_in_down {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes dropdown_pop_in_up {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
 .dropdown {
   position: relative;
   // block-level — 부모 너비 채움. 선택값/옵션 길이와 무관하게 일정한 폭 보장.
@@ -186,8 +176,6 @@
     overflow-x: hidden;
     padding: token.$spacing_4 0;
 
-    animation: dropdown_pop_in_down token.$transition_enter_fast forwards;
-    transform-origin: top center;
     will-change: transform, opacity;
 
     &_up {
@@ -195,8 +183,6 @@
       bottom: 100%;
       margin-top: 0;
       margin-bottom: token.$spacing_4;
-      animation-name: dropdown_pop_in_up;
-      transform-origin: bottom center;
     }
   }
 

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -165,11 +165,21 @@
     box-sizing: border-box;
     margin-top: token.$spacing_4;
 
-    // bg_solid_dim — dark 에서 canvas (navy_900) 보다 한 톤 밝음 → 패널 분리감
-    background: token.$color_bg_solid_dim;
+    // 라이트: 흰색 (canvas 와 동일하지만 border + shadow 로 분리)
+    // 다크: bg_solid_dim (navy_800) — canvas (navy_900) 보다 한 톤 밝아 elevation
+    background: token.$color_bg_solid;
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_lg; // 컨트롤과 동일 radius
     box-shadow: token.$elevation_level1; // 좀 더 가볍게
+
+    [data-theme="dark"] & {
+      background: token.$color_bg_solid_dim;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme]) & {
+        background: token.$color_bg_solid_dim;
+      }
+    }
 
     max-height: 18rem;
     overflow-y: auto;

--- a/src/ui/forms/file/file.stories.tsx
+++ b/src/ui/forms/file/file.stories.tsx
@@ -75,7 +75,7 @@ export const Basic: Story = {
 						console.log("files", files);
 					}}
 				/>
-				<p style={{ margin: 0, fontSize: 13, color: "#666" }}>{fileNames}</p>
+				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>{fileNames}</p>
 			</div>
 		);
 	},
@@ -137,7 +137,7 @@ export const AcceptFilter: Story = {
 					}}
 					supportingText="JPG, PNG, GIF 등 이미지 파일만 선택 가능합니다."
 				/>
-				<p style={{ margin: 0, fontSize: 13, color: "#666" }}>{fileNames}</p>
+				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>{fileNames}</p>
 			</div>
 		);
 	},

--- a/src/ui/forms/otp-input/otp-input.stories.tsx
+++ b/src/ui/forms/otp-input/otp-input.stories.tsx
@@ -65,7 +65,7 @@ export const Controlled: Story = {
 					supportingText="인증 코드를 입력하세요"
 					autoFocus
 				/>
-				<p style={{ margin: 0, fontSize: 13, color: "#666" }}>입력된 값: "{val}"</p>
+				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>입력된 값: "{val}"</p>
 			</div>
 		);
 	},
@@ -82,11 +82,11 @@ export const Lengths: Story = {
 		return (
 			<div style={{ display: "grid", gap: 24, padding: 20 }}>
 				<div>
-					<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>4자리</p>
+					<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>4자리</p>
 					<OtpInput length={4} value={val4} onChange={setVal4} supportingText="4자리 코드" />
 				</div>
 				<div>
-					<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>6자리</p>
+					<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>6자리</p>
 					<OtpInput length={6} value={val6} onChange={setVal6} supportingText="6자리 코드" />
 				</div>
 			</div>
@@ -101,15 +101,15 @@ export const States: Story = {
 	render: () => (
 		<div style={{ display: "grid", gap: 24, padding: 20 }}>
 			<div>
-				<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>기본</p>
+				<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>기본</p>
 				<OtpInput length={6} value="123456" supportingText="Supporting text" />
 			</div>
 			<div>
-				<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>에러</p>
+				<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>에러</p>
 				<OtpInput length={6} value="123456" error supportingText="인증 코드가 올바르지 않습니다" />
 			</div>
 			<div>
-				<p style={{ margin: "0 0 8px", fontSize: 13, color: "#666" }}>비활성화</p>
+				<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>비활성화</p>
 				<OtpInput length={6} disabled supportingText="Supporting text" />
 			</div>
 		</div>

--- a/src/ui/forms/toggle/toggle.stories.tsx
+++ b/src/ui/forms/toggle/toggle.stories.tsx
@@ -58,10 +58,10 @@ export const Controlled: Story = {
 						onChange={setIsOn}
 						ariaLabel="토글"
 					/>
-					<span style={{ fontSize: 14, color: "#666" }}>현재 상태: {isOn ? "ON" : "OFF"}</span>
+					<span style={{ fontSize: 14, color: "var(--bt-color-text-body)" }}>현재 상태: {isOn ? "ON" : "OFF"}</span>
 				</div>
 
-				<p style={{ margin: 0, fontSize: 13, color: "#666", lineHeight: 1.5 }}>
+				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)", lineHeight: 1.5 }}>
 					이 예시는 Toggle의 상태가 화면의 텍스트와 항상 동일하게 유지되는 형태입니다.
 					<br />
 					(실서비스에서는 이 방식이 가장 안전합니다)
@@ -78,7 +78,7 @@ export const Uncontrolled: Story = {
 	render: ({ size, disabled }) => (
 		<div style={{ display: "grid", gap: 10, padding: 20 }}>
 			<Toggle size={size} disabled={disabled} defaultChecked ariaLabel="토글" />
-			<p style={{ margin: 0, fontSize: 13, color: "#666", lineHeight: 1.5 }}>
+			<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)", lineHeight: 1.5 }}>
 				이 예시는 처음에만 ON으로 시작하고, 이후에는 컴포넌트 내부에서 켜짐/꺼짐을 관리합니다.
 			</p>
 		</div>
@@ -91,12 +91,12 @@ export const Sizes: Story = {
 		<div style={{ display: "grid", gap: 10, padding: 20 }}>
 			<div style={{ display: "flex", gap: 12, alignItems: "center" }}>
 				<Toggle size="sm" defaultChecked ariaLabel="sm 토글" />
-				<span style={{ fontSize: 13, color: "#666" }}>sm (기본)</span>
+				<span style={{ fontSize: 13, color: "var(--bt-color-text-body)" }}>sm (기본)</span>
 			</div>
 
 			<div style={{ display: "flex", gap: 12, alignItems: "center" }}>
 				<Toggle size="md" defaultChecked ariaLabel="md 토글" />
-				<span style={{ fontSize: 13, color: "#666" }}>md</span>
+				<span style={{ fontSize: 13, color: "var(--bt-color-text-body)" }}>md</span>
 			</div>
 		</div>
 	),
@@ -107,7 +107,7 @@ export const Disabled: Story = {
 	render: () => (
 		<div style={{ display: "grid", gap: 10, padding: 20 }}>
 			<Toggle disabled defaultChecked ariaLabel="토글" />
-			<p style={{ margin: 0, fontSize: 13, color: "#666", lineHeight: 1.5 }}>
+			<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)", lineHeight: 1.5 }}>
 				비활성화 상태에서는 토글을 눌러도 상태가 바뀌지 않습니다.
 			</p>
 		</div>

--- a/src/ui/layout/container/container.stories.tsx
+++ b/src/ui/layout/container/container.stories.tsx
@@ -53,7 +53,7 @@ const Box = ({ label, bg = "#E5F0FF" }: { label: string; bg?: string }) => (
 			borderRadius: "8px",
 			fontSize: "14px",
 			fontWeight: 600,
-			color: "#303841",
+			color: "var(--bt-color-text-heading)",
 			textAlign: "center",
 		}}
 	>
@@ -86,7 +86,7 @@ export const Sizes: Story = {
 export const WithSection: Story = {
 	name: "Section 내부 사용",
 	render: () => (
-		<div style={{ background: "#F2F5F8", padding: "48px 0" }}>
+		<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: "48px 0" }}>
 			<Container size="lg">
 				<Box label="Container inside Section" bg="#fff" />
 			</Container>

--- a/src/ui/layout/grid/grid.stories.tsx
+++ b/src/ui/layout/grid/grid.stories.tsx
@@ -24,14 +24,14 @@ type Story = StoryObj<typeof Grid>;
 const Card = ({ label }: { label: string }) => (
 	<div
 		style={{
-			background: "#F2F5F8",
+			background: "var(--bt-color-bg-solid-dim)",
 			border: "1px solid #DDE3E9",
 			borderRadius: 8,
 			padding: "24px 16px",
 			textAlign: "center",
 			fontSize: 13,
 			fontWeight: 600,
-			color: "#47555E",
+			color: "var(--bt-color-text-body)",
 		}}
 	>
 		{label}
@@ -66,7 +66,7 @@ export const ColVariants: Story = {
 		<div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
 			{([1, 2, 3, 4] as const).map((cols) => (
 				<div key={cols}>
-					<p style={{ margin: "0 0 8px", fontSize: 12, color: "#888", fontWeight: 600 }}>
+					<p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--bt-color-text-caption)", fontWeight: 600 }}>
 						cols={cols}
 					</p>
 					<Grid cols={cols} gap={12}>

--- a/src/ui/layout/stack/stack.stories.tsx
+++ b/src/ui/layout/stack/stack.stories.tsx
@@ -39,14 +39,14 @@ const Item = ({ label, w = 80, h = 48 }: { label: string; w?: number; h?: number
 		style={{
 			width: w,
 			height: h,
-			background: "#DDE3E9",
+			background: "var(--bt-color-bg-solid-dim)",
 			borderRadius: 6,
 			display: "flex",
 			alignItems: "center",
 			justifyContent: "center",
 			fontSize: 12,
 			fontWeight: 600,
-			color: "#47555E",
+			color: "var(--bt-color-text-body)",
 			flexShrink: 0,
 		}}
 	>
@@ -69,7 +69,7 @@ export const GapScale: Story = {
 		<Stack gap={32}>
 			{([4, 8, 16, 24, 32] as const).map((gap) => (
 				<div key={gap}>
-					<p style={{ margin: "0 0 8px", fontSize: 12, color: "#888" }}>gap={gap}</p>
+					<p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--bt-color-text-caption)" }}>gap={gap}</p>
 					<Stack direction="horizontal" gap={gap} align="center">
 						<Item label="1" />
 						<Item label="2" />

--- a/src/ui/navigation/menu/style.scss
+++ b/src/ui/navigation/menu/style.scss
@@ -10,13 +10,22 @@
   top: calc(100% + 4px);
   z-index: token.$z_level5;
   min-width: 180px;
-  // bg_solid_dim — light=거의 흰색 / dark=navy_800 (canvas navy_900 보다 한 톤 밝음 → 메뉴 panel 시각 분리)
-  background: token.$color_bg_solid_dim;
+  // 라이트: 흰색 / 다크: bg_solid_dim (navy_800, canvas 보다 한 톤 밝음 → elevation)
+  background: token.$color_bg_solid;
   border: token.$border_width_standard solid token.$color_border_default;
   border-radius: token.$radius_lg;
   box-shadow: token.$elevation_level2;
   padding: token.$spacing_4 0;
   will-change: transform, opacity;
+
+  [data-theme="dark"] & {
+    background: token.$color_bg_solid_dim;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) & {
+      background: token.$color_bg_solid_dim;
+    }
+  }
 
   &_align_start { left: 0; }
   &_align_end   { right: 0; }

--- a/src/ui/navigation/sidebar/sidebar.stories.tsx
+++ b/src/ui/navigation/sidebar/sidebar.stories.tsx
@@ -71,8 +71,8 @@ function ProfileFooter({ collapsed = false }: { collapsed?: boolean }) {
 					width: 32,
 					height: 32,
 					borderRadius: 999,
-					background: "#e5e5e5",
-					color: "#121212",
+					background: "var(--bt-color-bg-solid-dim)",
+					color: "var(--bt-color-text-heading)",
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "center",
@@ -85,7 +85,7 @@ function ProfileFooter({ collapsed = false }: { collapsed?: boolean }) {
 			{!collapsed && (
 				<div style={{ display: "grid", gap: 2, fontSize: 13, minWidth: 0 }}>
 					<strong>sangmin</strong>
-					<span style={{ color: "#666", fontSize: 11 }}>sangmin@bigtablet.com</span>
+					<span style={{ color: "var(--bt-color-text-body)", fontSize: 11 }}>sangmin@bigtablet.com</span>
 				</div>
 			)}
 		</div>
@@ -96,7 +96,7 @@ function FullDemo({ defaultCollapsed = false }: { defaultCollapsed?: boolean }) 
 	const [active, setActive] = React.useState("home");
 	const [collapsed, setCollapsed] = React.useState(defaultCollapsed);
 	return (
-		<div style={{ display: "flex", minHeight: 480, background: "#f4f4f4" }}>
+		<div style={{ display: "flex", minHeight: 480, background: "var(--bt-color-bg-solid-dim)" }}>
 			<Sidebar
 				header={<BrandHeader />}
 				headerCollapsed={<FaviconHeader />}
@@ -132,7 +132,7 @@ function FullDemo({ defaultCollapsed = false }: { defaultCollapsed?: boolean }) 
 			</Sidebar>
 			<main style={{ flex: 1, padding: 32 }}>
 				<h2 style={{ margin: 0 }}>{SAMPLE_ITEMS.find((i) => i.key === active)?.label}</h2>
-				<p style={{ color: "#666" }}>현재 활성 페이지의 콘텐츠 영역.</p>
+				<p style={{ color: "var(--bt-color-text-body)" }}>현재 활성 페이지의 콘텐츠 영역.</p>
 			</main>
 		</div>
 	);

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { animated, useSpring } from "@react-spring/web";
 import { X } from "lucide-react";
 import * as React from "react";
 import { cn, useFocusTrap } from "../../../utils";
@@ -34,7 +35,7 @@ export interface ModalProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "
 
 /**
  * 모달을 렌더링한다.
- * 포커스 트랩과 스크롤 잠금을 적용하고, 열림 상태에 따라 오버레이/패널을 구성한다.
+ * react-spring 기반 진입/퇴출 모션 + 포커스 트랩 + 바디 스크롤 잠금.
  * @param props 모달 속성
  * @returns 열림 상태일 때 렌더링된 모달, 닫힘 상태면 null
  */
@@ -57,34 +58,37 @@ export const Modal = ({
 	const panelRef = React.useRef<HTMLDivElement>(null);
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
-	const [isExiting, setIsExiting] = React.useState(false);
-	const wasOpenRef = React.useRef(open);
 
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
 
-	/**
-	 * Escape 키 입력 시 닫기 동작을 처리한다.
-	 * @param e 키보드 이벤트
-	 * @returns void
-	 */
+	// 진입 시 마운트 보장
+	React.useEffect(() => {
+		if (open) setShouldRender(true);
+	}, [open]);
+
+	// Spring: overlay (opacity) — onRest 로 exit 완료 후 unmount
+	const overlayStyle = useSpring({
+		opacity: open ? 1 : 0,
+		config: { tension: 280, friction: 28, clamp: !open },
+		onRest: (result) => {
+			if (!open && result.finished) setShouldRender(false);
+		},
+	});
+
+	// Spring: panel (opacity + scale + translateY)
+	const panelStyle = useSpring({
+		opacity: open ? 1 : 0,
+		transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		config: { tension: 280, friction: 28, clamp: !open },
+	});
+
 	const handleEscape = React.useEffectEvent((e: KeyboardEvent) => {
 		if (e.key === "Escape") onClose?.();
 	});
 
 	React.useEffect(() => {
-		if (open) {
-			setShouldRender(true);
-			setIsExiting(false);
-		} else if (wasOpenRef.current) {
-			setIsExiting(true);
-		}
-		wasOpenRef.current = open;
-	}, [open]);
-
-	React.useEffect(() => {
 		if (!open) return;
-
 		document.addEventListener("keydown", handleEscape);
 		return () => document.removeEventListener("keydown", handleEscape);
 	}, [open]);
@@ -119,13 +123,12 @@ export const Modal = ({
 
 	if (!shouldRender) return null;
 
-	const panelClassName = cn("modal_panel", className);
 	const hasTitle = !!title;
-	const rootClassName = cn("modal", isExiting && "modal_exiting");
 
 	return (
-		<div
-			className={rootClassName}
+		<animated.div
+			className="modal"
+			style={overlayStyle}
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
@@ -135,20 +138,14 @@ export const Modal = ({
 				if (e.key === "Escape") onClose?.();
 			}}
 		>
-			<div
+			<animated.div
 				ref={panelRef}
-				className={panelClassName}
-				style={{ width }}
+				className={cn("modal_panel", className)}
+				style={{ ...panelStyle, width }}
 				role="document"
 				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
-				}}
-				onAnimationEnd={(e) => {
-					if (isExiting && e.target === e.currentTarget) {
-						setShouldRender(false);
-						setIsExiting(false);
-					}
 				}}
 				{...props}
 			>
@@ -172,7 +169,7 @@ export const Modal = ({
 				{footer && (
 					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>{footer}</div>
 				)}
-			</div>
-		</div>
+			</animated.div>
+		</animated.div>
 	);
 };

--- a/src/ui/overlay/modal/style.scss
+++ b/src/ui/overlay/modal/style.scss
@@ -1,25 +1,5 @@
 @use "src/styles/token" as token;
 
-@keyframes modal_overlay_in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-@keyframes modal_overlay_out {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-
-@keyframes modal_panel_in {
-  from { opacity: 0; transform: scale(0.96) translateY(-4px); }
-  to   { opacity: 1; transform: scale(1) translateY(0); }
-}
-
-@keyframes modal_panel_out {
-  from { opacity: 1; transform: scale(1) translateY(0); }
-  to   { opacity: 0; transform: scale(0.98) translateY(2px); }
-}
-
 .modal {
   position: fixed;
   top: 0; right: 0; bottom: 0; left: 0;
@@ -27,7 +7,7 @@
   place-items: center;
   background: token.$color_bg_overlay;
   z-index: token.$z_level2;
-  animation: modal_overlay_in token.$transition_enter_base forwards;
+  will-change: opacity;
 
   &_panel {
     position: relative; // close button 의 absolute 기준
@@ -40,7 +20,6 @@
     max-width: calc(100% - #{token.$spacing_32 * 2});
     padding: token.$spacing_24;
     overflow: visible;
-    animation: modal_panel_in token.$transition_enter_base forwards;
     will-change: transform, opacity;
 
     @include token.from_medium {
@@ -120,11 +99,4 @@
     &_start   { justify-content: flex-start; }
   }
 
-  &_exiting {
-    animation: modal_overlay_out token.$transition_exit_fast forwards;
-
-    .modal_panel {
-      animation: modal_panel_out token.$transition_exit_fast forwards;
-    }
-  }
 }

--- a/src/ui/overlay/tooltip/style.scss
+++ b/src/ui/overlay/tooltip/style.scss
@@ -2,7 +2,8 @@
 
 .tooltip_wrapper {
   position: relative;
-  display: inline-flex;
+  display: inline-block;
+  vertical-align: middle; // baseline 정렬로 인한 미세 offset 제거
 }
 
 // 위치 정렬 wrapper — placement 별 translateX/Y 로 trigger 기준 중앙 잡음.
@@ -11,7 +12,8 @@
   position: absolute;
   z-index: token.$z_level5;
   pointer-events: none;
-  display: inline-block;
+  display: block;
+  width: max-content; // 내부 .tooltip 의 max-content 와 일치 — translateX(-50%) 정확
 
   &.tooltip_placement_top {
     bottom: calc(100% + 6px);
@@ -39,7 +41,7 @@
 }
 
 .tooltip {
-  display: inline-block;
+  display: block; // 정렬 quirk 제거
   background: token.$color_accent_strong;
   color: token.$color_accent_on_surface;
   padding: 6px 10px;
@@ -47,11 +49,13 @@
   font-size: 12px;
   line-height: 1.4;
   font-weight: token.$font_weight_medium;
-  // 긴 텍스트는 wrap 허용 — max-width 안에서 줄바꿈
+  // 긴 텍스트 wrap 허용 + 다중 라인 중앙 정렬
   white-space: normal;
   overflow-wrap: break-word;
-  word-break: keep-all; // 한글 단어 단위 줄바꿈 (어절 보존)
+  word-break: keep-all; // 한글 어절 단위 줄바꿈
+  text-align: center;
   box-shadow: token.$elevation_level2;
+  width: max-content; // 짧은 텍스트는 폭 자동, 긴 텍스트는 max-width 까지
   max-width: 240px;
   will-change: transform, opacity;
 }

--- a/src/utils/use-spring-presence.ts
+++ b/src/utils/use-spring-presence.ts
@@ -15,11 +15,14 @@ import { useSpring } from "@react-spring/web";
 export function useSpringPresence({
 	visible,
 	from = "translateY(8px)",
+	onExitComplete,
 }: {
 	/** 보이는 상태인지 — false면 사라짐 모션 */
 	visible: boolean;
 	/** 진입 시 시작 transform (기본: 아래에서 살짝 올라옴) */
 	from?: string;
+	/** exit 모션 완료 시 호출 — 부모에서 unmount 트리거용 */
+	onExitComplete?: () => void;
 }) {
 	return useSpring({
 		from: { opacity: 0, transform: from },
@@ -31,6 +34,11 @@ export function useSpringPresence({
 			tension: 280, // Vercel 식 부드러운 spring
 			friction: 28,
 			clamp: !visible, // 사라질 땐 진동 없이 빠르게
+		},
+		onRest: (result) => {
+			if (!visible && result.finished && onExitComplete) {
+				onExitComplete();
+			}
 		},
 	});
 }


### PR DESCRIPTION
## 작업 개요

closes #261

다크 모드 가독성 + react-spring 진입/퇴출 통일.

## 작업한 내용

### 다크 모드 가독성
- [x] cookbook (data/form/feedback/layout) + getting-started/introduction + 컴포넌트 스토리 ~20 파일의 하드코드 색을 theme token 으로 swap
  - `#121212/#888/#444` → `text-heading/text-caption/text-body`
  - `#fff/#F2F5F8/#fafafa` → `bg-solid/bg-solid-dim`
  - `#e5e5e5/#E5E7EB` → `border-default`
  - status 의미 색 → `status-success/warning/error` + `color-mix` light 변형
- [x] ThemeProvider 데모 Dark 토글 버튼 — `color: #fff` (하드코드) → `accent-on-surface` (반전 토큰) — 다크에서 흰 bg 위 흰 텍스트 invisible 문제 해결

### 레이아웃 패턴 정리
- [x] `EmptyStatePattern` (cookbook) — 2-card grid + outline/filled 페어 → 단일 풀-페이지 "검색 결과 없음" 패턴
- [x] `SidebarLayout` (cookbook) + `AdminDashboard` (examples) — 로고 height 20→28 + Profile footer 추가. Sidebar 컴포넌트 스토리와 시각 일관

### react-spring 진입/퇴출 통일
- [x] `useSpringPresence`: `onExitComplete` 콜백 추가 — exit 완료 시 부모 unmount 트리거
- [x] Test setup: `Globals.assign({ skipAnimation: true })` — jsdom 에서 spring 즉시 settle (RAF 없이 onRest 동작)
- [x] **Modal**: CSS @keyframes 4개 + isExiting/wasOpenRef + onAnimationEnd 패턴 → 2 useSpring (overlay + panel) + onRest unmount
- [x] **Alert**: 동일 패턴으로 Modal 과 동일 spring 페어
- [x] **Dropdown**: dropdown_pop_in_down/up keyframes → useSpringPresence (dropUp 따라 from transform 분기)
- [x] **Toast**: exiting state + setTimeout(260) + slide keyframes → useSpringPresence + onExitComplete → onRemove. closingRef 그대로 (double-close 가드)
- [x] 무한 loop animation (Skeleton/Spinner/TopLoading) 은 CSS 유지 (spring 부적합)

### 시각 변화 없는 사용처
- Tests: Alert/Toast 테스트는 클래스 검사 → 마운트/언마운트 상태 검사로 변경. spring skipAnimation 으로 동기적 동작

## 전달할 추가 이슈

- 무한 loop animation (Spinner/Skeleton/TopLoading) 의 spring 마이그레이션은 의도적 제외 — CSS 가 더 적합
- `useSpringHover` hook 은 정의만 있고 미사용 — 후속에서 적용 또는 제거 검토