### PR TITLE
docs/semver-major

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,7 +535,7 @@ label/domain
 
 ### Release & Changelog
 **태그 기반 배포** — semantic-release / changeset 미사용. 릴리즈 절차:
-1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `src/index.ts` export — 새 export 추가 시 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `src/index.ts` export — 하위 호환이 깨지는 변경(export 제거/이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
 2. `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`
 3. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -535,7 +535,7 @@ label/domain
 
 ### Release & Changelog
 **태그 기반 배포** — semantic-release / changeset 미사용. 릴리즈 절차:
-1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `src/index.ts` export — 하위 호환이 깨지는 변경(export 제거/이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `package.json` `exports` 의 모든 표면 — React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
 2. `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`
 3. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성
 


### PR DESCRIPTION
## 작업 개요

PR #305 리뷰(gemini)에서 나온 SemVer 가이드 보강.

## 작업한 내용
- [x] CLAUDE.md `Release & Changelog` 의 버전 bump 규칙에 **major(하위 호환 깨지는 변경)** 추가 — 기존엔 minor/patch 만 명시돼 있었음. export 제거·시그니처 변경·prop 제거 등을 major 로 규정.

## 참고
- 문서 한 줄 변경. #305(dev→main) 머지 전이면 develop 에 먼저 머지 후 #305 에 포함됨.