### PR TITLE
merge: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,527 +1,493 @@
-# [4.0.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v3.1.1...v4.0.0) (2026-06-16)
+# Changelog
 
+`@bigtablet/design-system` 의 모든 주요 변경 사항. / All notable changes.
 
-### Bug Fixes
+이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
-* address Gemini review feedback (PR [#276](https://github.com/Bigtablet/bigtablet-design-system/issues/276)) ([6cad4ad](https://github.com/Bigtablet/bigtablet-design-system/commit/6cad4ad7fc0ab75e7042d32aaa8b0da461717bf2)), closes [#7f1d1d](https://github.com/Bigtablet/bigtablet-design-system/issues/7f1d1d)
-* address Gemini review feedback (PR [#277](https://github.com/Bigtablet/bigtablet-design-system/issues/277)) ([5429be8](https://github.com/Bigtablet/bigtablet-design-system/commit/5429be833e8cd2f0c68ee02a06f21123ae69a5c0))
-* derived-state IME guard bug + emit useCallback (PR [#281](https://github.com/Bigtablet/bigtablet-design-system/issues/281) review) ([73995b9](https://github.com/Bigtablet/bigtablet-design-system/commit/73995b93ac0d5d6d39932897203df422ee4b336b))
-* glass variant card_footer border uses hover_on_dark token ([bfd2aa3](https://github.com/Bigtablet/bigtablet-design-system/commit/bfd2aa35dd2dac86c9c26da8bdf954477f7ea0c6))
-* list-item text slots span→div, story link stopPropagation ([fa16ebe](https://github.com/Bigtablet/bigtablet-design-system/commit/fa16ebe680ccdc5c9c66d656bd5a4c455ade6406))
-* popover exit animation, focus ring, div wrapper, placement interpolation ([ec3fc66](https://github.com/Bigtablet/bigtablet-design-system/commit/ec3fc66604820c711f3463302f614aa333bf3ed4))
-* status text color → *-on-surface for dark mode legibility ([cdd2db6](https://github.com/Bigtablet/bigtablet-design-system/commit/cdd2db63e3bf9aab8f750cfa0ebdbf99707e8ea7))
-* Textarea/TextField SSR-safe layout effect + derived state + IME dup guard (PR [#280](https://github.com/Bigtablet/bigtablet-design-system/issues/280) review) ([bfd5b2a](https://github.com/Bigtablet/bigtablet-design-system/commit/bfd5b2a5fcef8811f3ceea5e198af644bfa8f7fd))
-* update TokenComparison hex values and correct dark mode comments ([98aad53](https://github.com/Bigtablet/bigtablet-design-system/commit/98aad534bb07bb31bea2b15430626a11c356ac4a)), closes [B4C2CD/#3D4852](https://github.com/Bigtablet/bigtablet-design-system/issues/3D4852) [333333/#777777](https://github.com/Bigtablet/bigtablet-design-system/issues/777777)
+## [3.2.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.2.2) - 2026-06-18
 
+- caption 텍스트 색을 WCAG AA(4.5:1) 충족값으로 조정하고, axe `color-contrast` 검사를 재활성화해 전 컴포넌트 대비를 CI 가 가드
+- `prefers-reduced-motion` 대응 확대 — spring 훅(Modal/Toast/Dropdown/Menu/Tooltip/Popover) + CSS 모션 컴포넌트(button/checkbox/radio/toggle/tabs/sidebar/skeleton 등), 커버 7→20개
+- 커밋 컨벤션에 `refactor` 라벨 추가, 미사용 changeset 설정 정리
 
-### Features
+## [3.2.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.2.1) - 2026-06-17
 
-* add Popover - general-purpose non-modal popover overlay ([1f57a90](https://github.com/Bigtablet/bigtablet-design-system/commit/1f57a906f7a1d9f44a12b83edd9edbaf5ba3359e)), closes [#286](https://github.com/Bigtablet/bigtablet-design-system/issues/286)
-* add RadioGroup - Context-based composite wrapper for Radio ([3ed8c18](https://github.com/Bigtablet/bigtablet-design-system/commit/3ed8c18f91de7f47aad6e279d4763076704a923a)), closes [#284](https://github.com/Bigtablet/bigtablet-design-system/issues/284)
-* allow ReactNode in ListItem text slots (overline/label/supportingText/metadata) ([ef1c38b](https://github.com/Bigtablet/bigtablet-design-system/commit/ef1c38b89f9d527a0fe6c59c2a1ad5b7f8272d4a)), closes [#290](https://github.com/Bigtablet/bigtablet-design-system/issues/290)
-* Badge appearance prop — solid (default) | soft ([027bb3c](https://github.com/Bigtablet/bigtablet-design-system/commit/027bb3ce6a4596e58b4863b31ff99320946754e5))
-* ErrorState component (error boundary / widget fallback) ([5b92726](https://github.com/Bigtablet/bigtablet-design-system/commit/5b927268f4f76f635a57d06b55a27e0f8c45bebb))
-* export Textarea + ErrorState + update AGENT_GUIDE ([2324822](https://github.com/Bigtablet/bigtablet-design-system/commit/232482293bd0d5027137712a09f359fdd7211ac0))
-* extend Card with glass/outlined variants, interactive, footer slot ([23509c2](https://github.com/Bigtablet/bigtablet-design-system/commit/23509c27e9cbb1d9b968461ecc7bd09a31282724)), closes [#288](https://github.com/Bigtablet/bigtablet-design-system/issues/288)
-* status token contract — AA-pass hex + container/on-container/on-surface ([f0d68fc](https://github.com/Bigtablet/bigtablet-design-system/commit/f0d68fcc85b66569a742e0e9f427f04a69927a55)), closes [#fff](https://github.com/Bigtablet/bigtablet-design-system/issues/fff) [#10B981](https://github.com/Bigtablet/bigtablet-design-system/issues/10B981) [#047857](https://github.com/Bigtablet/bigtablet-design-system/issues/047857) [#3B82F6](https://github.com/Bigtablet/bigtablet-design-system/issues/3B82F6) [#1D4ED8](https://github.com/Bigtablet/bigtablet-design-system/issues/1D4ED8) [#F59E0B](https://github.com/Bigtablet/bigtablet-design-system/issues/F59E0B) [#B45309](https://github.com/Bigtablet/bigtablet-design-system/issues/B45309) [#EF4444](https://github.com/Bigtablet/bigtablet-design-system/issues/EF4444) [#B91C1C](https://github.com/Bigtablet/bigtablet-design-system/issues/B91C1C) [#DCFCE7](https://github.com/Bigtablet/bigtablet-design-system/issues/DCFCE7) [#F3F3F3](https://github.com/Bigtablet/bigtablet-design-system/issues/F3F3F3)
-* Textarea component (multi-line input) ([b7fc921](https://github.com/Bigtablet/bigtablet-design-system/commit/b7fc921ca110d1da17fd00534983fba95bf0c1e6))
-* TextField imeStrategy prop for live IME subscription ([59de002](https://github.com/Bigtablet/bigtablet-design-system/commit/59de00278621e386bd98be746f18bbb99cd5f20f))
+- 라이트/다크 테마 CSS custom property 를 `theme.scss` 로 분리 — `scss/token` 을 `@use` 하는 소비자에게 테마가 강제 주입되거나 CSS Modules pure-selector 검사가 깨지던 문제 수정
+- 컴포넌트 사용 시 `@bigtablet/design-system/style.css` 가 테마 변수를 제공 (단일 번들 포함)
+- dark 테마 속성 중복을 mixin 으로 정리 (출력 CSS 동일)
 
+## [3.2.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.2.0) - 2026-06-16
 
-### merge
+- `RadioGroup` 신규 컴포넌트 — Context 기반 합성 래퍼, name/value/onChange 중앙 관리
+- `Popover` 신규 컴포넌트 — 클릭 트리거 non-modal 패널, placement 4방향, spring 애니메이션
+- `Textarea` 신규 컴포넌트 — auto-grow, 글자 카운터, 한글 IME 정책
+- `ErrorState` 신규 컴포넌트 — error boundary / widget fallback, variant page/widget
+- Card variant 확장 — glass(frosted+blur), outlined(투명+테두리), interactive hover-lift, footer 슬롯
+- ListItem 텍스트 슬롯 string → ReactNode 확장 (하위호환)
+- 다크모드 표면 색상 navy → 순수 중성 그레이 전환
+- status 색상 WCAG AA 통과 hex + container/on-container/on-surface 토큰 신설
+- Badge `appearance` prop — solid/soft 지원
+- Stylelint `color-no-hex` CI 게이트 도입
+- semantic-release → 태그 기반 배포 전환
+- 보안 취약점 6건 수정 (vite, esbuild, @vitest/browser, js-yaml)
 
-* feat/status-a11y-tokens ([#276](https://github.com/Bigtablet/bigtablet-design-system/issues/276)) ([1166ec3](https://github.com/Bigtablet/bigtablet-design-system/commit/1166ec3f670b4593b1b4241119d8202f66e6ed30)), closes [#fff](https://github.com/Bigtablet/bigtablet-design-system/issues/fff) [#10B981](https://github.com/Bigtablet/bigtablet-design-system/issues/10B981) [#047857](https://github.com/Bigtablet/bigtablet-design-system/issues/047857) [#3B82F6](https://github.com/Bigtablet/bigtablet-design-system/issues/3B82F6) [#1D4ED8](https://github.com/Bigtablet/bigtablet-design-system/issues/1D4ED8) [#F59E0B](https://github.com/Bigtablet/bigtablet-design-system/issues/F59E0B) [#B45309](https://github.com/Bigtablet/bigtablet-design-system/issues/B45309) [#EF4444](https://github.com/Bigtablet/bigtablet-design-system/issues/EF4444) [#B91C1C](https://github.com/Bigtablet/bigtablet-design-system/issues/B91C1C) [#DCFCE7](https://github.com/Bigtablet/bigtablet-design-system/issues/DCFCE7) [#F3F3F3](https://github.com/Bigtablet/bigtablet-design-system/issues/F3F3F3) [#fff](https://github.com/Bigtablet/bigtablet-design-system/issues/fff) [#121212](https://github.com/Bigtablet/bigtablet-design-system/issues/121212) [#7f1d1d](https://github.com/Bigtablet/bigtablet-design-system/issues/7f1d1d)
-* release ([#280](https://github.com/Bigtablet/bigtablet-design-system/issues/280)) ([1174100](https://github.com/Bigtablet/bigtablet-design-system/commit/117410085e11b03389856dac03451c8bb219990a)), closes [#fff](https://github.com/Bigtablet/bigtablet-design-system/issues/fff) [#10B981](https://github.com/Bigtablet/bigtablet-design-system/issues/10B981) [#047857](https://github.com/Bigtablet/bigtablet-design-system/issues/047857) [#3B82F6](https://github.com/Bigtablet/bigtablet-design-system/issues/3B82F6) [#1D4ED8](https://github.com/Bigtablet/bigtablet-design-system/issues/1D4ED8) [#F59E0B](https://github.com/Bigtablet/bigtablet-design-system/issues/F59E0B) [#B45309](https://github.com/Bigtablet/bigtablet-design-system/issues/B45309) [#EF4444](https://github.com/Bigtablet/bigtablet-design-system/issues/EF4444) [#B91C1C](https://github.com/Bigtablet/bigtablet-design-system/issues/B91C1C) [#DCFCE7](https://github.com/Bigtablet/bigtablet-design-system/issues/DCFCE7) [#F3F3F3](https://github.com/Bigtablet/bigtablet-design-system/issues/F3F3F3) [#fff](https://github.com/Bigtablet/bigtablet-design-system/issues/fff) [#121212](https://github.com/Bigtablet/bigtablet-design-system/issues/121212) [#276](https://github.com/Bigtablet/bigtablet-design-system/issues/276) [#7f1d1d](https://github.com/Bigtablet/bigtablet-design-system/issues/7f1d1d) [#271](https://github.com/Bigtablet/bigtablet-design-system/issues/271)
-* style/dark-mode-neutral ([#292](https://github.com/Bigtablet/bigtablet-design-system/issues/292)) ([cef0292](https://github.com/Bigtablet/bigtablet-design-system/commit/cef0292bc1a3ca7546a695a5ad43ea2ea1481e9a)), closes [#141414](https://github.com/Bigtablet/bigtablet-design-system/issues/141414) [#0A0A0A](https://github.com/Bigtablet/bigtablet-design-system/issues/0A0A0A) [#0A0A0A](https://github.com/Bigtablet/bigtablet-design-system/issues/0A0A0A) [#141414](https://github.com/Bigtablet/bigtablet-design-system/issues/141414) [1F2630/#303841](https://github.com/Bigtablet/bigtablet-design-system/issues/303841) [#B3B3B3](https://github.com/Bigtablet/bigtablet-design-system/issues/B3B3B3) [B4C2CD/#3D4852](https://github.com/Bigtablet/bigtablet-design-system/issues/3D4852) [333333/#777777](https://github.com/Bigtablet/bigtablet-design-system/issues/777777)
+## [3.1.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.1.1) - 2026-05-26
 
+- npm v11+ 업그레이드 — OIDC Trusted Publisher 방식 npm 배포 정상화
+- release workflow에 `npm install -g npm@latest` step 추가
 
-### Styles
+## [3.1.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.1.0) - 2026-05-26
 
-* replace navy palette with pure neutral gray in dark mode ([6084c55](https://github.com/Bigtablet/bigtablet-design-system/commit/6084c5553169b6e7f36a91708447ab6d9efd8e6a)), closes [#141414](https://github.com/Bigtablet/bigtablet-design-system/issues/141414) [#0A0A0A](https://github.com/Bigtablet/bigtablet-design-system/issues/0A0A0A) [#0A0A0A](https://github.com/Bigtablet/bigtablet-design-system/issues/0A0A0A) [#141414](https://github.com/Bigtablet/bigtablet-design-system/issues/141414) [1F2630/#303841](https://github.com/Bigtablet/bigtablet-design-system/issues/303841) [#B3B3B3](https://github.com/Bigtablet/bigtablet-design-system/issues/B3B3B3)
+- `BottomNav` 신규 컴포넌트 — iOS safe-area 대응, 2–5 항목 균등 분할, `BottomNavSpacer` helper
+- `Sidebar` 자동 반응형 변신 — `mode="auto"` 시 600px 미만에서 하단 bar로 전환 (CSS-only, SSR 안전)
+- `SidebarItem` + `BottomNavItem` discriminated union 타입 전환 — as="a"/"button" 조합 컴파일 에러 차단
+- `docs/AGENT_GUIDE.md` 신규 — AI 코딩 에이전트용 영문 레퍼런스
 
+## [3.0.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.0.0) - 2026-05-26
 
-### BREAKING CHANGES
+- 다크 모드 풀 지원 — `ThemeProvider` + `useTheme` hook, CSS custom properties 자동 swap
+- Navy accent 팔레트 전면 도입 — `color_accent_*` 토큰 체계
+- 15+ 신규 컴포넌트: Modal, Toast, Tooltip, Menu, Dropdown, MediaCard, Hero, NavBar, Tabs, LinearProgress, FAB, FileInput, DatePicker, Pagination, Chip
+- react-spring 기반 진입/퇴출 애니메이션 — Modal, Toast, Tooltip, Menu 적용
+- Vanilla JS 패키지 완성 — Thymeleaf/JSP/PHP 환경 지원
+- `useSpringPresence` hook 공개 — 커스텀 overlay 애니메이션 지원
 
-* status base hex 값 변경 — 시각적으로 더 진한 톤. Notiiv 4개 앱은 brand.css 에서 status 자체 override 중이라 영향 없음. 다른 소비처는 PR 머지 전 시각 검토 권장.
+## [2.5.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.5.0) - 2026-05-18
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+- 6개 컴포넌트에 react-spring 자연스러운 애니메이션 일괄 적용 (Dropdown, Modal, Checkbox, Radio, Button, Card)
+- Modal: 오버레이 fade + 패널 scale-up 진입 / scale-down 퇴출
+- Dropdown: 패널 spring 열림/닫힘 (opacity + translateY)
 
-* feat: Badge appearance prop — solid (default) | soft
+## [2.4.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.4.4) - 2026-05-15
 
-신규 prop `appearance?: "solid" | "soft"` 추가 (기본 `solid` — 호환):
-- `solid`: 강한 fill bg + 흰/검 텍스트 (status hex darken 후 AA 통과)
-- `soft`: tint 배경 (status-*-container) + 진한 텍스트 (status-*-on-container) — 정보성 라벨용 차분한 인상, AA 5~7:1
+- FAB / LinearProgress 테스트 타입 에러 수정
+- Typography 비교 스토리 `fontWeightMap` 사용으로 수정
+- OtpInput / Dropdown SCSS 축약 변수명 → 명확한 이름으로 리네임
+- Biome 스캔에서 `.claude/`, tsup 빌드 아티팩트 제외
 
-Badge style.scss 의 raw `color: #fff` 4 라인 (info/success/warning/error) 제거 — `status-*-on-default` 토큰 사용. accent / neutral 도 solid/soft 분기 지원.
+## [2.4.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.4.3) - 2026-05-11
 
-테스트 + Storybook story (Solid vs Soft 비교) 추가.
+- CI 워크플로우 경로 기반 조건부 실행 최적화
+- 의존성 업데이트: `@biomejs/biome`, `chromatic`, `@semantic-release/github`, `@material-symbols/svg-400`, `@types/node`
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+## [2.4.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.4.2) - 2026-05-06
 
-* fix: status text color → *-on-surface for dark mode legibility
+- Vanilla 예제 파일 함수명 복원 — lint auto-fix가 잘못 변경한 function 이름 수정
+- 코드 품질 lint 에러 정리
 
-surface 위 직접 status 텍스트 사용처를 `*-on-surface` 토큰으로 교체 — light/dark 자동 swap (light=darkened, dark=brightened) 으로 다크 모드 가독성 보장:
+## [2.4.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.4.1) - 2026-05-04
 
-- TextField error label / helper — `status_error_on_surface`
-- OtpInput error supporting — 동일
-- DatePicker required (*) 표시 — 동일
-- Alert icon + title (variant 4종) — `status_*_on_surface`
-- Toast icon (variant 4종) — 동일
-- Menu destructive item — `status_error_on_surface`
+- 보안 취약점 수정 (npm audit fix)
+- 의존성 업데이트: `@biomejs/biome`, `@commitlint/cli`, `chromatic`, `@material-symbols/svg-300`
 
-다크 모드 (navy_900 surface) 위 대비:
-- error #F87171: 6.8:1 ✅
-- success #4ADE80: 10.5:1 ✅
-- warning #FBBF24: 13:1 ✅
-- info #60A5FA: 7.8:1 ✅
+## [2.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.4.0) - 2026-04-28
 
-border / solid bg 사용처 (Checkbox border, Button danger fill 등) 는 그대로 — surface 위 텍스트 아닌 케이스라 토큰 의미 다름.
+- `Dropdown` 신규 컴포넌트 — Figma 스펙 기반 완전 재설계, 옵션 그룹핑/검색/다중 선택 지원
+- `Select` 컴포넌트 deprecated (Dropdown으로 대체)
+- 키보드 네비게이션, aria-* 완전 지원
+- TypeScript 6.0.3 업그레이드
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+## [2.3.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.3.0) - 2026-04-24
 
-* style: replace raw hex in component SCSS with theme-invariant tokens
+- `neutral-600`, `neutral-800` 색상 토큰 값 조정
+- `bg.inverse-surface` 신규 토큰 추가
 
-src/ui/**/*.scss 의 raw hex 11건 제거 — Stylelint color-no-hex 룰 적용 준비:
+## [2.2.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.2.4) - 2026-04-20
 
-- nav-bar.scss (8): `color/background: #fff` → `token.\$color_brand_on_primary` (light/dark 동일 흰색 토큰)
-- hero.scss (2): `color: #1A1A1A` → `token.\$color_brand_primary`, `color: #fff` → `token.\$color_brand_on_primary`
-* HeroOverlay type no longer accepts "navy" (use "dark"); Section bg prop no longer accepts "navy" (use "inverted")
+- DatePicker `minDay` 상한 경계 유효하지 않은 입력 방어 (clamp 적용)
+- Select 포커스 하이라이트 정렬 수정
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+## [2.2.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.2.0) - 2026-04-17
 
-* fix: update TokenComparison hex values and correct dark mode comments
-* HeroOverlay type no longer accepts "navy" (use "dark"); Section bg prop no longer accepts "navy" (use "inverted")
+- Select label floating 스타일로 재설계, TextField와 높이 통일
+- TextField `size` prop 추가 (sm/md/lg)
+- OtpInput paste handler 개선 — 전체 입력에 적용, 첫 번째 빈 칸으로 포커스 이동
+- OtpInput disabled 상태 opacity 제거, 텍스트 색상 토큰으로 처리
 
-Co-Authored-By: Claude <noreply@anthropic.com>
-* status base hex 값 변경 — 시각적으로 더 진한 톤. Notiiv 4개 앱은 brand.css 에서 status 자체 override 중이라 영향 없음. 다른 소비처는 PR 머지 전 시각 검토 권장.
+## [2.1.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.1.0) - 2026-04-16
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+- `OtpInput` 신규 컴포넌트 — n자리 OTP 박스형 입력, 자동 포커스 이동, paste 지원
 
-* feat: Badge appearance prop — solid (default) | soft
+## [2.0.7](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.7) - 2026-04-15
 
-신규 prop `appearance?: "solid" | "soft"` 추가 (기본 `solid` — 호환):
-- `solid`: 강한 fill bg + 흰/검 텍스트 (status hex darken 후 AA 통과)
-- `soft`: tint 배경 (status-*-container) + 진한 텍스트 (status-*-on-container) — 정보성 라벨용 차분한 인상, AA 5~7:1
+- `Switch` → `Toggle` 전체 리네임 (컴포넌트, SCSS, Vanilla, 문서)
+- Toggle 크기 sm/md로 단순화, OFF 상태 bg 수정, disabled compound selector 수정
 
-Badge style.scss 의 raw `color: #fff` 4 라인 (info/success/warning/error) 제거 — `status-*-on-default` 토큰 사용. accent / neutral 도 solid/soft 분기 지원.
+## [2.0.6](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.6) - 2026-04-11
 
-테스트 + Storybook story (Solid vs Soft 비교) 추가.
+- 토큰 import 경로 수정
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+## [2.0.5](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.5) - 2026-04-10
 
-* fix: status text color → *-on-surface for dark mode legibility
+- Storybook 로고 및 파비콘 상대 경로 수정
+- next CVE 보안 업데이트
 
-surface 위 직접 status 텍스트 사용처를 `*-on-surface` 토큰으로 교체 — light/dark 자동 swap (light=darkened, dark=brightened) 으로 다크 모드 가독성 보장:
+## [2.0.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.4) - 2026-04-10
 
-- TextField error label / helper — `status_error_on_surface`
-- OtpInput error supporting — 동일
-- DatePicker required (*) 표시 — 동일
-- Alert icon + title (variant 4종) — `status_*_on_surface`
-- Toast icon (variant 4종) — 동일
-- Menu destructive item — `status_error_on_surface`
+- next CVE 보안 업데이트
 
-다크 모드 (navy_900 surface) 위 대비:
-- error #F87171: 6.8:1 ✅
-- success #4ADE80: 10.5:1 ✅
-- warning #FBBF24: 13:1 ✅
-- info #60A5FA: 7.8:1 ✅
+## [2.0.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.3) - 2026-04-10
 
-border / solid bg 사용처 (Checkbox border, Button danger fill 등) 는 그대로 — surface 위 텍스트 아닌 케이스라 토큰 의미 다름.
+- Chip active/pressed 상태 이중 state layer 중복 제거
+- Chip hover zone 리팩토링 — trailing 아이콘 circular hover 통일
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+## [2.0.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.2) - 2026-04-10
 
-* style: replace raw hex in component SCSS with theme-invariant tokens
+- Chip 더블 액션 / 더블 hover 버그 수정
+- Chip trailing 아이콘 circular hover 범위 수정
+- Spinner 애니메이션 수정
 
-src/ui/**/*.scss 의 raw hex 11건 제거 — Stylelint color-no-hex 룰 적용 준비:
+## [2.0.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.1) - 2026-04-10
 
-- nav-bar.scss (8): `color/background: #fff` → `token.\$color_brand_on_primary` (light/dark 동일 흰색 토큰)
-- hero.scss (2): `color: #1A1A1A` → `token.\$color_brand_primary`, `color: #fff` → `token.\$color_brand_on_primary`
-* status base hex 값 변경 — 시각적으로 더 진한 톤. Notiiv 4개 앱은 brand.css 에서 status 자체 override 중이라 영향 없음. 다른 소비처는 PR 머지 전 시각 검토 권장.
+- 버전 초기화 패치
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+## [2.0.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.0.0) - 2026-04-10
 
-## [3.1.1](https://github.com/Bigtablet/bigtablet-design-system/compare/v3.1.0...v3.1.1) (2026-05-26)
+- GitHub Pages Storybook 배포 — 클라이언트 사이드 비밀번호 보호 적용
+- Chip `aria-expanded` 및 TextField clear button 접근성 개선
 
-# [3.1.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v3.0.0...v3.1.0) (2026-05-26)
+## [1.24.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.24.2) - 2026-04-08
 
+- Vanilla CSS 변수 수정
+- 의존성 업데이트: playwright, sass-embedded
 
-### Bug Fixes
+## [1.24.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.24.1) - 2026-04-03
 
-* address Gemini review feedback (PR [#269](https://github.com/Bigtablet/bigtablet-design-system/issues/269)) ([22f5a1c](https://github.com/Bigtablet/bigtablet-design-system/commit/22f5a1c45b2798b5ed50051e2d89f347691e477b)), closes [#2](https://github.com/Bigtablet/bigtablet-design-system/issues/2)
-* convert SidebarItem + BottomNavItem to discriminated union (PR [#269](https://github.com/Bigtablet/bigtablet-design-system/issues/269)) ([a5aa1e0](https://github.com/Bigtablet/bigtablet-design-system/commit/a5aa1e071d5e88f802dff18803d4e7d3e238b3a9)), closes [#2](https://github.com/Bigtablet/bigtablet-design-system/issues/2)
+- Escape 키 핸들러 버그 수정
 
+## [1.24.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.24.0) - 2026-04-02
 
-### Features
+- `borderWidth`, `baseBorderWidth`, `opacity`, `baseTypography` 토큰 신규 export
+- border-width, opacity 토큰 Storybook foundation 스토리 추가
 
-* add BottomNav + Sidebar responsive transform for mobile nav ([f2f67b1](https://github.com/Bigtablet/bigtablet-design-system/commit/f2f67b111069f0187d9cc3dd0b2756675cbf0802))
+## [1.23.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.23.0) - 2026-04-01
 
-# [3.0.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.5.0...v3.0.0) (2026-05-26)
+- Vanilla Alert / Pagination HTML injection XSS 취약점 수정 — HTML escape 처리
+- 주요 의존성 업그레이드
 
+## [1.22.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.22.2) - 2026-03-31
 
-### Bug Fixes
+- 보안 취약점 수정 및 의존성 업데이트
 
-* Accordion hover bg leaks on opened trigger ([59f3741](https://github.com/Bigtablet/bigtablet-design-system/commit/59f3741b5908fd32787a60f2085cd218264bf318))
-* Accordion trigger padding too big (hover area felt too large) ([d058bdc](https://github.com/Bigtablet/bigtablet-design-system/commit/d058bdc9299d6bf240ca056dcb14fded87252ee7))
-* adapt component tokens for dark mode visibility ([8aa3ee7](https://github.com/Bigtablet/bigtablet-design-system/commit/8aa3ee787fe30078a7a000739be28fee71f14608)), closes [#121212](https://github.com/Bigtablet/bigtablet-design-system/issues/121212)
-* adapt stories hardcoded colors for dark mode ([54c9e62](https://github.com/Bigtablet/bigtablet-design-system/commit/54c9e628dc094ba171ac3d643848dfeb3b5902fd))
-* address gemini review feedback (PR [#258](https://github.com/Bigtablet/bigtablet-design-system/issues/258)) ([a151273](https://github.com/Bigtablet/bigtablet-design-system/commit/a151273f9855e0c6115f8bd0d6315caa51042f40))
-* address Gemini review feedback (PR [#268](https://github.com/Bigtablet/bigtablet-design-system/issues/268)) ([96adabd](https://github.com/Bigtablet/bigtablet-design-system/commit/96adabd682e53d67e61a18c9a12efcb6201758e5))
-* cookbook layout patterns visual consistency ([983ed74](https://github.com/Bigtablet/bigtablet-design-system/commit/983ed74979859570237def56fc98da6f727a965c))
-* dark mode coverage — elevation + focus ring + page composition tokens ([48ff083](https://github.com/Bigtablet/bigtablet-design-system/commit/48ff083a4c7637329bd3e1310639f841160ff9cb))
-* dark mode text invisible on dark/brand bg (5 components) ([97d6100](https://github.com/Bigtablet/bigtablet-design-system/commit/97d6100953428d7ca5e3b5f391b2917a14a21f73)), closes [#FFFFFF](https://github.com/Bigtablet/bigtablet-design-system/issues/FFFFFF) [#121212](https://github.com/Bigtablet/bigtablet-design-system/issues/121212) [#121212](https://github.com/Bigtablet/bigtablet-design-system/issues/121212) [#FFFFFF](https://github.com/Bigtablet/bigtablet-design-system/issues/FFFFFF)
-* dark mode text rendering (smoothing + opacity) ([3cac2a3](https://github.com/Bigtablet/bigtablet-design-system/commit/3cac2a30c7513fa8b398b042508ff09a27c2025c))
-* dropdown dropUp threshold conservative for small viewports ([c049224](https://github.com/Bigtablet/bigtablet-design-system/commit/c049224984a2aa73e442d2e2701640d7729ca5bd))
-* dropdown width stability and dark mode panel visibility ([98a323c](https://github.com/Bigtablet/bigtablet-design-system/commit/98a323c532b23b6f3656481a6942f13a6f20bd66))
-* dropdown/menu panel bg white in light, bg_solid_dim in dark ([38a6044](https://github.com/Bigtablet/bigtablet-design-system/commit/38a6044b86523054ca2c0ad762cc541c5dfe7a9c))
-* keep Dropdown on Menu/Tooltip spring pattern (no shouldRender) ([6809df0](https://github.com/Bigtablet/bigtablet-design-system/commit/6809df07522e7c3132aeb1bb3c8604658c477d2e))
-* menu trigger props forwarding + dark mode panel bg ([39ef952](https://github.com/Bigtablet/bigtablet-design-system/commit/39ef95238cf9dce2d7dd984c61975be1afcd08e6))
-* misc UI refinements across components ([d591fe5](https://github.com/Bigtablet/bigtablet-design-system/commit/d591fe5067e004ac5116f1f9e9a3aed0d5158583))
-* move chip to display category and symmetric padding ([dff1122](https://github.com/Bigtablet/bigtablet-design-system/commit/dff1122a0dd31f9cfdf754a7760e62f06954635a))
-* real logo + dark mode canvas background ([1c2aa02](https://github.com/Bigtablet/bigtablet-design-system/commit/1c2aa02492b5a0943d5a13e48bdd471855963f7e))
-* replace hardcoded black shadows with theme variable ([5c9ba58](https://github.com/Bigtablet/bigtablet-design-system/commit/5c9ba5854e6ed2773915708162d45d6465689011)), closes [#260](https://github.com/Bigtablet/bigtablet-design-system/issues/260)
-* replace hardcoded colors with theme tokens in stories ([6fcdedb](https://github.com/Bigtablet/bigtablet-design-system/commit/6fcdedb41c9edfb53d4c7d9d1db16e69431c9617)), closes [#121212](https://github.com/Bigtablet/bigtablet-design-system/issues/121212) [#888](https://github.com/Bigtablet/bigtablet-design-system/issues/888) [#444](https://github.com/Bigtablet/bigtablet-design-system/issues/444) [#fff](https://github.com/Bigtablet/bigtablet-design-system/issues/fff) [#F2F5F8](https://github.com/Bigtablet/bigtablet-design-system/issues/F2F5F8) [444/#303841](https://github.com/Bigtablet/bigtablet-design-system/issues/303841) [f8f9fa/#E5E5E5](https://github.com/Bigtablet/bigtablet-design-system/issues/E5E5E5) [e5e5e5/#E5E7EB](https://github.com/Bigtablet/bigtablet-design-system/issues/E5E7EB) [F59E0B/#94A3B8](https://github.com/Bigtablet/bigtablet-design-system/issues/94A3B8) [DCFCE7/#047857](https://github.com/Bigtablet/bigtablet-design-system/issues/047857)
-* restore Accordion hover bg on opened trigger (revert) ([a70b8a8](https://github.com/Bigtablet/bigtablet-design-system/commit/a70b8a88cceeec13f47032fd92db6b139b5ddb4a))
-* sidebar logo crossfade between expanded and collapsed states ([d1f3557](https://github.com/Bigtablet/bigtablet-design-system/commit/d1f3557772159aca44bc634c683f780b53476e41))
-* skip Chromatic review job on dependabot PRs ([ca8e721](https://github.com/Bigtablet/bigtablet-design-system/commit/ca8e721bdb61d355d41049b79654aaf6363f06b9))
-* skip Chromatic review job on dependabot PRs ([#267](https://github.com/Bigtablet/bigtablet-design-system/issues/267)) ([2887e77](https://github.com/Bigtablet/bigtablet-design-system/commit/2887e77b5462bf5454394f8c462f34331e967f82))
-* storybook test failures (React null + a11y) ([6708530](https://github.com/Bigtablet/bigtablet-design-system/commit/6708530699fbc3807ad25e3866a7a509d2c1a728))
-* Tabs support uncontrolled mode via defaultValue prop ([55adca2](https://github.com/Bigtablet/bigtablet-design-system/commit/55adca22de8ed4a7f68030a524ba5fb25f8d5f44))
-* ThemeProvider demo Dark button text invisible in dark mode ([148652a](https://github.com/Bigtablet/bigtablet-design-system/commit/148652a119c22abc5204e81421838049d4ef7474))
-* tooltip centering + long text wrap consistency ([41542fe](https://github.com/Bigtablet/bigtablet-design-system/commit/41542fef318a2c95667d4ef8b76eb03e5de8163a))
-* vanilla SCSS dark mode parity + Modal X close icon ([01b9ff4](https://github.com/Bigtablet/bigtablet-design-system/commit/01b9ff4ac69612492677fa71b8308866ecdbca09))
+## [1.22.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.22.1) - 2026-03-23
 
+- `next`를 optional peerDependency로 설정 — 중복 React 인스턴스 방지
 
-### Features
+## [1.22.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.22.0) - 2026-03-17
 
-* add Getting Started and Cookbook story sections ([b92a7f3](https://github.com/Bigtablet/bigtablet-design-system/commit/b92a7f377c33e3ab51e82cee4b80447542b1b8b5))
-* add preview variant to FileInput ([6607b5b](https://github.com/Bigtablet/bigtablet-design-system/commit/6607b5b021cc2d659e319d70cbcc82d7ba21a35c))
-* add top-right X close icon to Modal ([73f2e8e](https://github.com/Bigtablet/bigtablet-design-system/commit/73f2e8e9a83f9774abd595c05fd32f3300560a04))
-* Chip type='static' + tone variants (replaces Tag) ([a00b7a9](https://github.com/Bigtablet/bigtablet-design-system/commit/a00b7a9fd63bdb00da6eb9f333f6a5133cba88d2))
-* Icon component — Material Symbols → lucide-react ([b4b4b8b](https://github.com/Bigtablet/bigtablet-design-system/commit/b4b4b8bbbc0f84d624e612bafd0a794388a7badc))
-* migrate Dropdown and Toast to react-spring ([1b5853b](https://github.com/Bigtablet/bigtablet-design-system/commit/1b5853b1ed59e84eb704904f38409596cfabf674))
-* migrate Modal and Alert from CSS keyframes to react-spring ([780fef8](https://github.com/Bigtablet/bigtablet-design-system/commit/780fef82d063464264dfee12835fe5f729ae172f))
-* redesign Spinner and LinearProgress ([a6ea9e9](https://github.com/Bigtablet/bigtablet-design-system/commit/a6ea9e94233f32af9639713290a9c170ac3e45b4))
-* typography v3.0 — bold + responsive + semantic + utils ([213f42c](https://github.com/Bigtablet/bigtablet-design-system/commit/213f42c2c4aae6c0a732247ee55276561e2f78a4))
-* unify TextField w/ Dropdown label pattern + bump all deps to latest ([0540465](https://github.com/Bigtablet/bigtablet-design-system/commit/0540465b036cff8cf9b0a0f56e635f29ef3009c9))
-* useSpringPresence onExitComplete + test skipAnimation ([840c5e6](https://github.com/Bigtablet/bigtablet-design-system/commit/840c5e66cb074e5188c8855531b5b5d3e55f5182))
-* v3.0 — brand policy + ui reorg + coverage 90%+ ([52dd73f](https://github.com/Bigtablet/bigtablet-design-system/commit/52dd73ff6a8191331bb1464e4d5851dab4358916)), closes [#47555E](https://github.com/Bigtablet/bigtablet-design-system/issues/47555E) [#121212](https://github.com/Bigtablet/bigtablet-design-system/issues/121212) [#FFFFFF](https://github.com/Bigtablet/bigtablet-design-system/issues/FFFFFF)
-* v3.0 — navy accent DS, dark mode, 15 new components, layout primitives ([d305223](https://github.com/Bigtablet/bigtablet-design-system/commit/d3052230d931b0c30416bf5ef98ff624940667bc))
-* v3.0 release marker ([b8df580](https://github.com/Bigtablet/bigtablet-design-system/commit/b8df5803bf4801df8bfeec7c425b39dc12ad5950))
+- Skeleton 디자인 토큰 신규 추가 및 전체 토큰 export
+- Skeleton Storybook foundation 스토리 추가
 
+## [1.21.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.21.1) - 2026-03-13
 
-### BREAKING CHANGES
+- 접근성 개선 (focus ring, tap target)
+- 의존성 업데이트: sass-embedded, semantic-release
 
-* Select component removed (use Dropdown). Chip moved
-from src/ui/general/chip to src/ui/display/chip (path import update
-required). Vanilla --bt-color-primary now reserved for Button --primary
-fill only — accent indicators use new --bt-color-accent / --bt-color-
-accent-on-surface CSS vars. fullWidth prop on Dropdown is now a no-op
-(default fills parent).
+## [1.21.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.21.0) - 2026-03-13
 
-# [3.0.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.4.2...v3.0.0) (2026-05-20)
+- Figma 색상 변경 자동 동기화 workflow 추가
+- dependabot, commitlint, husky, CODEOWNERS 설정 추가
+- Node.js 20 → 22 업그레이드
 
+## [1.20.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.20.1) - 2026-03-12
 
-### ⚠ BREAKING CHANGES
+- Chromatic CI 환경 변수 수정 (`CHROMATIC_PROJECT_TOKEN` → `CHROMATIC_TOKEN`)
 
-* **Tag**: `Tag` component is removed — migrate to `Chip type="static" tone={...}`
-* **TextField**: markup changed from `<fieldset>` + `<legend>` to `<div>` + `<label>` (label now sits standalone above the control)
-* **TextField**: placeholder color updated from `text_caption` to `text_body`
-* **TextField**: inner padding reduced 6px → 4px
+## [1.20.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.20.0) - 2026-03-12
 
+- Size limit 설정 추가 — bundle 크기 CI 게이트
+- 보안 취약점 수정
 
-### Features
+## [1.19.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.19.4) - 2026-03-09
 
-* add 16 new components — `Tabs` (compound API), `Sidebar`, `NavBar`, `Breadcrumb`, `Avatar`, `Badge`, `EmptyState`, `Accordion`, `Tooltip`, `Menu`, `Skeleton`, `Table`, `MediaCard`, plus layout primitives `Container`, `Section`, `Stack`, `Grid`
-* add `ThemeProvider` + `useTheme` hook for light/dark theme management
-* add full dark mode support via CSS custom properties (`:root` + `[data-theme="dark"]`) — every component token auto-adapts
-* add `Chip` `type="static"` + `tone` prop (absorbs former `Tag` component)
-* add `Tabs` `defaultValue` for uncontrolled mode
-* add `Hero` `primaryAction` / `secondaryAction` props
-* add Storybook toolbar theme toggle (☀️ / 🌙 / 🖥)
+- a11y / i18n 컨벤션 개선
+- 구 `tokens/design-tokens.json` 제거 (src/styles/ts/tokens.json으로 대체)
+- README npm 패키지 기준으로 개선
 
+## [1.19.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.19.3) - 2026-03-09
 
-### Bug Fixes
+- 디자인 토큰 리뷰 피드백 반영 및 Storybook color 스토리 업데이트
 
-* fix `React.useState` null issue in Chip / Dropdown / TextField by importing hooks directly
-* fix Vite 8 upgrade resolves `import.meta.env` clone error in Storybook test environment
+## [1.19.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.19.2) - 2026-03-05
 
+- Storybook 10.1.11 다운그레이드 — Chromatic 빌드 오류 수정
 
-### Dependencies
+## [1.19.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.19.1) - 2026-03-03
 
-* upgrade `vite` 6 → 8 (major)
-* upgrade `storybook` 10.3 → 10.4
-* upgrade `vitest` 4.1.5 → 4.1.6
-* upgrade `chromatic` 16 → 17, `@commitlint/*` 20 → 21, `@types/node` 24 → 25
-* minor bumps on remaining dependencies
+- ToastProvider SSR 하이드레이션 불일치 수정
 
-## [2.4.2](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.4.1...v2.4.2) (2026-05-06)
+## [1.19.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.19.0) - 2026-02-27
 
+- 접근성 개선 — Gemini 리뷰 피드백 반영
+- 단위 테스트 커버리지 강화
 
-### Bug Fixes
+## [1.18.9](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.9) - 2026-02-26
 
-* restore vanilla example function names broken by lint auto-fix ([df706f8](https://github.com/Bigtablet/bigtablet-design-system/commit/df706f8a6a57c727ea6ffc1fe34ac2f5581c0bd8))
+- Chromatic main PR 빌드 오류 수정
+- ESM 빌드 경고 제거
 
-## [2.4.1](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.4.0...v2.4.1) (2026-05-04)
+## [1.18.8](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.8) - 2026-02-26
 
-# [2.4.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.3.0...v2.4.0) (2026-04-28)
+- main 브랜치 push 시 자동 릴리즈 workflow 추가
 
+## [1.18.7](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.7) - 2026-02-26
 
-### Bug Fixes
+- README 한국어 / 영어 분리 재작성 및 상세화
 
-* address Gemini code review on Dropdown component ([ab0c279](https://github.com/Bigtablet/bigtablet-design-system/commit/ab0c279da372adcb5d794303e46cd12145d33bf0))
+## [1.18.6](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.6) - 2026-02-26
 
+- rollup, lodash, lodash-es 보안 취약점 pnpm overrides로 패치
+- overrides caret range 적용으로 major 버전 점프 방지
 
-### Features
+## [1.18.5](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.5) - 2026-02-26
 
-* add Dropdown component — redesign from Figma spec ([a89e1e5](https://github.com/Bigtablet/bigtablet-design-system/commit/a89e1e55ffc4d8c4ad8b40c8774afd1b09101225))
+- DatePicker 옵션 상세 문서 보강
 
-# [2.3.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.2.4...v2.3.0) (2026-04-24)
+## [1.18.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.4) - 2026-02-13
 
+- Modal overflow 수정
+- AI 친화적 디자인 시스템 문서 업데이트
 
-### Bug Fixes
+## [1.18.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.3) - 2026-02-11
 
-* restore tokens.json original format, apply only targeted token changes ([7ad6e63](https://github.com/Bigtablet/bigtablet-design-system/commit/7ad6e63855146e9e3f6f4cdeff182c9c4cef363c)), closes [#6B6B6B](https://github.com/Bigtablet/bigtablet-design-system/issues/6B6B6B) [#777777](https://github.com/Bigtablet/bigtablet-design-system/issues/777777) [#333333](https://github.com/Bigtablet/bigtablet-design-system/issues/333333)
+- FileInput cursor pointer 수정
 
+## [1.18.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.2) - 2026-02-11
 
-### Features
+- FileInput cursor 수정
+- JSDoc 추가
 
-* update color tokens — neutral 600/800, add bg inverse-surface ([6c975a2](https://github.com/Bigtablet/bigtablet-design-system/commit/6c975a2b8341fed175979d790b2cc8f17c8d89a1)), closes [#6B6B6B](https://github.com/Bigtablet/bigtablet-design-system/issues/6B6B6B) [#777777](https://github.com/Bigtablet/bigtablet-design-system/issues/777777) [#333333](https://github.com/Bigtablet/bigtablet-design-system/issues/333333) [#228](https://github.com/Bigtablet/bigtablet-design-system/issues/228)
+## [1.18.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.1) - 2026-02-10
 
-## [2.2.4](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.2.3...v2.2.4) (2026-04-20)
+- 문서 구조 재정리
 
+## [1.18.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.18.0) - 2026-02-10
 
-### Bug Fixes
+- 전체 UI 컴포넌트 단위 테스트 추가 (form, display, overlay, navigation)
+- 커버리지 설정 최적화
 
-* align Select focus highlight style with TextField pattern ([e4c6917](https://github.com/Bigtablet/bigtablet-design-system/commit/e4c691743a4e3357f87a9b528018e5d9a9eb4968))
-* clamp minDay at definition to guard upper bound against invalid input ([ff6645c](https://github.com/Bigtablet/bigtablet-design-system/commit/ff6645c5adbe0521f061a617812fca0591b94478))
-* clamp minDay to 1–31 range to guard against invalid minDate input ([32c8f9c](https://github.com/Bigtablet/bigtablet-design-system/commit/32c8f9c23bcd3e964638dae84905250bbf31dd5c))
-* clamp minMonth to 1–12 range to guard against invalid minDate input ([7619fc7](https://github.com/Bigtablet/bigtablet-design-system/commit/7619fc7cc8d166334c12614f77feb0e725fe92c0))
-* refactor DatePicker to use DS Select component for consistent UX ([5387f9a](https://github.com/Bigtablet/bigtablet-design-system/commit/5387f9aa84a16c2365f17604d6d90780a790cc10))
-* remove default margin-top from Card title ([cf44ff7](https://github.com/Bigtablet/bigtablet-design-system/commit/cf44ff758f8c3423a46758bc3c88c4bd20dcd45c))
-* Select 밀림 및 클릭 테두리 강조 버그 수정 ([eeb8a0c](https://github.com/Bigtablet/bigtablet-design-system/commit/eeb8a0cdc350f5bbcfef93bc8300aeee32cbb834))
+## [1.17.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.17.4) - 2026-01-26
 
-## [2.2.2](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.2.1...v2.2.2) (2026-04-20)
+- npm 패키지 크기 최적화 — 비압축 파일 배포 제외
 
+## [1.17.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.17.3) - 2026-01-26
 
-### Bug Fixes
+- Vanilla CSS 빌드에서 source map 제거
 
-* align Select focus highlight style with TextField pattern ([e4c6917](https://github.com/Bigtablet/bigtablet-design-system/commit/e4c691743a4e3357f87a9b528018e5d9a9eb4968))
-* clamp minMonth to 1–12 range to guard against invalid minDate input ([7619fc7](https://github.com/Bigtablet/bigtablet-design-system/commit/7619fc7cc8d166334c12614f77feb0e725fe92c0))
-* refactor DatePicker to use DS Select component for consistent UX ([5387f9a](https://github.com/Bigtablet/bigtablet-design-system/commit/5387f9aa84a16c2365f17604d6d90780a790cc10))
-* remove default margin-top from Card title ([cf44ff7](https://github.com/Bigtablet/bigtablet-design-system/commit/cf44ff758f8c3423a46758bc3c88c4bd20dcd45c))
+## [1.17.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.17.2) - 2026-01-26
 
-## [2.2.1](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.2.0...v2.2.1) (2026-04-17)
+- 서버 개발자용 Vanilla JS 프롬프트 파일 추가
 
+## [1.17.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.17.1) - 2026-01-26
 
-### Bug Fixes
+- Vanilla JS CLAUDE.md 레퍼런스 추가
 
-* Select fieldset/legend 구조 전환으로 label 배경색 제거 ([b9113be](https://github.com/Bigtablet/bigtablet-design-system/commit/b9113becdb3dabfafca0808fff415832e345be41))
-* Select 밀림 및 클릭 테두리 강조 버그 수정 ([eeb8a0c](https://github.com/Bigtablet/bigtablet-design-system/commit/eeb8a0cdc350f5bbcfef93bc8300aeee32cbb834))
-* TextField fieldset/legend 구조 전환으로 label 배경색 제거 ([724bd1a](https://github.com/Bigtablet/bigtablet-design-system/commit/724bd1a65226966a59ccbe62bc10813ece152408))
-* TextField 컨테이너 흰색 배경 복구 ([ff57129](https://github.com/Bigtablet/bigtablet-design-system/commit/ff57129b5668c6913593ba7591178b3589584a2c))
-* TextField 코드리뷰 반영 ([3cb9cba](https://github.com/Bigtablet/bigtablet-design-system/commit/3cb9cba8f7a8e747a231f66827c9f767fdf4da7c))
+## [1.17.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.17.0) - 2026-01-26
 
-## [2.2.3](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.2.2...v2.2.3) (2026-04-17)
+- Vanilla JS 패키지 초기 릴리즈 — Thymeleaf/JSP/PHP 등 non-React 환경 지원
+- Vanilla JS 문서 추가
 
+## [1.16.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.16.2) - 2026-01-26
 
-### Bug Fixes
+- Select portal 롤백, absolute positioning + auto-flip으로 위치 깜빡임 수정
 
-* Select fieldset/legend 구조 전환으로 label 배경색 제거 ([b9113be](https://github.com/Bigtablet/bigtablet-design-system/commit/b9113becdb3dabfafca0808fff415832e345be41))
+## [1.16.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.16.1) - 2026-01-26
 
-## [2.2.2](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.2.1...v2.2.2) (2026-04-17)
+- Select overflow createPortal로 수정
 
+## [1.16.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.16.0) - 2026-01-26
 
-### Bug Fixes
+- Select 자동 flip 드롭다운 추가 — 화면 하단 여백 부족 시 위로 열림
 
-* TextField 컨테이너 흰색 배경 복구 ([ff57129](https://github.com/Bigtablet/bigtablet-design-system/commit/ff57129b5668c6913593ba7591178b3589584a2c))
-* TextField 코드리뷰 반영 ([3cb9cba](https://github.com/Bigtablet/bigtablet-design-system/commit/3cb9cba8f7a8e747a231f66827c9f767fdf4da7c))
+## [1.15.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.15.0) - 2026-01-23
 
-## [2.2.1](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.2.0...v2.2.1) (2026-04-17)
+- 의존성 및 설정 업데이트
 
+## [1.14.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.14.3) - 2026-01-22
 
-### Bug Fixes
+- Checkbox disabled 디자인 수정
 
-* TextField fieldset/legend 구조 전환으로 label 배경색 제거 ([724bd1a](https://github.com/Bigtablet/bigtablet-design-system/commit/724bd1a65226966a59ccbe62bc10813ece152408))
+## [1.14.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.14.2) - 2026-01-21
 
-# [2.2.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.1.0...v2.2.0) (2026-04-17)
+- README 전체 컴포넌트 문서화 업데이트
 
+## [1.14.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.14.1) - 2026-01-21
 
-### Bug Fixes
+- 문서 업데이트
 
-* apply paste handler to all OTP inputs and redirect focus to first empty box ([f1c48d7](https://github.com/Bigtablet/bigtablet-design-system/commit/f1c48d76bbdd636a350d1b9c5a8d64aa93525422))
+## [1.14.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.14.0) - 2026-01-21
 
+- Spinner / TopLoading 컴포넌트 분리 (기존 Loading 분할)
+- CSS Modules 제거, global SCSS 통일
 
-### Features
+## [1.13.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.13.0) - 2026-01-16
 
-* add size prop to TextField and use CSS variable for surface color ([4868811](https://github.com/Bigtablet/bigtablet-design-system/commit/4868811c90373d9b5379c3c6ebb5daef08ddafca)), closes [#fff](https://github.com/Bigtablet/bigtablet-design-system/issues/fff)
-* redesign Select label to floating style and align height with TextField ([15ca34c](https://github.com/Bigtablet/bigtablet-design-system/commit/15ca34ca4d107afed614f0699434124c2bdb6216))
+- Skeleton 디자인 토큰 추가
 
-# [2.1.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.7...v2.1.0) (2026-04-16)
+## [1.12.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.12.1) - 2026-01-15
 
+- 버전 문서 업데이트
 
-### Bug Fixes
+## [1.12.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.12.0) - 2026-01-15
 
-* remove opacity from disabled OtpInput, use text color token instead ([6f7a498](https://github.com/Bigtablet/bigtablet-design-system/commit/6f7a4982ad3547e38c6c651333fb5b41b0e08c41))
-* use text/body color for disabled OtpInput per Figma spec ([a6c060a](https://github.com/Bigtablet/bigtablet-design-system/commit/a6c060a75efaad51e3b2b1951d780ae3a675fe67))
+- GitHub release 복원
 
+## [1.11.6](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.11.6) - 2026-01-13
 
-### Features
+- DatePicker 윤년 버그 추가 수정
 
-* add OtpInput component per Figma spec ([fce5540](https://github.com/Bigtablet/bigtablet-design-system/commit/fce5540c68bce4a999177b8b6da558650a81c4e9))
+## [1.11.5](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.11.5) - 2026-01-13
 
-## [2.0.7](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.6...v2.0.7) (2026-04-15)
+- DatePicker 윤년 처리 수정
 
+## [1.11.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.11.4) - 2026-01-12
 
-### Bug Fixes
+- DatePicker yyyy-mm 로직 수정
 
-* correct Toggle thumb sizes and remove border in disabled state ([09163a5](https://github.com/Bigtablet/bigtablet-design-system/commit/09163a54bdd87a4b5a6beeeefa9b2559445a5456))
-* ensure disabled state overrides on-state via compound selector ([6d8973b](https://github.com/Bigtablet/bigtablet-design-system/commit/6d8973b4cce6c2389ec77c6e88c66429ad20bcf9))
-* rename switch folder and files to toggle ([cb8db54](https://github.com/Bigtablet/bigtablet-design-system/commit/cb8db547bffbb643773906baacca6a69120ca57b))
-* rename Switch to Toggle and reduce sizes to sm/md ([7864b1f](https://github.com/Bigtablet/bigtablet-design-system/commit/7864b1faa6685df4576046e8fa810701629258ea))
-* rename vanilla Switch to Toggle and update sizes ([3b6fe83](https://github.com/Bigtablet/bigtablet-design-system/commit/3b6fe83e74650887a23ca8490d920f23804ca004))
-* update Toggle disabled state to use explicit #B3B3B3 background ([e7ccdca](https://github.com/Bigtablet/bigtablet-design-system/commit/e7ccdca177fa147822dbc48f5ce35a69069e7c04)), closes [#B3B3B3](https://github.com/Bigtablet/bigtablet-design-system/issues/B3B3B3) [#B3B3B3](https://github.com/Bigtablet/bigtablet-design-system/issues/B3B3B3)
-* update Toggle OFF state background to #B3B3B3 per Figma spec ([a04003b](https://github.com/Bigtablet/bigtablet-design-system/commit/a04003b058f91eea6822328942786939ea8b129a)), closes [#B3B3B3](https://github.com/Bigtablet/bigtablet-design-system/issues/B3B3B3) [#F4F4F4](https://github.com/Bigtablet/bigtablet-design-system/issues/F4F4F4) [#B3B3B3](https://github.com/Bigtablet/bigtablet-design-system/issues/B3B3B3)
+## [1.11.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.11.3) - 2026-01-12
 
-## [2.0.6](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.5...v2.0.6) (2026-04-11)
+- 인증 차단 UI 반영
 
+## [1.11.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.11.2) - 2026-01-12
 
-### Bug Fixes
+- TextField 한글 IME 처리 수정
 
-* update token import ([025f397](https://github.com/Bigtablet/bigtablet-design-system/commit/025f3974b1ff714ededb4fa55fe6a7801c419d5a))
+## [1.11.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.11.1) - 2026-01-08
 
-## [2.0.5](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.4...v2.0.5) (2026-04-10)
+- background color 토큰 추가
 
+## [1.11.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.11.0) - 2026-01-08
 
-### Bug Fixes
+- spacing 토큰 체계 정비
+- 컬러 토큰 수정
 
-* use relative paths for Storybook logo and favicon ([ac2c2fa](https://github.com/Bigtablet/bigtablet-design-system/commit/ac2c2fa00f2de31e4e50b8cf1a4b03a3cf837288))
+## [1.10.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.10.0) - 2026-01-07
 
-## [2.0.4](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.3...v2.0.4) (2026-04-10)
+- Button `width` 속성 추가
 
-## [2.0.3](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.2...v2.0.3) (2026-04-10)
+## [1.9.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.9.1) - 2026-01-06
 
+- DatePicker Select label 수정
 
-### Bug Fixes
+## [1.9.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.9.0) - 2026-01-06
 
-* add full-area state layer to chip_trailing X button ([628ff7f](https://github.com/Bigtablet/bigtablet-design-system/commit/628ff7fc9ab87c9f5e184d6ce755cb1c4b055c4a))
-* chip_trailing X button full-area state layer on hover ([95e9ce8](https://github.com/Bigtablet/bigtablet-design-system/commit/95e9ce8d69fcc0f83c22af4cef5182410e7e143a))
-* eliminate double state layer overlap on Chip active/pressed ([6d264d4](https://github.com/Bigtablet/bigtablet-design-system/commit/6d264d4dc67f22dfa5ae7b2622c2ee04b9541d97))
-* move hover state layer from chip_content to chip container ([ef862e1](https://github.com/Bigtablet/bigtablet-design-system/commit/ef862e1145d299271461fc161bfabac3d5d8585f))
-* refactor Chip hover zones — split content into separate buttons ([a8691da](https://github.com/Bigtablet/bigtablet-design-system/commit/a8691da8cfb5977eae28bf1aca9db47782a67794))
-* revert Chip to single-button structure with smart icon hover toggle ([395c79c](https://github.com/Bigtablet/bigtablet-design-system/commit/395c79c59be26b0f4c045af2a8d570c0693b3037))
-* revert chip_trailing to icon-only circular hover for consistency ([7512e9a](https://github.com/Bigtablet/bigtablet-design-system/commit/7512e9aad5f02aca5b49111be617648b5264f68e))
-* simplify chip_trailing hover — full state layer only, no icon toggle ([88c9432](https://github.com/Bigtablet/bigtablet-design-system/commit/88c943264658645ffe932639571ef489f5d17f9c))
-* unify chip_trailing hover with other icons — circular only ([a7e99aa](https://github.com/Bigtablet/bigtablet-design-system/commit/a7e99aa95a9b2ab6d0c6f9022476120409370504))
-* zone-based hover for Chip — each icon/label area highlights independently ([3d5da7e](https://github.com/Bigtablet/bigtablet-design-system/commit/3d5da7ea693e6f67696b92b1fd7b9a5a699fe6df))
+- DatePicker 컴포넌트 export 추가
 
-## [2.0.2](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.1...v2.0.2) (2026-04-10)
+## [1.8.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.8.0) - 2026-01-06
 
+- Sidebar open/close 제어 기능 추가
 
-### Bug Fixes
+## [1.7.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.7.2) - 2025-12-18
 
-* fix chip double action and double hover, scope icon circular hover to trailing button only ([38fcdf0](https://github.com/Bigtablet/bigtablet-design-system/commit/38fcdf03f91e97bf7b1609633ef83f79ef673f81))
-* fix Spinner animation, add hover effect to chip_icon ([e1320f4](https://github.com/Bigtablet/bigtablet-design-system/commit/e1320f4267a7917fcdc2b6109cb7e770a907c95a))
-* restore Chip trailing hover, widen left padding, add removable interactive story ([0456c78](https://github.com/Bigtablet/bigtablet-design-system/commit/0456c782d5e118f342d7e08896b17e917fc9d2df))
+- 로컬 전용 코드 제거
 
-## [2.0.1](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.0...v2.0.1) (2026-04-10)
+## [1.7.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.7.1) - 2025-12-18
 
+- Sidebar 스타일 수정
 
-### Bug Fixes
+## [1.7.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.7.0) - 2025-12-18
 
-* reset version to 2.0.0 for 2.0.1 patch release ([6c093ff](https://github.com/Bigtablet/bigtablet-design-system/commit/6c093ff6544423636eb3c1d86a01c9e845e1d57d))
+- Sidebar 그룹 기능 추가
 
-# [2.0.1](https://github.com/Bigtablet/bigtablet-design-system/compare/v2.0.0...v2.0.1) (2026-04-10)
+## [1.6.7](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.7) - 2025-12-18
 
+- Radio dot 위치 수정
 
-### Bug Fixes
+## [1.6.6](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.6) - 2025-12-17
 
-* add chip aria attrs, textfield clearable story, tokenize borders, replace inset shorthand ([2f1f62c](https://github.com/Bigtablet/bigtablet-design-system/commit/2f1f62cffbd947e177fbac15f978be5f10c53449))
-* add equal right padding to ListItem state layer ([df5cf8b](https://github.com/Bigtablet/bigtablet-design-system/commit/df5cf8bc5907cbccbfb0083ba7470e713a6f9783))
-* align toast icon to text baseline, add clearable prop to TextField ([39f6f9e](https://github.com/Bigtablet/bigtablet-design-system/commit/39f6f9e717f3594f5977896c966218b95d354b7d))
-* improve Chip aria-expanded and TextField clear button accessibility ([6dfc7bf](https://github.com/Bigtablet/bigtablet-design-system/commit/6dfc7bf3012f5c423c593bbb39aba00418c04cc9))
-* make entire Chip clickable, move filter chevron into content button ([1e2505e](https://github.com/Bigtablet/bigtablet-design-system/commit/1e2505e31a2ac7c275e9d80250951fa38a475126))
-* use Icon component for TextField clear button, increase size-limit for icon data ([de8bff9](https://github.com/Bigtablet/bigtablet-design-system/commit/de8bff98db959724f978447c3d9931ca0a702dd0))
-* use inset + margin auto for Radio ::after centering ([3ea8880](https://github.com/Bigtablet/bigtablet-design-system/commit/3ea8880bd807bfc9d1e43ec485580dc9659cfc80))
-* use whole-pixel inner dot sizes for Radio, fix Icon story invalid name ([b9d864f](https://github.com/Bigtablet/bigtablet-design-system/commit/b9d864fe9597c022dadbb25b8389860230f89cd2))
+- layout import 수정
+- spacing Storybook 문서 추가
 
+## [1.6.5](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.5) - 2025-12-17
 
-### Features
+- spacing 4xl, 5xl 토큰 추가
 
-* add Icon component with 57 Material Symbols icons ([7a2ef79](https://github.com/Bigtablet/bigtablet-design-system/commit/7a2ef79a3fd1683e78e07fd2b6a4eba5d4b0e8fd))
+## [1.6.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.4) - 2025-12-17
 
-# [2.0.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v1.24.2...v2.0.0) (2026-04-10)
+- 커밋 컨벤션 수정
 
+## [1.6.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.3) - 2025-12-17
 
-### Bug Fixes
+- Sidebar pure export 제거
+- 커밋 컨벤션 문서 수정
 
-* add breaking change rule to semantic-release config ([811dc56](https://github.com/Bigtablet/bigtablet-design-system/commit/811dc561ab87320e95e469ae20a6610a7522e607))
-* add state layer to Radio for hover/focus/pressed feedback ([340d2c4](https://github.com/Bigtablet/bigtablet-design-system/commit/340d2c45de5e9e42740e3b61dc8fddb4ddf587c1))
-* address code review — a11y and default prop issues ([77c873c](https://github.com/Bigtablet/bigtablet-design-system/commit/77c873c99666cf05410b70027b866d3eb24046cf))
-* address code review issues and update text.body to neutral-500 ([d8591e8](https://github.com/Bigtablet/bigtablet-design-system/commit/d8591e80c9988eab3708b1124fd7bb7ef1c9ec37)), closes [#666666](https://github.com/Bigtablet/bigtablet-design-system/issues/666666) [#888888](https://github.com/Bigtablet/bigtablet-design-system/issues/888888)
-* align color tokens with Figma and rename helperText to supportingText ([a88dc9e](https://github.com/Bigtablet/bigtablet-design-system/commit/a88dc9e26161474bf97e475e9877d5f63dce8e94)), closes [#EF4444](https://github.com/Bigtablet/bigtablet-design-system/issues/EF4444) [#CC0000](https://github.com/Bigtablet/bigtablet-design-system/issues/CC0000) [#F2F2F2](https://github.com/Bigtablet/bigtablet-design-system/issues/F2F2F2)
-* align existing components with design token system ([5b0f695](https://github.com/Bigtablet/bigtablet-design-system/commit/5b0f6959fc2f8e16fca056583baba0c7b480a85e))
-* allow button label to wrap on long text, add headingAs select control to Card ([72d6a61](https://github.com/Bigtablet/bigtablet-design-system/commit/72d6a61d37919e2ff2711d2fffc73d40c3a0d32e))
-* apply code review feedback — use warning token, guard month range ([8a04139](https://github.com/Bigtablet/bigtablet-design-system/commit/8a041394646d5b3dde40792b2b05006f4b279ed7))
-* apply code review feedback on manager-head and TextField ([efcd009](https://github.com/Bigtablet/bigtablet-design-system/commit/efcd009eb14f29928a6253ec741b6be206de25b3))
-* complete token alignment, rename helperText, add missing tests ([0dac392](https://github.com/Bigtablet/bigtablet-design-system/commit/0dac392fcfcab652de189d2b288222009390efc1)), closes [#888](https://github.com/Bigtablet/bigtablet-design-system/issues/888) [#666](https://github.com/Bigtablet/bigtablet-design-system/issues/666)
-* darken success/info status colors for WCAG AA compliance ([5af63bf](https://github.com/Bigtablet/bigtablet-design-system/commit/5af63bf489adb5442c3500f22e91052f109e88b3)), closes [#10B981](https://github.com/Bigtablet/bigtablet-design-system/issues/10B981) [#047857](https://github.com/Bigtablet/bigtablet-design-system/issues/047857) [#3B82F6](https://github.com/Bigtablet/bigtablet-design-system/issues/3B82F6) [#2563EB](https://github.com/Bigtablet/bigtablet-design-system/issues/2563EB)
-* export all Props types, remove dead next.ts bundle, fix index.ts categories ([dfe9c7e](https://github.com/Bigtablet/bigtablet-design-system/commit/dfe9c7ef28b168344df2cf8cf9e2929f6ac6e388))
-* optimize DatePicker with memoization, type safety, and auto-correction ([cdd8811](https://github.com/Bigtablet/bigtablet-design-system/commit/cdd8811014a570241a5b648dad7cfc65ba9c315e))
-* redesign Switch to MD3 pattern, fix OFF contrast and disabled state ([7d71e73](https://github.com/Bigtablet/bigtablet-design-system/commit/7d71e733442e5ab1d69bc42e2e3c7fe92ea5faff))
-* reduce Storybook viewport heights to avoid scrolling ([7cd8e6b](https://github.com/Bigtablet/bigtablet-design-system/commit/7cd8e6ba8c32374a67ef0a7c2f7f3ab6284a6564))
-* reduce toast item size on mobile for compact appearance ([23b1c95](https://github.com/Bigtablet/bigtablet-design-system/commit/23b1c9570ddc5e1ec4c17573b613a2c0b63aadf8))
-* restore exitOnceUploaded for PR Chromatic checks ([55de0f4](https://github.com/Bigtablet/bigtablet-design-system/commit/55de0f4701b99138386f6a46102fade4e60cde42))
-* revert a11y test to "todo" (valid value) ([8428970](https://github.com/Bigtablet/bigtablet-design-system/commit/8428970aaae63ad46a27d4613b473c1746cc83c3))
-* skip z-index story from vitest to prevent React hooks teardown error in CI ([b4278f4](https://github.com/Bigtablet/bigtablet-design-system/commit/b4278f4ae76a1e3c5d2a7bc6226d8716091b9f42))
-* sync color tokens with tokens.json (status, alpha, border, state) ([480e6fd](https://github.com/Bigtablet/bigtablet-design-system/commit/480e6fd419a7730506186579b5fa03338e085121))
-* use Storybook 10 globals API for viewport auto-switching ([16514cd](https://github.com/Bigtablet/bigtablet-design-system/commit/16514cda64fca80eb2f678f51e50cbd9732bc44a))
+## [1.6.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.2) - 2025-12-17
 
+- SCSS 토큰 소비처 export 추가
 
-### Features
+## [1.6.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.1) - 2025-12-16
 
-* add automated a11y testing with axe-core in CI ([c279984](https://github.com/Bigtablet/bigtablet-design-system/commit/c279984bb1e1f16d303cb8fc261730f5a18e04b2)), closes [#6B6B6B](https://github.com/Bigtablet/bigtablet-design-system/issues/6B6B6B)
-* add Guide section to Storybook ([a11e97d](https://github.com/Bigtablet/bigtablet-design-system/commit/a11e97ddb2894c91b2b6aa804baec8fd8a5d7e3c))
-* add missing SCSS design tokens and update token structure ([4856e6a](https://github.com/Bigtablet/bigtablet-design-system/commit/4856e6a1908a668fe79544f4129b404c46803651))
-* add mobile responsive layout to Toast component ([f541e91](https://github.com/Bigtablet/bigtablet-design-system/commit/f541e91724c3cfda04035a31338cc62a3e24d951))
-* add new components — IconButton, Chip, FAB, Divider, LinearProgress, ListItem ([9df667d](https://github.com/Bigtablet/bigtablet-design-system/commit/9df667d0e95b368f0107ec6e3ca66badffd901b0))
-* add radius token prop to Button, add preview prop to FileInput ([86c474f](https://github.com/Bigtablet/bigtablet-design-system/commit/86c474f4d0fddf22ef9bbd6bc074adac69bf4c00))
-* add Thin(100) to Black(900) font weight base tokens ([bf7a90b](https://github.com/Bigtablet/bigtablet-design-system/commit/bf7a90bc4a1f74ea472125f4e425a94e2222839e))
-* renew Button component to match Figma DS ([5f87dc4](https://github.com/Bigtablet/bigtablet-design-system/commit/5f87dc4274ac1517f69b4748a5a8a676a09cda26))
-* renew Checkbox component to match Figma DS ([c74ad2d](https://github.com/Bigtablet/bigtablet-design-system/commit/c74ad2dae9173e68f711dcdf1006cc8d6db76e19))
-* TextField 리뉴얼 — Figma DS 기준 outlined + floating label ([2f37d06](https://github.com/Bigtablet/bigtablet-design-system/commit/2f37d06ba22a0f30c08c5a665f68ad63601817a3)), closes [#185](https://github.com/Bigtablet/bigtablet-design-system/issues/185)
-* trigger v2.0.0 major release ([f55a240](https://github.com/Bigtablet/bigtablet-design-system/commit/f55a240fe8932b31aad62f5ce63097e1e2db36c3))
-* v2.0.0 major release ([498f3cd](https://github.com/Bigtablet/bigtablet-design-system/commit/498f3cdc81e1cd9fcd1e83b3fe010bed7594a2d6))
+- Pretendard Safari 폰트 로딩 오류 수정
 
+## [1.6.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.6.0) - 2025-12-16
 
-### BREAKING CHANGES
+- 토큰 스타일링 수정
+- Storybook 설정 수정
 
-* helperText renamed to supportingText in TextField. src/styles restructured to domain-based architecture — import paths changed. src/ui directory flattened — import paths changed. Button, TextField, Checkbox APIs fully renewed.
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-* helperText renamed to supportingText in TextField. src/styles restructured to domain-based architecture — import paths changed. src/ui directory flattened — import paths changed. Button, TextField, Checkbox APIs fully renewed.
+## [1.5.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.5.0) - 2025-12-16
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+- Modal 문서 개선
 
-# [1.24.2](https://github.com/Bigtablet/bigtablet-design-system/compare/v1.24.1...v1.24.2) (2026-04-08)
+## [1.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.4.0) - 2025-12-16
 
+- Button `danger` variant 추가
 
-### Bug Fixes
+## [1.3.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.3.2) - 2025-12-04
 
-* restore exitOnceUploaded for PR Chromatic checks ([55de0f4](https://github.com/Bigtablet/bigtablet-design-system/commit/55de0f4701b99138386f6a46102fade4e60cde42))
+- next 보안 업데이트
 
+## [1.3.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.3.1) - 2025-12-01
 
-# [1.24.1](https://github.com/Bigtablet/bigtablet-design-system/compare/v1.24.0...v1.24.1) (2026-04-03)
+- Select Option export 추가
 
+## [1.3.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.3.0) - 2025-12-01
 
-### Bug Fixes
+- Card heading 텍스트 스타일 추가
+- 자동 설치 상태 수정
 
-* revert a11y test to "todo" (valid value) ([8428970](https://github.com/Bigtablet/bigtablet-design-system/commit/8428970aaae63ad46a27d4613b473c1746cc83c3))
-* skip z-index story from vitest to prevent React hooks teardown error in CI ([b4278f4](https://github.com/Bigtablet/bigtablet-design-system/commit/b4278f4ae76a1e3c5d2a7bc6226d8716091b9f42))
-* use Storybook 10 globals API for viewport auto-switching ([16514cd](https://github.com/Bigtablet/bigtablet-design-system/commit/16514cda64fca80eb2f678f51e50cbd9732bc44a))
+## [1.2.5](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.2.5) - 2025-11-24
 
+- Button size 수정
 
-# [1.24.0](https://github.com/Bigtablet/bigtablet-design-system/compare/v1.23.0...v1.24.0) (2026-04-02)
+## [1.2.4](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.2.4) - 2025-11-18
 
+- 커밋 컨벤션 및 릴리즈 라벨 수정
+- 불필요한 마크다운 파일 삭제
 
-### Features
+## [1.2.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.2.3) - 2025-11-13
 
-* add automated a11y testing with axe-core in CI ([c279984](https://github.com/Bigtablet/bigtablet-design-system/commit/c279984bb1e1f16d303cb8fc261730f5a18e04b2))
+- CSS import 수정
+- 서버 컴포넌트 사용 지원
+- 컴포넌트 export 정리
+
+## [1.2.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.2.2) - 2025-11-11
+
+- Sidebar, Pagination Storybook 수정
+- dist 파일 수정
+- pnpm 버전 언핀
+
+## [1.2.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.2.1) - 2025-11-11
+
+- Next.js 호환성 수정
+- Alert 재설계
+- Storybook 오류 수정, Pretendard 폰트 적용
+
+## [1.1.3](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.1.3) - 2025-11-07
+
+- Divider 클라이언트 지시어 수정
+
+## [1.1.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.1.2) - 2025-11-07
+
+- 클라이언트 컴포넌트 지시어 수정
+
+## [1.1.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.1.0) - 2025-11-06
+
+- Sidebar Next.js 라우팅 지원
+
+## [1.0.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.0.1) - 2025-11-06
+
+- Toast 위치 수정
+
+## [1.0.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.0.0) - 2025-11-06
+
+- 초기 릴리즈 — Button, TextField, Checkbox, Radio, Toggle, Select, Modal, Toast, Card, Chip, Avatar, Badge, Divider, Icon, Pagination, DatePicker, FileInput, Spinner 등 기본 컴포넌트 제공

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ return <div style={style}>...</div>;
 ## Important Files
 
 - `tsup.config.ts` - Build config (dual bundles for React/Next.js + Vanilla)
-- `.releaserc.json` - Semantic Release config
+- `.github/workflows/release.yml` - 태그 기반 배포 (`v*` 태그 → npm publish + GitHub Release)
 - `scripts/copy-scss.mjs` - Copies SCSS to dist
 - `scripts/build-vanilla.mjs` - Builds Vanilla CSS/JS
 - `.github/workflows/ci.yml` - CI/CD pipeline (test + coverage)
@@ -532,6 +532,29 @@ label/domain
 - 병합 커밋 메시지: `merge: branch-name`
 - main 배포: `merge: release`
 - 병합 전 반드시 코드 리뷰어 approve 필요
+
+### Release & Changelog
+**태그 기반 배포** — semantic-release / changeset 미사용. 릴리즈 절차:
+1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `src/index.ts` export — 새 export 추가 시 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+2. `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`
+3. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성
+
+**GitHub Release 노트는 Bigtablet 양식 필수** (title = 버전명만, 예: `v3.2.2`). `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체:
+```
+## Design System of Bigtablet, Inc.
+
+#### Key Updates
+- 핵심 변경 1
+- 핵심 변경 2
+```
+
+**CHANGELOG.md 는 GitHub Releases 를 미러링** — 릴리즈마다 새 버전 섹션을 파일 맨 위에 추가하고 semver 내림차순 유지:
+```
+## [X.Y.Z](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/vX.Y.Z) - YYYY-MM-DD
+- 릴리즈 노트의 Key Updates 불릿과 동일하게
+```
+- Key Updates 불릿만 — 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
+- 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,7 +535,7 @@ label/domain
 
 ### Release & Changelog
 **태그 기반 배포** — semantic-release / changeset 미사용. 릴리즈 절차:
-1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `src/index.ts` export — 새 export 추가 시 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `src/index.ts` export — 하위 호환이 깨지는 변경(export 제거/이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
 2. `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`
 3. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,7 +535,7 @@ label/domain
 
 ### Release & Changelog
 **태그 기반 배포** — semantic-release / changeset 미사용. 릴리즈 절차:
-1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `src/index.ts` export — 하위 호환이 깨지는 변경(export 제거/이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `package.json` `exports` 의 모든 표면 — React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
 2. `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`
 3. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성
 


### PR DESCRIPTION
## 작업 개요

문서 정리분을 main 에 반영한다. **코드 변경 없음 → 버전 bump/npm 배포 불필요** (문서 동기화 목적).

## 포함 (#304)
- **CHANGELOG.md 재생성** — semantic-release 잔재(유령 4.0.0, 깨진 `/issues/` hex 링크, 커밋 본문 덤프, 3.2.x 누락) 제거하고 GitHub Releases 기준 `v1.0.0`~`v3.2.2` 103개 버전을 semver 내림차순 + 날짜 + 링크로 정리
- **CLAUDE.md** — `Release & Changelog` 규칙 추가(태그 기반 배포 절차, GitHub Release Bigtablet 양식, CHANGELOG 미러링 규칙) + stale `.releaserc.json` 참조를 `release.yml` 로 교체

## 검증
- #304 gemini APPROVED (한글 표기 nitpick 5건은 미러링 원칙·하우스 스타일 사유로 보류, non-blocking)
- 문서 전용 변경이라 빌드/테스트 영향 없음

## 참고
- 배포 불필요. 단순 docs 승격이라 머지 후 별도 태그/release 작업 없음.