### PR TITLE
docs/stories-bilingual

### DIFF
--- a/src/stories/foundation/a11y.stories.tsx
+++ b/src/stories/foundation/a11y.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta = {
 				component: `
 ### 접근성 (Accessibility) 토큰
 
+**Accessibility tokens** — baseline values that help keyboard, low-vision, and touch users perceive every interaction clearly and safely. Covers focus rings, minimum tap targets, and color contrast (WCAG AA).
+
 **키보드 사용자, 저시력 사용자, 터치 사용자**를 고려해
 모든 인터랙션이 명확하고 안전하게 인식되도록 돕는 기준값입니다.
 

--- a/src/stories/foundation/border-width.stories.tsx
+++ b/src/stories/foundation/border-width.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta = {
 				component: `
 ### Border Width (테두리 두께)
 
+**Border Width** — expresses an element's boundary and emphasis level. \`none\`/\`standard\`/\`thick\`/\`indicator\` map from no border to focus/state indicators.
+
 테두리 두께는 **요소의 경계와 강조 수준**을 표현합니다.
 
 - **none (0px)**: 테두리 없음

--- a/src/stories/foundation/breakpoints.stories.tsx
+++ b/src/stories/foundation/breakpoints.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta = {
 				component: `
 ### 반응형 기준 (Breakpoints)
 
+**Breakpoints** — threshold values for changing layout and component placement based on screen size. A 4-tier system based on Material Design 3's Window Size Class.
+
 화면 크기에 따라 **레이아웃과 컴포넌트 배치를 변경하기 위한 기준값**입니다.
 
 Material Design 3의 Window Size Class에 기반한 4단계 시스템입니다.

--- a/src/stories/foundation/colors.stories.tsx
+++ b/src/stories/foundation/colors.stories.tsx
@@ -25,6 +25,8 @@ const meta: Meta = {
 				component: `
 ### Colors (색상 시스템)
 
+**Colors** — official color tokens defined in a two-tier Base / Semantic structure. Always use Semantic tokens (brand / text / bg / state / border / status) instead of raw HEX/RGB values.
+
 **Base / Semantic 2계층 구조**로 정의된 공식 색상 토큰입니다.
 
 - **Base**: raw 값 (직접 사용 지양)

--- a/src/stories/foundation/dark-mode.stories.tsx
+++ b/src/stories/foundation/dark-mode.stories.tsx
@@ -15,6 +15,8 @@ const meta: Meta = {
 				component: `
 ### Dark Mode
 
+**Dark Mode** — Bigtablet DS supports dark mode powered by CSS Custom Properties. Set a \`data-theme\` attribute (\`light\`/\`dark\`, or omit it to follow \`prefers-color-scheme\`), or use the \`ThemeProvider\` in React.
+
 Bigtablet DS는 CSS Custom Properties 기반 dark mode를 지원합니다.
 
 #### 작동 방식

--- a/src/stories/foundation/elevation.stories.tsx
+++ b/src/stories/foundation/elevation.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta = {
 				component: `
 ### Elevation(높이 위계) 기준
 
+**Elevation** — expresses "floating" (layering) and **height hierarchy** via shadows. \`level1\` (cards) through \`level5\` (strongest, top-most layers).
+
 Elevation은 "떠 있음(레이어)"과 **높이 위계** 를 표현합니다.
 
 - **level1**: 아주 가벼운 분리 (카드, 인풋 배경)

--- a/src/stories/foundation/motion.stories.tsx
+++ b/src/stories/foundation/motion.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta = {
 				component: `
 ### 모션(Motion) 기준
 
+**Motion** — defines **how fast and how smoothly** the UI responds. Shared across all interaction animations (button hover, card emphasis, modal entrance, etc.). Enter/exit pairs use different tokens — exits are shorter than entrances.
+
 UI가 **얼마나 빠르게, 얼마나 부드럽게 반응하는지**를 정의하는 기준입니다.
 
 👉 버튼 hover, 카드 강조, 모달 등장 같은

--- a/src/stories/foundation/opacity.stories.tsx
+++ b/src/stories/foundation/opacity.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta = {
 				component: `
 ### Opacity (불투명도)
 
+**Opacity** — transparency tokens used for overlays, disabled states, hover effects, etc. (\`0\` fully transparent → \`100\` fully opaque).
+
 투명도 토큰입니다. 오버레이, 비활성 상태, 호버 효과 등에서 사용합니다.
 
 - **0**: 완전 투명 (숨김)

--- a/src/stories/foundation/radius.stories.tsx
+++ b/src/stories/foundation/radius.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta = {
 				component: `
 ### Radius (모서리 둥글기)
 
+**Radius** — corner rounding expresses a component's **character and approachability**. \`none\`/\`xs\`/\`sm\` for crisp informational UI, \`md\`/\`lg\` for clickable elements, \`xl\` for hero areas, \`full\` for circles.
+
 모서리 둥글기는 컴포넌트의 **성격과 친밀도**를 표현합니다.
 
 - **none**: 모서리 없음 (표, 인라인 UI)

--- a/src/stories/foundation/skeleton.stories.tsx
+++ b/src/stories/foundation/skeleton.stories.tsx
@@ -41,6 +41,8 @@ const meta: Meta = {
 				component: `
 ### 스켈레톤(Skeleton) 토큰
 
+**Skeleton tokens** — used for **placeholder UI** that fills space while content is loading. Includes gradient colors, wave animation, shape radius, height steps, and animation timing.
+
 콘텐츠가 로딩 중일 때 자리를 채우는 **플레이스홀더 UI**에 사용하는 토큰입니다.
 
 - **color**: 스켈레톤 그라디언트를 구성하는 3가지 색상

--- a/src/stories/foundation/spacing.stories.tsx
+++ b/src/stories/foundation/spacing.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta = {
 				component: `
 ### Spacing (여백)
 
+**Spacing** — the baseline that creates the screen's **breathing room (gaps)**. Use these tokens for all margin / padding / gap "distances".
+
 Spacing은 화면의 **호흡(간격)** 을 만드는 기준입니다.
 margin / padding / gap 같은 "거리"는 가능한 한 **이 토큰만** 사용합니다.
 

--- a/src/stories/foundation/typography.stories.tsx
+++ b/src/stories/foundation/typography.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta = {
 				component: `
 ### Typography (타이포그래피)
 
+**Typography** — typography tokens defined in a two-tier Base / Semantic structure (5 scales × 3 sizes × 2 weights). Always use Semantic tokens instead of raw px values.
+
 **Base / Semantic 2계층 구조**로 정의된 타이포그래피 토큰입니다.
 
 - **Base**: 원시 값 (fontSize, fontWeight, lineHeight, letterSpacing)

--- a/src/stories/foundation/z-index.stories.tsx
+++ b/src/stories/foundation/z-index.stories.tsx
@@ -13,6 +13,8 @@ const meta: Meta = {
 				component: `
 ### Z-Index (레이어 우선순위)
 
+**Z-Index** — the standard for deciding **which element appears on top** on screen. Higher numbers render above; fix values to the level scale below (\`level0\` base → \`level5\` top-most).
+
 z-index는 **화면에서 어떤 요소가 위에 보일지**를 정하는 기준입니다.
 
 숫자가 클수록 위에 표시되며,

--- a/src/stories/getting-started/installation.stories.tsx
+++ b/src/stories/getting-started/installation.stories.tsx
@@ -9,9 +9,9 @@ const meta: Meta = {
 		docs: {
 			description: {
 				component: `
-### 설치 및 설정
+### Installation & Setup / 설치 및 설정
 
-프로젝트에 디자인 시스템을 설치하고 사용하는 방법입니다. React/Next.js와 Vanilla(Thymeleaf, JSP, PHP) 두 환경을 지원합니다.
+How to install and use the design system in your project. Supports both React/Next.js and Vanilla (Thymeleaf, JSP, PHP) environments. / 프로젝트에 디자인 시스템을 설치하고 사용하는 방법입니다. React/Next.js와 Vanilla(Thymeleaf, JSP, PHP) 두 환경을 지원합니다.
         `,
 			},
 		},

--- a/src/stories/getting-started/introduction.stories.tsx
+++ b/src/stories/getting-started/introduction.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta = {
 				component: `
 ### Bigtablet Design System
 
-서비스 전반에 사용되는 **UI 컴포넌트와 디자인 토큰**을 관리하는 디자인 시스템입니다.
+A design system that manages the **UI components and design tokens** used across the service. / 서비스 전반에 사용되는 **UI 컴포넌트와 디자인 토큰**을 관리하는 디자인 시스템입니다.
 
 ---
 

--- a/src/ui/display/accordion/accordion.stories.tsx
+++ b/src/ui/display/accordion/accordion.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Accordion> = {
 		docs: {
 			description: {
 				component: `
-**Accordion** — Progressively reveals content via expand/collapse panels. / 펼침/접힘으로 컨텐츠 점진 노출.
+**Accordion** — Progressively reveals content via expand/collapse panels. / **Accordion** — 펼침/접힘으로 컨텐츠 점진 노출.
 
 \`multiple={false}\` (default): one open at a time / \`multiple={true}\`: independent toggles. — \`multiple={false}\` (기본): 한 번에 하나 / \`multiple={true}\`: 독립 토글.
 WAI-ARIA Disclosure handled automatically (\`aria-expanded\`, \`aria-controls\`, \`role="region"\`). / WAI-ARIA Disclosure 자동.

--- a/src/ui/display/accordion/accordion.stories.tsx
+++ b/src/ui/display/accordion/accordion.stories.tsx
@@ -18,10 +18,10 @@ const meta: Meta<typeof Accordion> = {
 		docs: {
 			description: {
 				component: `
-**Accordion** — 펼침/접힘으로 컨텐츠 점진 노출.
+**Accordion** — Progressively reveals content via expand/collapse panels. / 펼침/접힘으로 컨텐츠 점진 노출.
 
-\`multiple={false}\` (기본): 한 번에 하나 / \`multiple={true}\`: 독립 토글.
-WAI-ARIA Disclosure 자동 (\`aria-expanded\`, \`aria-controls\`, \`role="region"\`).
+\`multiple={false}\` (default): one open at a time / \`multiple={true}\`: independent toggles. — \`multiple={false}\` (기본): 한 번에 하나 / \`multiple={true}\`: 독립 토글.
+WAI-ARIA Disclosure handled automatically (\`aria-expanded\`, \`aria-controls\`, \`role="region"\`). / WAI-ARIA Disclosure 자동.
 				`,
 			},
 		},

--- a/src/ui/display/avatar/avatar.stories.tsx
+++ b/src/ui/display/avatar/avatar.stories.tsx
@@ -17,10 +17,10 @@ const meta: Meta<typeof Avatar> = {
 		docs: {
 			description: {
 				component: `
-**Avatar** — User profile display. Image takes priority; falls back to \`name\` initials when missing or on load failure. / 사용자 프로필. 이미지 우선, 실패/없으면 \`name\` initials fallback.
+**Avatar** — User profile display. Image takes priority; falls back to \`name\` initials when missing or on load failure. / **Avatar** — 사용자 프로필. 이미지 우선, 실패/없으면 \`name\` initials fallback.
 
 Sizes: \`xs\` 24 / \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 64.
-Shapes: \`circle\` (people) / \`square\` (brand). — \`circle\` (사람) / \`square\` (브랜드).
+Shapes: \`circle\` (people) / \`square\` (brand). — **Shapes**: \`circle\` (사람) / \`square\` (브랜드).
 Initials rule: 1 word → first letter, 2+ words → first letter of first + last word. / initials 규칙: 1단어 → 첫 글자, 2+단어 → 첫+마지막 단어 첫 글자.
 				`,
 			},

--- a/src/ui/display/avatar/avatar.stories.tsx
+++ b/src/ui/display/avatar/avatar.stories.tsx
@@ -17,11 +17,11 @@ const meta: Meta<typeof Avatar> = {
 		docs: {
 			description: {
 				component: `
-**Avatar** — 사용자 프로필. 이미지 우선, 실패/없으면 \`name\` initials fallback.
+**Avatar** — User profile display. Image takes priority; falls back to \`name\` initials when missing or on load failure. / 사용자 프로필. 이미지 우선, 실패/없으면 \`name\` initials fallback.
 
 Sizes: \`xs\` 24 / \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 64.
-Shapes: \`circle\` (사람) / \`square\` (브랜드).
-initials 규칙: 1단어 → 첫 글자, 2+단어 → 첫+마지막 단어 첫 글자.
+Shapes: \`circle\` (people) / \`square\` (brand). — \`circle\` (사람) / \`square\` (브랜드).
+Initials rule: 1 word → first letter, 2+ words → first letter of first + last word. / initials 규칙: 1단어 → 첫 글자, 2+단어 → 첫+마지막 단어 첫 글자.
 				`,
 			},
 		},

--- a/src/ui/display/card/card.stories.tsx
+++ b/src/ui/display/card/card.stories.tsx
@@ -26,9 +26,9 @@ const meta: Meta<typeof Card> = {
 		docs: {
 			description: {
 				component: `
-**Card** — Container that groups related content into a single block. / 콘텐츠를 한 덩어리로 묶는 컨테이너.
+**Card** — Container that groups related content into a single block. / **Card** — 콘텐츠를 한 덩어리로 묶는 컨테이너.
 
-Variants: \`default\` / \`accent\` (navy bg + white text). — \`accent\` (navy bg + 흰 텍스트).
+Variants: \`default\` / \`accent\` (navy bg + white text). — **Variants**: \`accent\` (navy bg + 흰 텍스트).
 Key props: \`heading\`, \`shadow\` (none/sm/md/lg), \`padding\` (none/sm/md/lg), \`bordered\`. / 주요 prop.
 				`,
 			},

--- a/src/ui/display/card/card.stories.tsx
+++ b/src/ui/display/card/card.stories.tsx
@@ -26,10 +26,10 @@ const meta: Meta<typeof Card> = {
 		docs: {
 			description: {
 				component: `
-**Card** — 콘텐츠를 한 덩어리로 묶는 컨테이너.
+**Card** — Container that groups related content into a single block. / 콘텐츠를 한 덩어리로 묶는 컨테이너.
 
-Variants: \`default\` / \`accent\` (navy bg + 흰 텍스트).
-주요 prop: \`heading\`, \`shadow\` (none/sm/md/lg), \`padding\` (none/sm/md/lg), \`bordered\`.
+Variants: \`default\` / \`accent\` (navy bg + white text). — \`accent\` (navy bg + 흰 텍스트).
+Key props: \`heading\`, \`shadow\` (none/sm/md/lg), \`padding\` (none/sm/md/lg), \`bordered\`. / 주요 prop.
 				`,
 			},
 		},

--- a/src/ui/display/chip/chip.stories.tsx
+++ b/src/ui/display/chip/chip.stories.tsx
@@ -22,9 +22,9 @@ const meta: Meta<typeof Chip> = {
 		docs: {
 			description: {
 				component: `
-**Chip** — Compact element representing an attribute, filter, or input value. / 속성/필터/입력값을 표현하는 컴팩트 요소.
+**Chip** — Compact element representing an attribute, filter, or input value. / **Chip** — 속성/필터/입력값을 표현하는 컴팩트 요소.
 
-Types: \`basic\` (tag) / \`input\` (input value, removable) / \`filter\` (dropdown) / \`static\` (label, tone). — \`basic\` (태그) / \`input\` (입력값, removable) / \`filter\` (드롭다운) / \`static\` (라벨, tone).
+Types: \`basic\` (tag) / \`input\` (input value, removable) / \`filter\` (dropdown) / \`static\` (label, tone). — **Types**: \`basic\` (태그) / \`input\` (입력값, removable) / \`filter\` (드롭다운) / \`static\` (라벨, tone).
 Key props: \`type\`, \`tone\`, \`size\` (sm 24 / md 28 / default 32), \`selected\`, \`removable\`. / 주요 prop.
 				`,
 			},

--- a/src/ui/display/chip/chip.stories.tsx
+++ b/src/ui/display/chip/chip.stories.tsx
@@ -22,10 +22,10 @@ const meta: Meta<typeof Chip> = {
 		docs: {
 			description: {
 				component: `
-**Chip** — 속성/필터/입력값을 표현하는 컴팩트 요소.
+**Chip** — Compact element representing an attribute, filter, or input value. / 속성/필터/입력값을 표현하는 컴팩트 요소.
 
-Types: \`basic\` (태그) / \`input\` (입력값, removable) / \`filter\` (드롭다운) / \`static\` (라벨, tone).
-주요 prop: \`type\`, \`tone\`, \`size\` (sm 24 / md 28 / default 32), \`selected\`, \`removable\`.
+Types: \`basic\` (tag) / \`input\` (input value, removable) / \`filter\` (dropdown) / \`static\` (label, tone). — \`basic\` (태그) / \`input\` (입력값, removable) / \`filter\` (드롭다운) / \`static\` (라벨, tone).
+Key props: \`type\`, \`tone\`, \`size\` (sm 24 / md 28 / default 32), \`selected\`, \`removable\`. / 주요 prop.
 				`,
 			},
 		},

--- a/src/ui/display/divider/divider.stories.tsx
+++ b/src/ui/display/divider/divider.stories.tsx
@@ -20,9 +20,9 @@ const meta: Meta<typeof Divider> = {
 		docs: {
 			description: {
 				component: `
-**Divider** — 콘텐츠 영역 수평 구분선.
+**Divider** — Horizontal rule separating content areas. / 콘텐츠 영역 수평 구분선.
 
-\`weight\`: \`standard\` (1px, 기본) / \`heavy\` (2px, 섹션 강조).
+\`weight\`: \`standard\` (1px, default) / \`heavy\` (2px, section emphasis). — \`standard\` (1px, 기본) / \`heavy\` (2px, 섹션 강조).
         `,
 			},
 		},

--- a/src/ui/display/divider/divider.stories.tsx
+++ b/src/ui/display/divider/divider.stories.tsx
@@ -20,9 +20,9 @@ const meta: Meta<typeof Divider> = {
 		docs: {
 			description: {
 				component: `
-**Divider** — Horizontal rule separating content areas. / 콘텐츠 영역 수평 구분선.
+**Divider** — Horizontal rule separating content areas. / **Divider** — 콘텐츠 영역 수평 구분선.
 
-\`weight\`: \`standard\` (1px, default) / \`heavy\` (2px, section emphasis). — \`standard\` (1px, 기본) / \`heavy\` (2px, 섹션 강조).
+\`weight\`: \`standard\` (1px, default) / \`heavy\` (2px, section emphasis). — \`weight\`: \`standard\` (1px, 기본) / \`heavy\` (2px, 섹션 강조).
         `,
 			},
 		},

--- a/src/ui/display/hero/hero.stories.tsx
+++ b/src/ui/display/hero/hero.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Hero> = {
 		docs: {
 			description: {
 				component: `
-**Hero** — Large banner area at the top of a page. Renders \`<section>\` + \`<h1>\` (one per page). / 페이지 상단 큰 영역. \`<section>\` + \`<h1>\` (페이지당 하나).
+**Hero** — Large banner area at the top of a page. Renders \`<section>\` + \`<h1>\` (one per page). / **Hero** — 페이지 상단 큰 영역. \`<section>\` + \`<h1>\` (페이지당 하나).
 
 Slots: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`. / 슬롯.
 Key props: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`. / 주요 prop.

--- a/src/ui/display/hero/hero.stories.tsx
+++ b/src/ui/display/hero/hero.stories.tsx
@@ -13,8 +13,8 @@ const meta: Meta<typeof Hero> = {
 				component: `
 **Hero** — Large banner area at the top of a page. Renders \`<section>\` + \`<h1>\` (one per page). / **Hero** — 페이지 상단 큰 영역. \`<section>\` + \`<h1>\` (페이지당 하나).
 
-Slots: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`. / 슬롯.
-Key props: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`. / 주요 prop.
+Slots: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`. / 슬롯: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`.
+Key props: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`. / 주요 prop: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`.
 				`,
 			},
 		},

--- a/src/ui/display/hero/hero.stories.tsx
+++ b/src/ui/display/hero/hero.stories.tsx
@@ -11,10 +11,10 @@ const meta: Meta<typeof Hero> = {
 		docs: {
 			description: {
 				component: `
-**Hero** — 페이지 상단 큰 영역. \`<section>\` + \`<h1>\` (페이지당 하나).
+**Hero** — Large banner area at the top of a page. Renders \`<section>\` + \`<h1>\` (one per page). / 페이지 상단 큰 영역. \`<section>\` + \`<h1>\` (페이지당 하나).
 
-슬롯: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`.
-주요 prop: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`.
+Slots: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`. / 슬롯.
+Key props: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`. / 주요 prop.
 				`,
 			},
 		},

--- a/src/ui/display/icon/icon.stories.tsx
+++ b/src/ui/display/icon/icon.stories.tsx
@@ -31,9 +31,9 @@ const meta: Meta<typeof Icon> = {
 		docs: {
 			description: {
 				component: `
-**Icon** — lucide-react 아이콘 wrapper. 카탈로그: [lucide.dev/icons](https://lucide.dev/icons/).
+**Icon** — Wrapper around lucide-react icons. Catalog: [lucide.dev/icons](https://lucide.dev/icons/). / lucide-react 아이콘 wrapper.
 
-주요 prop: \`icon\` (lucide 컴포넌트), \`size\`, \`strokeWidth\`, \`aria-label\` (미지정 시 \`aria-hidden\` 자동).
+Key props: \`icon\` (lucide component), \`size\`, \`strokeWidth\`, \`aria-label\` (\`aria-hidden\` applied automatically when omitted). / 주요 prop: \`icon\` (lucide 컴포넌트), \`size\`, \`strokeWidth\`, \`aria-label\` (미지정 시 \`aria-hidden\` 자동).
         `,
 			},
 		},

--- a/src/ui/display/list-item/list-item.stories.tsx
+++ b/src/ui/display/list-item/list-item.stories.tsx
@@ -22,9 +22,9 @@ const meta: Meta<typeof ListItem> = {
 		docs: {
 			description: {
 				component: `
-**ListItem** — 목록 한 항목. 슬롯형 (\`leadingElement\` / \`trailingElement\`).
+**ListItem** — A single row in a list. Slot-based (\`leadingElement\` / \`trailingElement\`). / 목록 한 항목. 슬롯형.
 
-주요 prop: \`label\`, \`overline\` (위 작은 텍스트), \`supportingText\` (아래 보조), \`metadata\` (하단 메타), \`alignment\` (\`top\` 멀티라인 / \`middle\` 한 줄+아이콘), \`onClick\` (인터랙티브).
+Key props: \`label\`, \`overline\` (small text above), \`supportingText\` (secondary text below), \`metadata\` (bottom meta), \`alignment\` (\`top\` multi-line / \`middle\` single line + icon), \`onClick\` (interactive). / 주요 prop: \`label\`, \`overline\` (위 작은 텍스트), \`supportingText\` (아래 보조), \`metadata\` (하단 메타), \`alignment\` (\`top\` 멀티라인 / \`middle\` 한 줄+아이콘), \`onClick\` (인터랙티브).
 				`,
 			},
 		},

--- a/src/ui/display/list-item/list-item.stories.tsx
+++ b/src/ui/display/list-item/list-item.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof ListItem> = {
 		docs: {
 			description: {
 				component: `
-**ListItem** — A single row in a list. Slot-based (\`leadingElement\` / \`trailingElement\`). / 목록 한 항목. 슬롯형.
+**ListItem** — A single row in a list. Slot-based (\`leadingElement\` / \`trailingElement\`). / **ListItem** — 목록 한 항목. 슬롯형.
 
 Key props: \`label\`, \`overline\` (small text above), \`supportingText\` (secondary text below), \`metadata\` (bottom meta), \`alignment\` (\`top\` multi-line / \`middle\` single line + icon), \`onClick\` (interactive). / 주요 prop: \`label\`, \`overline\` (위 작은 텍스트), \`supportingText\` (아래 보조), \`metadata\` (하단 메타), \`alignment\` (\`top\` 멀티라인 / \`middle\` 한 줄+아이콘), \`onClick\` (인터랙티브).
 				`,

--- a/src/ui/display/media-card/media-card.stories.tsx
+++ b/src/ui/display/media-card/media-card.stories.tsx
@@ -13,9 +13,9 @@ const meta: Meta<typeof MediaCard> = {
 		docs: {
 			description: {
 				component: `
-**MediaCard** — Image + text content card for blog/product grids and menu displays. / 이미지 + 텍스트 콘텐츠 카드. 블로그/제품 그리드/메뉴 진열용.
+**MediaCard** — Image + text content card for blog/product grids and menu displays. / **MediaCard** — 이미지 + 텍스트 콘텐츠 카드. 블로그/제품 그리드/메뉴 진열용.
 
-\`imagePosition\`: \`top\` (grid, default 16/9) / \`left\` (list, auto top on mobile) / \`overlay\` (text over image, 4/3). — \`top\` (그리드, 기본 16/9) / \`left\` (리스트, 모바일 자동 top) / \`overlay\` (이미지 위 텍스트, 4/3).
+\`imagePosition\`: \`top\` (grid, default 16/9) / \`left\` (list, auto top on mobile) / \`overlay\` (text over image, 4/3). — \`imagePosition\`: \`top\` (그리드, 기본 16/9) / \`left\` (리스트, 모바일 자동 top) / \`overlay\` (이미지 위 텍스트, 4/3).
 Key props: \`image\`, \`heading\`, \`aspectRatio\`, \`shadow\`, \`bordered\`, \`clickable\` (hover lift). / 주요 prop.
 				`,
 			},

--- a/src/ui/display/media-card/media-card.stories.tsx
+++ b/src/ui/display/media-card/media-card.stories.tsx
@@ -13,10 +13,10 @@ const meta: Meta<typeof MediaCard> = {
 		docs: {
 			description: {
 				component: `
-**MediaCard** — 이미지 + 텍스트 콘텐츠 카드. 블로그/제품 그리드/메뉴 진열용.
+**MediaCard** — Image + text content card for blog/product grids and menu displays. / 이미지 + 텍스트 콘텐츠 카드. 블로그/제품 그리드/메뉴 진열용.
 
-\`imagePosition\`: \`top\` (그리드, 기본 16/9) / \`left\` (리스트, 모바일 자동 top) / \`overlay\` (이미지 위 텍스트, 4/3).
-주요 prop: \`image\`, \`heading\`, \`aspectRatio\`, \`shadow\`, \`bordered\`, \`clickable\` (hover lift).
+\`imagePosition\`: \`top\` (grid, default 16/9) / \`left\` (list, auto top on mobile) / \`overlay\` (text over image, 4/3). — \`top\` (그리드, 기본 16/9) / \`left\` (리스트, 모바일 자동 top) / \`overlay\` (이미지 위 텍스트, 4/3).
+Key props: \`image\`, \`heading\`, \`aspectRatio\`, \`shadow\`, \`bordered\`, \`clickable\` (hover lift). / 주요 prop.
 				`,
 			},
 		},

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -51,9 +51,9 @@ const meta: Meta<typeof Table> = {
 		docs: {
 			description: {
 				component: `
-**Table** — 정형 데이터 행/열 표시. 제네릭 row 타입 안전.
+**Table** — Displays structured data in rows/columns with generic row type safety. / 정형 데이터 행/열 표시. 제네릭 row 타입 안전.
 
-주요 prop: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (Skeleton 행 자동), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`.
+Key props: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (auto Skeleton rows), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`. / 주요 prop: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (Skeleton 행 자동), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`.
         `,
 			},
 		},

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -51,7 +51,7 @@ const meta: Meta<typeof Table> = {
 		docs: {
 			description: {
 				component: `
-**Table** — Displays structured data in rows/columns with generic row type safety. / 정형 데이터 행/열 표시. 제네릭 row 타입 안전.
+**Table** — Displays structured data in rows/columns with generic row type safety. / **Table** — 정형 데이터 행/열 표시. 제네릭 row 타입 안전.
 
 Key props: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (auto Skeleton rows), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`. / 주요 prop: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (Skeleton 행 자동), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`.
         `,

--- a/src/ui/feedback/alert/alert.stories.tsx
+++ b/src/ui/feedback/alert/alert.stories.tsx
@@ -89,11 +89,11 @@ const meta: Meta<typeof AlertDemo> = {
 		docs: {
 			description: {
 				component: `
-**Alert** — 즉각 확인이 필요한 모달 알림.
+**Alert** — Modal dialog for actions that need immediate confirmation. / 즉각 확인이 필요한 모달 알림.
 
 Variants: \`info\` / \`success\` / \`warning\` / \`error\`.
-주요 prop: \`title\`, \`message\`, \`showCancel\`, \`actionsAlign\`, \`destructive\` (confirm 빨간 강조), \`showIcon\`.
-사용: \`useAlert().showAlert({...})\` — \`AlertProvider\` 하위에서.
+Key props / 주요 prop: \`title\`, \`message\`, \`showCancel\`, \`actionsAlign\`, \`destructive\` (red confirm emphasis / confirm 빨간 강조), \`showIcon\`.
+Usage / 사용: \`useAlert().showAlert({...})\` — inside \`AlertProvider\`. / \`AlertProvider\` 하위에서.
 				`,
 			},
 		},

--- a/src/ui/feedback/alert/alert.stories.tsx
+++ b/src/ui/feedback/alert/alert.stories.tsx
@@ -89,7 +89,7 @@ const meta: Meta<typeof AlertDemo> = {
 		docs: {
 			description: {
 				component: `
-**Alert** — Modal dialog for actions that need immediate confirmation. / 즉각 확인이 필요한 모달 알림.
+**Alert** — Modal dialog for actions that need immediate confirmation. / **Alert** — 즉각 확인이 필요한 모달 알림.
 
 Variants: \`info\` / \`success\` / \`warning\` / \`error\`.
 Key props / 주요 prop: \`title\`, \`message\`, \`showCancel\`, \`actionsAlign\`, \`destructive\` (red confirm emphasis / confirm 빨간 강조), \`showIcon\`.

--- a/src/ui/feedback/empty-state/empty-state.stories.tsx
+++ b/src/ui/feedback/empty-state/empty-state.stories.tsx
@@ -39,7 +39,7 @@ const meta: Meta<typeof EmptyState> = {
 		docs: {
 			description: {
 				component: `
-**EmptyState** — Placeholder for areas with no data. / 데이터 없는 영역 placeholder. Slots / 슬롯: \`illustration\` + \`title\` + \`description\` + \`action\`.
+**EmptyState** — Placeholder for areas with no data. / **EmptyState** — 데이터 없는 영역 placeholder. Slots / 슬롯: \`illustration\` + \`title\` + \`description\` + \`action\`.
 
 Sizes: \`sm\` (modal/sidebar / 모달·사이드바) / \`md\` (content area, default / 콘텐츠 영역, 기본) / \`lg\` (page main / 페이지 메인).
 				`,

--- a/src/ui/feedback/empty-state/empty-state.stories.tsx
+++ b/src/ui/feedback/empty-state/empty-state.stories.tsx
@@ -39,9 +39,9 @@ const meta: Meta<typeof EmptyState> = {
 		docs: {
 			description: {
 				component: `
-**EmptyState** — 데이터 없는 영역 placeholder. \`illustration\` + \`title\` + \`description\` + \`action\` 슬롯.
+**EmptyState** — Placeholder for areas with no data. / 데이터 없는 영역 placeholder. Slots / 슬롯: \`illustration\` + \`title\` + \`description\` + \`action\`.
 
-Sizes: \`sm\` (모달/사이드바) / \`md\` (콘텐츠 영역, 기본) / \`lg\` (페이지 메인).
+Sizes: \`sm\` (modal/sidebar / 모달·사이드바) / \`md\` (content area, default / 콘텐츠 영역, 기본) / \`lg\` (page main / 페이지 메인).
 				`,
 			},
 		},

--- a/src/ui/feedback/linear-progress/linear-progress.stories.tsx
+++ b/src/ui/feedback/linear-progress/linear-progress.stories.tsx
@@ -14,10 +14,10 @@ const meta: Meta<typeof LinearProgress> = {
 		docs: {
 			description: {
 				component: `
-**LinearProgress** — 단계 기반 진행률 수평 바. 회원가입/설문 Stepper 용.
+**LinearProgress** — Horizontal step-based progress bar. / 단계 기반 진행률 수평 바. For signup/survey steppers. / 회원가입·설문 Stepper 용.
 
-주요 prop: \`totalSteps\`, \`currentStep\` (0 ~ totalSteps).
-비동기 로딩은 \`Spinner\`, 페이지 전환은 \`TopLoading\` 참고.
+Key props / 주요 prop: \`totalSteps\`, \`currentStep\` (0 ~ totalSteps).
+For async loading see \`Spinner\`, for page transitions see \`TopLoading\`. / 비동기 로딩은 \`Spinner\`, 페이지 전환은 \`TopLoading\` 참고.
 				`,
 			},
 		},

--- a/src/ui/feedback/linear-progress/linear-progress.stories.tsx
+++ b/src/ui/feedback/linear-progress/linear-progress.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof LinearProgress> = {
 		docs: {
 			description: {
 				component: `
-**LinearProgress** — Horizontal step-based progress bar. / 단계 기반 진행률 수평 바. For signup/survey steppers. / 회원가입·설문 Stepper 용.
+**LinearProgress** — Horizontal step-based progress bar. / **LinearProgress** — 단계 기반 진행률 수평 바. For signup/survey steppers. / 회원가입·설문 Stepper 용.
 
 Key props / 주요 prop: \`totalSteps\`, \`currentStep\` (0 ~ totalSteps).
 For async loading see \`Spinner\`, for page transitions see \`TopLoading\`. / 비동기 로딩은 \`Spinner\`, 페이지 전환은 \`TopLoading\` 참고.

--- a/src/ui/feedback/skeleton/skeleton.stories.tsx
+++ b/src/ui/feedback/skeleton/skeleton.stories.tsx
@@ -16,9 +16,9 @@ const meta: Meta<typeof Skeleton> = {
 		docs: {
 			description: {
 				component: `
-**Skeleton** — 로딩 플레이스홀더. \`aria-hidden\` 자동.
+**Skeleton** — Loading placeholder. / 로딩 플레이스홀더. \`aria-hidden\` applied automatically. / \`aria-hidden\` 자동.
 
-Variants: \`text\` (12px) / \`title\` (20px) / \`avatar\` (40×40 원형) / \`rect\` (카드/이미지).
+Variants: \`text\` (12px) / \`title\` (20px) / \`avatar\` (40×40 circle / 원형) / \`rect\` (card/image / 카드·이미지).
 				`,
 			},
 		},

--- a/src/ui/feedback/skeleton/skeleton.stories.tsx
+++ b/src/ui/feedback/skeleton/skeleton.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof Skeleton> = {
 		docs: {
 			description: {
 				component: `
-**Skeleton** — Loading placeholder. / 로딩 플레이스홀더. \`aria-hidden\` applied automatically. / \`aria-hidden\` 자동.
+**Skeleton** — Loading placeholder. / **Skeleton** — 로딩 플레이스홀더. \`aria-hidden\` applied automatically. / \`aria-hidden\` 자동.
 
 Variants: \`text\` (12px) / \`title\` (20px) / \`avatar\` (40×40 circle / 원형) / \`rect\` (card/image / 카드·이미지).
 				`,

--- a/src/ui/feedback/spinner/spinner.stories.tsx
+++ b/src/ui/feedback/spinner/spinner.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Spinner> = {
 		docs: {
 			description: {
 				component: `
-**Spinner** — Inline rotating loading indicator. / 인라인 회전 로딩 표시. For use inside buttons/cards. / 버튼·카드 내부용.
+**Spinner** — Inline rotating loading indicator. / **Spinner** — 인라인 회전 로딩 표시. For use inside buttons/cards. / 버튼·카드 내부용.
 
 Size / 크기: button 16–24 / 버튼, card 24–32 / 카드, emphasis 40+ / 강조. For page transitions see \`TopLoading\`. / 페이지 전환은 \`TopLoading\` 참고.
 

--- a/src/ui/feedback/spinner/spinner.stories.tsx
+++ b/src/ui/feedback/spinner/spinner.stories.tsx
@@ -18,11 +18,11 @@ const meta: Meta<typeof Spinner> = {
 		docs: {
 			description: {
 				component: `
-**Spinner** — 인라인 회전 로딩 표시. 버튼/카드 내부용.
+**Spinner** — Inline rotating loading indicator. / 인라인 회전 로딩 표시. For use inside buttons/cards. / 버튼·카드 내부용.
 
-크기: 버튼 16–24, 카드 24–32, 강조 40+. 페이지 전환은 \`TopLoading\` 참고.
+Size / 크기: button 16–24 / 버튼, card 24–32 / 카드, emphasis 40+ / 강조. For page transitions see \`TopLoading\`. / 페이지 전환은 \`TopLoading\` 참고.
 
-> ⚠️ **Docs 뷰 안내** — 이 페이지의 미리보기는 정적 캡처라 spinner 가 멈춰 있거나 한 프레임만 보일 수 있다. 실제 회전은 좌측 사이드바에서 개별 스토리 (Basic 등) 를 열면 확인 가능.
+> ⚠️ **Docs view note / Docs 뷰 안내** — The preview on this page is a static capture, so the spinner may appear frozen or show a single frame. / 이 페이지의 미리보기는 정적 캡처라 spinner 가 멈춰 있거나 한 프레임만 보일 수 있다. To see the real rotation, open an individual story (e.g. Basic) from the left sidebar. / 실제 회전은 좌측 사이드바에서 개별 스토리 (Basic 등) 를 열면 확인 가능.
         `,
 			},
 		},

--- a/src/ui/feedback/toast/toast.stories.tsx
+++ b/src/ui/feedback/toast/toast.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta = {
 		docs: {
 			description: {
 				component: `
-**Toast** — Brief, non-blocking notification that auto-dismisses. / 화면을 막지 않는 짧은 알림. 자동 사라짐.
+**Toast** — Brief, non-blocking notification that auto-dismisses. / **Toast** — 화면을 막지 않는 짧은 알림. 자동 사라짐.
 
 Types: \`message\` (default) / \`success\` / \`warning\` / \`error\` / \`info\`.
 Usage / 사용: wrap with \`<ToastProvider>\` and use the \`useToast()\` hook — \`t.success("저장 완료", 5000)\`. / \`<ToastProvider>\` 감싸고 \`useToast()\` 훅.

--- a/src/ui/feedback/toast/toast.stories.tsx
+++ b/src/ui/feedback/toast/toast.stories.tsx
@@ -58,10 +58,10 @@ const meta: Meta = {
 		docs: {
 			description: {
 				component: `
-**Toast** — 화면을 막지 않는 짧은 알림. 자동 사라짐.
+**Toast** — Brief, non-blocking notification that auto-dismisses. / 화면을 막지 않는 짧은 알림. 자동 사라짐.
 
 Types: \`message\` (default) / \`success\` / \`warning\` / \`error\` / \`info\`.
-사용: \`<ToastProvider>\` 감싸고 \`useToast()\` 훅 — \`t.success("저장 완료", 5000)\`.
+Usage / 사용: wrap with \`<ToastProvider>\` and use the \`useToast()\` hook — \`t.success("저장 완료", 5000)\`. / \`<ToastProvider>\` 감싸고 \`useToast()\` 훅.
 				`,
 			},
 		},

--- a/src/ui/feedback/top-loading/top-loading.stories.tsx
+++ b/src/ui/feedback/top-loading/top-loading.stories.tsx
@@ -37,10 +37,10 @@ const meta: Meta<typeof TopLoading> = {
 		docs: {
 			description: {
 				component: `
-**TopLoading** — 화면 상단 고정 프로그레스 바. 페이지 전환/전역 로딩용.
+**TopLoading** — Progress bar pinned to the top of the screen. / 화면 상단 고정 프로그레스 바. For page transitions/global loading. / 페이지 전환·전역 로딩용.
 
-\`progress\` 미지정 → indeterminate 무한 애니메이션 / 지정 → determinate 퍼센트 fill.
-인라인 로딩은 \`Spinner\` 참고.
+\`progress\` unset → indeterminate infinite animation / 미지정 → indeterminate 무한 애니메이션; set → determinate percent fill / 지정 → determinate 퍼센트 fill.
+For inline loading see \`Spinner\`. / 인라인 로딩은 \`Spinner\` 참고.
         `,
 			},
 		},

--- a/src/ui/feedback/top-loading/top-loading.stories.tsx
+++ b/src/ui/feedback/top-loading/top-loading.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta<typeof TopLoading> = {
 		docs: {
 			description: {
 				component: `
-**TopLoading** — Progress bar pinned to the top of the screen. / 화면 상단 고정 프로그레스 바. For page transitions/global loading. / 페이지 전환·전역 로딩용.
+**TopLoading** — Progress bar pinned to the top of the screen. / **TopLoading** — 화면 상단 고정 프로그레스 바. For page transitions/global loading. / 페이지 전환·전역 로딩용.
 
 \`progress\` unset → indeterminate infinite animation / 미지정 → indeterminate 무한 애니메이션; set → determinate percent fill / 지정 → determinate 퍼센트 fill.
 For inline loading see \`Spinner\`. / 인라인 로딩은 \`Spinner\` 참고.

--- a/src/ui/forms/checkbox/checkbox.stories.tsx
+++ b/src/ui/forms/checkbox/checkbox.stories.tsx
@@ -19,12 +19,12 @@ const meta: Meta<typeof Checkbox> = {
 		docs: {
 			description: {
 				component: `
-**Checkbox** — 다중 선택 (단일 선택은 Radio).
+**Checkbox** — Multi-select control (use Radio for single-select). / 다중 선택 (단일 선택은 Radio).
 
-States: \`checked\` / \`indeterminate\` (전체 선택의 일부) / \`disabled\` / \`error\`.
-네이티브 \`<input type="checkbox">\` — Tab/Space 자동.
+States: \`checked\` / \`indeterminate\` (part of a select-all) / \`disabled\` / \`error\`. / \`checked\` / \`indeterminate\` (전체 선택의 일부) / \`disabled\` / \`error\`.
+Native \`<input type="checkbox">\` — Tab/Space handled automatically. / 네이티브 \`<input type="checkbox">\` — Tab/Space 자동.
 
-> ⚠️ **Docs 뷰 안내** — Hover/focus/active 인터랙션 상태는 정적 미리보기에 안 보인다. 실제 동작은 좌측 사이드바에서 개별 스토리 (Basic 등) 를 열고 마우스/키보드 입력으로 확인. Checked/Indeterminate 박스 색은 다크 모드에서 자동 반전 (검정↔흰).
+> ⚠️ **Docs view note / Docs 뷰 안내** — Hover/focus/active interaction states are not visible in the static preview; open an individual story (e.g. Basic) from the left sidebar and use mouse/keyboard to see real behavior. Checked/Indeterminate box color auto-inverts in dark mode (black↔white). / Hover/focus/active 인터랙션 상태는 정적 미리보기에 안 보인다. 실제 동작은 좌측 사이드바에서 개별 스토리 (Basic 등) 를 열고 마우스/키보드 입력으로 확인. Checked/Indeterminate 박스 색은 다크 모드에서 자동 반전 (검정↔흰).
 				`,
 			},
 		},

--- a/src/ui/forms/checkbox/checkbox.stories.tsx
+++ b/src/ui/forms/checkbox/checkbox.stories.tsx
@@ -19,9 +19,9 @@ const meta: Meta<typeof Checkbox> = {
 		docs: {
 			description: {
 				component: `
-**Checkbox** — Multi-select control (use Radio for single-select). / 다중 선택 (단일 선택은 Radio).
+**Checkbox** — Multi-select control (use Radio for single-select). / **Checkbox** — 다중 선택 (단일 선택은 Radio).
 
-States: \`checked\` / \`indeterminate\` (part of a select-all) / \`disabled\` / \`error\`. / \`checked\` / \`indeterminate\` (전체 선택의 일부) / \`disabled\` / \`error\`.
+States: \`checked\` / \`indeterminate\` (part of a select-all) / \`disabled\` / \`error\`. / States: \`checked\` / \`indeterminate\` (전체 선택의 일부) / \`disabled\` / \`error\`.
 Native \`<input type="checkbox">\` — Tab/Space handled automatically. / 네이티브 \`<input type="checkbox">\` — Tab/Space 자동.
 
 > ⚠️ **Docs view note / Docs 뷰 안내** — Hover/focus/active interaction states are not visible in the static preview; open an individual story (e.g. Basic) from the left sidebar and use mouse/keyboard to see real behavior. Checked/Indeterminate box color auto-inverts in dark mode (black↔white). / Hover/focus/active 인터랙션 상태는 정적 미리보기에 안 보인다. 실제 동작은 좌측 사이드바에서 개별 스토리 (Basic 등) 를 열고 마우스/키보드 입력으로 확인. Checked/Indeterminate 박스 색은 다크 모드에서 자동 반전 (검정↔흰).

--- a/src/ui/forms/date-picker/date-picker.stories.tsx
+++ b/src/ui/forms/date-picker/date-picker.stories.tsx
@@ -62,7 +62,7 @@ const meta: Meta<typeof DateFieldDemo> = {
 		docs: {
 			description: {
 				component: `
-**DatePicker** — Year/month/day Dropdown combo. \`onChange\` always returns \`YYYY-MM-DD\`. / 연/월/일 Dropdown 조합. \`onChange\` 항상 \`YYYY-MM-DD\` 반환.
+**DatePicker** — Year/month/day Dropdown combo. \`onChange\` always returns \`YYYY-MM-DD\`. / **DatePicker** — 연/월/일 Dropdown 조합. \`onChange\` 항상 \`YYYY-MM-DD\` 반환.
 
 \`mode\`: \`year-month\` (normalized → YYYY-MM-01) / \`year-month-day\`. / \`year-month\` (정규화 → YYYY-MM-01) / \`year-month-day\`.
 Key props: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`. / 주요 prop: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`.

--- a/src/ui/forms/date-picker/date-picker.stories.tsx
+++ b/src/ui/forms/date-picker/date-picker.stories.tsx
@@ -62,10 +62,10 @@ const meta: Meta<typeof DateFieldDemo> = {
 		docs: {
 			description: {
 				component: `
-**DatePicker** — 연/월/일 Dropdown 조합. \`onChange\` 항상 \`YYYY-MM-DD\` 반환.
+**DatePicker** — Year/month/day Dropdown combo. \`onChange\` always returns \`YYYY-MM-DD\`. / 연/월/일 Dropdown 조합. \`onChange\` 항상 \`YYYY-MM-DD\` 반환.
 
-\`mode\`: \`year-month\` (정규화 → YYYY-MM-01) / \`year-month-day\`.
-주요 prop: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`.
+\`mode\`: \`year-month\` (normalized → YYYY-MM-01) / \`year-month-day\`. / \`year-month\` (정규화 → YYYY-MM-01) / \`year-month-day\`.
+Key props: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`. / 주요 prop: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`.
 				`,
 			},
 		},

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -33,11 +33,11 @@ const meta: Meta<typeof Dropdown> = {
 		docs: {
 			description: {
 				component: `
-**Dropdown** — 단일 선택 드롭다운. 플로팅 라벨 (값 선택/열림 시 표시).
+**Dropdown** — Single-select dropdown. Floating label (shows when a value is selected/opened). / 단일 선택 드롭다운. 플로팅 라벨 (값 선택/열림 시 표시).
 
-Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
-\`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
-키보드: ↑↓/Enter/Esc/Home/End.
+Sizes: \`sm\` / \`md\` (default) / \`lg\`. / \`sm\` / \`md\` (기본) / \`lg\`.
+\`DropdownOption\` fields: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`. / \`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
+Keyboard: ↑↓/Enter/Esc/Home/End. / 키보드: ↑↓/Enter/Esc/Home/End.
 				`,
 			},
 		},

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -33,9 +33,9 @@ const meta: Meta<typeof Dropdown> = {
 		docs: {
 			description: {
 				component: `
-**Dropdown** — Single-select dropdown. Floating label (shows when a value is selected/opened). / 단일 선택 드롭다운. 플로팅 라벨 (값 선택/열림 시 표시).
+**Dropdown** — Single-select dropdown. Floating label (shows when a value is selected/opened). / **Dropdown** — 단일 선택 드롭다운. 플로팅 라벨 (값 선택/열림 시 표시).
 
-Sizes: \`sm\` / \`md\` (default) / \`lg\`. / \`sm\` / \`md\` (기본) / \`lg\`.
+Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
 \`DropdownOption\` fields: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`. / \`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
 Keyboard: ↑↓/Enter/Esc/Home/End. / 키보드: ↑↓/Enter/Esc/Home/End.
 				`,

--- a/src/ui/forms/file/file.stories.tsx
+++ b/src/ui/forms/file/file.stories.tsx
@@ -9,24 +9,24 @@ const meta: Meta<typeof FileInput> = {
 	argTypes: {
 		label: {
 			control: "text",
-			description: "버튼 라벨 / preview 빈 상태 텍스트.",
+			description: "Button label / preview empty-state text. / 버튼 라벨 / preview 빈 상태 텍스트.",
 		},
 		variant: {
 			control: "radio",
 			options: ["button", "preview"],
-			description: "표시 형태. `button` 일반 버튼 / `preview` 큰 박스 안 이미지 미리보기.",
+			description: "Display form. `button` regular button / `preview` image preview inside a large box. / 표시 형태. `button` 일반 버튼 / `preview` 큰 박스 안 이미지 미리보기.",
 		},
 		previewSize: {
 			control: { type: "number", min: 80, max: 400, step: 8 },
-			description: "variant=\"preview\" 박스 크기 (px).",
+			description: "variant=\"preview\" box size (px). / variant=\"preview\" 박스 크기 (px).",
 		},
 		multiple: {
 			control: "boolean",
-			description: "여러 파일 선택 허용 여부 (button variant 만).",
+			description: "Allow selecting multiple files (button variant only). / 여러 파일 선택 허용 여부 (button variant 만).",
 		},
 		disabled: {
 			control: "boolean",
-			description: "비활성화 상태.",
+			description: "Disabled state. / 비활성화 상태.",
 		},
 		onFiles: { control: false },
 	},
@@ -41,12 +41,12 @@ const meta: Meta<typeof FileInput> = {
 		docs: {
 			description: {
 				component: `
-**FileInput** — 파일 선택. \`variant\` 로 표시 형태 선택.
+**FileInput** — File selection. Choose the display form with \`variant\`. / 파일 선택. \`variant\` 로 표시 형태 선택.
 
-- \`variant="button"\` (기본): 일반 파일 선택 버튼. \`preview\` 옵션으로 아래 썸네일 표시.
-- \`variant="preview"\`: 큰 박스 안에 단일 이미지 미리보기 (avatar / 이미지 업로더 패턴). \`previewSize\` 로 박스 크기 조정.
+- \`variant="button"\` (default): regular file-select button. Show thumbnails below via the \`preview\` option. / (기본): 일반 파일 선택 버튼. \`preview\` 옵션으로 아래 썸네일 표시.
+- \`variant="preview"\`: single image preview inside a large box (avatar / image uploader pattern). Adjust box size with \`previewSize\`. / 큰 박스 안에 단일 이미지 미리보기 (avatar / 이미지 업로더 패턴). \`previewSize\` 로 박스 크기 조정.
 
-주요 prop: \`accept\`, \`multiple\`, \`onFiles(files)\`. 업로드는 별도 API.
+Key props: \`accept\`, \`multiple\`, \`onFiles(files)\`. Uploading is a separate API. / 주요 prop: \`accept\`, \`multiple\`, \`onFiles(files)\`. 업로드는 별도 API.
         `,
 			},
 		},
@@ -110,7 +110,7 @@ export const Multiple: Story = {
 		docs: {
 			description: {
 				story:
-					"`multiple={true}` + `preview={true}` — 여러 이미지 선택 시 64×64 썸네일이 버튼 아래 가로로 나열. 파일 이름은 아래 텍스트로 확인.",
+					"`multiple={true}` + `preview={true}` — when multiple images are selected, 64×64 thumbnails are laid out horizontally below the button. File names show in the text below. / 여러 이미지 선택 시 64×64 썸네일이 버튼 아래 가로로 나열. 파일 이름은 아래 텍스트로 확인.",
 			},
 		},
 	},
@@ -159,7 +159,7 @@ export const Preview: Story = {
 		docs: {
 			description: {
 				story:
-					"큰 박스 안에 이미지 미리보기. 비어 있을 때 점선 border + 아이콘 + 라벨. 선택 후 이미지가 박스 채움 + 우상단 X 로 제거 가능.",
+					"Image preview inside a large box. When empty, shows a dashed border + icon + label. After selection the image fills the box and can be removed via the X in the top-right. / 큰 박스 안에 이미지 미리보기. 비어 있을 때 점선 border + 아이콘 + 라벨. 선택 후 이미지가 박스 채움 + 우상단 X 로 제거 가능.",
 			},
 		},
 	},

--- a/src/ui/forms/file/file.stories.tsx
+++ b/src/ui/forms/file/file.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof FileInput> = {
 		docs: {
 			description: {
 				component: `
-**FileInput** — File selection. Choose the display form with \`variant\`. / 파일 선택. \`variant\` 로 표시 형태 선택.
+**FileInput** — File selection. Choose the display form with \`variant\`. / **FileInput** — 파일 선택. \`variant\` 로 표시 형태 선택.
 
 - \`variant="button"\` (default): regular file-select button. Show thumbnails below via the \`preview\` option. / (기본): 일반 파일 선택 버튼. \`preview\` 옵션으로 아래 썸네일 표시.
 - \`variant="preview"\`: single image preview inside a large box (avatar / image uploader pattern). Adjust box size with \`previewSize\`. / 큰 박스 안에 단일 이미지 미리보기 (avatar / 이미지 업로더 패턴). \`previewSize\` 로 박스 크기 조정.

--- a/src/ui/forms/otp-input/otp-input.stories.tsx
+++ b/src/ui/forms/otp-input/otp-input.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof OtpInput> = {
 		docs: {
 			description: {
 				component: `
-**OtpInput** — OTP/2FA code entry. Auto focus advance, backspace/arrow/paste support. / OTP/2FA 코드 입력. 자동 포커스 이동, 백스페이스/화살표/붙여넣기 지원.
+**OtpInput** — OTP/2FA code entry. Auto focus advance, backspace/arrow/paste support. / **OtpInput** — OTP/2FA 코드 입력. 자동 포커스 이동, 백스페이스/화살표/붙여넣기 지원.
 
 Key props: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`. / 주요 prop: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`.
         `,

--- a/src/ui/forms/otp-input/otp-input.stories.tsx
+++ b/src/ui/forms/otp-input/otp-input.stories.tsx
@@ -10,19 +10,19 @@ const meta: Meta<typeof OtpInput> = {
 		length: {
 			control: "select",
 			options: [4, 6],
-			description: "OTP 자릿수입니다.",
+			description: "Number of OTP digits. / OTP 자릿수입니다.",
 		},
 		error: {
 			control: "boolean",
-			description: "에러 상태입니다.",
+			description: "Error state. / 에러 상태입니다.",
 		},
 		disabled: {
 			control: "boolean",
-			description: "비활성화 상태입니다.",
+			description: "Disabled state. / 비활성화 상태입니다.",
 		},
 		supportingText: {
 			control: "text",
-			description: "하단 도움말 텍스트입니다.",
+			description: "Helper text shown below. / 하단 도움말 텍스트입니다.",
 		},
 	},
 	args: {
@@ -34,9 +34,9 @@ const meta: Meta<typeof OtpInput> = {
 		docs: {
 			description: {
 				component: `
-**OtpInput** — OTP/2FA 코드 입력. 자동 포커스 이동, 백스페이스/화살표/붙여넣기 지원.
+**OtpInput** — OTP/2FA code entry. Auto focus advance, backspace/arrow/paste support. / OTP/2FA 코드 입력. 자동 포커스 이동, 백스페이스/화살표/붙여넣기 지원.
 
-주요 prop: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`.
+Key props: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`. / 주요 prop: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`.
         `,
 			},
 		},

--- a/src/ui/forms/radio/radio.stories.tsx
+++ b/src/ui/forms/radio/radio.stories.tsx
@@ -10,11 +10,11 @@ const meta: Meta<typeof Radio> = {
 		size: {
 			control: "select",
 			options: ["sm", "md", "lg"],
-			description: "라디오 버튼의 크기입니다. 텍스트와 선택 원(circle)의 크기가 함께 변경됩니다.",
+			description: "Radio button size. The text and the selection circle scale together. / 라디오 버튼의 크기입니다. 텍스트와 선택 원(circle)의 크기가 함께 변경됩니다.",
 		},
 		disabled: {
 			control: "boolean",
-			description: "비활성화 상태입니다. 선택할 수 없으며 흐리게 표시됩니다.",
+			description: "Disabled state. Cannot be selected and appears dimmed. / 비활성화 상태입니다. 선택할 수 없으며 흐리게 표시됩니다.",
 		},
 	},
 	args: {
@@ -25,9 +25,9 @@ const meta: Meta<typeof Radio> = {
 		docs: {
 			description: {
 				component: `
-**Radio** — 단일 선택 (다중은 Checkbox).
+**Radio** — Single-select (use Checkbox for multi-select). / 단일 선택 (다중은 Checkbox).
 
-같은 그룹은 \`name\` 동일 + 각 \`value\`. \`checked\` / \`onChange\` 제어.
+Items in the same group share \`name\` and each has its own \`value\`. Control via \`checked\` / \`onChange\`. / 같은 그룹은 \`name\` 동일 + 각 \`value\`. \`checked\` / \`onChange\` 제어.
         `,
 			},
 		},

--- a/src/ui/forms/radio/radio.stories.tsx
+++ b/src/ui/forms/radio/radio.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof Radio> = {
 		docs: {
 			description: {
 				component: `
-**Radio** — Single-select (use Checkbox for multi-select). / 단일 선택 (다중은 Checkbox).
+**Radio** — Single-select (use Checkbox for multi-select). / **Radio** — 단일 선택 (다중은 Checkbox).
 
 Items in the same group share \`name\` and each has its own \`value\`. Control via \`checked\` / \`onChange\`. / 같은 그룹은 \`name\` 동일 + 각 \`value\`. \`checked\` / \`onChange\` 제어.
         `,

--- a/src/ui/forms/textfield/textfield.stories.tsx
+++ b/src/ui/forms/textfield/textfield.stories.tsx
@@ -47,9 +47,9 @@ const meta: Meta<typeof TextField> = {
 		docs: {
 			description: {
 				component: `
-**TextField** — Single-line text input. Floating label + leading/trailing icon + supporting text. / 한 줄 텍스트 입력. 플로팅 라벨 + leading/trailing 아이콘 + supporting text.
+**TextField** — Single-line text input. Floating label + leading/trailing icon + supporting text. / **TextField** — 한 줄 텍스트 입력. 플로팅 라벨 + leading/trailing 아이콘 + supporting text.
 
-Sizes: \`sm\` / \`md\` (default) / \`lg\`. / \`sm\` / \`md\` (기본) / \`lg\`.
+Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
 \`error\` → \`aria-invalid\` + \`aria-describedby\` set automatically. / \`error\` → \`aria-invalid\` + \`aria-describedby\` 자동.
 				`,
 			},

--- a/src/ui/forms/textfield/textfield.stories.tsx
+++ b/src/ui/forms/textfield/textfield.stories.tsx
@@ -47,10 +47,10 @@ const meta: Meta<typeof TextField> = {
 		docs: {
 			description: {
 				component: `
-**TextField** — 한 줄 텍스트 입력. Floating label + leading/trailing icon + supporting text.
+**TextField** — Single-line text input. Floating label + leading/trailing icon + supporting text. / 한 줄 텍스트 입력. 플로팅 라벨 + leading/trailing 아이콘 + supporting text.
 
-Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
-\`error\` → \`aria-invalid\` + \`aria-describedby\` 자동.
+Sizes: \`sm\` / \`md\` (default) / \`lg\`. / \`sm\` / \`md\` (기본) / \`lg\`.
+\`error\` → \`aria-invalid\` + \`aria-describedby\` set automatically. / \`error\` → \`aria-invalid\` + \`aria-describedby\` 자동.
 				`,
 			},
 		},

--- a/src/ui/forms/toggle/toggle.stories.tsx
+++ b/src/ui/forms/toggle/toggle.stories.tsx
@@ -10,11 +10,11 @@ const meta: Meta<typeof Toggle> = {
 		size: {
 			control: "select",
 			options: ["sm", "md"],
-			description: "토글 크기입니다. 화면에서 토글이 차지하는 크기(가로/세로)가 함께 바뀝니다.",
+			description: "Toggle size. The width/height it occupies on screen scale together. / 토글 크기입니다. 화면에서 토글이 차지하는 크기(가로/세로)가 함께 바뀝니다.",
 		},
 		disabled: {
 			control: "boolean",
-			description: "비활성화 상태입니다. 켜기/끄기 조작이 불가능하며 흐리게 표시됩니다.",
+			description: "Disabled state. Cannot be turned on/off and appears dimmed. / 비활성화 상태입니다. 켜기/끄기 조작이 불가능하며 흐리게 표시됩니다.",
 		},
 		checked: { control: false },
 		defaultChecked: { control: false },
@@ -29,7 +29,7 @@ const meta: Meta<typeof Toggle> = {
 		docs: {
 			description: {
 				component: `
-**Toggle** — ON/OFF 즉시 전환. 다중 선택은 Checkbox 사용.
+**Toggle** — Instant ON/OFF switch. Use Checkbox for multi-select. / ON/OFF 즉시 전환. 다중 선택은 Checkbox 사용.
 
 Controlled: \`checked\` + \`onChange\` / Uncontrolled: \`defaultChecked\`.
         `,

--- a/src/ui/forms/toggle/toggle.stories.tsx
+++ b/src/ui/forms/toggle/toggle.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof Toggle> = {
 		docs: {
 			description: {
 				component: `
-**Toggle** — Instant ON/OFF switch. Use Checkbox for multi-select. / ON/OFF 즉시 전환. 다중 선택은 Checkbox 사용.
+**Toggle** — Instant ON/OFF switch. Use Checkbox for multi-select. / **Toggle** — ON/OFF 즉시 전환. 다중 선택은 Checkbox 사용.
 
 Controlled: \`checked\` + \`onChange\` / Uncontrolled: \`defaultChecked\`.
         `,

--- a/src/ui/general/button/button.stories.tsx
+++ b/src/ui/general/button/button.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof Button> = {
 		docs: {
 			description: {
 				component: `
-**Button** — Triggers a user action. / 사용자 액션 트리거.
+**Button** — Triggers a user action. / **Button** — 사용자 액션 트리거.
 
 Variants: \`filled\` (primary action / 주 액션) / \`tonal\` (soft emphasis / 부드러운 강조) / \`outline\` (secondary / 보조) / \`text\` (inline / 인라인).
 Sizes: \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 56 (auto-bumps one step up on mobile / 모바일 자동 한 단계 ↑).

--- a/src/ui/general/button/button.stories.tsx
+++ b/src/ui/general/button/button.stories.tsx
@@ -23,10 +23,10 @@ const meta: Meta<typeof Button> = {
 		docs: {
 			description: {
 				component: `
-**Button** — 사용자 액션 트리거.
+**Button** — Triggers a user action. / 사용자 액션 트리거.
 
-Variants: \`filled\` (주 액션) / \`tonal\` (부드러운 강조) / \`outline\` (보조) / \`text\` (인라인).
-Sizes: \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 56 (모바일 자동 한 단계 ↑).
+Variants: \`filled\` (primary action / 주 액션) / \`tonal\` (soft emphasis / 부드러운 강조) / \`outline\` (secondary / 보조) / \`text\` (inline / 인라인).
+Sizes: \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 56 (auto-bumps one step up on mobile / 모바일 자동 한 단계 ↑).
 				`,
 			},
 		},

--- a/src/ui/general/icon-button/icon-button.stories.tsx
+++ b/src/ui/general/icon-button/icon-button.stories.tsx
@@ -42,12 +42,12 @@ const meta: Meta<typeof IconButton> = {
 		docs: {
 			description: {
 				component: `
-**IconButton** — 아이콘만 가진 버튼. \`aria-label\` 필수.
+**IconButton** — A button containing only an icon. \`aria-label\` required. / 아이콘만 가진 버튼. \`aria-label\` 필수.
 
 Variants: \`standard\` / \`filled\` / \`tonal\` / \`outlined\`.
-Sizes: \`sm\` 40 (아이콘 20) / \`md\` 48 (아이콘 24).
+Sizes: \`sm\` 40 (icon 20 / 아이콘 20) / \`md\` 48 (icon 24 / 아이콘 24).
 
-> ⚠️ **Docs 뷰 안내** — \`standard\` variant 는 배경이 투명이라 부모 색에 의존. Storybook Docs 의 스토리 프리뷰 패널은 흰 배경 고정이라 다크 모드 토글 시 아이콘이 흰 위에 흰으로 안 보일 수 있다. 실제 동작은 좌측 사이드바에서 개별 스토리를 열어 Canvas 뷰에서 확인.
+> ⚠️ **Docs view note / Docs 뷰 안내** — The \`standard\` variant has a transparent background and depends on the parent color. Storybook Docs' story preview panel has a fixed white background, so toggling dark mode may render the icon white-on-white and invisible. To check actual behavior, open an individual story from the left sidebar in Canvas view. / \`standard\` variant 는 배경이 투명이라 부모 색에 의존. Storybook Docs 의 스토리 프리뷰 패널은 흰 배경 고정이라 다크 모드 토글 시 아이콘이 흰 위에 흰으로 안 보일 수 있다. 실제 동작은 좌측 사이드바에서 개별 스토리를 열어 Canvas 뷰에서 확인.
 				`,
 			},
 		},

--- a/src/ui/general/icon-button/icon-button.stories.tsx
+++ b/src/ui/general/icon-button/icon-button.stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<typeof IconButton> = {
 		docs: {
 			description: {
 				component: `
-**IconButton** — A button containing only an icon. \`aria-label\` required. / 아이콘만 가진 버튼. \`aria-label\` 필수.
+**IconButton** — A button containing only an icon. \`aria-label\` required. / **IconButton** — 아이콘만 가진 버튼. \`aria-label\` 필수.
 
 Variants: \`standard\` / \`filled\` / \`tonal\` / \`outlined\`.
 Sizes: \`sm\` 40 (icon 20 / 아이콘 20) / \`md\` 48 (icon 24 / 아이콘 24).

--- a/src/ui/layout/stack/stack.stories.tsx
+++ b/src/ui/layout/stack/stack.stories.tsx
@@ -22,9 +22,9 @@ const meta: Meta<typeof Stack> = {
 		docs: {
 			description: {
 				component: `
-**Stack** — Flex 기반 1D 레이아웃. 2D 격자는 \`Grid\`.
+**Stack** — Flex-based 1D layout. For a 2D grid use \`Grid\`. / Flex 기반 1D 레이아웃. 2D 격자는 \`Grid\`.
 
-주요 prop: \`direction\` (\`vertical\`/\`horizontal\`), \`gap\` (px), \`align\` (교차축), \`justify\` (주축), \`wrap\`.
+Key props: \`direction\` (\`vertical\`/\`horizontal\`), \`gap\` (px), \`align\` (cross axis), \`justify\` (main axis), \`wrap\`. / 주요 prop: \`direction\` (\`vertical\`/\`horizontal\`), \`gap\` (px), \`align\` (교차축), \`justify\` (주축), \`wrap\`.
 				`,
 			},
 		},

--- a/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
+++ b/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
@@ -14,11 +14,11 @@ const meta: Meta<typeof BottomNav> = {
 		docs: {
 			description: {
 				component: `
-**BottomNav** — 모바일 하단 네비게이션. 2–5개 \`BottomNavItem\` 으로 구성.
+**BottomNav** — Mobile bottom navigation, composed of 2–5 \`BottomNavItem\`s. / 모바일 하단 네비게이션. 2–5개 \`BottomNavItem\` 으로 구성.
 
-\`position: fixed; bottom: 0\` 으로 viewport 하단 고정. iOS 홈 인디케이터 영역 (\`env(safe-area-inset-bottom)\`) 자동 패딩. 본문이 가려지지 않게 페이지 끝에 \`<BottomNavSpacer />\` 깔거나 \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS 변수로 layout 계산.
+Pinned to the bottom of the viewport via \`position: fixed; bottom: 0\`. Auto-padding for the iOS home-indicator area (\`env(safe-area-inset-bottom)\`). To keep content from being hidden, add a \`<BottomNavSpacer />\` at the end of the page or use the \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS variables for layout calculation. / \`position: fixed; bottom: 0\` 으로 viewport 하단 고정. iOS 홈 인디케이터 영역 (\`env(safe-area-inset-bottom)\`) 자동 패딩. 본문이 가려지지 않게 페이지 끝에 \`<BottomNavSpacer />\` 깔거나 \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS 변수로 layout 계산.
 
-\`<BottomNavItem icon label active badge as href />\` — \`active\` 시 \`aria-current="page"\` 자동.
+\`<BottomNavItem icon label active badge as href />\` — \`aria-current="page"\` is set automatically when \`active\`. / \`active\` 시 \`aria-current="page"\` 자동.
 				`,
 			},
 		},
@@ -87,7 +87,7 @@ export const WithBadge: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "아이콘 우상단에 `badge` prop 으로 알림 dot/카운트 표시. `<Badge>` 컴포넌트 활용.",
+				story: "Show a notification dot/count at the top-right of the icon via the `badge` prop, using the `<Badge>` component. / 아이콘 우상단에 `badge` prop 으로 알림 dot/카운트 표시. `<Badge>` 컴포넌트 활용.",
 			},
 		},
 	},
@@ -131,7 +131,7 @@ export const FiveItems: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "5개까지 균등 분할 권장. 그 이상은 라벨 잘림 / 탭 영역 부족.",
+				story: "Recommended up to 5 items with even distribution. More than that causes label truncation / insufficient tap area. / 5개까지 균등 분할 권장. 그 이상은 라벨 잘림 / 탭 영역 부족.",
 			},
 		},
 	},

--- a/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
+++ b/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
@@ -14,11 +14,11 @@ const meta: Meta<typeof BottomNav> = {
 		docs: {
 			description: {
 				component: `
-**BottomNav** — Mobile bottom navigation, composed of 2–5 \`BottomNavItem\`s. / 모바일 하단 네비게이션. 2–5개 \`BottomNavItem\` 으로 구성.
+**BottomNav** — Mobile bottom navigation, composed of 2–5 \`BottomNavItem\`s. / **BottomNav** — 모바일 하단 네비게이션. 2–5개 \`BottomNavItem\` 으로 구성.
 
 Pinned to the bottom of the viewport via \`position: fixed; bottom: 0\`. Auto-padding for the iOS home-indicator area (\`env(safe-area-inset-bottom)\`). To keep content from being hidden, add a \`<BottomNavSpacer />\` at the end of the page or use the \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS variables for layout calculation. / \`position: fixed; bottom: 0\` 으로 viewport 하단 고정. iOS 홈 인디케이터 영역 (\`env(safe-area-inset-bottom)\`) 자동 패딩. 본문이 가려지지 않게 페이지 끝에 \`<BottomNavSpacer />\` 깔거나 \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS 변수로 layout 계산.
 
-\`<BottomNavItem icon label active badge as href />\` — \`aria-current="page"\` is set automatically when \`active\`. / \`active\` 시 \`aria-current="page"\` 자동.
+\`<BottomNavItem icon label active badge as href />\` — \`aria-current="page"\` is set automatically when \`active\`. / \`<BottomNavItem icon label active badge as href />\` — \`active\` 시 \`aria-current="page"\` 자동.
 				`,
 			},
 		},

--- a/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
+++ b/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
@@ -10,9 +10,9 @@ const meta: Meta<typeof Breadcrumb> = {
 		docs: {
 			description: {
 				component: `
-**Breadcrumb** — 페이지 위계 네비게이션. 마지막 아이템 자동 \`aria-current="page"\`.
+**Breadcrumb** — Page hierarchy navigation. The last item automatically gets \`aria-current="page"\`. / 페이지 위계 네비게이션. 마지막 아이템 자동 \`aria-current="page"\`.
 
-\`items\` 동작: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / 마지막 → \`<span>\`. \`separator\` prop 커스텀 가능.
+\`items\` behavior: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / last → \`<span>\`. The \`separator\` prop is customizable. / \`items\` 동작: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / 마지막 → \`<span>\`. \`separator\` prop 커스텀 가능.
 				`,
 			},
 		},

--- a/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
+++ b/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Breadcrumb> = {
 		docs: {
 			description: {
 				component: `
-**Breadcrumb** — Page hierarchy navigation. The last item automatically gets \`aria-current="page"\`. / 페이지 위계 네비게이션. 마지막 아이템 자동 \`aria-current="page"\`.
+**Breadcrumb** — Page hierarchy navigation. The last item automatically gets \`aria-current="page"\`. / **Breadcrumb** — 페이지 위계 네비게이션. 마지막 아이템 자동 \`aria-current="page"\`.
 
 \`items\` behavior: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / last → \`<span>\`. The \`separator\` prop is customizable. / \`items\` 동작: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / 마지막 → \`<span>\`. \`separator\` prop 커스텀 가능.
 				`,

--- a/src/ui/navigation/menu/menu.stories.tsx
+++ b/src/ui/navigation/menu/menu.stories.tsx
@@ -29,10 +29,10 @@ const meta: Meta<typeof Menu> = {
 		docs: {
 			description: {
 				component: `
-**Menu** — 액션 메뉴 (컨텍스트/케밥/행 단위). 값 선택은 \`Dropdown\`.
+**Menu** — Action menu (context / kebab / per-row). For value selection use \`Dropdown\`. / 액션 메뉴 (컨텍스트/케밥/행 단위). 값 선택은 \`Dropdown\`.
 
-\`align\`: \`start\` (기본) / \`end\` (우측 화면 밖 방지).
-\`MenuItem\` 필드: \`key\`, \`label\`, \`icon\`, \`onSelect\` (자동 close), \`destructive\`, \`disabled\`.
+\`align\`: \`start\` (default) / \`end\` (prevents overflow off the right edge). / \`align\`: \`start\` (기본) / \`end\` (우측 화면 밖 방지).
+\`MenuItem\` fields: \`key\`, \`label\`, \`icon\`, \`onSelect\` (auto close), \`destructive\`, \`disabled\`. / \`MenuItem\` 필드: \`key\`, \`label\`, \`icon\`, \`onSelect\` (자동 close), \`destructive\`, \`disabled\`.
 				`.trim(),
 			},
 		},

--- a/src/ui/navigation/menu/menu.stories.tsx
+++ b/src/ui/navigation/menu/menu.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof Menu> = {
 		docs: {
 			description: {
 				component: `
-**Menu** — Action menu (context / kebab / per-row). For value selection use \`Dropdown\`. / 액션 메뉴 (컨텍스트/케밥/행 단위). 값 선택은 \`Dropdown\`.
+**Menu** — Action menu (context / kebab / per-row). For value selection use \`Dropdown\`. / **Menu** — 액션 메뉴 (컨텍스트/케밥/행 단위). 값 선택은 \`Dropdown\`.
 
 \`align\`: \`start\` (default) / \`end\` (prevents overflow off the right edge). / \`align\`: \`start\` (기본) / \`end\` (우측 화면 밖 방지).
 \`MenuItem\` fields: \`key\`, \`label\`, \`icon\`, \`onSelect\` (auto close), \`destructive\`, \`disabled\`. / \`MenuItem\` 필드: \`key\`, \`label\`, \`icon\`, \`onSelect\` (자동 close), \`destructive\`, \`disabled\`.

--- a/src/ui/navigation/nav-bar/nav-bar.stories.tsx
+++ b/src/ui/navigation/nav-bar/nav-bar.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof NavBar> = {
 		docs: {
 			description: {
 				component: `
-**NavBar** — Top page navigation. Slots: \`brand\` / \`children (NavLink)\` / \`actions\`. / 페이지 상단 네비게이션. \`brand\` / \`children (NavLink)\` / \`actions\` 슬롯.
+**NavBar** — Top page navigation. Slots: \`brand\` / \`children (NavLink)\` / \`actions\`. / **NavBar** — 페이지 상단 네비게이션. \`brand\` / \`children (NavLink)\` / \`actions\` 슬롯.
 
 Variants: \`default\` (white bg + border), \`accent\` (navy bg), \`transparent\` (over a hero). / Variants: \`default\` (흰 bg + border), \`accent\` (navy bg), \`transparent\` (hero 위).
 \`active={true}\` → \`aria-current="page"\` set automatically. / \`active={true}\` → \`aria-current="page"\` 자동.

--- a/src/ui/navigation/nav-bar/nav-bar.stories.tsx
+++ b/src/ui/navigation/nav-bar/nav-bar.stories.tsx
@@ -12,10 +12,10 @@ const meta: Meta<typeof NavBar> = {
 		docs: {
 			description: {
 				component: `
-**NavBar** — 페이지 상단 네비게이션. \`brand\` / \`children (NavLink)\` / \`actions\` 슬롯.
+**NavBar** — Top page navigation. Slots: \`brand\` / \`children (NavLink)\` / \`actions\`. / 페이지 상단 네비게이션. \`brand\` / \`children (NavLink)\` / \`actions\` 슬롯.
 
-Variants: \`default\` (흰 bg + border), \`accent\` (navy bg), \`transparent\` (hero 위).
-\`active={true}\` → \`aria-current="page"\` 자동.
+Variants: \`default\` (white bg + border), \`accent\` (navy bg), \`transparent\` (over a hero). / Variants: \`default\` (흰 bg + border), \`accent\` (navy bg), \`transparent\` (hero 위).
+\`active={true}\` → \`aria-current="page"\` set automatically. / \`active={true}\` → \`aria-current="page"\` 자동.
 				`,
 			},
 		},
@@ -93,7 +93,7 @@ export const Interactive: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "클릭 시 active underline 부드럽게 이동.",
+				story: "The active underline slides smoothly on click. / 클릭 시 active underline 부드럽게 이동.",
 			},
 		},
 	},

--- a/src/ui/navigation/pagination/pagenation.stories.tsx
+++ b/src/ui/navigation/pagination/pagenation.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof Pagination> = {
 		docs: {
 			description: {
 				component: `
-**Pagination** — Page navigation. Collapses with \`…\` beyond 7 pages; prev/next are disabled at the first/last page. / 페이지 이동 네비게이션. 7페이지 초과 시 \`…\` 축약, 첫/마지막에서 prev/next 비활성.
+**Pagination** — Page navigation. Collapses with \`…\` beyond 7 pages; prev/next are disabled at the first/last page. / **Pagination** — 페이지 이동 네비게이션. 7페이지 초과 시 \`…\` 축약, 첫/마지막에서 prev/next 비활성.
         `,
 			},
 		},

--- a/src/ui/navigation/pagination/pagenation.stories.tsx
+++ b/src/ui/navigation/pagination/pagenation.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof Pagination> = {
 		docs: {
 			description: {
 				component: `
-**Pagination** — 페이지 이동 네비게이션. 7페이지 초과 시 \`…\` 축약, 첫/마지막에서 prev/next 비활성.
+**Pagination** — Page navigation. Collapses with \`…\` beyond 7 pages; prev/next are disabled at the first/last page. / 페이지 이동 네비게이션. 7페이지 초과 시 \`…\` 축약, 첫/마지막에서 prev/next 비활성.
         `,
 			},
 		},

--- a/src/ui/navigation/sidebar/sidebar.stories.tsx
+++ b/src/ui/navigation/sidebar/sidebar.stories.tsx
@@ -12,11 +12,11 @@ const meta: Meta<typeof Sidebar> = {
 		docs: {
 			description: {
 				component: `
-**Sidebar** — Left navigation for admin/dashboard. Combine \`SidebarItem\` + \`SidebarSection\`. / admin/dashboard 좌측 네비게이션. \`SidebarItem\` + \`SidebarSection\` 조합.
+**Sidebar** — Left navigation for admin/dashboard. Combine \`SidebarItem\` + \`SidebarSection\`. / **Sidebar** — admin/dashboard 좌측 네비게이션. \`SidebarItem\` + \`SidebarSection\` 조합.
 
 \`collapsed\` (240→64px) — icons only, with a favicon node via \`headerCollapsed\`. \`collapsible\` (default true) → floating chevron toggle. \`active={true}\` → \`aria-current="page"\` set automatically. / \`collapsed\` (240→64px) — 아이콘만 표시, \`headerCollapsed\` 로 favicon 노드. \`collapsible\` (기본 true) → floating chevron 토글. \`active={true}\` → \`aria-current="page"\` 자동.
 
-**Responsive** — default \`mode="auto"\`: below viewport \`< 600px\` it automatically transforms into a bottom bar (BottomNav style). Header/footer/section labels are hidden and items become a horizontal stack. Use \`mode="static"\` to disable the transform (admin desktop-only cases). / 기본 \`mode="auto"\`: viewport \`< 600px\` 에서 자동으로 하단 bar (BottomNav 형태) 로 변신. header/footer/섹션 라벨 hide, 아이템은 horizontal stack. \`mode="static"\` 으로 변신 끄기 (admin desktop-only 케이스).
+**Responsive** — default \`mode="auto"\`: below viewport \`< 600px\` it automatically transforms into a bottom bar (BottomNav style). Header/footer/section labels are hidden and items become a horizontal stack. Use \`mode="static"\` to disable the transform (admin desktop-only cases). / **Responsive** — 기본 \`mode="auto"\`: viewport \`< 600px\` 에서 자동으로 하단 bar (BottomNav 형태) 로 변신. header/footer/섹션 라벨 hide, 아이템은 horizontal stack. \`mode="static"\` 으로 변신 끄기 (admin desktop-only 케이스).
 				`,
 			},
 		},

--- a/src/ui/navigation/sidebar/sidebar.stories.tsx
+++ b/src/ui/navigation/sidebar/sidebar.stories.tsx
@@ -12,11 +12,11 @@ const meta: Meta<typeof Sidebar> = {
 		docs: {
 			description: {
 				component: `
-**Sidebar** — admin/dashboard 좌측 네비게이션. \`SidebarItem\` + \`SidebarSection\` 조합.
+**Sidebar** — Left navigation for admin/dashboard. Combine \`SidebarItem\` + \`SidebarSection\`. / admin/dashboard 좌측 네비게이션. \`SidebarItem\` + \`SidebarSection\` 조합.
 
-\`collapsed\` (240→64px) — 아이콘만 표시, \`headerCollapsed\` 로 favicon 노드. \`collapsible\` (기본 true) → floating chevron 토글. \`active={true}\` → \`aria-current="page"\` 자동.
+\`collapsed\` (240→64px) — icons only, with a favicon node via \`headerCollapsed\`. \`collapsible\` (default true) → floating chevron toggle. \`active={true}\` → \`aria-current="page"\` set automatically. / \`collapsed\` (240→64px) — 아이콘만 표시, \`headerCollapsed\` 로 favicon 노드. \`collapsible\` (기본 true) → floating chevron 토글. \`active={true}\` → \`aria-current="page"\` 자동.
 
-**Responsive** — 기본 \`mode="auto"\`: viewport \`< 600px\` 에서 자동으로 하단 bar (BottomNav 형태) 로 변신. header/footer/섹션 라벨 hide, 아이템은 horizontal stack. \`mode="static"\` 으로 변신 끄기 (admin desktop-only 케이스).
+**Responsive** — default \`mode="auto"\`: below viewport \`< 600px\` it automatically transforms into a bottom bar (BottomNav style). Header/footer/section labels are hidden and items become a horizontal stack. Use \`mode="static"\` to disable the transform (admin desktop-only cases). / 기본 \`mode="auto"\`: viewport \`< 600px\` 에서 자동으로 하단 bar (BottomNav 형태) 로 변신. header/footer/섹션 라벨 hide, 아이템은 horizontal stack. \`mode="static"\` 으로 변신 끄기 (admin desktop-only 케이스).
 				`,
 			},
 		},

--- a/src/ui/navigation/tabs/tabs.stories.tsx
+++ b/src/ui/navigation/tabs/tabs.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Tabs> = {
 		docs: {
 			description: {
 				component: `
-**Tabs** — Exclusive panel switching. Compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`. / 배타적 패널 전환. compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`.
+**Tabs** — Exclusive panel switching. Compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`. / **Tabs** — 배타적 패널 전환. compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`.
 
 Variants: \`line\` (default, bottom underline) / \`fills\` (segmented control). / Variants: \`line\` (기본, 하단 underline) / \`fills\` (segmented control).
 WAI-ARIA + roving tabIndex + keyboard (←→/Home/End, skips disabled). / WAI-ARIA + roving tabIndex + 키보드 (←→/Home/End, disabled 스킵).

--- a/src/ui/navigation/tabs/tabs.stories.tsx
+++ b/src/ui/navigation/tabs/tabs.stories.tsx
@@ -10,10 +10,10 @@ const meta: Meta<typeof Tabs> = {
 		docs: {
 			description: {
 				component: `
-**Tabs** — 배타적 패널 전환. compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`.
+**Tabs** — Exclusive panel switching. Compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`. / 배타적 패널 전환. compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`.
 
-Variants: \`line\` (기본, 하단 underline) / \`fills\` (segmented control).
-WAI-ARIA + roving tabIndex + 키보드 (←→/Home/End, disabled 스킵).
+Variants: \`line\` (default, bottom underline) / \`fills\` (segmented control). / Variants: \`line\` (기본, 하단 underline) / \`fills\` (segmented control).
+WAI-ARIA + roving tabIndex + keyboard (←→/Home/End, skips disabled). / WAI-ARIA + roving tabIndex + 키보드 (←→/Home/End, disabled 스킵).
         `,
 			},
 		},

--- a/src/ui/overlay/modal/modal.stories.tsx
+++ b/src/ui/overlay/modal/modal.stories.tsx
@@ -25,9 +25,9 @@ const meta: Meta<typeof Modal> = {
 		docs: {
 			description: {
 				component: `
-**Modal** — 화면 중앙 팝업 레이어. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금 자동.
+**Modal** — Centered popup layer. Automatic focus trap + Esc to close + background scroll lock. / 화면 중앙 팝업 레이어. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금 자동.
 
-주요 prop: \`open\`, \`onClose\`, \`width\`, \`closeOnOverlay\`, \`title\` (자동 \`aria-labelledby\`).
+Key props: \`open\`, \`onClose\`, \`width\`, \`closeOnOverlay\`, \`title\` (auto \`aria-labelledby\`). / 주요 prop: \`open\`, \`onClose\`, \`width\`, \`closeOnOverlay\`, \`title\` (자동 \`aria-labelledby\`).
         `,
 			},
 		},
@@ -45,7 +45,7 @@ export const CreateToken: Story = {
 		docs: {
 			description: {
 				story:
-					"새 디자인 — 큰 title, paragraph description, 우측 정렬 footer 액션. 가장 일반적인 confirm/form 모달 패턴.",
+					"New design — large title, paragraph description, right-aligned footer actions. The most common confirm/form modal pattern. / 새 디자인 — 큰 title, paragraph description, 우측 정렬 footer 액션. 가장 일반적인 confirm/form 모달 패턴.",
 			},
 		},
 	},
@@ -84,7 +84,7 @@ export const DestructiveAction: Story = {
 		docs: {
 			description: {
 				story:
-					"`footerAlign=\"between\"` — 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성 시각화.",
+					"`footerAlign=\"between\"` — destructive (Delete) on the left, safe (Cancel) on the right. Visualizes the risk. / `footerAlign=\"between\"` — 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성 시각화.",
 			},
 		},
 	},

--- a/src/ui/overlay/tooltip/tooltip.stories.tsx
+++ b/src/ui/overlay/tooltip/tooltip.stories.tsx
@@ -38,10 +38,10 @@ const meta: Meta<typeof Tooltip> = {
 		docs: {
 			description: {
 				component: `
-**Tooltip** — hover/focus 시 비차단 보조 설명. 클릭 상호작용은 Popover.
+**Tooltip** — Non-blocking supplementary description on hover/focus. For click interactions use Popover. / hover/focus 시 비차단 보조 설명. 클릭 상호작용은 Popover.
 
-주요 prop: \`content\`, \`placement\` (\`top\`/\`bottom\`/\`left\`/\`right\`, 자동 flip 없음), \`delay\` (기본 200ms), \`disabled\`.
-\`role="tooltip"\` + \`aria-describedby\` 자동.
+Key props: \`content\`, \`placement\` (\`top\`/\`bottom\`/\`left\`/\`right\`, no auto-flip), \`delay\` (default 200ms), \`disabled\`. / 주요 prop: \`content\`, \`placement\` (\`top\`/\`bottom\`/\`left\`/\`right\`, 자동 flip 없음), \`delay\` (기본 200ms), \`disabled\`.
+\`role="tooltip"\` + \`aria-describedby\` set automatically. / \`role="tooltip"\` + \`aria-describedby\` 자동.
 				`.trim(),
 			},
 		},


### PR DESCRIPTION
## 작업 개요

CLAUDE.md 가이드라인("Include bilingual descriptions (Korean/English)")을 광범위하게 미준수하던 Storybook stories 설명을 일괄 한/영 병기로 정비. CodeRabbit PR #280 리뷰에서 제기된 부채 해소.

## 작업한 내용

52개 stories 파일의 `description.component` (및 일부 story-level / argTypes description) 에 영문 병기 추가. 기존 한국어 유지, 패턴 `**Name** — English. / 한국어.`

| 카테고리 | 파일 수 |
|---|---|
| foundation | 13 |
| display | 10 |
| feedback | 7 |
| forms | 8 |
| navigation · overlay · layout | 10 |
| general · getting-started | 4 |

**제외**: `textarea` / `error-state` / `badge` stories — PR #281 에서 이미 bilingual 처리됨 (파일 충돌 회피).

## 검증

- **description 문자열만 변경** — 코드/렌더/argTypes 컨트롤/로직 무변경 (diff 확인: import/render/hooks 라인 0)
- 52 files, +147 / -121 (순수 문자열)
- 기존 tsc 부채 4건(StackGap, page-composition SidebarItem, form-comparison TextField)은 이 PR 과 무관 (별도 정리 대상)

## 비고

병렬 작업으로 카테고리별 분담 처리. `"use client"` 는 stories 에 추가하지 않음 (레포 관례 — 전체 stories Storybook 전용, 빌드 번들 제외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서 개선 사항**
  * Storybook의 Foundation(토큰) 및 UI 컴포넌트 전반 문서 설명을 다수 업데이트
  * 접근성, Border Width, Breakpoints, Colors, Elevation, Dark Mode, Motion/Opacity/Radius/Spacing/Typography/Z-Index 등 토큰 안내 섹션을 보강
  * 컴포넌트 문서를 Variants·Key props·Usage 중심으로 더 구조화하고, WAI-ARIA/키보드 규칙 및 예시 문구를 정리
  * 설치/도입 및 컴포넌트 설명 전반에 영문/한글 이중 표기와 안내 문장 다듬기 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->