### PR TITLE
fix/chromatic-dependabot

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -30,8 +30,9 @@ on:
 
 jobs:
   # ── develop / PR: 시각적 리뷰용 (변경사항 비교) ──────────────────────
+  # dependabot PR 은 secrets 접근 불가 — Chromatic 토큰 없어 skip
   review:
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 작업 개요

Dependabot PR (#263~266) 에서 Chromatic review job 이 `Missing project token` 으로 실패. 원인: GitHub Actions secrets 는 dependabot context 에 노출되지 않음.

## 작업한 내용

- [x] storybook.yml review job 에 `github.actor != 'dependabot[bot]'` 조건 추가 — dependabot PR 에선 Chromatic skip
- [x] develop / 일반 PR 은 그대로 review 실행 (변경 사항 비교)
- [x] main 은 publish job 그대로 (autoAcceptChanges)

## 전달할 추가 이슈

- 의존성 bump 가 시각 변화 일으킬 가능성 있는 케이스 (e.g. major Storybook/React 버전 업) 는 dependabot 머지 직후 develop push trigger 로 Chromatic 다시 돌아감 — 그때 검출 가능