### PR TITLE
fix/reduced-motion-coverage

### DIFF
--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -248,6 +248,7 @@
 
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
-  .button { transition: none; }
+  .button,
+  .button::before { transition: none; }
   .button:active { transform: none; }
 }

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -365,6 +365,11 @@
 
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
+  .sidebar,
+  .sidebar_header,
+  .sidebar_header_layer,
+  .sidebar_item,
+  .sidebar_item_label,
   .sidebar_collapse_btn { transition: none; }
   .sidebar_collapse_btn:hover { transform: none; }
 }

--- a/src/ui/navigation/tabs/style.scss
+++ b/src/ui/navigation/tabs/style.scss
@@ -146,5 +146,6 @@
 
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
-  .tabs_indicator_animated { transition: none; }
+  .tabs_indicator_animated,
+  .tabs_tab { transition: none; }
 }

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -2,12 +2,35 @@
 
 import * as React from "react";
 
-const isClient = typeof window !== "undefined";
 const QUERY = "(prefers-reduced-motion: reduce)";
+
+function hasMatchMedia(): boolean {
+	return typeof window !== "undefined" && typeof window.matchMedia === "function";
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+	if (!hasMatchMedia()) return () => {};
+	const mq = window.matchMedia(QUERY);
+	mq.addEventListener("change", onStoreChange);
+	return () => mq.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot(): boolean {
+	if (!hasMatchMedia()) return false;
+	return window.matchMedia(QUERY).matches;
+}
+
+// SSR 초기값 - 서버 마크업과 일치(hydration mismatch 방지)
+function getServerSnapshot(): boolean {
+	return false;
+}
 
 /**
  * 사용자가 OS 수준에서 "동작 줄이기"를 켰는지 반환한다 (WCAG 2.3.3).
  * spring 훅이나 JS 애니메이션에서 모션을 끌 때 사용. SSR에서는 false.
+ *
+ * React 표준 `useSyncExternalStore` 로 matchMedia 를 구독한다 - 불필요한
+ * 마운트 리렌더 없이 hydration-safe 하게 동작.
  *
  * @example
  * ```tsx
@@ -16,17 +39,5 @@ const QUERY = "(prefers-reduced-motion: reduce)";
  * ```
  */
 export function useReducedMotion(): boolean {
-	// SSR/hydration 안전: 초기값은 항상 false (서버 마크업과 일치). 클라이언트 마운트 후 effect 에서 실제 값 보정.
-	const [reduced, setReduced] = React.useState<boolean>(false);
-
-	React.useEffect(() => {
-		if (!isClient || typeof window.matchMedia !== "function") return;
-		const mq = window.matchMedia(QUERY);
-		const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
-		setReduced(mq.matches);
-		mq.addEventListener("change", handler);
-		return () => mq.removeEventListener("change", handler);
-	}, []);
-
-	return reduced;
+	return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -4,20 +4,33 @@ import * as React from "react";
 
 const QUERY = "(prefers-reduced-motion: reduce)";
 
-function hasMatchMedia(): boolean {
-	return typeof window !== "undefined" && typeof window.matchMedia === "function";
+// MediaQueryList 를 모듈 스코프에 1회 생성·재사용 (getSnapshot 이 렌더마다 호출되므로).
+// 단, window.matchMedia 참조가 바뀌면(테스트 목 교체/SSR) 캐시를 무효화한다.
+let mqCache: MediaQueryList | null = null;
+let cachedFor: typeof window.matchMedia | null = null;
+
+function getMediaQuery(): MediaQueryList | null {
+	if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+		mqCache = null;
+		cachedFor = null;
+		return null;
+	}
+	if (!mqCache || cachedFor !== window.matchMedia) {
+		mqCache = window.matchMedia(QUERY);
+		cachedFor = window.matchMedia;
+	}
+	return mqCache;
 }
 
 function subscribe(onStoreChange: () => void): () => void {
-	if (!hasMatchMedia()) return () => {};
-	const mq = window.matchMedia(QUERY);
+	const mq = getMediaQuery();
+	if (!mq) return () => {};
 	mq.addEventListener("change", onStoreChange);
 	return () => mq.removeEventListener("change", onStoreChange);
 }
 
 function getSnapshot(): boolean {
-	if (!hasMatchMedia()) return false;
-	return window.matchMedia(QUERY).matches;
+	return getMediaQuery()?.matches ?? false;
 }
 
 // SSR 초기값 - 서버 마크업과 일치(hydration mismatch 방지)


### PR DESCRIPTION
## 작업 개요

PR #301 리뷰(gemini·coderabbit)에서 나온 reduced-motion 후속 보강.

## 작업한 내용
- [x] **button** — `.button::before` 오버레이 배경 전환도 reduced-motion 에서 끔 (coderabbit)
- [x] **tabs** — `.tabs_tab` 전환 추가 (indicator 만 끄던 것 → 탭 전환까지) (coderabbit)
- [x] **sidebar** — collapse 버튼만 끄던 것 → 본체(`width`)/`header`/`header_layer`/`item`/`item_label` 전환까지 포함 (coderabbit). 실제 존재 클래스만 타겟(소스 검증).
- [x] **useReducedMotion** — `useState`+`useEffect` 구독을 React 표준 `useSyncExternalStore` 로 교체 (gemini). `getServerSnapshot`=false 로 hydration-safe, 마운트 리렌더 제거. 공개 시그니처 불변.

## 검증
- `pnpm test` 605 passed (훅 회귀 5개 포함) / `pnpm build` OK / `pnpm lint:css` 0