### PR TITLE
merge: release

### DIFF
--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -248,6 +248,7 @@
 
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
-  .button { transition: none; }
+  .button,
+  .button::before { transition: none; }
   .button:active { transform: none; }
 }

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -365,6 +365,11 @@
 
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
+  .sidebar,
+  .sidebar_header,
+  .sidebar_header_layer,
+  .sidebar_item,
+  .sidebar_item_label,
   .sidebar_collapse_btn { transition: none; }
   .sidebar_collapse_btn:hover { transform: none; }
 }

--- a/src/ui/navigation/tabs/style.scss
+++ b/src/ui/navigation/tabs/style.scss
@@ -146,5 +146,6 @@
 
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
-  .tabs_indicator_animated { transition: none; }
+  .tabs_indicator_animated,
+  .tabs_tab { transition: none; }
 }

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -2,12 +2,35 @@
 
 import * as React from "react";
 
-const isClient = typeof window !== "undefined";
 const QUERY = "(prefers-reduced-motion: reduce)";
+
+function hasMatchMedia(): boolean {
+	return typeof window !== "undefined" && typeof window.matchMedia === "function";
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+	if (!hasMatchMedia()) return () => {};
+	const mq = window.matchMedia(QUERY);
+	mq.addEventListener("change", onStoreChange);
+	return () => mq.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot(): boolean {
+	if (!hasMatchMedia()) return false;
+	return window.matchMedia(QUERY).matches;
+}
+
+// SSR 초기값 - 서버 마크업과 일치(hydration mismatch 방지)
+function getServerSnapshot(): boolean {
+	return false;
+}
 
 /**
  * 사용자가 OS 수준에서 "동작 줄이기"를 켰는지 반환한다 (WCAG 2.3.3).
  * spring 훅이나 JS 애니메이션에서 모션을 끌 때 사용. SSR에서는 false.
+ *
+ * React 표준 `useSyncExternalStore` 로 matchMedia 를 구독한다 - 불필요한
+ * 마운트 리렌더 없이 hydration-safe 하게 동작.
  *
  * @example
  * ```tsx
@@ -16,17 +39,5 @@ const QUERY = "(prefers-reduced-motion: reduce)";
  * ```
  */
 export function useReducedMotion(): boolean {
-	// SSR/hydration 안전: 초기값은 항상 false (서버 마크업과 일치). 클라이언트 마운트 후 effect 에서 실제 값 보정.
-	const [reduced, setReduced] = React.useState<boolean>(false);
-
-	React.useEffect(() => {
-		if (!isClient || typeof window.matchMedia !== "function") return;
-		const mq = window.matchMedia(QUERY);
-		const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
-		setReduced(mq.matches);
-		mq.addEventListener("change", handler);
-		return () => mq.removeEventListener("change", handler);
-	}, []);
-
-	return reduced;
+	return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -4,20 +4,33 @@ import * as React from "react";
 
 const QUERY = "(prefers-reduced-motion: reduce)";
 
-function hasMatchMedia(): boolean {
-	return typeof window !== "undefined" && typeof window.matchMedia === "function";
+// MediaQueryList 를 모듈 스코프에 1회 생성·재사용 (getSnapshot 이 렌더마다 호출되므로).
+// 단, window.matchMedia 참조가 바뀌면(테스트 목 교체/SSR) 캐시를 무효화한다.
+let mqCache: MediaQueryList | null = null;
+let cachedFor: typeof window.matchMedia | null = null;
+
+function getMediaQuery(): MediaQueryList | null {
+	if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+		mqCache = null;
+		cachedFor = null;
+		return null;
+	}
+	if (!mqCache || cachedFor !== window.matchMedia) {
+		mqCache = window.matchMedia(QUERY);
+		cachedFor = window.matchMedia;
+	}
+	return mqCache;
 }
 
 function subscribe(onStoreChange: () => void): () => void {
-	if (!hasMatchMedia()) return () => {};
-	const mq = window.matchMedia(QUERY);
+	const mq = getMediaQuery();
+	if (!mq) return () => {};
 	mq.addEventListener("change", onStoreChange);
 	return () => mq.removeEventListener("change", onStoreChange);
 }
 
 function getSnapshot(): boolean {
-	if (!hasMatchMedia()) return false;
-	return window.matchMedia(QUERY).matches;
+	return getMediaQuery()?.matches ?? false;
 }
 
 // SSR 초기값 - 서버 마크업과 일치(hydration mismatch 방지)


### PR DESCRIPTION
## 작업 개요

먼저 머지된 #301(접근성·reduced-motion·commitlint·changeset정리)에 이어, 리뷰 후속 보강 #302 를 main 으로 승격한다. 누적분을 **3.2.2 (patch)** 로 배포 예정.

## 포함 (main 미반영분 = #302)
- **reduced-motion 범위 보강** — button `::before`, tabs `.tabs_tab`, sidebar 본체(width)/header/header_layer/item/item_label 전환까지 (coderabbit 리뷰)
- **useReducedMotion → `useSyncExternalStore`** 리팩터 + `MediaQueryList` 캐싱 (gemini 리뷰). hydration-safe, 마운트 리렌더 제거.

> 참고: #301 배치(caption AA + color-contrast 룰 재활성화 + reduced-motion 기반 + commitlint refactor + changeset 삭제)는 이미 main 에 머지됐으나 아직 npm 미배포 — 이번 3.2.2 태그로 #301+#302 가 함께 publish 됩니다.

## 버전
- **patch 3.2.1 → 3.2.2** — `useReducedMotion` 은 패키지 공개 entry(`src/index.ts`)에 export 되지 않는 내부 훅이라 공개 API 변화 없음 → patch 적정.

## 검증 (develop 기준)
- `pnpm test` 605 passed / `pnpm test:storybook` 264 passed / `pnpm build` / `pnpm lint:css` 통과
- #301·#302 모든 리뷰 thread APPROVED + resolved

## 머지 후
- main 에서 버전 3.2.2 bump + `v3.2.2` 태그 push → GitHub Actions npm publish + release 생성