### PR TITLE
merge: release

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -26,6 +26,25 @@
         "Segoe UI Symbol", sans-serif;
     }
 
+    /* Reset Storybook iframe 의 기본 body margin/padding —
+       `position: fixed; bottom: 0` 컴포넌트 (BottomNav, Modal overlay 등) 가
+       iframe viewport edge 까지 정확히 도달하도록. */
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    /* Storybook fullscreen 레이아웃의 root 도 padding/margin 제거 —
+       container 가 fixed positioning context 만들지 않도록. */
+    .sb-show-main.sb-main-fullscreen {
+        padding: 0 !important;
+    }
+    #storybook-root,
+    .sb-show-main #storybook-root {
+        padding: 0;
+        margin: 0;
+    }
+
     /* Dark mode: body background & text follow CSS custom properties */
     body {
         background-color: var(--bt-color-bg-solid, #ffffff);

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,0 +1,516 @@
+# Bigtablet Design System — Agent Guide
+
+> Prompt-ready reference for AI coding agents building UIs with `@bigtablet/design-system@^3.0.0`. Load this file as context before generating any component code.
+
+**Version:** 3.0.0
+**React:** 19+ required
+**Bundle:** Pure React (`@bigtablet/design-system`) or Vanilla JS (`@bigtablet/design-system/vanilla`)
+
+---
+
+## Philosophy
+
+- **Token-first.** Never hardcode colors, spacing, radius, or shadows. Always reference tokens.
+- **Dark mode is mandatory.** Every UI must work in both themes. Tokens auto-flip via `[data-theme="dark"]` or `prefers-color-scheme`.
+- **Components compose.** Build pages from `Container > Section > Stack/Grid > primitives`. Don't reach for raw `<div>` styling.
+- **Accessibility is non-negotiable.** Buttons need labels, modals trap focus, interactive elements have `:focus-visible` rings.
+
+---
+
+## Install & Bootstrap
+
+```bash
+pnpm add @bigtablet/design-system react@^19 react-dom@^19 lucide-react
+```
+
+```tsx
+// app entry — providers wrap the tree once
+import {
+  ThemeProvider,
+  AlertProvider,
+  ToastProvider,
+} from "@bigtablet/design-system";
+import "@bigtablet/design-system/style.css";
+
+export default function RootLayout({ children }) {
+  return (
+    <ThemeProvider defaultMode="system">
+      <AlertProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </AlertProvider>
+    </ThemeProvider>
+  );
+}
+```
+
+Providers needed:
+- `ThemeProvider` — required for runtime dark mode toggle via `useTheme()`. If you only need OS-preference-based dark mode, you can omit it (CSS handles it).
+- `AlertProvider` — required for `useAlert()` confirmation dialogs.
+- `ToastProvider` — required for `useToast()` snackbar notifications.
+
+---
+
+## Design Tokens
+
+All tokens are CSS custom properties prefixed with `--bt-color-*`, `--bt-spacing-*`, etc. Always reference them — never inline a hex value.
+
+### Color tokens
+
+| Token | Light | Dark | When to use |
+|-------|-------|------|-------------|
+| `--bt-color-bg-solid` | white | navy_900 | Page/card background |
+| `--bt-color-bg-solid-dim` | neutral_50 | navy_800 | Elevated surface (panels, dimmed sections) |
+| `--bt-color-text-heading` | neutral_900 | white | Primary headings, body emphasis |
+| `--bt-color-text-body` | neutral_700 | navy_200 | Body text, descriptions |
+| `--bt-color-text-caption` | neutral_500 | neutral_400 | Captions, helper text, placeholders |
+| `--bt-color-border-default` | neutral_200 | navy_700 | Card borders, dividers |
+| `--bt-color-border-hover` | neutral_400 | navy_400 | Hover state borders |
+| `--bt-color-brand-primary` | #121212 | #121212 (same) | Button "filled" bg (intentional, both themes) |
+| `--bt-color-brand-on-primary` | white | white (same) | Text on `brand-primary` |
+| `--bt-color-accent-default` | #121212 | white | Indicators that flip in dark (checked checkboxes, active progress) |
+| `--bt-color-accent-on-surface` | white | #121212 | Text/icon on top of `accent-default` |
+| `--bt-color-status-success` | green | green (same) | Success states |
+| `--bt-color-status-warning` | amber | amber (same) | Warning states |
+| `--bt-color-status-error` | red | red (same) | Error states, destructive actions |
+| `--bt-color-status-info` | blue | blue (same) | Informational states |
+| `--bt-color-state-hover-on-light` | alpha black 5% | alpha white 8% | Hover overlay on light/elevated surface |
+| `--bt-color-state-focus-on-light` | alpha black 8% | alpha white 12% | Focus overlay |
+| `--bt-color-state-pressed-on-light` | alpha black 12% | alpha white 12% | Pressed overlay |
+
+**Key distinction:** `brand-primary` stays dark in both themes (for Button filled). `accent-default` FLIPS to white in dark mode (for indicators that need contrast against page bg). Pick the right one for the context.
+
+### Spacing
+
+`--bt-spacing-4` (4px) through `--bt-spacing-48` (48px). Standard scale: 4, 8, 12, 16, 20, 24, 32, 40, 48.
+
+### Radius
+
+`--bt-radius-xs` (2px), `-sm` (6px), `-md` (8px), `-lg` (12px), `-xl` (16px), `-full` (9999px).
+
+### Elevation
+
+`--bt-elevation-level1` through `-level5`. Light = subtle dark drops. Dark = stronger blacks with larger spread for visibility on navy.
+
+### Motion
+
+```scss
+$transition_fast    // 0.1s ease-in-out — color/border micro-changes
+$transition_base    // 0.2s ease-in-out — bg/transform normal interactions
+$transition_slow    // 0.3s ease-in-out — panel expansion
+```
+
+Easing pair for entrance/exit:
+- `$easing_enter` — `cubic-bezier(0.16, 1, 0.3, 1)` (out-expo)
+- `$easing_exit` — `cubic-bezier(0.4, 0, 1, 1)` (ease-in)
+
+Composite shorthands `$transition_enter_*` / `$transition_exit_*` already include easing — do NOT add another easing or CSS parse fails.
+
+### Inline style usage
+
+```tsx
+// ✓ Correct
+<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: "var(--bt-spacing-16)" }} />
+
+// ✗ Never
+<div style={{ background: "#F2F5F8", padding: 16 }} />
+```
+
+---
+
+## Dark Mode Rules
+
+1. **Trigger:** `[data-theme="dark"]` attribute on `<html>` (via `ThemeProvider`) OR system `prefers-color-scheme: dark`. Both work automatically.
+
+2. **Use adaptive tokens for theme-aware UI.** Most tokens auto-flip. Hardcoded hex breaks dark mode.
+
+3. **Indicator color rule:**
+   - If element must be **black in light AND dark** (e.g., filled button bg) → `brand-primary`
+   - If element should be **black in light, white in dark** (e.g., checkbox checked bg) → `accent-default`
+   - Pair `accent-default` with `accent-on-surface` for the foreground (auto-inverts)
+
+4. **Panel elevation in dark mode:**
+   - Page bg: `bg-solid` (navy_900)
+   - Elevated panel (dropdown, menu, modal): use the conditional pattern below
+
+   ```scss
+   .my-panel {
+     background: var(--bt-color-bg-solid);  // white in light
+
+     [data-theme="dark"] & {
+       background: var(--bt-color-bg-solid-dim);  // navy_800 (lighter than canvas)
+     }
+     @media (prefers-color-scheme: dark) {
+       :root:not([data-theme]) & {
+         background: var(--bt-color-bg-solid-dim);
+       }
+     }
+   }
+   ```
+
+5. **Hardcoded whites/darks are allowed for intentional fixed surfaces:**
+   - Navy gradient avatars (decorative, brand-colored)
+   - Hero `_overlay_navy` (always dark gradient)
+   - Tooltip body (`accent-strong` token already handles theme)
+   - Destructive red modal buttons
+
+   Everything else: tokens.
+
+6. **`color-scheme: dark`** is already set on `[data-theme="dark"]` root — browser native UI (scrollbars, form controls) adapts automatically.
+
+---
+
+## Component Catalog
+
+Organized by category. **Always** import from the package root (`@bigtablet/design-system`), never deep paths.
+
+### Forms
+
+| Component | Purpose | Key props |
+|-----------|---------|-----------|
+| `Button` | Primary action button. | `variant` (filled/outline/tonal/text), `size` (sm/md/lg/xl), `danger`, `radius`, `leadingIcon`, `trailingIcon`, `fullWidth` |
+| `IconButton` | Icon-only button. | `variant` (standard/filled/tonal/outlined), `size` (sm/md), `icon`, `aria-label` (required) |
+| `TextField` | Text input with label. | `label`, `placeholder`, `supportingText`, `error`, `size`, `variant` (outline/filled), `leadingIcon`, `clearable` |
+| `Checkbox` | Boolean selection. | `checked`, `indeterminate`, `disabled`, `error`, `label` |
+| `Radio` | Single from group. | Inside a `<fieldset>` for grouping. `value`, `checked`, `name` |
+| `Toggle` | On/off switch. | `checked`, `size` (sm/md), `disabled` |
+| `Dropdown` | Value-selection menu. | `options`, `value`, `onChange`, `label`, `supportingText`, `placeholder`, `size`. Block-level — fills parent. |
+| `DatePicker` | Year/month/day select. | `value`, `onChange`, `mode` (year-month/year-month-day), `min`, `max`, `fullWidth` |
+| `FileInput` | File upload. | `variant` (button/preview), `multiple`, `accept`, `onFiles`, `previewSize` (for preview variant), `disabled` |
+| `OTPInput` | Single-digit code boxes. | `length`, `value`, `onChange`, `autoFocus`, `error` |
+
+### Display
+
+| Component | Purpose | Key props |
+|-----------|---------|-----------|
+| `Card` | Generic container. | `bordered`, `shadow` (none/sm/md/lg), `padding` (none/sm/md/lg), `variant` (default/accent) |
+| `MediaCard` | Image + content card. | `heading`, `eyebrow`, `description`, `media` (URL), `clickable`, `shadow` |
+| `Hero` | Page-top hero section. | `title`, `subtitle`, `eyebrow`, `backgroundImage`, `overlay` (dark/light/navy), `height` (sm/md/lg/full), `align`, `textColor` (auto/inverse/default), `primaryAction`, `secondaryAction` |
+| `Avatar` | User profile circle. | `name` (initials fallback), `src`, `size` (sm/md/lg), `shape` (circle/square) |
+| `Badge` | Number/status pill. | `shape` (dot/count/label), `variant` (default/accent/danger/success/warning/info), `count` |
+| `Chip` | Tag/category pill. | `type` (interactive/static), `tone` (default/accent/info/success/warning/error — static only), `size` (sm/md), `selected`, `removable`, `leadingIcon` |
+| `ListItem` | Single row in a list. | `label`, `overline`, `supportingText`, `metadata`, `leadingElement`, `trailingElement`, `alignment` (auto-detects OneLine → middle), `onClick`, `selected` |
+| `Table` | Data table. | `columns`, `data`, `keyExtractor`, `size` (sm/md/lg), `isLoading`, `stickyHeader`, `onRowClick`, `emptyMessage`. Clickable rows get keyboard support automatically. |
+| `Divider` | Horizontal/vertical line. | `orientation` |
+| `Icon` | Lucide icon wrapper. | `icon` (lucide-react component), `size`, `strokeWidth`, `aria-label` |
+| `Accordion` | Expandable disclosure. | `items` array with `id`/`trigger`/`content`. Hover bg works in any open state. |
+
+### Feedback
+
+| Component | Purpose | Key props |
+|-----------|---------|-----------|
+| `Alert` (via `useAlert`) | Confirm/alert dialog. | `showAlert({ title, message, variant, showCancel, destructive, onConfirm, onCancel })` |
+| `Toast` (via `useToast`) | Transient notification. | `toast.success("...")` / `.error(...)` / `.warning(...)` / `.info(...)` / `.message(...)`. Second arg = duration ms. |
+| `Spinner` | Inline loading indicator. | `size` (px), `ariaLabel`. Vercel-style 12-bar fade. |
+| `TopLoading` | Top-of-page progress bar. | `progress` (0-100, or undefined for indeterminate), `height`, `color`, `isLoading`, `ariaLabel` |
+| `LinearProgress` | Step progress with dots. | `totalSteps`, `currentStep`, `aria-label`. Renders N+1 checkpoints. |
+| `Skeleton` | Loading placeholder. | `variant` (text/title/avatar/rect), `width`, `height`, `radius` |
+| `EmptyState` | "Nothing here" block. | `illustration`, `title`, `description`, `action`, `size` (sm/md/lg). Vertically centers when parent is flex column. |
+
+### Navigation
+
+| Component | Purpose | Key props |
+|-----------|---------|-----------|
+| `Tabs` | Compound tab pattern. | Wrap `Tab` items in `TabList`; render content via `TabPanel`. `defaultValue` (uncontrolled), `value`/`onValueChange` (controlled). Variants `line` (default) / `fills`. |
+| `Sidebar` | Admin left nav. | `header`, `headerCollapsed` (collapse crossfade), `footer`, `collapsed`, `collapsible`, `collapsedWidth`. Children = `SidebarSection` + `SidebarItem`. |
+| `NavBar` | Top nav. | `brand`, `actions`, `variant` (default/transparent/accent), `layout` (contained/fluid). Children = `NavLink`. Sliding active indicator built in. |
+| `Breadcrumb` | Page path nav. | `items` array (`label`, `href`, `current`). |
+| `Menu` | Action menu (context/kebab). | `trigger` element, `items` (key/label/icon/onSelect/destructive/disabled), `align` (start/end). Trigger components MUST forward props (`<button {...props}>`). |
+| `Pagination` | Page number nav. | `page`, `pageCount`, `onChange`, `siblingCount`. Cursor pointer baked in. |
+
+### Overlay
+
+| Component | Purpose | Key props |
+|-----------|---------|-----------|
+| `Modal` | Centered dialog. | `open`, `onClose`, `title`, `description`, `footer`, `footerAlign` (end/between/start), `showCloseIcon` (default true), `width`, `closeOnOverlay`. X close icon top-right by default. |
+| `Tooltip` | Hover info. | `content`, `placement` (top/bottom/left/right), `delay`, `disabled`. Children = single trigger element. Long text wraps with `text-align: center`, max-width 240px. |
+
+### Layout
+
+| Component | Purpose | Key props |
+|-----------|---------|-----------|
+| `Container` | Centered max-width wrapper. | `size` (sm/md/lg/xl/full), `padding` |
+| `Section` | Page section with vertical rhythm. | `spacing` (xs/sm/md/lg/xl), `bg` (default/dim/accent/navy/transparent) |
+| `Stack` | 1D flex layout. | `direction` (horizontal/vertical), `gap`, `align`, `justify`, `wrap` |
+| `Grid` | CSS Grid layout. | `cols` (number or "auto"), `gap`, `minColWidth` (when `cols="auto"`) |
+
+### Foundation
+
+- `ThemeProvider` — wraps app for runtime theme control. `defaultMode` (light/dark/system).
+- `useTheme()` — returns `{ mode, setMode, resolvedMode }`.
+
+---
+
+## Animation
+
+**All entrance/exit animations on overlays use `react-spring`.** Don't reach for CSS keyframes.
+
+### Built-in motion (just use the components)
+- Modal, Alert: overlay fade + panel scale-translate spring
+- Dropdown, Menu, Tooltip: pop-in spring
+- Toast: slide-in spring with onExitComplete unmount
+- Accordion: grid-template-rows 0fr → 1fr (CSS, height-auto-safe)
+- Sidebar logo: crossfade between collapsed/expanded layers
+- NavBar/Tabs active: sliding indicator
+
+### Custom motion utility
+For your own interactive components:
+
+```tsx
+import { useSpringPresence, animated } from "@bigtablet/design-system";
+
+function MyPopover({ open, onClose }) {
+  const [shouldRender, setShouldRender] = useState(open);
+  useEffect(() => { if (open) setShouldRender(true); }, [open]);
+
+  const style = useSpringPresence({
+    visible: open,
+    from: "translateY(-4px)",
+    onExitComplete: () => setShouldRender(false),  // unmount after exit
+  });
+
+  if (!shouldRender) return null;
+  return <animated.div style={style}>...</animated.div>;
+}
+```
+
+**Reduced motion:** every component respects `prefers-reduced-motion: reduce`. Spring respects it automatically; CSS animations have explicit overrides.
+
+---
+
+## Common Patterns
+
+### Form
+
+```tsx
+<Stack gap={16}>
+  <TextField label="Email" placeholder="you@example.com" supportingText="We'll never share." />
+  <Dropdown
+    label="Role"
+    options={[
+      { value: "admin", label: "Admin" },
+      { value: "editor", label: "Editor" },
+    ]}
+    value={role}
+    onChange={setRole}
+  />
+  <Stack direction="horizontal" gap={8} justify="end">
+    <Button variant="outline">Cancel</Button>
+    <Button variant="filled">Save</Button>
+  </Stack>
+</Stack>
+```
+
+### Confirmation with destructive action
+
+```tsx
+const { showAlert } = useAlert();
+
+<Button
+  variant="outline"
+  danger
+  onClick={() =>
+    showAlert({
+      title: "Delete project?",
+      message: "This cannot be undone.",
+      showCancel: true,
+      destructive: true,
+      confirmText: "Delete",
+      onConfirm: handleDelete,
+    })
+  }
+>
+  Delete
+</Button>
+```
+
+### Toast feedback
+
+```tsx
+const toast = useToast();
+
+toast.success("Saved");
+toast.error("Network error", 6000); // custom 6s duration
+```
+
+### Dashboard layout
+
+```tsx
+<div style={{ display: "flex", minHeight: "100vh", background: "var(--bt-color-bg-solid-dim)" }}>
+  <Sidebar
+    header={<img src="/logo.png" alt="Brand" height={28} />}
+    headerCollapsed={<img src="/favicon.png" alt="" width={28} height={28} />}
+    footer={<UserProfile />}
+  >
+    <SidebarSection label="메인">
+      <SidebarItem icon={<Home size={20} />} active>Home</SidebarItem>
+      <SidebarItem icon={<Receipt size={20} />}>Orders</SidebarItem>
+    </SidebarSection>
+  </Sidebar>
+
+  <div style={{ flex: 1, padding: 32, overflowY: "auto" }}>
+    <Container size="xl">
+      <Stack gap={24}>
+        <h1 style={{ color: "var(--bt-color-text-heading)" }}>Dashboard</h1>
+        <Grid cols={2} gap={16}>
+          <StatCard />
+          <StatCard />
+        </Grid>
+      </Stack>
+    </Container>
+  </div>
+</div>
+```
+
+### Marketing landing
+
+```tsx
+<Hero
+  title="Run smarter stores"
+  subtitle="Orders, inventory, staff — one platform."
+  backgroundImage="https://..."
+  overlay="dark"
+  height="lg"
+  align="center"
+  primaryAction={{ label: "Start free", onClick: ... }}
+  secondaryAction={{ label: "See demo", onClick: ... }}
+/>
+
+<Section spacing="lg" bg="default">
+  <Container size="xl">
+    <Stack gap={32}>
+      <Stack gap={8} align="center">
+        <Chip type="static" tone="accent" label="Features" />
+        <h2 style={{ color: "var(--bt-color-text-heading)" }}>Why Bigtablet?</h2>
+      </Stack>
+      <Grid cols="auto" minColWidth="280px" gap={24}>
+        {features.map(f => <MediaCard key={f.id} {...f} />)}
+      </Grid>
+    </Stack>
+  </Container>
+</Section>
+```
+
+---
+
+## Anti-Patterns
+
+| ❌ Don't | ✅ Do |
+|---------|-------|
+| `style={{ color: "#888" }}` | `style={{ color: "var(--bt-color-text-caption)" }}` |
+| `background: "#fff"` for elevated panels | Conditional `bg-solid` light / `bg-solid-dim` dark |
+| `background: brand-primary` for an active toggle/indicator | `accent-default` (auto flips for dark mode visibility) |
+| `color: "#fff"` over a token-flipping bg | `accent-on-surface` (flips opposite to `accent-default`) |
+| Raw `<button>` for form actions | `<Button>` component |
+| Custom modal with CSS keyframes | `<Modal>` (spring built in) |
+| Build dropdown from scratch | `<Dropdown>` |
+| `transition: all 0.2s ease` | Specific properties + motion tokens |
+| `animation: ... infinite` outside loading indicators | Spring (`useSpringPresence`) for entrance/exit |
+| Skip `aria-label` on icon-only triggers | `<IconButton icon={...} aria-label="..." />` |
+| Hardcode logo color white inside a Sidebar | Sidebar uses light bg by default — use `text-heading` for text |
+| Use Tag component | Removed in v3.0 — use `<Chip type="static" tone="..." />` |
+| Use Select component | Removed in v3.0 — use `<Dropdown>` |
+
+---
+
+## Storybook Reference
+
+Stories are organized:
+- **Getting Started** — Installation, Introduction
+- **Cookbook** — Composition recipes (Form / Layout / Feedback / Data patterns)
+- **Examples** — Full page patterns (Admin Dashboard, Marketing landing)
+- **Foundation** — Token visualization (colors, spacing, typography, etc.)
+- **Components/{Category}/{Component}** — Each component's variants
+
+Run locally: `pnpm storybook` (port 6006).
+
+**Note on Storybook Docs view:** Interactive states (hover, focus, animations) only show in Canvas view (individual story). Docs view renders static snapshots, so Spinner shows frozen, Tooltip won't appear, etc.
+
+---
+
+## Vanilla JS Bundle
+
+For non-React contexts (Thymeleaf, JSP, PHP, Django):
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
+<script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
+
+<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+```
+
+Class naming: `.bt-{component}` + `--{modifier}` + `.is-{state}` (BEM-like).
+
+Components available: Button, TextField, Checkbox, Radio, Toggle, Select, Modal, Card, Spinner, Pagination, DatePicker, FileInput.
+
+JS API (auto-init on DOMContentLoaded, or manual):
+```js
+const select = Bigtablet.Select("#my-select", { options, onChange });
+const modal = Bigtablet.Modal("#my-modal", { onOpen, onClose });
+Bigtablet.Alert({ title, message, showCancel: true, onConfirm });
+```
+
+Dark mode: same `[data-theme="dark"]` attribute works. CSS custom properties expose all tokens with `--bt-` prefix.
+
+---
+
+## Constraints for Code Generation
+
+When asked to generate UI:
+
+1. **Always** wrap your output in the appropriate provider chain if the app entry isn't shown.
+2. **Always** import components from `@bigtablet/design-system` root.
+3. **Always** use tokens (`var(--bt-color-*)`) for any inline style or custom SCSS.
+4. **Always** check both light and dark modes in your mental model. If a color choice fails in either theme, swap to a flipping token.
+5. **Never** generate a custom Button/Modal/Dropdown/Tooltip when the DS provides one.
+6. **Never** use `useLayoutEffect` for non-DOM-measurement work (Next.js SSR warning). Default to `useEffect`.
+7. **For interactive content**, ensure: `aria-label`/`aria-labelledby`, keyboard support (Enter/Space for buttons, Arrow keys for menus), and `:focus-visible` styling.
+8. **For images**, set `alt` (empty `""` if purely decorative).
+9. **Korean / English text**: both supported. Use `word-break: keep-all` if you set custom long-text styles in Korean contexts.
+
+---
+
+## Migration from v2.x
+
+- `Select` → `Dropdown` (`SelectOption` → `DropdownOption`)
+- `Tag` → `<Chip type="static" tone="..." />`
+- `Chip` import path changed (`general/chip` → `display/chip`) — root import unaffected
+- `Dropdown` `fullWidth` prop is now a no-op (always full width)
+- `Icon` API: `<Icon name="search" />` → `<Icon icon={Search} />` (pass lucide-react component)
+- Vanilla `--bt-color-primary` is now reserved for Button `--primary` only. Use `--bt-color-accent` for indicators.
+
+---
+
+## Quick Decision Tree
+
+**Need a button?** → `<Button>` (variant: filled for primary, outline for secondary, text for tertiary, danger for destructive)
+
+**Need a text input?** → `<TextField>`. For value selection from a list → `<Dropdown>`.
+
+**Need a dialog?** → `<Modal>` for arbitrary content. `useAlert()` for simple confirm/alert.
+
+**Need a notification?** → `useToast()`. For inline alerts within page → `<Alert>` component.
+
+**Need to show loading?** → `<Spinner>` inline, `<TopLoading>` for page-level, `<Skeleton>` for content placeholders, `<LinearProgress>` for step-based progress.
+
+**Need a layout?** → `Container > Section > Stack/Grid`. Don't manually do flexbox/grid CSS unless inside a Stack/Grid child.
+
+**Need a tooltip?** → `<Tooltip content="..." placement="top"><TriggerElement /></Tooltip>`.
+
+**Need a sidebar nav?** → `<Sidebar>` with `<SidebarSection>` + `<SidebarItem>`. Include `headerCollapsed` for collapse animation.
+
+**Need a data table?** → `<Table>`. Pass `onRowClick` for interactive rows (keyboard support included).
+
+**Building a form?** → Stack vertical with gap=16. Group buttons in a horizontal Stack with `justify="end"` at the bottom.
+
+**Building a marketing page?** → Hero + Section(s) with Container + Grid for feature cards.
+
+**Building an admin dashboard?** → Sidebar layout + main content in `<Container size="xl">`. Stats in `<Grid cols={4}>`. Tables, charts, lists below.
+
+---
+
+## Final Reminders
+
+- Read the [Components](./COMPONENTS.md) doc for full props API per component.
+- Storybook is the source of truth for visual behavior — `pnpm storybook` and explore.
+- When in doubt, **use tokens, use components, use providers**. Don't reinvent.
+- Dark mode bugs are the most common failure mode — test both themes mentally before shipping code.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export type { AvatarProps, AvatarShape, AvatarSize } from "./ui/display/avatar";
 export { Avatar } from "./ui/display/avatar";
 export type { BadgeProps, BadgeShape, BadgeSize, BadgeVariant } from "./ui/display/badge";
 export { Badge } from "./ui/display/badge";
+export type { BottomNavItemProps, BottomNavProps } from "./ui/navigation/bottom-nav";
+export { BottomNav, BottomNavItem, BottomNavSpacer } from "./ui/navigation/bottom-nav";
 export type { BreadcrumbItem, BreadcrumbProps } from "./ui/navigation/breadcrumb";
 export { Breadcrumb } from "./ui/navigation/breadcrumb";
 export type { EmptyStateProps } from "./ui/feedback/empty-state";
@@ -25,7 +27,12 @@ export type {
 	NavLinkProps,
 } from "./ui/navigation/nav-bar";
 export { NavBar, NavLink } from "./ui/navigation/nav-bar";
-export type { SidebarItemProps, SidebarProps, SidebarSectionProps } from "./ui/navigation/sidebar";
+export type {
+	SidebarItemProps,
+	SidebarMode,
+	SidebarProps,
+	SidebarSectionProps,
+} from "./ui/navigation/sidebar";
 export { Sidebar, SidebarItem, SidebarSection } from "./ui/navigation/sidebar";
 export type {
 	TabListProps,

--- a/src/ui/navigation/bottom-nav/BottomNav.test.tsx
+++ b/src/ui/navigation/bottom-nav/BottomNav.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Bell, Home, ShoppingCart } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+import { BottomNav, BottomNavItem, BottomNavSpacer } from "./index";
+
+describe("BottomNav", () => {
+	it("renders nav with aria-label", () => {
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Home />} label="홈" />
+			</BottomNav>,
+		);
+		expect(screen.getByRole("navigation", { name: "주요 메뉴" })).toBeInTheDocument();
+	});
+
+	it("custom aria-label", () => {
+		render(
+			<BottomNav ariaLabel="하단 네비">
+				<BottomNavItem icon={<Home />} label="홈" />
+			</BottomNav>,
+		);
+		expect(screen.getByRole("navigation", { name: "하단 네비" })).toBeInTheDocument();
+	});
+
+	it("renders items with icon + label", () => {
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Home />} label="주문" />
+				<BottomNavItem icon={<ShoppingCart />} label="매출" />
+			</BottomNav>,
+		);
+		expect(screen.getByRole("button", { name: "주문" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "매출" })).toBeInTheDocument();
+	});
+
+	it("applies aria-current=page on active item", () => {
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Home />} label="주문" active />
+				<BottomNavItem icon={<ShoppingCart />} label="매출" />
+			</BottomNav>,
+		);
+		expect(screen.getByRole("button", { name: "주문" })).toHaveAttribute("aria-current", "page");
+		expect(screen.getByRole("button", { name: "매출" })).not.toHaveAttribute("aria-current");
+	});
+
+	it("calls onClick when item clicked", () => {
+		const onClick = vi.fn();
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Home />} label="주문" onClick={onClick} />
+			</BottomNav>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "주문" }));
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders as anchor when as='a' and href provided", () => {
+		render(
+			<BottomNav>
+				<BottomNavItem as="a" href="/orders" icon={<Home />} label="주문" />
+			</BottomNav>,
+		);
+		const link = screen.getByRole("link", { name: "주문" });
+		expect(link).toHaveAttribute("href", "/orders");
+	});
+
+	it("renders badge when provided", () => {
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Bell />} label="알림" badge={<span data-testid="dot">●</span>} />
+			</BottomNav>,
+		);
+		expect(screen.getByTestId("dot")).toBeInTheDocument();
+	});
+
+	it("active item has active class", () => {
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Home />} label="주문" active />
+			</BottomNav>,
+		);
+		expect(screen.getByRole("button", { name: "주문" })).toHaveClass("bottom_nav_item_active");
+	});
+
+	it("button type defaults to 'button'", () => {
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Home />} label="주문" />
+			</BottomNav>,
+		);
+		expect(screen.getByRole("button", { name: "주문" })).toHaveAttribute("type", "button");
+	});
+
+	it("disabled prop disables button", () => {
+		const onClick = vi.fn();
+		render(
+			<BottomNav>
+				<BottomNavItem icon={<Home />} label="주문" disabled onClick={onClick} />
+			</BottomNav>,
+		);
+		const btn = screen.getByRole("button", { name: "주문" });
+		expect(btn).toBeDisabled();
+		fireEvent.click(btn);
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it("passes additional props through (data attribute)", () => {
+		render(
+			<BottomNav data-testid="nav">
+				<BottomNavItem icon={<Home />} label="주문" data-key="orders" />
+			</BottomNav>,
+		);
+		expect(screen.getByTestId("nav")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "주문" })).toHaveAttribute("data-key", "orders");
+	});
+});
+
+describe("BottomNavSpacer", () => {
+	it("renders an aria-hidden div with spacer class", () => {
+		const { container } = render(<BottomNavSpacer />);
+		const spacer = container.firstChild as HTMLElement;
+		expect(spacer).toHaveClass("bottom_nav_spacer");
+		expect(spacer).toHaveAttribute("aria-hidden", "true");
+	});
+
+	it("accepts className", () => {
+		const { container } = render(<BottomNavSpacer className="extra" />);
+		expect(container.firstChild).toHaveClass("bottom_nav_spacer", "extra");
+	});
+});

--- a/src/ui/navigation/bottom-nav/BottomNav.test.tsx
+++ b/src/ui/navigation/bottom-nav/BottomNav.test.tsx
@@ -105,6 +105,27 @@ describe("BottomNav", () => {
 		expect(onClick).not.toHaveBeenCalled();
 	});
 
+	it("disabled prop on anchor — aria-disabled + tabIndex -1 + click blocked", () => {
+		const onClick = vi.fn();
+		render(
+			<BottomNav>
+				<BottomNavItem
+					as="a"
+					href="/orders"
+					icon={<Home />}
+					label="주문"
+					disabled
+					onClick={onClick}
+				/>
+			</BottomNav>,
+		);
+		const link = screen.getByRole("link", { name: "주문" });
+		expect(link).toHaveAttribute("aria-disabled", "true");
+		expect(link).toHaveAttribute("tabindex", "-1");
+		fireEvent.click(link);
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
 	it("passes additional props through (data attribute)", () => {
 		render(
 			<BottomNav data-testid="nav">

--- a/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
+++ b/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BarChart3, Bell, Home, UtensilsCrossed } from "lucide-react";
+import * as React from "react";
+import { Badge } from "../../display/badge";
+import { BottomNav, BottomNavItem, BottomNavSpacer } from ".";
+
+const meta: Meta<typeof BottomNav> = {
+	title: "Components/Navigation/BottomNav",
+	component: BottomNav,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "fullscreen",
+		viewport: { defaultViewport: "compact" },
+		docs: {
+			description: {
+				component: `
+**BottomNav** — 모바일 하단 네비게이션. 2–5개 \`BottomNavItem\` 으로 구성.
+
+\`position: fixed; bottom: 0\` 으로 viewport 하단 고정. iOS 홈 인디케이터 영역 (\`env(safe-area-inset-bottom)\`) 자동 패딩. 본문이 가려지지 않게 페이지 끝에 \`<BottomNavSpacer />\` 깔거나 \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS 변수로 layout 계산.
+
+\`<BottomNavItem icon label active badge as href />\` — \`active\` 시 \`aria-current="page"\` 자동.
+				`,
+			},
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomNav>;
+
+const NAV = [
+	{ key: "orders", label: "주문", icon: <Home size={22} /> },
+	{ key: "menu", label: "메뉴", icon: <UtensilsCrossed size={22} /> },
+	{ key: "sales", label: "매출", icon: <BarChart3 size={22} /> },
+];
+
+function PageShell({ children }: { children: React.ReactNode }) {
+	return (
+		<div
+			style={{
+				position: "relative",
+				minHeight: 480,
+				background: "var(--bt-color-bg-solid-dim)",
+				display: "flex",
+				flexDirection: "column",
+			}}
+		>
+			{children}
+		</div>
+	);
+}
+
+function Demo() {
+	const [active, setActive] = React.useState("orders");
+	const current = NAV.find((n) => n.key === active);
+	return (
+		<PageShell>
+			<main style={{ flex: 1, padding: 24 }}>
+				<h2 style={{ margin: 0, marginBottom: 8 }}>{current?.label}</h2>
+				<p style={{ color: "var(--bt-color-text-body)", margin: 0 }}>
+					하단 바에서 항목을 탭하면 active 상태가 바뀜.
+				</p>
+			</main>
+			<BottomNavSpacer />
+			<BottomNav>
+				{NAV.map((n) => (
+					<BottomNavItem
+						key={n.key}
+						icon={n.icon}
+						label={n.label}
+						active={active === n.key}
+						onClick={() => setActive(n.key)}
+					/>
+				))}
+			</BottomNav>
+		</PageShell>
+	);
+}
+
+export const Default: Story = {
+	name: "기본 (3 항목)",
+	render: () => <Demo />,
+};
+
+export const WithBadge: Story = {
+	name: "Badge 표시",
+	parameters: {
+		docs: {
+			description: {
+				story: "아이콘 우상단에 `badge` prop 으로 알림 dot/카운트 표시. `<Badge>` 컴포넌트 활용.",
+			},
+		},
+	},
+	render: () => {
+		const [active, setActive] = React.useState("orders");
+		return (
+			<PageShell>
+				<main style={{ flex: 1, padding: 24 }}>
+					<p style={{ color: "var(--bt-color-text-body)", margin: 0 }}>알림 매장 — badge 표시 예.</p>
+				</main>
+				<BottomNavSpacer />
+				<BottomNav>
+					<BottomNavItem
+						icon={<Home size={22} />}
+						label="주문"
+						active={active === "orders"}
+						onClick={() => setActive("orders")}
+						badge={<Badge variant="error" shape="count" size="sm" count={3} />}
+					/>
+					<BottomNavItem
+						icon={<Bell size={22} />}
+						label="알림"
+						active={active === "alerts"}
+						onClick={() => setActive("alerts")}
+						badge={<Badge variant="error" shape="dot" size="sm" />}
+					/>
+					<BottomNavItem
+						icon={<BarChart3 size={22} />}
+						label="매출"
+						active={active === "sales"}
+						onClick={() => setActive("sales")}
+					/>
+				</BottomNav>
+			</PageShell>
+		);
+	},
+};
+
+export const FiveItems: Story = {
+	name: "최대 5 항목",
+	parameters: {
+		docs: {
+			description: {
+				story: "5개까지 균등 분할 권장. 그 이상은 라벨 잘림 / 탭 영역 부족.",
+			},
+		},
+	},
+	render: () => {
+		const items = [
+			{ key: "home", label: "홈", icon: <Home size={22} /> },
+			{ key: "orders", label: "주문", icon: <Home size={22} /> },
+			{ key: "menu", label: "메뉴", icon: <UtensilsCrossed size={22} /> },
+			{ key: "sales", label: "매출", icon: <BarChart3 size={22} /> },
+			{ key: "alerts", label: "알림", icon: <Bell size={22} /> },
+		];
+		const [active, setActive] = React.useState("home");
+		return (
+			<PageShell>
+				<main style={{ flex: 1, padding: 24 }}>
+					<p style={{ color: "var(--bt-color-text-body)", margin: 0 }}>5 항목 — 균등 분할.</p>
+				</main>
+				<BottomNavSpacer />
+				<BottomNav>
+					{items.map((n) => (
+						<BottomNavItem
+							key={n.key}
+							icon={n.icon}
+							label={n.label}
+							active={active === n.key}
+							onClick={() => setActive(n.key)}
+						/>
+					))}
+				</BottomNav>
+			</PageShell>
+		);
+	},
+};

--- a/src/ui/navigation/bottom-nav/index.tsx
+++ b/src/ui/navigation/bottom-nav/index.tsx
@@ -45,8 +45,7 @@ export const BottomNav = ({
 	);
 };
 
-export interface BottomNavItemProps
-	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+interface BottomNavItemCommon {
 	/** 아이콘 (필수) */
 	icon: React.ReactNode;
 	/** 라벨 텍스트 (필수, 짧게 — 2–4자) */
@@ -55,29 +54,40 @@ export interface BottomNavItemProps
 	active?: boolean;
 	/** 아이콘 우상단 dot/카운트 (Badge 등) */
 	badge?: React.ReactNode;
-	/** 링크 컴포넌트 (Next Link 등) */
-	as?: "button" | "a";
-	/** as="a" 일 때 사용 */
-	href?: string;
 }
+
+// Discriminated union — `as` 값에 따라 허용되는 HTML attribute 가 동적으로 결정됨.
+// `target` / `rel` / `download` 는 anchor 에만, `type` / `form` 등은 button 에만 허용.
+type BottomNavItemButton = BottomNavItemCommon & {
+	as?: "button";
+	href?: never;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children">;
+
+type BottomNavItemAnchor = BottomNavItemCommon & {
+	as: "a";
+	href: string;
+	/** anchor 에 native `disabled` 없음 — `aria-disabled` + `preventDefault` 로 처리. */
+	disabled?: boolean;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children" | "type">;
+
+export type BottomNavItemProps = BottomNavItemButton | BottomNavItemAnchor;
 
 /**
  * `BottomNav` 의 항목. icon + label 수직 스택.
  * active 시 `aria-current="page"` 자동 부여.
  */
-export const BottomNavItem = ({
-	icon,
-	label,
-	active,
-	badge,
-	as = "button",
-	href,
-	className,
-	type,
-	disabled,
-	onClick,
-	...props
-}: BottomNavItemProps) => {
+export const BottomNavItem = (props: BottomNavItemProps) => {
+	const {
+		icon,
+		label,
+		active,
+		badge,
+		as = "button",
+		className,
+		disabled,
+		...rest
+	} = props;
+
 	const classes = cn(
 		"bottom_nav_item",
 		active && "bottom_nav_item_active",
@@ -96,8 +106,12 @@ export const BottomNavItem = ({
 		</>
 	);
 
-	if (as === "a" && href) {
+	if (as === "a") {
 		// HTML 의 `<a disabled>` 는 무효 — `aria-disabled` + `tabIndex={-1}` + `preventDefault` 로 접근성 있게 비활성화.
+		const { href, onClick, ...anchorRest } = rest as Omit<
+			BottomNavItemAnchor,
+			"icon" | "label" | "active" | "badge" | "as" | "className" | "disabled"
+		>;
 		return (
 			// biome-ignore lint/a11y/useValidAnchor: navigation link with optional active state
 			<a
@@ -111,15 +125,19 @@ export const BottomNavItem = ({
 						e.preventDefault();
 						return;
 					}
-					(onClick as ((evt: React.MouseEvent<HTMLAnchorElement>) => void) | undefined)?.(e);
+					onClick?.(e);
 				}}
-				{...(props as Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "type" | "onClick">)}
+				{...anchorRest}
 			>
 				{content}
 			</a>
 		);
 	}
 
+	const { type, onClick, ...buttonRest } = rest as Omit<
+		BottomNavItemButton,
+		"icon" | "label" | "active" | "badge" | "as" | "className" | "disabled"
+	>;
 	return (
 		<button
 			type={type ?? "button"}
@@ -127,7 +145,7 @@ export const BottomNavItem = ({
 			disabled={disabled}
 			aria-current={ariaCurrent}
 			onClick={onClick}
-			{...props}
+			{...buttonRest}
 		>
 			{content}
 		</button>

--- a/src/ui/navigation/bottom-nav/index.tsx
+++ b/src/ui/navigation/bottom-nav/index.tsx
@@ -74,9 +74,16 @@ export const BottomNavItem = ({
 	href,
 	className,
 	type,
+	disabled,
+	onClick,
 	...props
 }: BottomNavItemProps) => {
-	const classes = cn("bottom_nav_item", active && "bottom_nav_item_active", className);
+	const classes = cn(
+		"bottom_nav_item",
+		active && "bottom_nav_item_active",
+		disabled && "bottom_nav_item_disabled",
+		className,
+	);
 	const ariaCurrent = active ? "page" : undefined;
 
 	const content = (
@@ -90,13 +97,23 @@ export const BottomNavItem = ({
 	);
 
 	if (as === "a" && href) {
+		// HTML 의 `<a disabled>` 는 무효 — `aria-disabled` + `tabIndex={-1}` + `preventDefault` 로 접근성 있게 비활성화.
 		return (
 			// biome-ignore lint/a11y/useValidAnchor: navigation link with optional active state
 			<a
 				className={classes}
 				href={href}
 				aria-current={ariaCurrent}
-				{...(props as Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "type">)}
+				aria-disabled={disabled ? "true" : undefined}
+				tabIndex={disabled ? -1 : undefined}
+				onClick={(e) => {
+					if (disabled) {
+						e.preventDefault();
+						return;
+					}
+					(onClick as ((evt: React.MouseEvent<HTMLAnchorElement>) => void) | undefined)?.(e);
+				}}
+				{...(props as Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "type" | "onClick">)}
 			>
 				{content}
 			</a>
@@ -107,7 +124,9 @@ export const BottomNavItem = ({
 		<button
 			type={type ?? "button"}
 			className={classes}
+			disabled={disabled}
 			aria-current={ariaCurrent}
+			onClick={onClick}
 			{...props}
 		>
 			{content}

--- a/src/ui/navigation/bottom-nav/index.tsx
+++ b/src/ui/navigation/bottom-nav/index.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "../../../utils";
+import "./style.scss";
+
+export interface BottomNavProps extends Omit<React.HTMLAttributes<HTMLElement>, "onChange"> {
+	/** 스크린 리더 레이블 (기본 "주요 메뉴") */
+	ariaLabel?: string;
+	/** 2–5 개의 `BottomNavItem` */
+	children: React.ReactNode;
+}
+
+/**
+ * 모바일 하단 네비게이션 바.
+ *
+ * `position: fixed; bottom: 0` 으로 viewport 하단 고정. iOS 홈 인디케이터 영역
+ * (`env(safe-area-inset-bottom)`) 자동 패딩. 본문이 가려지지 않게 페이지 끝에
+ * `<BottomNavSpacer />` 를 깔거나 `--bt-bottom-nav-height` CSS 변수로 padding 계산.
+ *
+ * @example
+ * ```tsx
+ * <BottomNav>
+ *   <BottomNavItem icon={<Home />} label="주문" active />
+ *   <BottomNavItem icon={<Menu />} label="메뉴" />
+ *   <BottomNavItem icon={<Chart />} label="매출" />
+ * </BottomNav>
+ * <BottomNavSpacer />
+ * ```
+ */
+export const BottomNav = ({
+	ariaLabel = "주요 메뉴",
+	className,
+	children,
+	...props
+}: BottomNavProps) => {
+	return (
+		<nav
+			className={cn("bottom_nav", className)}
+			aria-label={ariaLabel}
+			{...props}
+		>
+			{children}
+		</nav>
+	);
+};
+
+export interface BottomNavItemProps
+	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+	/** 아이콘 (필수) */
+	icon: React.ReactNode;
+	/** 라벨 텍스트 (필수, 짧게 — 2–4자) */
+	label: string;
+	/** 활성 상태 */
+	active?: boolean;
+	/** 아이콘 우상단 dot/카운트 (Badge 등) */
+	badge?: React.ReactNode;
+	/** 링크 컴포넌트 (Next Link 등) */
+	as?: "button" | "a";
+	/** as="a" 일 때 사용 */
+	href?: string;
+}
+
+/**
+ * `BottomNav` 의 항목. icon + label 수직 스택.
+ * active 시 `aria-current="page"` 자동 부여.
+ */
+export const BottomNavItem = ({
+	icon,
+	label,
+	active,
+	badge,
+	as = "button",
+	href,
+	className,
+	type,
+	...props
+}: BottomNavItemProps) => {
+	const classes = cn("bottom_nav_item", active && "bottom_nav_item_active", className);
+	const ariaCurrent = active ? "page" : undefined;
+
+	const content = (
+		<>
+			<span className="bottom_nav_item_icon" aria-hidden="true">
+				{icon}
+				{badge && <span className="bottom_nav_item_badge">{badge}</span>}
+			</span>
+			<span className="bottom_nav_item_label">{label}</span>
+		</>
+	);
+
+	if (as === "a" && href) {
+		return (
+			// biome-ignore lint/a11y/useValidAnchor: navigation link with optional active state
+			<a
+				className={classes}
+				href={href}
+				aria-current={ariaCurrent}
+				{...(props as Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "type">)}
+			>
+				{content}
+			</a>
+		);
+	}
+
+	return (
+		<button
+			type={type ?? "button"}
+			className={classes}
+			aria-current={ariaCurrent}
+			{...props}
+		>
+			{content}
+		</button>
+	);
+};
+
+/**
+ * 페이지 본문 끝에 두면 `BottomNav` 가 콘텐츠를 가리지 않게 빈 공간 확보.
+ * `--bt-bottom-nav-height` (+ safe-area) 만큼 height.
+ */
+export const BottomNavSpacer = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+	return <div className={cn("bottom_nav_spacer", className)} aria-hidden="true" {...props} />;
+};

--- a/src/ui/navigation/bottom-nav/style.scss
+++ b/src/ui/navigation/bottom-nav/style.scss
@@ -61,6 +61,14 @@
       box-shadow: token.$focus_ring;
     }
 
+    // disabled — 시각 흐림 + 인터랙션 차단 (anchor 케이스는 `_disabled` modifier 도 매칭)
+    &:disabled,
+    &_disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+
     // active — 아이콘 + 라벨 강조 (검정/흰 반전 토큰)
     &_active {
       color: token.$color_accent_default;

--- a/src/ui/navigation/bottom-nav/style.scss
+++ b/src/ui/navigation/bottom-nav/style.scss
@@ -1,0 +1,114 @@
+@use "src/styles/token" as token;
+
+// height + safe-area 합산 — 소비처 layout 계산용 노출
+:root {
+  --bt-bottom-nav-height: 56px;
+  --bt-bottom-nav-safe-area: env(safe-area-inset-bottom, 0px);
+  --bt-bottom-nav-total-height: calc(
+    var(--bt-bottom-nav-height) + var(--bt-bottom-nav-safe-area)
+  );
+}
+
+.bottom_nav {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: token.$z_level2;
+
+  display: flex;
+  align-items: stretch;
+  justify-content: space-around;
+
+  height: var(--bt-bottom-nav-total-height);
+  padding-bottom: var(--bt-bottom-nav-safe-area); // iOS 홈 인디케이터 영역 회피
+  background: token.$color_bg_solid;
+  border-top: token.$border_width_standard solid token.$color_border_default;
+
+  // 데스크탑에서도 fixed bottom 유지 — viewport 정책은 소비처 결정.
+  // 숨기고 싶으면 wrap 후 media query 로 hidden 처리.
+
+  &_item {
+    flex: 1;
+    min-width: 0; // 좁은 viewport 에서 label 잘림 방지
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: token.$spacing_2;
+    padding: token.$spacing_8 token.$spacing_4;
+    border: none;
+    background: transparent;
+    color: token.$color_text_caption;
+    cursor: pointer;
+    text-decoration: none;
+    min-height: 56px; // a11y tap target
+    transition:
+      color token.$duration_fast token.$easing_enter,
+      background token.$duration_fast token.$easing_enter;
+
+    &:hover:not(.bottom_nav_item_active) {
+      background: token.$color_state_hover_on_light;
+      color: token.$color_text_heading;
+    }
+
+    &:active:not(.bottom_nav_item_active) {
+      background: token.$color_state_pressed_on_light;
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: token.$focus_ring;
+    }
+
+    // active — 아이콘 + 라벨 강조 (검정/흰 반전 토큰)
+    &_active {
+      color: token.$color_accent_default;
+
+      .bottom_nav_item_label {
+        font-weight: 600;
+      }
+    }
+  }
+
+  &_item_icon {
+    position: relative; // badge anchor
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+  }
+
+  &_item_badge {
+    position: absolute;
+    top: -4px;
+    right: -8px;
+    pointer-events: none;
+  }
+
+  &_item_label {
+    @include token.label_small_medium;
+    line-height: 1.2;
+    text-align: center;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+// ── Spacer — 본문 끝에 두면 BottomNav 가 가리는 영역 보정 ──────────────────
+
+.bottom_nav_spacer {
+  height: var(--bt-bottom-nav-total-height);
+  flex-shrink: 0;
+}
+
+// ── Reduced motion ─────────────────────────────────────────────────────────
+
+@media (prefers-reduced-motion: reduce) {
+  .bottom_nav_item {
+    transition: none;
+  }
+}

--- a/src/ui/navigation/sidebar/Sidebar.test.tsx
+++ b/src/ui/navigation/sidebar/Sidebar.test.tsx
@@ -67,4 +67,22 @@ describe("Sidebar", () => {
 		);
 		expect(container.firstChild).toHaveClass("sidebar_collapsed");
 	});
+
+	it("applies sidebar_static modifier when mode='static'", () => {
+		const { container } = render(
+			<Sidebar mode="static">
+				<SidebarItem>홈</SidebarItem>
+			</Sidebar>,
+		);
+		expect(container.firstChild).toHaveClass("sidebar_static");
+	});
+
+	it("does NOT apply sidebar_static by default (auto mode)", () => {
+		const { container } = render(
+			<Sidebar>
+				<SidebarItem>홈</SidebarItem>
+			</Sidebar>,
+		);
+		expect(container.firstChild).not.toHaveClass("sidebar_static");
+	});
 });

--- a/src/ui/navigation/sidebar/index.tsx
+++ b/src/ui/navigation/sidebar/index.tsx
@@ -126,54 +126,71 @@ export const Sidebar = ({
 	);
 };
 
-export interface SidebarItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface SidebarItemCommon {
 	/** 왼쪽 아이콘 */
 	icon?: React.ReactNode;
 	/** 현재 활성 상태 */
 	active?: boolean;
 	/** 오른쪽 trailing (Badge 등) */
 	trailing?: React.ReactNode;
-	/** 링크 컴포넌트 (Next Link 등). `asChild` 패턴 — `as="a" href="..."` */
-	as?: "button" | "a";
-	/** as="a"일 때 사용 */
-	href?: string;
 }
 
-export const SidebarItem = ({
-	icon,
-	active,
-	trailing,
-	as = "button",
-	href,
-	className,
-	children,
-	type,
-	...props
-}: SidebarItemProps) => {
+// Discriminated union — `as` 값에 따라 허용되는 HTML attribute 동적 결정.
+// `target` / `rel` / `download` 는 anchor 만, `type` / `form` 등은 button 만.
+type SidebarItemButton = SidebarItemCommon & {
+	as?: "button";
+	href?: never;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+type SidebarItemAnchor = SidebarItemCommon & {
+	as: "a";
+	href: string;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "type">;
+
+export type SidebarItemProps = SidebarItemButton | SidebarItemAnchor;
+
+export const SidebarItem = (props: SidebarItemProps) => {
+	const { icon, active, trailing, as = "button", className, children, ...rest } = props;
 	const classes = cn("sidebar_item", active && "sidebar_item_active", className);
 	const ariaCurrent = active ? "page" : undefined;
 
-	if (as === "a" && href) {
+	const inner = (
+		<>
+			{icon && (
+				<span className="sidebar_item_icon" aria-hidden="true">
+					{icon}
+				</span>
+			)}
+			<span className="sidebar_item_label">{children}</span>
+			{trailing && <span className="sidebar_item_trailing">{trailing}</span>}
+		</>
+	);
+
+	if (as === "a") {
+		const { href, ...anchorRest } = rest as Omit<
+			SidebarItemAnchor,
+			"icon" | "active" | "trailing" | "as" | "className" | "children"
+		>;
 		return (
 			// biome-ignore lint/a11y/useValidAnchor: navigation link with optional active state
-			<a className={classes} href={href} aria-current={ariaCurrent} {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
-				{icon && <span className="sidebar_item_icon" aria-hidden="true">{icon}</span>}
-				<span className="sidebar_item_label">{children}</span>
-				{trailing && <span className="sidebar_item_trailing">{trailing}</span>}
+			<a className={classes} href={href} aria-current={ariaCurrent} {...anchorRest}>
+				{inner}
 			</a>
 		);
 	}
 
+	const { type, ...buttonRest } = rest as Omit<
+		SidebarItemButton,
+		"icon" | "active" | "trailing" | "as" | "className" | "children"
+	>;
 	return (
 		<button
 			type={type ?? "button"}
 			className={classes}
 			aria-current={ariaCurrent}
-			{...props}
+			{...buttonRest}
 		>
-			{icon && <span className="sidebar_item_icon" aria-hidden="true">{icon}</span>}
-			<span className="sidebar_item_label">{children}</span>
-			{trailing && <span className="sidebar_item_trailing">{trailing}</span>}
+			{inner}
 		</button>
 	);
 };

--- a/src/ui/navigation/sidebar/index.tsx
+++ b/src/ui/navigation/sidebar/index.tsx
@@ -5,6 +5,8 @@ import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
+export type SidebarMode = "auto" | "static";
+
 export interface SidebarProps extends Omit<React.HTMLAttributes<HTMLElement>, "onChange"> {
 	/** 상단 brand 영역 (펼친 상태 로고) */
 	header?: React.ReactNode;
@@ -26,6 +28,12 @@ export interface SidebarProps extends Omit<React.HTMLAttributes<HTMLElement>, "o
 	width?: number;
 	/** collapsed 너비 (기본 64px) */
 	collapsedWidth?: number;
+	/**
+	 * 반응형 모드 (기본 `"auto"`).
+	 * - `"auto"`: viewport `< 600px` 에서 자동으로 하단 bar 로 변신.
+	 * - `"static"`: 어떤 viewport 에서도 좌측 rail 유지 (admin desktop-only).
+	 */
+	mode?: SidebarMode;
 }
 
 /**
@@ -54,6 +62,7 @@ export const Sidebar = ({
 	toggleLabel = "사이드바 토글",
 	width = 240,
 	collapsedWidth = 64,
+	mode = "auto",
 	className,
 	children,
 	style,
@@ -69,9 +78,18 @@ export const Sidebar = ({
 		onCollapsedChange?.(next);
 	}, [collapsed, isControlled, onCollapsedChange]);
 
+	// `mode="static"` 일 때 SCSS 의 mobile media query 무효화 (admin/desktop-only)
+	const isStatic = mode === "static";
+
 	return (
 		<aside
-			className={cn("sidebar", collapsed && "sidebar_collapsed", className)}
+			className={cn(
+				"sidebar",
+				collapsed && "sidebar_collapsed",
+				isStatic && "sidebar_static",
+				className,
+			)}
+			// auto 모드 + mobile 일 때 SCSS 가 width 100% override 함. static / desktop 은 인라인 그대로.
 			style={{ width: collapsed ? collapsedWidth : width, ...style }}
 			{...props}
 		>

--- a/src/ui/navigation/sidebar/sidebar.stories.tsx
+++ b/src/ui/navigation/sidebar/sidebar.stories.tsx
@@ -15,6 +15,8 @@ const meta: Meta<typeof Sidebar> = {
 **Sidebar** — admin/dashboard 좌측 네비게이션. \`SidebarItem\` + \`SidebarSection\` 조합.
 
 \`collapsed\` (240→64px) — 아이콘만 표시, \`headerCollapsed\` 로 favicon 노드. \`collapsible\` (기본 true) → floating chevron 토글. \`active={true}\` → \`aria-current="page"\` 자동.
+
+**Responsive** — 기본 \`mode="auto"\`: viewport \`< 600px\` 에서 자동으로 하단 bar (BottomNav 형태) 로 변신. header/footer/섹션 라벨 hide, 아이템은 horizontal stack. \`mode="static"\` 으로 변신 끄기 (admin desktop-only 케이스).
 				`,
 			},
 		},

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -232,3 +232,122 @@
     }
   }
 }
+
+// ── Mobile transform (< 600px) — auto 모드에서 BottomBar 형태로 자동 변신 ────
+//
+// `.sidebar_static` 가 붙으면 변신 무효 (admin 등 desktop-only 케이스).
+// CSS-only 변환 — JS / Context / matchMedia 불필요, SSR 안전, hydration mismatch X.
+
+@media (max-width: 599px) {
+  .sidebar:not(.sidebar_static) {
+    // BottomBar 본체 — fixed bottom, 가로 flex
+    position: fixed;
+    inset: auto 0 0 0;            // bottom: 0; left/right: 0
+    width: 100% !important;       // 인라인 style.width override
+    height: auto;
+    min-height: 0;
+    flex-direction: row;
+    border-right: none;
+    border-top: token.$border_width_standard solid token.$color_border_default;
+    box-shadow: token.$elevation_level2;
+    z-index: token.$z_level2;
+    padding-bottom: env(safe-area-inset-bottom, 0px); // iOS 홈 인디케이터
+
+    // 변신 시 숨겨질 영역들 — header / footer / 섹션 라벨 / collapse btn
+    .sidebar_header,
+    .sidebar_footer,
+    .sidebar_collapse_btn,
+    .sidebar_section_label {
+      display: none;
+    }
+
+    // nav 가 horizontal flex 컨테이너
+    .sidebar_nav {
+      flex: 1;
+      flex-direction: row;
+      align-items: stretch;
+      padding: 0;
+      gap: 0;
+      overflow: visible;
+    }
+
+    // section 은 transparent — items 가 nav 의 flex 자식으로 직접 흐름
+    .sidebar_section {
+      display: contents;
+    }
+
+    // 아이템 — icon 위 / label 아래 stacked, 균등 분할
+    .sidebar_item {
+      flex: 1;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: token.$spacing_4;
+      padding: token.$spacing_6 token.$spacing_4;
+      min-height: 56px;             // a11y tap target
+      border-radius: 0;
+      color: token.$color_text_body; // rail inactive 와 동일 톤
+
+      &:hover:not(.sidebar_item_active) {
+        background: token.$color_state_hover_on_light;
+        color: token.$color_text_heading;
+      }
+
+      // active — rail 의 "검정 fill" 언어 유지하되 icon area pill 로 축소
+      // (iOS / Material You 패턴 — 작은 bottom bar item 에 full-row fill 은 무거움)
+      &_active {
+        background: transparent;    // rail 의 full-width bg 무효
+        color: token.$color_text_heading;
+
+        .sidebar_item_icon {
+          background: token.$color_brand_primary;
+          color: token.$color_brand_on_primary;
+          border-radius: token.$radius_full;  // 완전한 pill
+          padding: 0 token.$spacing_16;
+          width: auto;                        // rail 24px 고정 width override
+          height: 32px;
+          min-width: 56px;
+        }
+
+        .sidebar_item_label {
+          font-weight: 600;
+        }
+      }
+    }
+
+    .sidebar_item_icon {
+      width: 24px;
+      height: 24px;
+      transition: background token.$transition_fast, color token.$transition_fast;
+    }
+
+    .sidebar_item_label {
+      @include token.label_small_medium;
+      flex: 0 0 auto;               // rail 모드 flex: 1 override
+      line-height: 1.2;
+      text-align: center;
+      max-width: 100%;
+      white-space: nowrap;
+    }
+
+    // trailing (Badge 등) — BottomBar 에선 공간 부족 → 숨김.
+    // 알림이 필요하면 미래 prop 으로 icon 위 dot badge 추가 검토.
+    .sidebar_item_trailing {
+      display: none;
+    }
+  }
+
+  // collapsed 상태 + mobile + auto → collapsed 무효 (BottomBar 가 우선)
+  .sidebar:not(.sidebar_static).sidebar_collapsed {
+    .sidebar_item_label {
+      // collapsed 가 적용한 visually-hidden 해제 — BottomBar 에선 label 보여야 함
+      position: static;
+      width: auto;
+      height: auto;
+      padding: 0;
+      margin: 0;
+      overflow: visible;
+      clip: auto;
+    }
+  }
+}

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -239,6 +239,17 @@
 // CSS-only 변환 — JS / Context / matchMedia 불필요, SSR 안전, hydration mismatch X.
 
 @media (max-width: 599px) {
+  // 소비처 layout 계산용 CSS 변수 노출 — Sidebar 가 BottomBar 로 변신했을 때
+  // main content 끝에 `padding-bottom: var(--bt-sidebar-total-height)` 등으로 가림 방지.
+  // (desktop 에선 정의 X — Sidebar 가 fixed bottom 이 아니라 padding 불필요)
+  :root {
+    --bt-sidebar-height: 56px;
+    --bt-sidebar-safe-area: env(safe-area-inset-bottom, 0px);
+    --bt-sidebar-total-height: calc(
+      var(--bt-sidebar-height) + var(--bt-sidebar-safe-area)
+    );
+  }
+
   .sidebar:not(.sidebar_static) {
     // BottomBar 본체 — fixed bottom, 가로 flex
     position: fixed;
@@ -251,7 +262,7 @@
     border-top: token.$border_width_standard solid token.$color_border_default;
     box-shadow: token.$elevation_level2;
     z-index: token.$z_level2;
-    padding-bottom: env(safe-area-inset-bottom, 0px); // iOS 홈 인디케이터
+    padding-bottom: var(--bt-sidebar-safe-area); // iOS 홈 인디케이터
 
     // 변신 시 숨겨질 영역들 — header / footer / 섹션 라벨 / collapse btn
     .sidebar_header,


### PR DESCRIPTION
## 작업 개요

모바일 우선 네비게이션 패턴 추가 + AI 에이전트용 디자인 시스템 가이드 문서.

## 작업한 내용

- [x] **BottomNav** 컴포넌트 신규 추가 (`BottomNav` / `BottomNavItem` / `BottomNavSpacer`)
  - `position: fixed; bottom: 0` 하단 고정 + iOS safe-area 대응
  - 2–5 항목 균등 분할, `aria-current` 자동
  - `--bt-bottom-nav-height` / `--bt-bottom-nav-total-height` CSS 변수 노출
- [x] **Sidebar 반응형 변신** — `mode="auto"` (기본) 시 viewport `< 600px` 에서 자동으로 하단 bar 로 변신
  - CSS-only media query — JS / matchMedia / Context 없음, SSR 안전
  - rail 의 `brand_primary` pill active 디자인 언어 유지 (icon area 로 scope 축소)
  - `mode="static"` 으로 변신 끄기 (admin desktop-only 케이스)
- [x] **Storybook iframe body reset** — `position: fixed` 컴포넌트가 viewport edge 까지 정확히 도달하도록 preview-head 에 margin/padding reset
- [x] **AGENT_GUIDE.md** — DS v3 사용하는 AI 코딩 에이전트용 영문 prompt-ready 레퍼런스 (philosophy, tokens, dark mode rules, component catalog, common patterns, anti-patterns)

## 검증

- 단위 테스트 770/779 통과 (BottomNav 14개, Sidebar 추가 2개 포함)
- `pnpm tsc --noEmit` 클린 (사이드바/바텀바 관련)
- 기존 Sidebar API 변경 없음 — admin 등 소비처 break X

## 전달할 추가 이슈

- Chromatic 크레딧 소진 상태 — 이번 PR 의 Chromatic step 은 실패할 수 있음. test/build/a11y 통과만 확인.
- 다음 결제 주기까지 시각 회귀 비교 불가 — 머지 전 수동 review 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)