### PR TITLE
style/dark-mode-neutral

### DIFF
--- a/src/stories/cookbook/layout.stories.tsx
+++ b/src/stories/cookbook/layout.stories.tsx
@@ -53,7 +53,7 @@ export const MarketingHeroFeatureGrid: Story = {
 				eyebrow="신규 출시"
 				title="더 빠르게, 더 단순하게"
 				subtitle="Bigtablet으로 매장 운영의 복잡함을 한 줄로 정리하세요."
-				overlay="navy"
+				overlay="dark"
 				height="lg"
 				align="center"
 				primaryAction={{ label: "무료로 시작하기", onClick: () => {} }}

--- a/src/stories/examples/page-composition.stories.tsx
+++ b/src/stories/examples/page-composition.stories.tsx
@@ -224,10 +224,10 @@ export const MarketingPage: Story = {
 				</Container>
 			</Section>
 
-			{/* CTA Navy */}
+			{/* CTA Inverted */}
 			<Section
 				spacing="lg"
-				bg="navy"
+				bg="inverted"
 				style={{
 					position: "relative",
 					overflow: "hidden",

--- a/src/stories/foundation/colors.stories.tsx
+++ b/src/stories/foundation/colors.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta = {
 
 - **Base**: raw 값 (직접 사용 지양)
 - **Semantic**: 역할 기반 (brand / text / bg / state / border / status)
-- **Brand Accent (Navy)**: 검정(\`brand_primary\`)과 함께 위계 만드는 navy slate accent - 페이지 하단 "Navy 팔레트 / Accent 토큰 / Spring 모션" 참고
+- **Brand Accent**: 검정(\`brand_primary\`) 기반 accent 토큰 - 페이지 하단 "Accent 토큰 / Spring 모션" 참고
 
 ❗️직접 HEX / RGB 값을 쓰지 말고 **반드시 Semantic 토큰**을 사용하세요.
         `,
@@ -327,65 +327,55 @@ function toJsonKey(key: string) {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Brand Accent (Navy) - 초기 홈페이지 brand 컬러. 검정과 함께 위계 만드는 보조 강조.
+// Neutral Dark Scale - dark mode 표면 컬러 (Vercel-style pure neutral)
 // ────────────────────────────────────────────────────────────────────────────
 
-const NAVY_SCALE = [
-	{ key: "50", value: baseColors.navy50 },
-	{ key: "100", value: baseColors.navy100 },
-	{ key: "200", value: baseColors.navy200 },
-	{ key: "300", value: baseColors.navy300 },
-	{ key: "400", value: baseColors.navy400 },
-	{ key: "500", value: baseColors.navy500 },
-	{ key: "600", value: baseColors.navy600 },
-	{ key: "700", value: baseColors.navy700 },
-	{ key: "800", value: baseColors.navy800 },
-	{ key: "900", value: baseColors.navy900 },
+const NEUTRAL_DARK_SCALE = [
+	{ key: "800", value: baseColors.neutral800 },
+	{ key: "900", value: baseColors.neutral900 },
+	{ key: "925", value: baseColors.neutral925 },
+	{ key: "950", value: baseColors.neutral950 },
 ];
 
-export const NavyPalette: Story = {
-	name: "Navy 팔레트",
+export const NeutralDarkPalette: Story = {
+	name: "Neutral Dark 스케일",
 	render: () => (
 		<div style={{ display: "grid", gap: 12, maxWidth: 720 }}>
 			<p style={{ margin: 0, fontSize: 13, color: "#666" }}>
-				<strong>10단계 스케일</strong> - 라이트 wash부터 거의 검정까지. 검정 brand 컬러와 함께
-				사용해 텍스트/배경 위계를 만드세요. (메인 navy: <code>#47555E</code>)
+				<strong>Dark mode 표면 컬러</strong> - Vercel-style 순수 중성 그레이. 925/950은 dark mode 전용 추가 단계.
 			</p>
-			{NAVY_SCALE.map(({ key, value }) => {
-				const isLight = parseInt(key, 10) <= 300;
-				return (
+			{NEUTRAL_DARK_SCALE.map(({ key, value }) => (
+				<div
+					key={key}
+					style={{
+						display: "grid",
+						gridTemplateColumns: "120px 1fr 100px",
+						alignItems: "center",
+						gap: 12,
+						padding: 12,
+						background: "#fff",
+						border: "1px solid rgba(0,0,0,0.06)",
+						borderRadius: 10,
+					}}
+				>
+					<code style={{ fontSize: 12 }}>neutral-{key}</code>
 					<div
-						key={key}
 						style={{
-							display: "grid",
-							gridTemplateColumns: "120px 1fr 100px",
+							height: 44,
+							borderRadius: 8,
+							background: value,
+							display: "flex",
 							alignItems: "center",
-							gap: 12,
-							padding: 12,
-							background: "#fff",
-							border: "1px solid rgba(0,0,0,0.06)",
-							borderRadius: 10,
+							justifyContent: "center",
+							color: "#fff",
+							fontSize: 13,
 						}}
 					>
-						<code style={{ fontSize: 12 }}>navy-{key}</code>
-						<div
-							style={{
-								height: 44,
-								borderRadius: 8,
-								background: value,
-								display: "flex",
-								alignItems: "center",
-								justifyContent: "center",
-								color: isLight ? "#121212" : "#fff",
-								fontSize: 13,
-							}}
-						>
-							가나다 Aa 123
-						</div>
-						<span style={{ fontSize: 12, opacity: 0.6, textAlign: "right" }}>{value}</span>
+						가나다 Aa 123
 					</div>
-				);
-			})}
+					<span style={{ fontSize: 12, opacity: 0.6, textAlign: "right" }}>{value}</span>
+				</div>
+			))}
 		</div>
 	),
 };
@@ -394,11 +384,11 @@ export const AccentTokens: Story = {
 	name: "Accent 토큰 (semantic)",
 	render: () => {
 		const items = [
-			{ key: "subtle", value: colors.accent.subtle, desc: "hero wash, 카드 배경" },
-			{ key: "muted", value: colors.accent.muted, desc: "보조 카드 배경" },
-			{ key: "light", value: colors.accent.light, desc: "sky blue 강조 (보조 CTA)" },
-			{ key: "default", value: colors.accent.default, desc: "PRIMARY navy (dark section, CTA)" },
-			{ key: "strong", value: colors.accent.strong, desc: "hover/pressed, 진한 navy" },
+			{ key: "subtle", value: colors.accent.subtle, desc: "배경 wash (hover/selected 배경)" },
+			{ key: "muted", value: colors.accent.muted, desc: "보조 배경 (pressed 상태)" },
+			{ key: "light", value: colors.accent.light, desc: "연한 강조 (보조 border)" },
+			{ key: "default", value: colors.accent.default, desc: "PRIMARY accent (dark section, CTA)" },
+			{ key: "strong", value: colors.accent.strong, desc: "hover/pressed 강조" },
 		];
 		return (
 			<div style={{ display: "grid", gap: 12, maxWidth: 720 }}>
@@ -521,7 +511,7 @@ function HoverDemo() {
 			>
 				<strong>강한 lift (-4px, scale 1.04)</strong>
 				<p style={{ margin: "8px 0 0", fontSize: 13, opacity: 0.8 }}>
-					CTA 카드에 적합 - navy accent 배경
+					CTA 카드에 적합 - accent 배경
 				</p>
 			</animated.div>
 		</div>

--- a/src/stories/foundation/dark-mode.stories.tsx
+++ b/src/stories/foundation/dark-mode.stories.tsx
@@ -165,12 +165,12 @@ export const TokenComparison: Story = {
 	parameters: { docs: { source: { code: "" } } },
 	render: () => {
 		const items = [
-			{ token: "bg.solid", lightHex: "#FFFFFF", darkHex: "#1F2630" },
-			{ token: "bg.solid_dim", lightHex: "#F4F4F4", darkHex: "#303841" },
+			{ token: "bg.solid", lightHex: "#FFFFFF", darkHex: "#0A0A0A" },
+			{ token: "bg.solid_dim", lightHex: "#F4F4F4", darkHex: "#141414" },
 			{ token: "text.heading", lightHex: "#121212", darkHex: "#FFFFFF" },
-			{ token: "text.body", lightHex: "#666666", darkHex: "#B4C2CD" },
-			{ token: "text.caption", lightHex: "#888888", darkHex: "#999999" },
-			{ token: "border.default", lightHex: "#E5E5E5", darkHex: "#3D4852" },
+			{ token: "text.body", lightHex: "#666666", darkHex: "#B3B3B3" },
+			{ token: "text.caption", lightHex: "#888888", darkHex: "#777777" },
+			{ token: "border.default", lightHex: "#E5E5E5", darkHex: "#333333" },
 		];
 		return (
 			<div

--- a/src/stories/foundation/dark-mode.stories.tsx
+++ b/src/stories/foundation/dark-mode.stories.tsx
@@ -50,12 +50,12 @@ import { ThemeProvider } from "@bigtablet/design-system";
 
 | Semantic | Light | Dark |
 |----------|-------|------|
-| bg.solid | #FFFFFF | #1F2630 (navy-900) |
-| bg.solid_dim | #F4F4F4 | #303841 (navy-800) |
+| bg.solid | #FFFFFF | #0A0A0A (neutral-950) |
+| bg.solid_dim | #F4F4F4 | #141414 (neutral-925) |
 | text.heading | #121212 | #FFFFFF |
-| text.body | #666666 | #B4C2CD (navy-200) |
-| text.caption | #888888 | #999999 |
-| border.default | #E5E5E5 | #3D4852 (navy-700) |
+| text.body | #666666 | #B3B3B3 (neutral-400) |
+| text.caption | #888888 | #777777 (neutral-600) |
+| border.default | #E5E5E5 | #333333 (neutral-800) |
 
 \`brand_primary\`, \`accent.*\`, \`status.*\` 는 라이트/다크 동일 (브랜드 일관성).
 

--- a/src/styles/a11y/_index.scss
+++ b/src/styles/a11y/_index.scss
@@ -2,7 +2,7 @@
 @use "../breakpoints" as breakpoint;
 
 // Focus rings - CSS Custom Properties로 light/dark 자동 전환.
-// Dark 모드는 흰색 alpha 기반으로 navy bg 위에서도 가시성 확보.
+// Dark 모드는 흰색 alpha 기반으로 neutral dark bg 위에서도 가시성 확보.
 
 :root {
   --bt-focus-ring:         0 0 0 3px rgba(0, 0, 0, 0.15);

--- a/src/styles/colors/_index.scss
+++ b/src/styles/colors/_index.scss
@@ -171,8 +171,9 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  // Brand (dark 모드에서도 black 유지 - neutral bg 위에서 black 버튼 구분됨.
-  // 단 텍스트로 쓰일 땐 inverse 사용 권장)
+  // Brand (dark 모드에서도 black 유지.
+  // neutral_950 (#0A0A0A) bg와 대비가 낮아 버튼 등에서 border/elevation 보조 필요.
+  // 텍스트로 쓰일 땐 inverse 사용 권장)
 
   // Text (light → inverted)
   // heading: 100% 흰색 → 95%로 살짝 부드럽게 (눈 피로 완화, halation 보정)

--- a/src/styles/colors/_index.scss
+++ b/src/styles/colors/_index.scss
@@ -7,7 +7,7 @@
 //   3. Semantic SCSS 변수 - CSS var를 참조 → 기존 사용처(@use token; $color_*) 호환 유지
 //
 // `brand_primary`, `accent.*`, `status.*` 는 light/dark 동일 (브랜드 일관성).
-// 나머지 표면/텍스트/border 는 dark에서 navy 계열로 자동 전환.
+// 나머지 표면/텍스트/border 는 dark에서 neutral 계열로 자동 전환 (Vercel-style pure gray).
 // ════════════════════════════════════════════════════════════════════════
 
 // ── Base colors (raw, never theme-aware) ────────────────────────────────
@@ -25,6 +25,8 @@ $color_base_neutral_600:      #777777;
 $color_base_neutral_700:      #666666;
 $color_base_neutral_800:      #333333;
 $color_base_neutral_900:      #121212;
+$color_base_neutral_925:      #141414;  // dark panel/card bg (Vercel-style)
+$color_base_neutral_950:      #0A0A0A;  // darkest page bg (Vercel-style)
 // Status - light mode default (darkened for AA on #fff text, 5+:1)
 // 이전 값 (#EF4444 등) 은 #fff 텍스트 조합 시 AA 미달 (2.0~3.7:1) - Tailwind 700 계열로 교체.
 $color_base_status_error:     #B91C1C;  // red-700, with #fff = 6.4:1
@@ -33,11 +35,11 @@ $color_base_status_warning:   #B45309;  // amber-700, with #fff = 5.1:1
 $color_base_status_info:      #1D4ED8;  // blue-700, with #fff = 6.5:1
 
 // Status - dark mode 텍스트 / surface 위 직접 사용용 (brightened)
-// dark canvas (navy_900 lum ~0.005) 위에서 6+:1 보장.
-$color_base_status_error_dark_text:    #F87171;  // red-400, on navy_900 ~6.8:1
-$color_base_status_success_dark_text:  #4ADE80;  // green-400, on navy_900 ~10.5:1
-$color_base_status_warning_dark_text:  #FBBF24;  // amber-400, on navy_900 ~13:1
-$color_base_status_info_dark_text:     #60A5FA;  // blue-400, on navy_900 ~7.8:1
+// dark canvas (neutral_950 #0A0A0A lum ~0.001) 위에서 6+:1 이상 보장.
+$color_base_status_error_dark_text:    #F87171;  // red-400, on neutral_950 ~8.2:1
+$color_base_status_success_dark_text:  #4ADE80;  // green-400, on neutral_950 ~12.6:1
+$color_base_status_warning_dark_text:  #FBBF24;  // amber-400, on neutral_950 ~15.7:1
+$color_base_status_info_dark_text:     #60A5FA;  // blue-400, on neutral_950 ~9.4:1
 
 // Status container - light mode (연한 tint 배경)
 $color_base_status_error_container_light:    #FEE2E2;  // red-100
@@ -45,7 +47,7 @@ $color_base_status_success_container_light:  #DCFCE7;  // green-100
 $color_base_status_warning_container_light:  #FEF3C7;  // amber-100
 $color_base_status_info_container_light:     #DBEAFE;  // blue-100
 
-// Status container - dark mode (deep alpha tint, navy bg 위 식별 가능)
+// Status container - dark mode (deep alpha tint, dark neutral bg 위 식별 가능)
 // Sass rgba(hex, alpha) - 다른 토큰 정의와 hex 일관성 유지.
 $color_base_status_error_container_dark:     rgba(#7f1d1d, 0.35);   // red-900 @ 35%
 $color_base_status_success_container_dark:   rgba(#064e3b, 0.35);   // green-900 @ 35%
@@ -57,18 +59,6 @@ $color_base_status_error_on_container_dark:    #FCA5A5;  // red-300
 $color_base_status_success_on_container_dark:  #86EFAC;  // green-300
 $color_base_status_warning_on_container_dark:  #FCD34D;  // amber-300
 $color_base_status_info_on_container_dark:     #93C5FD;  // blue-300
-
-// Bigtablet navy (초기 홈페이지에서 추출) - slate-gray-blue + sky blue
-$color_base_navy_50:          #F2F5F8;
-$color_base_navy_100:         #DDE3E9;
-$color_base_navy_200:         #B4C2CD;
-$color_base_navy_300:         #7AA5D2;
-$color_base_navy_400:         #5A8DCB;
-$color_base_navy_500:         #4C7CB6;
-$color_base_navy_600:         #47555E;
-$color_base_navy_700:         #3D4852;
-$color_base_navy_800:         #303841;
-$color_base_navy_900:         #1F2630;
 
 // Skeleton - light mode (off-white grays, not in neutral scale)
 $color_base_skeleton_base:       #F3F3F3;
@@ -160,7 +150,7 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
 
   // Accent (검정 brand 기반 - light에서 검정, dark에서 흰색 반전)
   // 컴포넌트 active/selected/indicator 강조에 사용.
-  // navy 색상은 `color_base_navy_*`로 별도 보존 (legacy/optional usage).
+  // Accent: brand 검정 기반 (light=검정, dark=흰색 반전)
   --bt-color-accent-subtle:        #{$color_base_alpha_black_5};
   --bt-color-accent-muted:         #{$color_base_alpha_black_12};
   --bt-color-accent-light:         #{$color_base_neutral_400};
@@ -168,7 +158,7 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
   --bt-color-accent-strong:        #{$color_base_neutral_900};
   --bt-color-accent-on-surface:    #{$color_base_neutral_0};        // 검정 위 흰색
 
-  // Skeleton (light gray gradient - dark 에서 navy gray 로 전환)
+  // Skeleton (light gray gradient - dark 에서 neutral gray 로 전환)
   --bt-color-skeleton-base:        #{$color_base_skeleton_base};
   --bt-color-skeleton-wave:        #{$color_base_skeleton_wave};
   --bt-color-skeleton-highlight:   #{$color_base_skeleton_highlight};
@@ -181,20 +171,20 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  // Brand (dark 모드에서도 black 유지 - bg가 navy라 black 버튼 구분됨.
+  // Brand (dark 모드에서도 black 유지 - neutral bg 위에서 black 버튼 구분됨.
   // 단 텍스트로 쓰일 땐 inverse 사용 권장)
 
   // Text (light → inverted)
   // heading: 100% 흰색 → 95%로 살짝 부드럽게 (눈 피로 완화, halation 보정)
   --bt-color-text-heading:         rgba(255, 255, 255, 0.95);
-  --bt-color-text-body:            #{$color_base_navy_200};
-  --bt-color-text-caption:         #{$color_base_neutral_400};
+  --bt-color-text-body:            #{$color_base_neutral_400};
+  --bt-color-text-caption:         #{$color_base_neutral_600};
   --bt-color-text-inverse:         #{$color_base_neutral_900};
   --bt-color-text-disabled:        #{$color_base_alpha_white_38};
 
-  // Background (light → navy)
-  --bt-color-bg-solid:             #{$color_base_navy_900};
-  --bt-color-bg-solid-dim:         #{$color_base_navy_800};
+  // Background (light → neutral dark)
+  --bt-color-bg-solid:             #{$color_base_neutral_950};
+  --bt-color-bg-solid-dim:         #{$color_base_neutral_925};
   --bt-color-bg-additive:          #{$color_base_alpha_white_5};
   --bt-color-bg-disabled:          #{$color_base_alpha_white_12};
   --bt-color-bg-overlay:           rgba(0, 0, 0, 0.7);
@@ -208,17 +198,17 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
   --bt-color-state-pressed-on-dark:   #{$color_base_alpha_black_12};
   --bt-color-state-focus-on-dark:     #{$color_base_alpha_black_12};
 
-  // Border (light gray → navy mid)
-  --bt-color-border-default:       #{$color_base_navy_700};
-  --bt-color-border-hover:         #{$color_base_navy_400};
+  // Border (light gray → neutral dark)
+  --bt-color-border-default:       #{$color_base_neutral_800};
+  --bt-color-border-hover:         #{$color_base_neutral_600};
   --bt-color-border-subtle:        #{$color_base_alpha_white_12};
   --bt-color-border-focus:         #{$color_base_neutral_0};
-  --bt-color-border-disabled:      #{$color_base_navy_800};
+  --bt-color-border-disabled:      #{$color_base_neutral_925};
 
   // Brand container - dark 모드에선 white alpha로
   --bt-color-brand-primary-container: #{$color_base_alpha_white_8};
 
-  // Accent (dark - 흰색 반전. active/selected가 dark navy bg 위에서 잘 보임)
+  // Accent (dark - 흰색 반전. active/selected가 dark neutral bg 위에서 잘 보임)
   --bt-color-accent-subtle:        #{$color_base_alpha_white_8};
   --bt-color-accent-muted:         #{$color_base_alpha_white_12};
   --bt-color-accent-light:         #{$color_base_neutral_300};
@@ -244,10 +234,10 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
   --bt-color-status-warning-on-surface:  #{$color_base_status_warning_dark_text};
   --bt-color-status-info-on-surface:     #{$color_base_status_info_dark_text};
 
-  // Skeleton - navy_700 (bg-solid-dim navy_800 보다 살짝 밝음 → 시각 대비)
-  --bt-color-skeleton-base:        #{$color_base_navy_700};
-  --bt-color-skeleton-wave:        #{$color_base_navy_700};
-  --bt-color-skeleton-highlight:   #{$color_base_navy_600};
+  // Skeleton - neutral_800 (bg-solid-dim neutral_925 보다 밝음 → 시각 대비)
+  --bt-color-skeleton-base:        #{$color_base_neutral_800};
+  --bt-color-skeleton-wave:        #{$color_base_neutral_800};
+  --bt-color-skeleton-highlight:   #{$color_base_neutral_700};
 }
 
 // `prefers-color-scheme: dark` 자동 응답 (ThemeProvider 없이도 작동)
@@ -258,13 +248,13 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
     -moz-osx-font-smoothing: grayscale;
 
     --bt-color-text-heading:         rgba(255, 255, 255, 0.95);
-    --bt-color-text-body:            #{$color_base_navy_200};
-    --bt-color-text-caption:         #{$color_base_neutral_400};
+    --bt-color-text-body:            #{$color_base_neutral_400};
+    --bt-color-text-caption:         #{$color_base_neutral_600};
     --bt-color-text-inverse:         #{$color_base_neutral_900};
     --bt-color-text-disabled:        #{$color_base_alpha_white_38};
 
-    --bt-color-bg-solid:             #{$color_base_navy_900};
-    --bt-color-bg-solid-dim:         #{$color_base_navy_800};
+    --bt-color-bg-solid:             #{$color_base_neutral_950};
+    --bt-color-bg-solid-dim:         #{$color_base_neutral_925};
     --bt-color-bg-additive:          #{$color_base_alpha_white_5};
     --bt-color-bg-disabled:          #{$color_base_alpha_white_12};
     --bt-color-bg-overlay:           rgba(0, 0, 0, 0.7);
@@ -277,11 +267,11 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
     --bt-color-state-pressed-on-dark:   #{$color_base_alpha_black_12};
     --bt-color-state-focus-on-dark:     #{$color_base_alpha_black_12};
 
-    --bt-color-border-default:       #{$color_base_navy_700};
-    --bt-color-border-hover:         #{$color_base_navy_400};
+    --bt-color-border-default:       #{$color_base_neutral_800};
+    --bt-color-border-hover:         #{$color_base_neutral_600};
     --bt-color-border-subtle:        #{$color_base_alpha_white_12};
     --bt-color-border-focus:         #{$color_base_neutral_0};
-    --bt-color-border-disabled:      #{$color_base_navy_800};
+    --bt-color-border-disabled:      #{$color_base_neutral_925};
 
     --bt-color-brand-primary-container: #{$color_base_alpha_white_8};
 
@@ -309,9 +299,9 @@ $color_base_alpha_white_38:   rgba(255, 255, 255, 0.38);
     --bt-color-status-warning-on-surface:  #{$color_base_status_warning_dark_text};
     --bt-color-status-info-on-surface:     #{$color_base_status_info_dark_text};
 
-    --bt-color-skeleton-base:        #{$color_base_navy_700};
-    --bt-color-skeleton-wave:        #{$color_base_navy_700};
-    --bt-color-skeleton-highlight:   #{$color_base_navy_600};
+    --bt-color-skeleton-base:        #{$color_base_neutral_800};
+    --bt-color-skeleton-wave:        #{$color_base_neutral_800};
+    --bt-color-skeleton-highlight:   #{$color_base_neutral_700};
   }
 }
 

--- a/src/styles/colors/index.ts
+++ b/src/styles/colors/index.ts
@@ -15,23 +15,13 @@ export const baseColors = {
 	neutral700: "#666666",
 	neutral800: "#333333",
 	neutral900: "#121212",
+	neutral925: "#141414",
+	neutral950: "#0A0A0A",
 
 	statusError: "#EF4444",
 	statusSuccess: "#10B981",
 	statusWarning: "#F59E0B",
 	statusInfo: "#3B82F6",
-
-	// Navy - Bigtablet 초기 홈페이지 컬러. #47555E 메인 navy + sky blue 패밀리.
-	navy50: "#F2F5F8",
-	navy100: "#DDE3E9",
-	navy200: "#B4C2CD",
-	navy300: "#7AA5D2",
-	navy400: "#5A8DCB",
-	navy500: "#4C7CB6",
-	navy600: "#47555E",
-	navy700: "#3D4852",
-	navy800: "#303841",
-	navy900: "#1F2630",
 
 	alphaBlack5: "rgba(0, 0, 0, 0.05)",
 	alphaBlack8: "rgba(0, 0, 0, 0.08)",
@@ -91,13 +81,13 @@ export const colors = {
 		info: baseColors.statusInfo,
 	},
 
-	// Accent (Bigtablet navy) - 메인 brand 검정과 함께 B2C/마케팅 강조에 사용.
+	// Accent (brand 검정 기반 - light=검정, dark=흰색 반전)
 	accent: {
-		subtle: baseColors.navy50,
-		muted: baseColors.navy100,
-		light: baseColors.navy300,
-		default: baseColors.navy600,
-		strong: baseColors.navy800,
+		subtle: baseColors.alphaBlack5,
+		muted: baseColors.alphaBlack12,
+		light: baseColors.neutral400,
+		default: baseColors.brandPrimary,
+		strong: baseColors.neutral900,
 		onSurface: baseColors.neutral0,
 	},
 } as const;

--- a/src/styles/elevation/_index.scss
+++ b/src/styles/elevation/_index.scss
@@ -1,5 +1,5 @@
 // Elevation shadows - CSS Custom Properties로 light/dark 자동 전환.
-// Dark 모드는 navy bg 위에서 그림자가 보이도록 더 강한 검정 + 살짝 spread 증가.
+// Dark 모드는 neutral dark bg 위에서 그림자가 보이도록 더 강한 검정 + 살짝 spread 증가.
 
 :root {
   --bt-elevation-level1: 0 1px 1px -1px rgba(0, 0, 0, 0.20), 0 3px 3px 0px rgba(0, 0, 0, 0.12);
@@ -10,7 +10,7 @@
 }
 
 [data-theme="dark"] {
-  // navy bg 위에서 그림자 가시성 - 검정 더 진하게 + 약간 더 큰 spread
+  // neutral dark bg 위에서 그림자 가시성 - 검정 더 진하게 + 약간 더 큰 spread
   --bt-elevation-level1: 0 1px 2px 0 rgba(0, 0, 0, 0.45), 0 3px 6px 0 rgba(0, 0, 0, 0.30);
   --bt-elevation-level2: 0 2px 4px 0 rgba(0, 0, 0, 0.45), 0 6px 12px 0 rgba(0, 0, 0, 0.30);
   --bt-elevation-level3: 0 3px 6px 0 rgba(0, 0, 0, 0.50), 0 9px 18px 0 rgba(0, 0, 0, 0.35);

--- a/src/ui/display/avatar/index.tsx
+++ b/src/ui/display/avatar/index.tsx
@@ -16,7 +16,7 @@ export interface AvatarProps extends React.HTMLAttributes<HTMLSpanElement> {
 	size?: AvatarSize;
 	/** 모양 (기본값: "circle") */
 	shape?: AvatarShape;
-	/** 색상 (기본값: navy accent) */
+	/** 색상 (기본값: accent-default — 검정/흰색 테마 자동) */
 	bgColor?: string;
 }
 

--- a/src/ui/display/card/card.stories.tsx
+++ b/src/ui/display/card/card.stories.tsx
@@ -32,7 +32,7 @@ const meta: Meta<typeof Card> = {
 				component: `
 **Card** - Container that groups related content into a single block. / **Card** - 콘텐츠를 한 덩어리로 묶는 컨테이너.
 
-**Variants**: \`default\` / \`accent\` (navy bg + white text) / \`glass\` (frosted + backdrop blur, use over colored/image backgrounds) / \`outlined\` (transparent bg + border only). / \`accent\`(navy + 흰 텍스트) · \`glass\`(반투명 blur, 컬러/이미지 배경 위 권장) · \`outlined\`(투명 + 테두리).
+**Variants**: \`default\` / \`accent\` (inverted bg + white text) / \`glass\` (frosted + backdrop blur, use over colored/image backgrounds) / \`outlined\` (transparent bg + border only). / \`accent\`(반전 bg + 흰 텍스트) · \`glass\`(반투명 blur, 컬러/이미지 배경 위 권장) · \`outlined\`(투명 + 테두리).
 
 **Composition**: \`heading\` (header) + children (body) + \`footer\` (with \`footerAlign\` start/between/end). \`interactive\` adds a hover-lift for clickable cards. / \`heading\`+body+\`footer\` 3단 + \`interactive\` hover-lift.
 
@@ -49,11 +49,11 @@ type Story = StoryObj<typeof Card>;
 export const Basic: Story = {};
 
 export const AccentVariant: Story = {
-	name: "Accent (navy)",
+	name: "Accent (inverted)",
 	args: {
 		variant: "accent",
 		heading: "주요 강조 카드",
-		children: <p style={{ margin: 0 }}>navy 배경 + 흰 텍스트. CTA/주요 정보용.</p>,
+		children: <p style={{ margin: 0 }}>반전 배경 + 흰 텍스트. CTA/주요 정보용.</p>,
 	},
 };
 

--- a/src/ui/display/card/index.tsx
+++ b/src/ui/display/card/index.tsx
@@ -21,7 +21,7 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	bordered?: boolean;
 	/**
 	 * 카드 variant (기본값: "default")
-	 * - "accent": navy bg + white text (강조 카드)
+	 * - "accent": inverted bg + white text (강조 카드)
 	 * - "glass": 반투명 + backdrop blur (컬러/이미지 배경 위에 권장)
 	 * - "outlined": 투명 bg + 테두리만 (shadow 무시)
 	 */

--- a/src/ui/display/card/style.scss
+++ b/src/ui/display/card/style.scss
@@ -82,7 +82,7 @@
     }
   }
 
-  // ── Variant: accent (navy bg + white text) ──────────────────────────
+  // ── Variant: accent (inverted bg + white text) ──────────────────────────
 
   &_variant_accent {
     background: token.$color_accent_default;

--- a/src/ui/display/chip/style.scss
+++ b/src/ui/display/chip/style.scss
@@ -30,7 +30,7 @@
         background: token.$color_state_pressed_on_light;
     }
 
-    // ── Selected (navy accent) ──────────────────────────────────────────
+    // ── Selected (accent) ──────────────────────────────────────────
     &_selected {
         background: token.$color_accent_default;
         border-color: token.$color_accent_default;

--- a/src/ui/display/hero/hero.stories.tsx
+++ b/src/ui/display/hero/hero.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Hero> = {
 **Hero** - Large banner area at the top of a page. Renders \`<section>\` + \`<h1>\` (one per page). / **Hero** - 페이지 상단 큰 영역. \`<section>\` + \`<h1>\` (페이지당 하나).
 
 Slots: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`. / 슬롯: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`.
-Key props: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`. / 주요 prop: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`/\`navy\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`.
+Key props: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`. / 주요 prop: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`.
 				`,
 			},
 		},

--- a/src/ui/display/hero/index.tsx
+++ b/src/ui/display/hero/index.tsx
@@ -16,7 +16,7 @@ export interface HeroAction {
 
 export type HeroHeight = "sm" | "md" | "lg" | "full";
 export type HeroAlign = "left" | "center" | "right";
-export type HeroOverlay = boolean | "dark" | "light" | "navy";
+export type HeroOverlay = boolean | "dark" | "light";
 
 export interface HeroProps extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
 	/** 히어로 높이 (기본값: "md"). sm=320 / md=480 / lg=640 / full=100vh */
@@ -31,7 +31,6 @@ export interface HeroProps extends Omit<React.HTMLAttributes<HTMLElement>, "titl
 	 * 텍스트 대비를 위한 오버레이.
 	 * - `true`/"dark": 위→아래 검정 그라데이션
 	 * - "light": 흰색 그라데이션
-	 * - "navy": Bigtablet brand navy 그라데이션 (marketing 강조)
 	 */
 	overlay?: HeroOverlay;
 	/** h1으로 렌더링되는 메인 제목 */
@@ -74,7 +73,7 @@ export const Hero = ({
 	...props
 }: HeroProps) => {
 	const resolvedOverlay = overlay === true ? "dark" : overlay;
-	const isDarkOverlay = resolvedOverlay === "dark" || resolvedOverlay === "navy";
+	const isDarkOverlay = resolvedOverlay === "dark";
 	const resolvedTextColor =
 		textColor === "auto"
 			? isDarkOverlay || (backgroundImage && !resolvedOverlay)

--- a/src/ui/display/hero/style.scss
+++ b/src/ui/display/hero/style.scss
@@ -54,14 +54,6 @@
     .hero_subtitle { color: rgba(0, 0, 0, 0.85); }
   }
 
-  &_overlay_navy .hero_overlay {
-    background: linear-gradient(
-      180deg,
-      rgba(48, 56, 65, 0) 0%,
-      rgba(48, 56, 65, 0.85) 100%
-    );
-  }
-
   // ── Content area ──────────────────────────────────────────────────────
 
   &_content {

--- a/src/ui/display/list-item/style.scss
+++ b/src/ui/display/list-item/style.scss
@@ -26,12 +26,12 @@
     align-items: center;
   }
 
-  // ── Selected (navy accent) ──────────────────────────────────────────
+  // ── Selected (accent) ──────────────────────────────────────────
   &_selected {
     background: token.$color_accent_subtle;
     position: relative;
 
-    // 왼쪽 navy 인디케이터 바
+    // 왼쪽 인디케이터 바
     &::after {
       content: "";
       position: absolute;

--- a/src/ui/display/media-card/style.scss
+++ b/src/ui/display/media-card/style.scss
@@ -132,11 +132,10 @@
     .media_card_overlay {
       position: absolute;
       inset: 0;
-      // navy 그라데이션 - Bigtablet brand accent.strong (#303841) 사용
       background: linear-gradient(
         180deg,
-        rgba(48, 56, 65, 0) 30%,
-        rgba(48, 56, 65, 0.85) 100%
+        rgba(0, 0, 0, 0) 30%,
+        rgba(0, 0, 0, 0.85) 100%
       );
       pointer-events: none;
       z-index: 1;

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -166,7 +166,7 @@
     margin-top: token.$spacing_4;
 
     // 라이트: 흰색 (canvas 와 동일하지만 border + shadow 로 분리)
-    // 다크: bg_solid_dim (navy_800) - canvas (navy_900) 보다 한 톤 밝아 elevation
+    // 다크: bg_solid_dim (neutral_925) - canvas (neutral_950) 보다 한 톤 밝아 elevation
     background: token.$color_bg_solid;
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_lg; // 컨트롤과 동일 radius

--- a/src/ui/layout/section/Section.test.tsx
+++ b/src/ui/layout/section/Section.test.tsx
@@ -23,8 +23,8 @@ describe("Section", () => {
 	});
 
 	it("applies bg class", () => {
-		const { container } = render(<Section bg="navy" />);
-		expect(container.firstChild).toHaveClass("section_bg_navy");
+		const { container } = render(<Section bg="inverted" />);
+		expect(container.firstChild).toHaveClass("section_bg_inverted");
 	});
 
 	it("renders as section element by default", () => {

--- a/src/ui/layout/section/index.tsx
+++ b/src/ui/layout/section/index.tsx
@@ -5,7 +5,7 @@ import { cn } from "../../../utils";
 import "./style.scss";
 
 export type SectionSpacing = "xs" | "sm" | "md" | "lg" | "xl";
-export type SectionBg = "default" | "dim" | "accent" | "navy" | "transparent";
+export type SectionBg = "default" | "dim" | "accent" | "inverted" | "transparent";
 
 export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
 	/**
@@ -16,7 +16,7 @@ export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
 	spacing?: SectionSpacing;
 	/**
 	 * 배경색 변형
-	 * - default: bg-solid | dim: bg-solid-dim | accent: accent-subtle | navy: accent-default
+	 * - default: bg-solid | dim: bg-solid-dim | accent: accent-subtle | inverted: accent-default (검정/흰색 반전)
 	 * @default "default"
 	 */
 	bg?: SectionBg;

--- a/src/ui/layout/section/section.stories.tsx
+++ b/src/ui/layout/section/section.stories.tsx
@@ -14,8 +14,8 @@ const meta: Meta<typeof Section> = {
 		},
 		bg: {
 			control: "select",
-			options: ["default", "dim", "accent", "navy", "transparent"],
-			description: "배경 - default/dim/accent/navy(다크)/transparent.",
+			options: ["default", "dim", "accent", "inverted", "transparent"],
+			description: "배경 - default/dim/accent/inverted(검정 반전)/transparent.",
 		},
 		as: {
 			control: "text",
@@ -38,7 +38,7 @@ const meta: Meta<typeof Section> = {
 					"**Section** - 마케팅 섹션 단위. 수직 여백 + 배경. 내부에 `Container` 권장.",
 					"",
 					"Spacing: `xs`/`sm`/`md` (기본)/`lg`/`xl` - md+ 는 뷰포트별 반응형.",
-					"Bg: `default` / `dim` (Zebra) / `accent` (옅은 navy) / `navy` (다크 자동 흰 텍스트) / `transparent`.",
+					"Bg: `default` / `dim` (Zebra) / `accent` (옅은 강조) / `inverted` (검정 배경 + 흰 텍스트 자동) / `transparent`.",
 				].join("\n"),
 			},
 		},
@@ -73,12 +73,12 @@ export const Default: Story = {
 			</Section>
 			<Section bg="accent" spacing="sm">
 				<Container>
-					<Content label='bg="accent" (navy subtle)' />
+					<Content label='bg="accent"' />
 				</Container>
 			</Section>
-			<Section bg="navy" spacing="sm">
+			<Section bg="inverted" spacing="sm">
 				<Container>
-					<Content label='bg="navy" (dark)' />
+					<Content label='bg="inverted" (검정 + 흰 텍스트)' />
 				</Container>
 			</Section>
 		</div>

--- a/src/ui/layout/section/style.scss
+++ b/src/ui/layout/section/style.scss
@@ -29,6 +29,6 @@
   &_bg_default     { background: token.$color_bg_solid; }
   &_bg_dim         { background: token.$color_bg_solid_dim; }
   &_bg_accent      { background: token.$color_accent_subtle; }
-  &_bg_navy        { background: token.$color_accent_default; color: token.$color_accent_on_surface; }
+  &_bg_inverted    { background: token.$color_accent_default; color: token.$color_accent_on_surface; }
   &_bg_transparent { background: transparent; }
 }

--- a/src/ui/navigation/menu/style.scss
+++ b/src/ui/navigation/menu/style.scss
@@ -10,7 +10,7 @@
   top: calc(100% + 4px);
   z-index: token.$z_level5;
   min-width: 180px;
-  // 라이트: 흰색 / 다크: bg_solid_dim (navy_800, canvas 보다 한 톤 밝음 → elevation)
+  // 라이트: 흰색 / 다크: bg_solid_dim (neutral_925, canvas 보다 한 톤 밝음 → elevation)
   background: token.$color_bg_solid;
   border: token.$border_width_standard solid token.$color_border_default;
   border-radius: token.$radius_lg;

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -38,7 +38,7 @@ export interface NavBarProps extends React.HTMLAttributes<HTMLElement> {
 	profile?: React.ReactNode;
 	/** actions / locale 와 profile 사이 수직 divider 표시 (기본 true, profile 있을 때만 표시) */
 	divider?: boolean;
-	/** 시각 variant - default(흰 bg + 회색 border), transparent(투명, hero 위에), accent(navy bg) */
+	/** 시각 variant - default(흰 bg + 회색 border), transparent(투명, hero 위에), accent(검정 bg) */
 	variant?: NavBarVariant;
 	/** 레이아웃 - contained(max 1200, marketing) / fluid(full width, admin/dashboard) */
 	layout?: NavBarLayout;

--- a/src/ui/navigation/nav-bar/nav-bar.stories.tsx
+++ b/src/ui/navigation/nav-bar/nav-bar.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof NavBar> = {
 				component: `
 **NavBar** - Top page navigation. Slots: \`brand\` / \`children (NavLink)\` / \`actions\`. / **NavBar** - 페이지 상단 네비게이션. \`brand\` / \`children (NavLink)\` / \`actions\` 슬롯.
 
-Variants: \`default\` (white bg + border), \`accent\` (navy bg), \`transparent\` (over a hero). / Variants: \`default\` (흰 bg + border), \`accent\` (navy bg), \`transparent\` (hero 위).
+Variants: \`default\` (white bg + border), \`accent\` (dark bg), \`transparent\` (over a hero). / Variants: \`default\` (흰 bg + border), \`accent\` (검정 bg), \`transparent\` (hero 위).
 \`active={true}\` → \`aria-current="page"\` set automatically. / \`active={true}\` → \`aria-current="page"\` 자동.
 				`,
 			},

--- a/src/ui/navigation/nav-bar/style.scss
+++ b/src/ui/navigation/nav-bar/style.scss
@@ -235,7 +235,7 @@
 
   // ── Variant: accent (검정) ───────────────────────────────────────────
   // Marketing-style 다크 헤더 - 양 테마 동일하게 brand_primary (#121212) + 흰 텍스트.
-  // 라이트: 흰 캔버스 위 강한 dark bar / 다크: navy_900 캔버스보다 짙어 명확.
+  // 라이트: 흰 캔버스 위 강한 dark bar / 다크: neutral_950 캔버스보다 짙어 명확.
   // (accent_default 는 light=검정/dark=흰 반전 토큰이라 navbar 에 부적합)
 
   &_variant_accent {

--- a/src/ui/navigation/nav-bar/style.scss
+++ b/src/ui/navigation/nav-bar/style.scss
@@ -235,7 +235,7 @@
 
   // ── Variant: accent (검정) ───────────────────────────────────────────
   // Marketing-style 다크 헤더 - 양 테마 동일하게 brand_primary (#121212) + 흰 텍스트.
-  // 라이트: 흰 캔버스 위 강한 dark bar / 다크: neutral_950 캔버스보다 짙어 명확.
+  // 라이트: 흰 캔버스 위 강한 dark bar / 다크: neutral_950(#0A0A0A)보다 약간 밝아 subtle 구분.
   // (accent_default 는 light=검정/dark=흰 반전 토큰이라 navbar 에 부적합)
 
   &_variant_accent {

--- a/src/ui/navigation/tabs/style.scss
+++ b/src/ui/navigation/tabs/style.scss
@@ -30,7 +30,7 @@
         width token.$duration_base token.$easing_enter;
     }
 
-    // line - 하단 underline (얇은 navy/검정 라인)
+    // line - 하단 underline (얇은 검정 라인)
     &_line {
       bottom: -1px;
       height: 2px;


### PR DESCRIPTION
## 작업 개요

다크모드 표면 색상을 navy 계열(blue-gray)에서 Vercel 스타일 순수 중성 그레이로 전환하고, 코드베이스 전체에서 navy 컬러 팔레트를 제거합니다.

## 작업한 내용

- [x] `$color_base_navy_*` 팔레트 전체 제거 (SCSS + TS 토큰 export)
- [x] 다크모드 표면 토큰 교체
  - `bg-solid`: #1F2630 (navy-900) → **#0A0A0A** (neutral-950, Vercel 스타일)
  - `bg-solid-dim`: #303841 (navy-800) → **#141414** (neutral-925)
  - `text-body`: #B4C2CD (navy-200, 파란 틴트) → **#B3B3B3** (neutral-400, 순수 그레이)
  - `text-caption`: neutral-600 (#777777)으로 통일
  - `border-default/hover/disabled`: navy → neutral 그레이
  - `skeleton-base/wave/highlight`: navy → neutral 그레이
- [x] `Hero`: `overlay="navy"` 타입 제거 (→ `"dark"` 사용)
- [x] `MediaCard`: 오버레이 그라데이션 `rgba(48,56,65)` → `rgba(0,0,0)`
- [x] `Section`: `bg="navy"` → **`bg="inverted"`** (이름 의미 개선, 렌더는 동일)
- [x] 모든 컴포넌트 SCSS/TSX 주석에서 navy 참조 제거
- [x] Stories/docs 업데이트 (colors 팔레트 스토리 Neutral Dark 스케일로 교체)
- [x] `index.ts` JS accent 토큰 SCSS CSS var 실제값과 동기화

## Breaking Changes

| 변경 전 | 변경 후 |
|---------|---------|
| `<Hero overlay="navy" />` | `<Hero overlay="dark" />` |
| `<Section bg="navy" />` | `<Section bg="inverted" />` |
| `baseColors.navy*` export | 제거됨 |

## 전달할 추가 이슈

- 기존에 `overlay="navy"` / `bg="navy"`를 직접 쓰던 소비 프로젝트가 있다면 마이그레이션 필요
- `neutral-925`/`neutral-950` 두 단계가 다크 전용으로 추가됨