### PR TITLE
fix/reduced-motion

### DIFF
--- a/src/ui/display/media-card/style.scss
+++ b/src/ui/display/media-card/style.scss
@@ -159,3 +159,9 @@
     .media_card_meta     { color: rgba(255, 255, 255, 0.6); }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .media_card { transition: none; }
+  .media_card_clickable:hover { transform: none; }
+}

--- a/src/ui/feedback/skeleton/style.scss
+++ b/src/ui/feedback/skeleton/style.scss
@@ -43,3 +43,8 @@
   0%   { background-position: 100% 0; }
   100% { background-position: 0 0; }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .skeleton { animation: none; }
+}

--- a/src/ui/feedback/top-loading/style.scss
+++ b/src/ui/feedback/top-loading/style.scss
@@ -30,3 +30,9 @@
     transform: translateX(400%);
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .top_loading_bar { transition: none; }
+  .top_loading_indeterminate { animation: none; }
+}

--- a/src/ui/forms/checkbox/style.scss
+++ b/src/ui/forms/checkbox/style.scss
@@ -161,3 +161,8 @@
     transform: translate(-50%, -50%) scaleX(1);
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .checkbox_icon::after { animation: none; }
+}

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -291,3 +291,8 @@
     margin: 0;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .dropdown_icon { transition: none; }
+}

--- a/src/ui/forms/file/style.scss
+++ b/src/ui/forms/file/style.scss
@@ -168,3 +168,9 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .file_input_preview_remove { transition: none; }
+  .file_input_preview_remove:hover { transform: none; }
+}

--- a/src/ui/forms/radio/style.scss
+++ b/src/ui/forms/radio/style.scss
@@ -163,3 +163,8 @@
     transform: translate(-50%, -50%) scale(1);
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .radio_dot::after { animation: none; }
+}

--- a/src/ui/forms/toggle/style.scss
+++ b/src/ui/forms/toggle/style.scss
@@ -125,3 +125,9 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .toggle,
+  .toggle_thumb { transition: none; }
+}

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -245,3 +245,9 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .button { transition: none; }
+  .button:active { transform: none; }
+}

--- a/src/ui/navigation/menu/style.scss
+++ b/src/ui/navigation/menu/style.scss
@@ -83,3 +83,8 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .menu_item { transition: none; }
+}

--- a/src/ui/navigation/nav-bar/style.scss
+++ b/src/ui/navigation/nav-bar/style.scss
@@ -299,3 +299,9 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .nav_bar_indicator_animated { transition: none; }
+  .nav_bar_locale_chevron { transition: none; }
+}

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -362,3 +362,9 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .sidebar_collapse_btn { transition: none; }
+  .sidebar_collapse_btn:hover { transform: none; }
+}

--- a/src/ui/navigation/tabs/style.scss
+++ b/src/ui/navigation/tabs/style.scss
@@ -143,3 +143,8 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .tabs_indicator_animated { transition: none; }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { cn } from "./cn";
 export { useFocusTrap } from "./use-focus-trap";
+export { useReducedMotion } from "./use-reduced-motion";
 export { useSafeLayoutEffect } from "./use-safe-layout-effect";
 export { useSpringHover } from "./use-spring-hover";
 export { useSpringPresence } from "./use-spring-presence";

--- a/src/utils/use-reduced-motion.test.ts
+++ b/src/utils/use-reduced-motion.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useReducedMotion } from "./use-reduced-motion";
+
+type Listener = (e: { matches: boolean }) => void;
+
+const originalMatchMedia = window.matchMedia;
+
+/** 제어 가능한 matchMedia 목 - matches 값 + change 이벤트 발화 지원 */
+function mockMatchMedia(initial: boolean) {
+	const listeners = new Set<Listener>();
+	const mql = {
+		matches: initial,
+		media: "(prefers-reduced-motion: reduce)",
+		addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+		removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+		emit(next: boolean) {
+			mql.matches = next;
+			for (const cb of listeners) cb({ matches: next });
+		},
+	};
+	window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+	return mql;
+}
+
+afterEach(() => {
+	window.matchMedia = originalMatchMedia;
+	vi.restoreAllMocks();
+});
+
+describe("useReducedMotion", () => {
+	it("returns false when the user has no reduced-motion preference", () => {
+		mockMatchMedia(false);
+		const { result } = renderHook(() => useReducedMotion());
+		expect(result.current).toBe(false);
+	});
+
+	it("returns true when prefers-reduced-motion: reduce matches", () => {
+		mockMatchMedia(true);
+		const { result } = renderHook(() => useReducedMotion());
+		expect(result.current).toBe(true);
+	});
+
+	it("updates reactively when the preference changes", () => {
+		const mql = mockMatchMedia(false);
+		const { result } = renderHook(() => useReducedMotion());
+		expect(result.current).toBe(false);
+
+		act(() => mql.emit(true));
+		expect(result.current).toBe(true);
+
+		act(() => mql.emit(false));
+		expect(result.current).toBe(false);
+	});
+
+	it("unsubscribes the listener on unmount", () => {
+		const mql = mockMatchMedia(true);
+		const removeSpy = vi.spyOn(mql, "removeEventListener");
+		const { unmount } = renderHook(() => useReducedMotion());
+		unmount();
+		expect(removeSpy).toHaveBeenCalled();
+	});
+
+	it("falls back to false when matchMedia is unavailable (SSR-safe)", () => {
+		(window as { matchMedia?: typeof window.matchMedia }).matchMedia = undefined;
+		const { result } = renderHook(() => useReducedMotion());
+		expect(result.current).toBe(false);
+	});
+});

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import * as React from "react";
+
+const isClient = typeof window !== "undefined";
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * 사용자가 OS 수준에서 "동작 줄이기"를 켰는지 반환한다 (WCAG 2.3.3).
+ * spring 훅이나 JS 애니메이션에서 모션을 끌 때 사용. SSR에서는 false.
+ *
+ * @example
+ * ```tsx
+ * const reduced = useReducedMotion();
+ * const style = useSpring({ ..., immediate: reduced });
+ * ```
+ */
+export function useReducedMotion(): boolean {
+	const [reduced, setReduced] = React.useState<boolean>(() => {
+		if (!isClient || typeof window.matchMedia !== "function") return false;
+		return window.matchMedia(QUERY).matches;
+	});
+
+	React.useEffect(() => {
+		if (!isClient || typeof window.matchMedia !== "function") return;
+		const mq = window.matchMedia(QUERY);
+		const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+		setReduced(mq.matches);
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	}, []);
+
+	return reduced;
+}

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -16,10 +16,8 @@ const QUERY = "(prefers-reduced-motion: reduce)";
  * ```
  */
 export function useReducedMotion(): boolean {
-	const [reduced, setReduced] = React.useState<boolean>(() => {
-		if (!isClient || typeof window.matchMedia !== "function") return false;
-		return window.matchMedia(QUERY).matches;
-	});
+	// SSR/hydration 안전: 초기값은 항상 false (서버 마크업과 일치). 클라이언트 마운트 후 effect 에서 실제 값 보정.
+	const [reduced, setReduced] = React.useState<boolean>(false);
 
 	React.useEffect(() => {
 		if (!isClient || typeof window.matchMedia !== "function") return;

--- a/src/utils/use-spring-hover.ts
+++ b/src/utils/use-spring-hover.ts
@@ -2,6 +2,7 @@
 
 import { useSpring } from "@react-spring/web";
 import * as React from "react";
+import { useReducedMotion } from "./use-reduced-motion";
 
 /**
  * 마우스 hover 시 spring 기반 lift 효과를 만든다. 카드/CTA 강조에 사용.
@@ -22,11 +23,14 @@ export function useSpringHover({
 	lift?: number;
 } = {}) {
 	const [hovered, setHovered] = React.useState(false);
+	const reduced = useReducedMotion();
 
 	const style = useSpring({
 		transform: hovered
 			? `translateY(${lift}px) scale(${scale})`
 			: "translateY(0px) scale(1)",
+		// reduced-motion: lift/scale 모션 제거 (WCAG 2.3.3)
+		immediate: reduced,
 		config: { tension: 320, friction: 22 },
 	});
 

--- a/src/utils/use-spring-presence.ts
+++ b/src/utils/use-spring-presence.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSpring } from "@react-spring/web";
+import { useReducedMotion } from "./use-reduced-motion";
 
 /**
  * 컴포넌트가 마운트/언마운트되거나 visible 상태가 토글될 때 자연스러운 진입/퇴출을 만든다.
@@ -24,12 +25,16 @@ export function useSpringPresence({
 	/** exit 모션 완료 시 호출 - 부모에서 unmount 트리거용 */
 	onExitComplete?: () => void;
 }) {
+	const reduced = useReducedMotion();
+
 	return useSpring({
 		from: { opacity: 0, transform: from },
 		to: {
 			opacity: visible ? 1 : 0,
 			transform: visible ? "translateY(0px)" : from,
 		},
+		// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태로 점프 (WCAG 2.3.3). onRest는 그대로 발화.
+		immediate: reduced,
 		config: {
 			tension: 280, // Vercel 식 부드러운 spring
 			friction: 28,


### PR DESCRIPTION
## 작업 개요

`prefers-reduced-motion: reduce` 미대응 컴포넌트를 보강한다(WCAG 2.1 SC 2.3.3). transition/animation 쓰는 30개 중 15개가 누락이었고, 특히 spring 훅이 reduced-motion 을 전혀 안 봐서 Modal/Toast/Dropdown/Menu/Tooltip/Popover/hover-lift 가 전부 무시하던 상태.

## 작업한 내용
- [x] **`useReducedMotion` 훅 신규** (`src/utils/use-reduced-motion.ts`) — SSR-safe matchMedia 구독, lazy init + change 이벤트 반응. `src/utils/index.ts` export.
- [x] **spring 훅 2개**(`useSpringPresence`/`useSpringHover`)에 `immediate: reduced` 연결 → reduced 시 모션 없이 즉시 최종 상태로 점프(API 불변, `onRest`/`onExitComplete` 유지). 이 한 곳으로 Modal·Toast·Dropdown·Menu·Tooltip·Popover 진입/퇴출 + hover-lift 일괄 대응.
- [x] **CSS 모션 13개 컴포넌트**에 `@media (prefers-reduced-motion: reduce)` 블록 추가 — button(press), checkbox·radio(check-in), toggle·dropdown, file·sidebar·media-card(hover transform), tabs·nav-bar(indicator slide), menu, skeleton·top-loading(infinite loop). 실제 모션(transform/animation/슬라이드)만 끔.
- [x] **회귀 테스트** — `use-reduced-motion.test.ts` 5개(match/no-match/change/unmount/SSR fallback).

## 검증
- `pnpm test` 605 passed / 9 skipped (신규 5개 포함)
- `pnpm test:storybook` 264 passed (회귀 무사)
- `pnpm build` OK (DTS 타입 0 에러) / `pnpm lint:css` 0 위반

## 참고
- spring 훅 API 시그니처 불변 → Modal/Toast/Dropdown 등 기존 소비자 영향 없음.
- reduced-motion 커버 컴포넌트 7 → 20개.