### PR TITLE
feat/card-variants

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -183,7 +183,7 @@ Organized by category. **Always** import from the package root (`@bigtablet/desi
 
 | Component | Purpose | Key props |
 |-----------|---------|-----------|
-| `Card` | Generic container. | `bordered`, `shadow` (none/sm/md/lg), `padding` (none/sm/md/lg), `variant` (default/accent) |
+| `Card` | Generic container (header/body/footer composition). | `heading`, `variant` (default/accent/glass/outlined — glass=frosted blur over colored bg, outlined=transparent+border), `interactive` (hover-lift for clickable cards), `footer` + `footerAlign` (start/between/end), `bordered`, `shadow` (none/sm/md/lg), `padding` (none/sm/md/lg) |
 | `MediaCard` | Image + content card. | `heading`, `eyebrow`, `description`, `media` (URL), `clickable`, `shadow` |
 | `Hero` | Page-top hero section. | `title`, `subtitle`, `eyebrow`, `backgroundImage`, `overlay` (dark/light/navy), `height` (sm/md/lg/full), `align`, `textColor` (auto/inverse/default), `primaryAction`, `secondaryAction` |
 | `Avatar` | User profile circle. | `name` (initials fallback), `src`, `size` (sm/md/lg), `shape` (circle/square) |

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1641,7 +1641,7 @@ import { MoreVertical, Edit, Copy, Trash, Share, Archive } from "lucide-react";
 ### Card
 
 ```tsx
-import { Card } from '@bigtablet/design-system';
+import { Card, Button } from '@bigtablet/design-system';
 
 <Card heading="카드 제목">
   <p>카드 내용입니다.</p>
@@ -1651,14 +1651,36 @@ import { Card } from '@bigtablet/design-system';
 <Card heading="제목" shadow="lg" padding="lg" bordered>
   내용
 </Card>
+
+// variant - glass 는 컬러/이미지 배경 위에서 빛난다, outlined 는 투명 + 테두리
+<Card variant="glass" heading="Glass">내용</Card>
+<Card variant="outlined" heading="Outlined">내용</Card>
+
+// interactive - hover 시 살짝 떠오름 (클릭 가능한 카드)
+<Card interactive onClick={open}>내용</Card>
+
+// footer 슬롯 - header / body / footer 3단 composition
+<Card
+  heading="제목"
+  footer={<><Button variant="text">취소</Button><Button>저장</Button></>}
+>
+  내용
+</Card>
 ```
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `heading` | `ReactNode` | - | 카드 제목 |
-| `shadow` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'sm'` | 그림자 |
+| `heading` | `ReactNode` | - | 카드 제목 (header) |
+| `headingAs` | `'h2'~'h6'` | `'h3'` | 제목 시맨틱 태그 |
+| `variant` | `'default' \| 'accent' \| 'glass' \| 'outlined'` | `'default'` | accent=navy bg+흰 텍스트 / glass=반투명 frosted+blur(컬러·이미지 배경 위 권장, 흰 텍스트) / outlined=투명 bg+테두리(shadow 무시) |
+| `interactive` | `boolean` | `false` | hover-lift (클릭 가능한 카드용 시각 효과) |
+| `footer` | `ReactNode` | - | 카드 하단 영역 (구분선과 함께 표시) |
+| `footerAlign` | `'start' \| 'between' \| 'end'` | `'end'` | footer 정렬 |
+| `shadow` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'sm'` | 그림자 (outlined/glass 는 자체 처리) |
 | `padding` | `'none' \| 'sm' \| 'md' \| 'lg'` | `'md'` | 내부 여백 |
 | `bordered` | `boolean` | `false` | 테두리 표시 |
+
+> ℹ️ `interactive` 는 hover-lift **시각 효과만** 제공한다 (MediaCard `clickable` 과 동일 범위). 실제 클릭/키보드 처리는 `onClick` 이나 래핑 요소로 직접 연결하라. `glass` 는 흰 배경 라이트 모드에서는 약하게 보이므로 컬러/이미지 배경 위에 사용한다.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export { zIndex } from "./styles/z-index";
 export { AlertProvider, useAlert } from "./ui/feedback/alert";
 export type { ButtonProps } from "./ui/general/button";
 export { Button } from "./ui/general/button";
-export type { CardProps } from "./ui/display/card";
+export type { CardFooterAlign, CardProps, CardVariant } from "./ui/display/card";
 export { Card } from "./ui/display/card";
 export type { CheckboxProps } from "./ui/forms/checkbox";
 export { Checkbox } from "./ui/forms/checkbox";

--- a/src/ui/display/card/Card.test.tsx
+++ b/src/ui/display/card/Card.test.tsx
@@ -81,4 +81,74 @@ describe("Card", () => {
 		const { container } = render(<Card padding="none">Content</Card>);
 		expect(container.firstChild).toHaveClass("card_p_none");
 	});
+
+	// ── variant (glass / outlined) ──────────────────────────────────────
+
+	it("does not apply a variant class for default variant", () => {
+		const { container } = render(<Card>Content</Card>);
+		expect(container.firstChild).not.toHaveClass("card_variant_default");
+	});
+
+	it("applies accent variant class", () => {
+		const { container } = render(<Card variant="accent">Content</Card>);
+		expect(container.firstChild).toHaveClass("card_variant_accent");
+	});
+
+	it("applies glass variant class", () => {
+		const { container } = render(<Card variant="glass">Content</Card>);
+		expect(container.firstChild).toHaveClass("card_variant_glass");
+	});
+
+	it("applies outlined variant class", () => {
+		const { container } = render(<Card variant="outlined">Content</Card>);
+		expect(container.firstChild).toHaveClass("card_variant_outlined");
+	});
+
+	// ── interactive (hover-lift) ────────────────────────────────────────
+
+	it("applies interactive class when interactive is true", () => {
+		const { container } = render(<Card interactive>Content</Card>);
+		expect(container.firstChild).toHaveClass("card_interactive");
+	});
+
+	it("does not apply interactive class by default", () => {
+		const { container } = render(<Card>Content</Card>);
+		expect(container.firstChild).not.toHaveClass("card_interactive");
+	});
+
+	// ── footer slot ─────────────────────────────────────────────────────
+
+	it("renders footer when provided", () => {
+		render(<Card footer={<button type="button">Save</button>}>Content</Card>);
+		expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+	});
+
+	it("does not render footer element when not provided", () => {
+		const { container } = render(<Card>Content</Card>);
+		expect(container.querySelector(".card_footer")).not.toBeInTheDocument();
+	});
+
+	it("applies footerAlign=end by default", () => {
+		const { container } = render(<Card footer={<span>f</span>}>Content</Card>);
+		expect(container.querySelector(".card_footer")).toHaveClass("card_footer_end");
+	});
+
+	it("applies custom footerAlign class", () => {
+		const { container } = render(
+			<Card footer={<span>f</span>} footerAlign="between">
+				Content
+			</Card>,
+		);
+		expect(container.querySelector(".card_footer")).toHaveClass("card_footer_between");
+	});
+
+	// ── 회귀: 신규 prop 미지정 시 기존 동작 유지 ────────────────────────
+
+	it("keeps default behavior when new props are omitted", () => {
+		const { container } = render(<Card heading="T">Content</Card>);
+		const card = container.firstChild as HTMLElement;
+		expect(card).toHaveClass("card", "card_shadow_sm", "card_p_md");
+		expect(card).not.toHaveClass("card_interactive");
+		expect(card.querySelector(".card_footer")).not.toBeInTheDocument();
+	});
 });

--- a/src/ui/display/card/card.stories.tsx
+++ b/src/ui/display/card/card.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../../general/button";
 import { Card } from ".";
 
 const meta: Meta<typeof Card> = {
@@ -11,7 +12,10 @@ const meta: Meta<typeof Card> = {
 		shadow: { control: "select", options: ["none", "sm", "md", "lg"] },
 		padding: { control: "select", options: ["none", "sm", "md", "lg"] },
 		bordered: { control: "boolean" },
-		variant: { control: "select", options: ["default", "accent"] },
+		variant: { control: "select", options: ["default", "accent", "glass", "outlined"] },
+		interactive: { control: "boolean" },
+		footerAlign: { control: "select", options: ["start", "between", "end"] },
+		footer: { control: false },
 		children: { control: false },
 		className: { control: false },
 	},
@@ -28,8 +32,11 @@ const meta: Meta<typeof Card> = {
 				component: `
 **Card** - Container that groups related content into a single block. / **Card** - 콘텐츠를 한 덩어리로 묶는 컨테이너.
 
-Variants: \`default\` / \`accent\` (navy bg + white text). - **Variants**: \`accent\` (navy bg + 흰 텍스트).
-Key props: \`heading\`, \`shadow\` (none/sm/md/lg), \`padding\` (none/sm/md/lg), \`bordered\`. / 주요 prop.
+**Variants**: \`default\` / \`accent\` (navy bg + white text) / \`glass\` (frosted + backdrop blur, use over colored/image backgrounds) / \`outlined\` (transparent bg + border only). / \`accent\`(navy + 흰 텍스트) · \`glass\`(반투명 blur, 컬러/이미지 배경 위 권장) · \`outlined\`(투명 + 테두리).
+
+**Composition**: \`heading\` (header) + children (body) + \`footer\` (with \`footerAlign\` start/between/end). \`interactive\` adds a hover-lift for clickable cards. / \`heading\`+body+\`footer\` 3단 + \`interactive\` hover-lift.
+
+Other props: \`shadow\` (none/sm/md/lg), \`padding\` (none/sm/md/lg), \`bordered\`.
 				`,
 			},
 		},
@@ -57,4 +64,81 @@ export const Bordered: Story = {
 export const LargeShadow: Story = {
 	name: "Shadow lg + padding lg",
 	args: { shadow: "lg", padding: "lg", heading: "강조 카드" },
+};
+
+export const Variants: Story = {
+	name: "Variants 비교",
+	parameters: { controls: { disable: true } },
+	render: () => (
+		<div
+			style={{
+				display: "grid",
+				gridTemplateColumns: "repeat(2, minmax(200px, 1fr))",
+				gap: 24,
+				// glass 가시화를 위한 컬러 그라데이션 배경
+				padding: 32,
+				borderRadius: 16,
+				background: "linear-gradient(135deg, #6d83f2 0%, #a86df2 100%)",
+			}}
+		>
+			<Card variant="default" heading="default">
+				<p style={{ margin: 0 }}>기본 흰 배경 카드.</p>
+			</Card>
+			<Card variant="accent" heading="accent">
+				<p style={{ margin: 0 }}>navy 배경 + 흰 텍스트.</p>
+			</Card>
+			<Card variant="glass" heading="glass">
+				<p style={{ margin: 0 }}>반투명 frosted + blur. 컬러 배경 위에서 빛남.</p>
+			</Card>
+			<Card variant="outlined" heading="outlined">
+				<p style={{ margin: 0 }}>투명 배경 + 테두리만.</p>
+			</Card>
+		</div>
+	),
+};
+
+export const Interactive: Story = {
+	name: "Interactive (hover-lift)",
+	args: {
+		interactive: true,
+		heading: "클릭 가능한 카드",
+		children: <p style={{ margin: 0 }}>마우스를 올리면 살짝 떠오릅니다.</p>,
+	},
+};
+
+export const WithFooter: Story = {
+	name: "Footer 슬롯",
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 360 }}>
+			<Card
+				heading="footerAlign=end (기본)"
+				footer={
+					<>
+						<Button variant="text" size="sm">
+							취소
+						</Button>
+						<Button size="sm">저장</Button>
+					</>
+				}
+			>
+				<p style={{ margin: 0 }}>header / body / footer 3단 구성.</p>
+			</Card>
+			<Card
+				heading="footerAlign=between"
+				footerAlign="between"
+				footer={
+					<>
+						<span style={{ color: "var(--bt-color-text-caption)", fontSize: 13 }}>
+							2026-06-16
+						</span>
+						<Button size="sm" variant="outline">
+							자세히
+						</Button>
+					</>
+				}
+			>
+				<p style={{ margin: 0 }}>메타 정보 + 액션을 양끝 정렬.</p>
+			</Card>
+		</div>
+	),
 };

--- a/src/ui/display/card/index.tsx
+++ b/src/ui/display/card/index.tsx
@@ -4,7 +4,9 @@ import type * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
-export type CardVariant = "default" | "accent";
+export type CardVariant = "default" | "accent" | "glass" | "outlined";
+
+export type CardFooterAlign = "start" | "between" | "end";
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	/** 카드 상단에 표시할 제목 */
@@ -17,8 +19,19 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	padding?: "none" | "sm" | "md" | "lg";
 	/** 테두리 표시 여부 (기본값: false) */
 	bordered?: boolean;
-	/** 카드 variant - "accent"는 navy bg + white text (강조 카드) */
+	/**
+	 * 카드 variant (기본값: "default")
+	 * - "accent": navy bg + white text (강조 카드)
+	 * - "glass": 반투명 + backdrop blur (컬러/이미지 배경 위에 권장)
+	 * - "outlined": 투명 bg + 테두리만 (shadow 무시)
+	 */
 	variant?: CardVariant;
+	/** hover 시 살짝 떠오르는 인터랙션 (기본값: false). 클릭 가능한 카드에 사용 */
+	interactive?: boolean;
+	/** 카드 하단 영역 - 액션 버튼 등 (구분선과 함께 표시) */
+	footer?: React.ReactNode;
+	/** footer 정렬 (기본값: "end") */
+	footerAlign?: CardFooterAlign;
 }
 
 /**
@@ -34,6 +47,9 @@ export const Card = ({
 	padding = "md",
 	bordered = false,
 	variant = "default",
+	interactive = false,
+	footer,
+	footerAlign = "end",
 	className,
 	children,
 	...props
@@ -43,7 +59,7 @@ export const Card = ({
 		`card_shadow_${shadow}`,
 		`card_p_${padding}`,
 		variant !== "default" && `card_variant_${variant}`,
-		{ card_bordered: bordered },
+		{ card_bordered: bordered, card_interactive: interactive },
 		className,
 	);
 
@@ -51,6 +67,9 @@ export const Card = ({
 		<div className={cardClassName} {...props}>
 			{heading ? <HeadingTag className="card_title">{heading}</HeadingTag> : null}
 			<div className="card_body">{children}</div>
+			{footer ? (
+				<div className={cn("card_footer", `card_footer_${footerAlign}`)}>{footer}</div>
+			) : null}
 		</div>
 	);
 };

--- a/src/ui/display/card/style.scss
+++ b/src/ui/display/card/style.scss
@@ -5,9 +5,13 @@
   border-radius: token.$radius_lg;
   transition: token.$transition_lift;
 
-  &_hoverable:hover {
-    transform: translateY(-2px);
-    box-shadow: token.$elevation_level2;
+  &_interactive {
+    cursor: pointer;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: token.$elevation_level2;
+    }
   }
 
   &_bordered {
@@ -57,6 +61,27 @@
     width: 100%;
   }
 
+  // ── Footer (header/body/footer composition) ─────────────────────────
+
+  &_footer {
+    display: flex;
+    gap: token.$spacing_8;
+    align-items: center;
+    margin-top: token.$spacing_16;
+    padding-top: token.$spacing_16;
+    border-top: token.$border_width_standard solid token.$color_border_default;
+
+    &_start {
+      justify-content: flex-start;
+    }
+    &_between {
+      justify-content: space-between;
+    }
+    &_end {
+      justify-content: flex-end;
+    }
+  }
+
   // ── Variant: accent (navy bg + white text) ──────────────────────────
 
   &_variant_accent {
@@ -65,6 +90,52 @@
 
     .card_title {
       color: token.$color_accent_on_surface;
+    }
+
+    .card_footer {
+      // navy bg 위에서는 반투명 흰 구분선이 자연스러움
+      border-top-color: token.$color_state_hover_on_dark;
+    }
+  }
+
+  // ── Variant: outlined (투명 bg + 테두리만) ──────────────────────────
+
+  &_variant_outlined {
+    background: transparent;
+    border: token.$border_width_standard solid token.$color_border_default;
+    box-shadow: none;
+  }
+
+  // ── Variant: glass (반투명 frosted + backdrop blur) ─────────────────
+  // 컬러/이미지 배경 위에서 빛난다. light = 어두운 frosted(밝은 배경 위 가시),
+  // dark = 밝은 frosted(navy 위 가시). rgba/blur 는 layout mixin 내부 처리.
+
+  &_variant_glass {
+    @include token.glass_dark;
+    // 어두운 frosted(또는 navy 위 밝은 frosted) 표면 - 흰 텍스트로 가독성 확보
+    color: token.$color_brand_on_primary;
+
+    .card_title {
+      color: token.$color_brand_on_primary;
+    }
+
+    [data-theme="dark"] & {
+      @include token.glass_card;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme]) & {
+        @include token.glass_card;
+      }
+    }
+  }
+
+  // ── Reduced motion ──────────────────────────────────────────────────
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &_interactive:hover {
+      transform: none;
     }
   }
 }

--- a/src/ui/display/card/style.scss
+++ b/src/ui/display/card/style.scss
@@ -119,6 +119,10 @@
       color: token.$color_brand_on_primary;
     }
 
+    .card_footer {
+      border-top-color: token.$color_state_hover_on_dark;
+    }
+
     [data-theme="dark"] & {
       @include token.glass_card;
     }


### PR DESCRIPTION
## 작업 개요

Card 를 더 유연하게 확장. variant 추가(glass/outlined), hover-lift(`interactive`), footer 슬롯(header/body/footer composition). 전부 **additive** — 기존 default/accent/shadow/padding/bordered 동작 그대로.

Closes #288

## 작업한 내용

- [x] `CardVariant` 확장: `glass`(반투명 frosted + backdrop blur — 라이트=어두운 frosted/다크=밝은 frosted, 흰 텍스트로 대비 확보, layout glass mixin 재사용), `outlined`(투명 bg + 테두리, shadow 무시)
- [x] `interactive?: boolean` — `style.scss` 에 이미 있던 hover-lift(translateY + elevation) 로직을 prop 으로 연결 + cursor pointer (MediaCard `clickable` 패턴 일관)
- [x] `footer?: React.ReactNode` + `footerAlign?: 'start'|'between'|'end'`(기본 end) — 구분선과 함께 header/body/footer 3단 구성 (Modal footer 패턴)
- [x] reduced-motion 가드(lift 비활성)
- [x] 스토리(Variants/Interactive/WithFooter, KO·EN) + 단위 테스트 12개 추가(총 20) + `CardVariant`/`CardFooterAlign` export
- [x] 문서 — COMPONENTS.md Card 섹션 + AGENT_GUIDE.md Display 표

## 검증

- `pnpm vitest run src/ui/display/card` — 33 passed (단위 20 + 스토리 13)
- `pnpm build` 통과, `pnpm lint:css` 위반 0 (glass 의 rgba/blur 는 layout mixin 내부 — Card scss 엔 hex 없음)
- `pnpm tsc --noEmit` — Card 관련 에러 0
- Storybook 시각(preview): glass 라이트(어두운 frosted)/다크(밝은 frosted blur 20px) + 컬러 배경 위 가시성, glass 흰 텍스트, outlined 투명+테두리+shadow none, footer 정렬 end/between + 구분선, console 에러 0

## 전달할 추가 이슈

- `glass` 는 흰 배경 라이트 모드에서는 약하게 보임 → 컬러/이미지 배경 위 사용 전제(문서 명시). 자동 배경 대비 감지는 범위 밖
- `interactive` 는 hover-lift 시각 효과만 — 클릭/키보드 시맨틱은 소비자가 onClick/래핑으로 연결