### PR TITLE
merge: release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,17 @@ jobs:
         with:
           node-version: 22.14.0
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # registry-url 를 설정하면 setup-node 가 `~/.npmrc` 에
+          # `:_authToken=${NODE_AUTH_TOKEN}` 을 깔아둠 — NODE_AUTH_TOKEN 미설정 시
+          # 리터럴 `${NODE_AUTH_TOKEN}` 가 잘못된 토큰으로 인식되어 npm CLI 의
+          # 자동 OIDC 가 트리거 안됨. Trusted Publisher 만 쓸 거라 빈 npmrc 가 정답.
+
+      # Node 22.14 ships npm 10.x — auto-OIDC (Trusted Publisher) 는 npm 11.5+ 에서 추가됨.
+      # @semantic-release/npm@13.1.5 의 oidc-context.js 는 토큰 exchange 후 토큰을 버려서 (`!!exchangeToken(...)`)
+      # npmrc 에 안 씀 → publish 시 npm CLI 가 직접 OIDC 해야 동작.
+      # 따라서 npm 11+ 으로 업그레이드 필수.
+      - name: Update npm to latest (OIDC Trusted Publisher 지원)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -40,5 +50,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 작업 개요

`@semantic-release/npm@13.1.5` 의 OIDC Trusted Publisher 통합 버그 우회 — npm CLI 가 직접 auto-OIDC 수행하도록 워크플로우 조정.

## 문제 진단

v3.1.0 release 시 npm publish 가 `ENEEDAUTH` 로 실패. 소스 분석 결과:

`@semantic-release/npm@13.1.5/lib/trusted-publishing/oidc-context.js`:
\`\`\`js
return OFFICIAL_REGISTRY === registry && !!(await exchangeToken(pkg, context));
\`\`\`

`exchangeToken` 이 npm 으로부터 publish 토큰 받아옴 (\`responseBody.token\`) — exchange 성공. 그러나 `!!` 로 boolean 만 반환하고 **토큰 자체를 버림**. `verify-auth.js` 는 OIDC context 인식되면 early return → npmrc 에 토큰 안 씀.

결과: `npm publish --userconfig <빈 npmrc>` → 인증 정보 없음 → `ENEEDAUTH`.

## 작업한 내용

- [x] `npm install -g npm@latest` step 추가 — Node 22.14 의 기본 npm 10.x 는 auto-OIDC 미지원, npm 11.5+ 필요
- [x] `setup-node` 의 `registry-url` 제거 — `~/.npmrc` 에 \`:_authToken=\${NODE_AUTH_TOKEN}\` 깔아두는 부작용 방지 (placeholder 미치환 시 npm 이 잘못된 토큰으로 인식 → auto-OIDC 트리거 안됨)
- [x] `NODE_AUTH_TOKEN` env 제거 — Trusted Publisher OIDC 에서 불필요

## 검증

- Trusted Publisher 설정 확인 — v3.0.0 / v3.1.0 release 로그에 \"OIDC token exchange with the npm registry succeeded\" 출력됨 → npm.com 에 이미 등록되어 있음
- 다음 release 부터 npm CLI 가 직접 OIDC exchange + publish 수행

## 전달할 추가 이슈

- v3.1.0 은 이미 git tag + CHANGELOG 까지 진행되었으나 npm 에는 미배포. 이번 PR 머지 후 새 release 가 트리거되지 않으므로 **수동으로 로컬에서 \`npm publish\`** 필요 (v3.0.0 때와 동일).
- 또는 향후 v3.1.1 patch release 시점에 자동으로 publish 됨 — v3.1.0 은 npm 에서 skip 된 채로 남음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)