### PR TITLE
feat/popover

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -226,6 +226,7 @@ Organized by category. **Always** import from the package root (`@bigtablet/desi
 |-----------|---------|-----------|
 | `Modal` | Centered dialog. | `open`, `onClose`, `title`, `description`, `footer`, `footerAlign` (end/between/start), `showCloseIcon` (default true), `width`, `closeOnOverlay`. X close icon top-right by default. |
 | `Tooltip` | Hover info. | `content`, `placement` (top/bottom/left/right), `delay`, `disabled`. Children = single trigger element. Long text wraps with `text-align: center`, max-width 240px. |
+| `Popover` | Click-triggered non-modal panel for arbitrary interactive content (form/explanation/actions). | `trigger` element, `content` (ReactNode), `placement` (top/bottom/left/right, default bottom), `open`/`defaultOpen`/`onOpenChange` (controlled/uncontrolled), `aria-label`/`aria-labelledby`. `role="dialog"`. Focus moves into panel on open; `Esc` closes + returns focus to trigger. Use `Menu` for action lists, `Tooltip` for hover info. Trigger MUST forward props (`<button {...props}>`). |
 
 ### Layout
 
@@ -249,7 +250,7 @@ Organized by category. **Always** import from the package root (`@bigtablet/desi
 
 ### Built-in motion (just use the components)
 - Modal, Alert: overlay fade + panel scale-translate spring
-- Dropdown, Menu, Tooltip: pop-in spring
+- Dropdown, Menu, Tooltip, Popover: pop-in spring
 - Toast: slide-in spring with onExitComplete unmount
 - Accordion: grid-template-rows 0fr → 1fr (CSS, height-auto-safe)
 - Sidebar logo: crossfade between collapsed/expanded layers
@@ -498,6 +499,8 @@ When asked to generate UI:
 **Need a layout?** → `Container > Section > Stack/Grid`. Don't manually do flexbox/grid CSS unless inside a Stack/Grid child.
 
 **Need a tooltip?** → `<Tooltip content="..." placement="top"><TriggerElement /></Tooltip>`.
+
+**Need a click-triggered panel with interactive content (filter form, profile card, inline actions)?** → `<Popover trigger={<Button>…</Button>} content={…} aria-label="…" />`. For a plain action list use `<Menu>`; for hover-only info use `<Tooltip>`; for a blocking center dialog use `<Modal>`.
 
 **Need a sidebar nav?** → `<Sidebar>` with `<SidebarSection>` + `<SidebarItem>`. Include `headerCollapsed` for collapse animation.
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -39,6 +39,7 @@ Bigtablet Design System의 모든 React 컴포넌트 문서입니다.
   - [Modal](#modal)
   - [Tooltip](#tooltip)
   - [Menu](#menu)
+  - [Popover](#popover)
 - [Display](#display)
   - [Card](#card)
   - [Divider](#divider)
@@ -1631,6 +1632,139 @@ import { MoreVertical, Edit, Copy, Trash, Share, Archive } from "lucide-react";
     { key: "export", label: "내보내기", onSelect: handleExport },
     { key: "import", label: "가져오기", onSelect: handleImport },
   ]}
+/>
+```
+
+---
+
+### Popover
+
+trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 interactive 콘텐츠 (폼, 설명, 액션 조합)**를 담는다. Menu(액션 리스트) / Tooltip(hover 정보)과 역할이 다르다.
+
+#### 언제 쓰는가
+
+| 상황 | 선택 |
+|------|------|
+| 클릭으로 여는 작은 폼/필터 (체크박스, 입력, 적용 버튼) | ✅ Popover |
+| 프로필 카드, 미리보기, 부가 설명 + 액션 버튼 | ✅ Popover |
+| 단순 액션 리스트 (Edit / Duplicate / Delete) | ❌ Menu 권장 |
+| hover로 뜨는 짧은 텍스트 라벨 | ❌ Tooltip 권장 (`pointer-events: none`) |
+| 화면 중앙 차단(modal) 다이얼로그 / 확인창 | ❌ Modal · `useAlert()` 권장 |
+| 폼 필드 상시 도움말 | ❌ helper text 권장 |
+
+**Popover vs Menu vs Tooltip**
+- **Popover**: 클릭으로 열고 외부 클릭/Esc로 닫음. `role="dialog"` (non-modal). 임의의 상호작용 콘텐츠. 열릴 때 포커스가 패널로 이동.
+- **Menu**: 클릭으로 열리는 **액션 리스트**. `role="menu"` + `menuitem`. 선택 시 사이드 이펙트.
+- **Tooltip**: hover/focus로 뜨는 **짧은 정보**. `pointer-events: none`, dismissable 아님.
+
+#### 선택 가이드
+
+**placement (4방향)**
+- `"bottom"` (기본) - trigger 아래. 대부분의 케이스.
+- `"top"` - trigger가 화면 하단에 가까울 때.
+- `"left"` / `"right"` - 가로 공간이 충분하고 위/아래가 막혔을 때.
+
+> ℹ️ 현재 구현은 **자동 flipping이 없으니** 뷰포트 경계 근처라면 placement를 직접 지정하라.
+
+**제어 / 비제어**
+- 비제어 (기본) - `defaultOpen`만 주고 내부 state로 토글. 가장 간단.
+- 제어 - `open` + `onOpenChange`로 외부 state가 소유. 외부 버튼/로직과 연동하거나 닫힘 시점을 직접 제어할 때.
+
+**Props**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `trigger` | `ReactElement` | required | 클릭 시 팝오버를 토글하는 trigger (단일 ReactElement) |
+| `content` | `ReactNode` | required | 팝오버 내부 콘텐츠 (임의 interactive 노드) |
+| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'bottom'` | trigger 기준 위치 |
+| `open` | `boolean` | - | 제어 모드 열림 상태 (주면 비제어 state 무시) |
+| `defaultOpen` | `boolean` | `false` | 비제어 모드 초기 열림 상태 |
+| `onOpenChange` | `(open: boolean) => void` | - | 열림 상태 변경 콜백 |
+| `aria-label` | `string` | - | dialog 접근성 라벨 (content에 제목 없으면 권장) |
+| `aria-labelledby` | `string` | - | dialog 접근성 라벨 요소 id |
+| `className` | `string` | - | 팝오버 패널에 추가 |
+
+> ⚠️ `trigger`는 **반드시 단일 ReactElement**. `cloneElement`로 `onClick`/`aria-*` 주입 (trigger의 기존 `onClick`은 보존). trigger 컴포넌트는 props를 forward해야 한다 (`<button {...props}>`).
+
+#### 접근성 (WAI-ARIA non-modal dialog)
+
+자동 처리되는 a11y 속성:
+
+- 패널: `role="dialog"`, `tabIndex={-1}`, `id={useId()}`
+- 트리거: `aria-haspopup="dialog"`, `aria-expanded={open}`, `aria-controls={popoverId}` (열렸을 때)
+- **포커스**: 열릴 때 패널 내 **첫 focusable**로 이동 (없으면 패널 자체). `Esc`로 닫으면 **trigger로 복귀**
+- **키보드**: <kbd>Tab</kbd> trigger 포커스 → Enter/Space로 토글 / <kbd>Esc</kbd> 닫음 (+ trigger 복귀)
+- non-modal이므로 Tab을 트랩하지 않음 (Modal과 차이). 페이지 나머지와 상호작용 가능
+
+> 📌 `dialog`는 접근성 이름이 필요하다. content에 제목이 없으면 `aria-label`을, 있으면 그 요소 id로 `aria-labelledby`를 줘라.
+
+#### 애니메이션
+
+`useSpringPresence` 훅 + react-spring:
+
+- **진입**: opacity `0→1` + transform `translate(4px) → 0` (placement별 진입 방향 다름 - Tooltip과 동일 규칙)
+- **퇴출**: `clamp: true`로 진동 없이 빠르게
+- spring config: `tension: 280, friction: 28`
+
+#### 외부 클릭/Esc 처리
+
+열린 동안에만 listener 등록:
+- **외부 클릭** (`mousedown`, wrapper 바깥) → close (포커스는 자연 이동, trigger 복귀 안 함)
+- **Esc 키** (`keydown`) → close + trigger로 포커스 복귀
+- 패널 내부 클릭은 닫지 않음 (interactive 콘텐츠 보호)
+- `open === false`로 바뀌면 listener 모두 cleanup
+
+#### DOM 구조 (SCSS override 시 참고)
+
+```
+span.popover_wrapper               ← position: relative; ref 부착 (외부 클릭 판정)
+├── {trigger}                      ← cloneElement로 onClick/aria 주입
+└── span.popover_position          ← position: absolute, placement별 정렬
+    └── popover_placement_*        ← top|bottom|left|right
+        └── div.popover            ← role="dialog", spring transform
+```
+
+Portal을 **쓰지 않음** → trigger의 `position: relative` 조상 기준 absolute. `overflow: hidden` 컨테이너 안에서 잘릴 수 있으니 주의. `z-index`는 `z_level5` 사용.
+
+**Usage**
+
+```tsx
+import { Popover, Button, Checkbox, Stack } from "@bigtablet/design-system";
+
+// 1) 필터 팝오버 - 폼 + 적용 버튼
+<Popover
+  aria-label="상태 필터"
+  trigger={<Button variant="outline">필터</Button>}
+  content={
+    <Stack gap={12}>
+      <Checkbox label="활성" defaultChecked />
+      <Checkbox label="대기" />
+      <Button size="sm">적용</Button>
+    </Stack>
+  }
+/>
+
+// 2) placement 지정
+<Popover
+  placement="top"
+  aria-label="도움말"
+  trigger={<Button variant="text">?</Button>}
+  content={<p>이 항목은 월 단위로 집계됩니다.</p>}
+/>
+
+// 3) 제어 모드 - 외부 state가 소유
+const [open, setOpen] = useState(false);
+<Popover
+  open={open}
+  onOpenChange={setOpen}
+  aria-labelledby="pop-title"
+  trigger={<Button>프로필</Button>}
+  content={
+    <Stack gap={8}>
+      <strong id="pop-title">박상민</strong>
+      <Button size="sm" onClick={() => setOpen(false)}>닫기</Button>
+    </Stack>
+  }
 />
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ export type {
 	TabsVariant,
 } from "./ui/navigation/tabs";
 export { Tab, TabList, TabPanel, Tabs } from "./ui/navigation/tabs";
+export type { PopoverPlacement, PopoverProps } from "./ui/overlay/popover";
+export { Popover } from "./ui/overlay/popover";
 export type { TooltipPlacement, TooltipProps } from "./ui/overlay/tooltip";
 export { Tooltip } from "./ui/overlay/tooltip";
 

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -1,0 +1,254 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { Popover } from "./index";
+
+describe("Popover", () => {
+	it("does not render content initially", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(screen.queryByText("Panel content")).not.toBeInTheDocument();
+	});
+
+	it("opens on trigger click and shows content", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByText("Panel content")).toBeInTheDocument();
+	});
+
+	it("toggles closed when trigger is clicked again", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Open" });
+		fireEvent.click(trigger);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		fireEvent.click(trigger);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("closes on Escape and restores focus to trigger", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<button type="button">inner</button>}
+				aria-label="popover"
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Open" });
+		trigger.focus();
+		fireEvent.click(trigger);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+		fireEvent.keyDown(document, { key: "Escape" });
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(trigger).toHaveFocus();
+	});
+
+	it("closes when clicking outside", () => {
+		render(
+			<div>
+				<Popover
+					trigger={<button type="button">Open</button>}
+					content={<span>Panel content</span>}
+					aria-label="popover"
+				/>
+				<button type="button" data-testid="outside">
+					outside
+				</button>
+			</div>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+		fireEvent.mouseDown(screen.getByTestId("outside"));
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("does not close when clicking inside the panel", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const dialog = screen.getByRole("dialog");
+		fireEvent.mouseDown(dialog);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("moves focus to first focusable inside the panel on open", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<button type="button">inner</button>}
+				aria-label="popover"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("button", { name: "inner" })).toHaveFocus();
+	});
+
+	it("focuses the panel itself when no focusable content", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>just text</span>}
+				aria-label="popover"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog")).toHaveFocus();
+	});
+
+	it("sets aria attributes on the trigger", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Open" });
+		expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+		expect(trigger).toHaveAttribute("aria-expanded", "false");
+		expect(trigger).not.toHaveAttribute("aria-controls");
+
+		fireEvent.click(trigger);
+		const dialog = screen.getByRole("dialog");
+		expect(trigger).toHaveAttribute("aria-expanded", "true");
+		expect(trigger).toHaveAttribute("aria-controls", dialog.getAttribute("id")!);
+
+		fireEvent.click(trigger);
+		expect(trigger).not.toHaveAttribute("aria-controls");
+	});
+
+	it("applies placement class (default bottom)", () => {
+		const { rerender } = render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog").parentElement).toHaveClass("popover_placement_bottom");
+
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		rerender(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				placement="right"
+				aria-label="popover"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog").parentElement).toHaveClass("popover_placement_right");
+	});
+
+	it("propagates aria-label to the dialog", () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="필터 옵션"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog", { name: "필터 옵션" })).toBeInTheDocument();
+	});
+
+	it("preserves the trigger's own onClick handler", () => {
+		const onClick = vi.fn();
+		render(
+			<Popover
+				trigger={
+					<button type="button" onClick={onClick}>
+						Open
+					</button>
+				}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("controlled mode: open prop drives visibility and onOpenChange fires", () => {
+		const onOpenChange = vi.fn();
+		const { rerender } = render(
+			<Popover
+				open={false}
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		// 제어 모드: 클릭해도 내부 state 로 열리지 않고 콜백만 호출
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(onOpenChange).toHaveBeenCalledWith(true);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		// 부모가 open=true 로 반영해야 보임
+		rerender(
+			<Popover
+				open
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("uncontrolled mode: respects defaultOpen", () => {
+		render(
+			<Popover
+				defaultOpen
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("Escape while closed does not throw", () => {
+		const { unmount } = render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+				aria-label="popover"
+			/>,
+		);
+		expect(() => fireEvent.keyDown(document, { key: "Escape" })).not.toThrow();
+		unmount();
+		expect(() => fireEvent.keyDown(document, { key: "Escape" })).not.toThrow();
+	});
+});

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { Popover } from "./index";
@@ -29,7 +29,7 @@ describe("Popover", () => {
 		expect(screen.getByText("Panel content")).toBeInTheDocument();
 	});
 
-	it("toggles closed when trigger is clicked again", () => {
+	it("toggles closed when trigger is clicked again", async () => {
 		render(
 			<Popover
 				trigger={<button type="button">Open</button>}
@@ -41,10 +41,12 @@ describe("Popover", () => {
 		fireEvent.click(trigger);
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 		fireEvent.click(trigger);
-		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
 	});
 
-	it("closes on Escape and restores focus to trigger", () => {
+	it("closes on Escape and restores focus to trigger", async () => {
 		render(
 			<Popover
 				trigger={<button type="button">Open</button>}
@@ -58,11 +60,13 @@ describe("Popover", () => {
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 
 		fireEvent.keyDown(document, { key: "Escape" });
-		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
 		expect(trigger).toHaveFocus();
 	});
 
-	it("closes when clicking outside", () => {
+	it("closes when clicking outside", async () => {
 		render(
 			<div>
 				<Popover
@@ -79,7 +83,9 @@ describe("Popover", () => {
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 
 		fireEvent.mouseDown(screen.getByTestId("outside"));
-		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
 	});
 
 	it("does not close when clicking inside the panel", () => {

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { animated } from "@react-spring/web";
+import * as React from "react";
+import { cn, useSpringPresence } from "../../../utils";
+import "./style.scss";
+
+export type PopoverPlacement = "top" | "bottom" | "left" | "right";
+
+export interface PopoverProps {
+	/** trigger 요소 - 클릭 시 팝오버 토글 */
+	trigger: React.ReactElement;
+	/** 팝오버 내부 콘텐츠 - 임의 ReactNode (폼/설명/액션 조합) */
+	content: React.ReactNode;
+	/** 위치 (기본값: "bottom") */
+	placement?: PopoverPlacement;
+	/** 제어 모드 - 열림 상태 */
+	open?: boolean;
+	/** 비제어 모드 초기 열림 상태 (기본값: false) */
+	defaultOpen?: boolean;
+	/** 열림 상태 변경 콜백 */
+	onOpenChange?: (open: boolean) => void;
+	/** dialog 의 접근성 라벨 - content 에 제목이 없을 때 권장 */
+	"aria-label"?: string;
+	/** dialog 의 접근성 라벨 요소 id */
+	"aria-labelledby"?: string;
+	/** 추가 className - 팝오버 패널에 적용 */
+	className?: string;
+}
+
+const FOCUSABLE_SELECTORS = [
+	"a[href]",
+	"button:not([disabled])",
+	"input:not([disabled])",
+	"select:not([disabled])",
+	"textarea:not([disabled])",
+	'[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+/**
+ * 클릭 트리거로 임의의 interactive content 를 띄우는 범용 non-modal 팝오버.
+ * Menu(액션 리스트) / Tooltip(hover 정보) 과 역할 분리 - 폼/설명/액션 조합을 담는다.
+ * 외부 클릭/Esc 로 닫히며, 열릴 때 content 로 포커스 이동, Esc 로 닫으면 trigger 로 복귀.
+ *
+ * @example
+ * ```tsx
+ * <Popover
+ *   trigger={<Button>필터</Button>}
+ *   aria-label="필터 옵션"
+ *   content={
+ *     <Stack gap={8}>
+ *       <Checkbox label="활성" />
+ *       <Button size="sm">적용</Button>
+ *     </Stack>
+ *   }
+ * />
+ * ```
+ */
+export const Popover = ({
+	trigger,
+	content,
+	placement = "bottom",
+	open: openProp,
+	defaultOpen = false,
+	onOpenChange,
+	"aria-label": ariaLabel,
+	"aria-labelledby": ariaLabelledby,
+	className,
+}: PopoverProps) => {
+	const isControlled = openProp !== undefined;
+	const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+	const open = isControlled ? openProp : internalOpen;
+
+	const wrapperRef = React.useRef<HTMLSpanElement>(null);
+	const popoverRef = React.useRef<HTMLDivElement>(null);
+	/** 팝오버 열기 직전의 포커스 요소 (보통 trigger) - Esc 닫힘 시 복귀 대상 */
+	const previousFocusRef = React.useRef<HTMLElement | null>(null);
+	const popoverId = React.useId();
+
+	const setOpen = React.useCallback(
+		(next: boolean) => {
+			if (!isControlled) setInternalOpen(next);
+			onOpenChange?.(next);
+		},
+		[isControlled, onOpenChange],
+	);
+
+	const fromTransform = (() => {
+		switch (placement) {
+			case "top":
+				return "translateY(4px)";
+			case "bottom":
+				return "translateY(-4px)";
+			case "left":
+				return "translateX(4px)";
+			case "right":
+				return "translateX(-4px)";
+		}
+	})();
+
+	const style = useSpringPresence({ visible: open, from: fromTransform });
+
+	// 열릴 때 content 첫 focusable(없으면 패널 자체)로 포커스 이동
+	React.useEffect(() => {
+		if (!open) return;
+		previousFocusRef.current = document.activeElement as HTMLElement | null;
+		const node = popoverRef.current;
+		if (!node) return;
+		const focusable = node.querySelector<HTMLElement>(FOCUSABLE_SELECTORS);
+		(focusable ?? node).focus();
+	}, [open]);
+
+	// 외부 클릭 / Esc 로 닫기 (Esc 는 trigger 로 포커스 복귀)
+	React.useEffect(() => {
+		if (!open) return;
+		const handleClick = (e: MouseEvent) => {
+			if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+		};
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				setOpen(false);
+				previousFocusRef.current?.focus();
+			}
+		};
+		document.addEventListener("mousedown", handleClick);
+		document.addEventListener("keydown", handleKeyDown);
+		return () => {
+			document.removeEventListener("mousedown", handleClick);
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [open, setOpen]);
+
+	const triggerWithProps = React.cloneElement(
+		trigger as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
+		{
+			onClick: (e: React.MouseEvent<HTMLElement>) => {
+				(trigger.props as React.HTMLAttributes<HTMLElement>).onClick?.(e);
+				setOpen(!open);
+			},
+			"aria-haspopup": "dialog",
+			"aria-expanded": open,
+			"aria-controls": open ? popoverId : undefined,
+		} as React.HTMLAttributes<HTMLElement>,
+	);
+
+	return (
+		<span className="popover_wrapper" ref={wrapperRef}>
+			{triggerWithProps}
+			{open && (
+				<span className={cn("popover_position", `popover_placement_${placement}`)}>
+					<animated.div
+						id={popoverId}
+						ref={popoverRef}
+						role="dialog"
+						tabIndex={-1}
+						aria-label={ariaLabel}
+						aria-labelledby={ariaLabelledby}
+						style={style}
+						className={cn("popover", className)}
+					>
+						{content}
+					</animated.div>
+				</span>
+			)}
+		</span>
+	);
+};
+
+Popover.displayName = "Popover";

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -71,7 +71,10 @@ export const Popover = ({
 	const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
 	const open = isControlled ? openProp : internalOpen;
 
-	const wrapperRef = React.useRef<HTMLSpanElement>(null);
+	const [shouldRender, setShouldRender] = React.useState(open ?? false);
+	if (open && !shouldRender) setShouldRender(true);
+
+	const wrapperRef = React.useRef<HTMLDivElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
 	/** 팝오버 열기 직전의 포커스 요소 (보통 trigger) - Esc 닫힘 시 복귀 대상 */
 	const previousFocusRef = React.useRef<HTMLElement | null>(null);
@@ -98,7 +101,7 @@ export const Popover = ({
 		}
 	})();
 
-	const style = useSpringPresence({ visible: open, from: fromTransform });
+	const style = useSpringPresence({ visible: open, from: fromTransform, onExitComplete: () => setShouldRender(false) });
 
 	// 열릴 때 content 첫 focusable(없으면 패널 자체)로 포커스 이동
 	React.useEffect(() => {
@@ -135,6 +138,7 @@ export const Popover = ({
 		{
 			onClick: (e: React.MouseEvent<HTMLElement>) => {
 				(trigger.props as React.HTMLAttributes<HTMLElement>).onClick?.(e);
+				if (e.defaultPrevented) return;
 				setOpen(!open);
 			},
 			"aria-haspopup": "dialog",
@@ -144,10 +148,10 @@ export const Popover = ({
 	);
 
 	return (
-		<span className="popover_wrapper" ref={wrapperRef}>
+		<div className="popover_wrapper" ref={wrapperRef}>
 			{triggerWithProps}
-			{open && (
-				<span className={cn("popover_position", `popover_placement_${placement}`)}>
+			{shouldRender && (
+				<div className={cn("popover_position", `popover_placement_${placement}`)}>
 					<animated.div
 						id={popoverId}
 						ref={popoverRef}
@@ -160,9 +164,9 @@ export const Popover = ({
 					>
 						{content}
 					</animated.div>
-				</span>
+				</div>
 			)}
-		</span>
+		</div>
 	);
 };
 

--- a/src/ui/overlay/popover/popover.stories.tsx
+++ b/src/ui/overlay/popover/popover.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import { Button } from "../../general/button";
+import { Checkbox } from "../../forms/checkbox";
+import { Stack } from "../../layout/stack";
+import { Popover } from ".";
+
+const meta: Meta<typeof Popover> = {
+	title: "Components/Overlay/Popover",
+	component: Popover,
+	tags: ["autodocs"],
+	argTypes: {
+		placement: {
+			control: "select",
+			options: ["top", "bottom", "left", "right"],
+			description: "trigger 기준 위치. / Position relative to the trigger.",
+		},
+		trigger: {
+			control: false,
+			description: "팝오버를 여는 트리거 ReactElement. / Trigger element that opens the popover.",
+		},
+		content: {
+			control: false,
+			description: "임의의 interactive 콘텐츠. / Arbitrary interactive content.",
+		},
+		open: {
+			control: false,
+			description: "제어 모드 열림 상태. / Controlled open state.",
+		},
+	},
+	args: {
+		placement: "bottom",
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: `
+**Popover** - Click-triggered, non-modal panel for arbitrary interactive content (form / explanation / actions). For an action list use \`Menu\`; for hover info use \`Tooltip\`. / **Popover** - 클릭으로 여는 non-modal 패널. 임의의 interactive 콘텐츠(폼/설명/액션)를 담는다. 액션 리스트는 \`Menu\`, hover 정보는 \`Tooltip\`.
+
+Closes on outside click / \`Esc\`. Moves focus into the panel on open; \`Esc\` returns focus to the trigger. / 외부 클릭·\`Esc\`로 닫힘. 열릴 때 패널로 포커스 이동, \`Esc\`로 닫으면 trigger 로 복귀.
+
+\`role="dialog"\` (non-modal) - pass \`aria-label\` or \`aria-labelledby\` for an accessible name. / \`role="dialog"\`(non-modal) - 접근성 이름을 위해 \`aria-label\` 또는 \`aria-labelledby\` 전달.
+				`.trim(),
+			},
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+	render: (args) => (
+		<div style={{ padding: 80, display: "flex", justifyContent: "center" }}>
+			<Popover
+				{...args}
+				aria-label="필터 옵션"
+				trigger={<Button variant="outline">필터</Button>}
+				content={
+					<Stack gap={12}>
+						<strong style={{ color: "var(--bt-color-text-heading)" }}>상태 필터</strong>
+						<Checkbox label="활성" defaultChecked />
+						<Checkbox label="대기" />
+						<Checkbox label="종료" />
+						<Button size="sm">적용</Button>
+					</Stack>
+				}
+			/>
+		</div>
+	),
+};
+
+export const Placements: Story = {
+	name: "위치 (4방향)",
+	render: () => (
+		<div
+			style={{
+				padding: 120,
+				display: "grid",
+				gridTemplateColumns: "repeat(2, auto)",
+				gap: 80,
+				justifyItems: "center",
+			}}
+		>
+			{(["top", "bottom", "left", "right"] as const).map((placement) => (
+				<Popover
+					key={placement}
+					placement={placement}
+					aria-label={`${placement} 팝오버`}
+					trigger={<Button variant="outline">{placement}</Button>}
+					content={
+						<div style={{ color: "var(--bt-color-text-body)" }}>
+							placement="{placement}"
+						</div>
+					}
+				/>
+			))}
+		</div>
+	),
+};
+
+export const RichContent: Story = {
+	name: "리치 콘텐츠",
+	render: () => (
+		<div style={{ padding: 80, display: "flex", justifyContent: "center" }}>
+			<Popover
+				placement="bottom"
+				aria-labelledby="pop-title"
+				trigger={<Button>프로필</Button>}
+				content={
+					<Stack gap={8}>
+						<strong id="pop-title" style={{ color: "var(--bt-color-text-heading)" }}>
+							박상민
+						</strong>
+						<span style={{ color: "var(--bt-color-text-caption)" }}>
+							sangmin@bigtablet.com
+						</span>
+						<Stack direction="horizontal" gap={8}>
+							<Button size="sm" variant="outline">
+								메시지
+							</Button>
+							<Button size="sm">팔로우</Button>
+						</Stack>
+					</Stack>
+				}
+			/>
+		</div>
+	),
+};
+
+export const Controlled: Story = {
+	name: "제어 모드",
+	render: () => {
+		const [open, setOpen] = React.useState(false);
+		return (
+			<div style={{ padding: 80, display: "flex", justifyContent: "center", gap: 16 }}>
+				<Popover
+					open={open}
+					onOpenChange={setOpen}
+					aria-label="제어 팝오버"
+					trigger={<Button variant="outline">토글</Button>}
+					content={
+						<Stack gap={8}>
+							<span style={{ color: "var(--bt-color-text-body)" }}>외부 state 로 제어됨.</span>
+							<Button size="sm" onClick={() => setOpen(false)}>
+								닫기
+							</Button>
+						</Stack>
+					}
+				/>
+				<Button variant="text" onClick={() => setOpen((o) => !o)}>
+					{open ? "열림" : "닫힘"} (외부 버튼)
+				</Button>
+			</div>
+		);
+	},
+};

--- a/src/ui/overlay/popover/popover.stories.tsx
+++ b/src/ui/overlay/popover/popover.stories.tsx
@@ -90,7 +90,7 @@ export const Placements: Story = {
 					trigger={<Button variant="outline">{placement}</Button>}
 					content={
 						<div style={{ color: "var(--bt-color-text-body)" }}>
-							placement="{placement}"
+							{}
 						</div>
 					}
 				/>

--- a/src/ui/overlay/popover/style.scss
+++ b/src/ui/overlay/popover/style.scss
@@ -1,0 +1,67 @@
+@use "src/styles/token" as token;
+
+.popover_wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+// 위치 정렬 wrapper - placement 별 translateX/Y 로 trigger 기준 중앙 잡음.
+// 안의 .popover 는 spring 으로 entrance transform 사용 - 두 transform context 분리해서 충돌 X.
+// Tooltip 과 달리 interactive content 라 pointer-events 유지.
+.popover_position {
+  position: absolute;
+  z-index: token.$z_level5;
+  width: max-content;
+
+  &.popover_placement_top {
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  &.popover_placement_bottom {
+    top: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  &.popover_placement_left {
+    right: calc(100% + 8px);
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  &.popover_placement_right {
+    left: calc(100% + 8px);
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}
+
+.popover {
+  // 라이트: 흰색 / 다크: bg_solid_dim (navy_800, canvas 보다 한 톤 밝음 → elevation)
+  background: token.$color_bg_solid;
+  border: token.$border_width_standard solid token.$color_border_default;
+  border-radius: token.$radius_lg;
+  box-shadow: token.$elevation_level2;
+  padding: token.$spacing_16;
+  min-width: 200px;
+  max-width: 320px;
+  color: token.$color_text_body;
+  @include token.body_small;
+  will-change: transform, opacity;
+
+  // 패널 자체 포커스(첫 focusable 없을 때 fallback) 시 ring 숨김 - 내부 요소가 ring 가짐
+  &:focus-visible {
+    outline: none;
+  }
+
+  [data-theme="dark"] & {
+    background: token.$color_bg_solid_dim;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) & {
+      background: token.$color_bg_solid_dim;
+    }
+  }
+}

--- a/src/ui/overlay/popover/style.scss
+++ b/src/ui/overlay/popover/style.scss
@@ -39,7 +39,7 @@
 }
 
 .popover {
-  // 라이트: 흰색 / 다크: bg_solid_dim (navy_800, canvas 보다 한 톤 밝음 → elevation)
+  // 라이트: 흰색 / 다크: bg_solid_dim (canvas 보다 한 톤 밝음 → elevation)
   background: token.$color_bg_solid;
   border: token.$border_width_standard solid token.$color_border_default;
   border-radius: token.$radius_lg;
@@ -51,9 +51,10 @@
   @include token.body_small;
   will-change: transform, opacity;
 
-  // 패널 자체 포커스(첫 focusable 없을 때 fallback) 시 ring 숨김 - 내부 요소가 ring 가짐
+  // 패널 자체 포커스(첫 focusable 없을 때 fallback) - subtle ring
   &:focus-visible {
     outline: none;
+    box-shadow: token.$focus_ring;
   }
 
   [data-theme="dark"] & {
@@ -63,5 +64,12 @@
     :root:not([data-theme]) & {
       background: token.$color_bg_solid_dim;
     }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popover {
+    transition: none;
+    animation: none;
   }
 }


### PR DESCRIPTION
## 작업 개요

범용 **Popover** 컴포넌트 추가. 클릭 트리거로 임의의 interactive content(폼/설명/액션 조합)를 띄우는 non-modal 패널. Menu(액션 리스트) / Tooltip(hover 정보)과 역할을 명확히 분리했다.

Closes #286

## Menu / Tooltip 과 차별

| | Tooltip | Menu | **Popover** |
|---|---|---|---|
| 트리거 | hover/focus | click | click |
| content | 짧은 정보 (비interactive) | 액션 리스트 (menuitem) | **임의 ReactNode (interactive)** |
| role | tooltip | menu | **dialog (non-modal)** |
| focus | 없음 | 없음 | **열림 시 패널로 이동 + Esc/닫힘 시 trigger 복귀** |

## 작업한 내용

- [x] `src/ui/overlay/popover/index.tsx` - trigger + content, placement(top/bottom/left/right), 제어/비제어(`open`/`defaultOpen`/`onOpenChange`)
- [x] 외부 클릭 / `Esc` 로 닫힘, `Esc` 시 trigger 로 포커스 복귀, 열릴 때 패널 첫 focusable 로 포커스 이동
- [x] `role="dialog"`(non-modal) + `aria-haspopup`/`aria-expanded`/`aria-controls` 자동 주입, trigger 기존 `onClick` 보존
- [x] `style.scss` - token-only(하드코딩 0), 다크모드 패널 elevation(bg_solid_dim), react-spring 진입(placement별 방향)
- [x] Storybook 스토리(Default/Placements/RichContent/Controlled, KO·EN bilingual + autodocs) + 단위 테스트 15개
- [x] `src/index.ts` barrel export (`Popover`, `PopoverPlacement`, `PopoverProps`)
- [x] 문서 - `docs/COMPONENTS.md` 섹션 + TOC, `docs/AGENT_GUIDE.md` Overlay 표/결정 트리/모션 목록

## 검증

- `pnpm vitest run src/ui/overlay/popover` - **19 passed** (단위 테스트 15 + 스토리 smoke 4)
- `pnpm build` 통과, `pnpm lint:css` 위반 0
- Storybook 수동 확인: 열림/닫힘, placement(bottom 아래 배치), 다크모드 패널 navy_800, 포커스 이동·Esc 복귀, console error 0
- 추가 prop 전부 optional - 기존 컴포넌트 영향 없음 (additive)

## 전달할 추가 이슈

- placement 자동 flipping(뷰포트 경계 감지)은 현재 미구현 - Tooltip/Menu 와 동일 정책. 필요 시 별도 이슈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 클릭 트리거로 열리는 **Popover** 컴포넌트 추가 (top/bottom/left/right 배치)
  * 제어/비제어 모드, 외부 클릭·Esc로 닫기, 포커스 이동/복원 및 WAI-ARIA 지원

* **문서**
  * Popover 가이드/컴포넌트 문서 보강 (사용법, 접근성, 애니메이션 규칙)
  * Storybook 스토리 추가 (기본/배치/리치 콘텐츠/제어)

* **테스트**
  * 렌더링, 토글, 포커스 동작, 닫힘 조건, 접근성 속성 및 모드별 흐름 검증 테스트 추가

* **스타일**
  * Popover 전용 SCSS 레이아웃/애니메이션/다크 모드/모션 감소 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->