### PR TITLE
docs/release-changelog-rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,12 +534,25 @@ label/domain
 - 병합 전 반드시 코드 리뷰어 approve 필요
 
 ### Release & Changelog
-**태그 기반 배포** — semantic-release / changeset 미사용. 릴리즈 절차:
-1. `package.json` `version` 수동 bump (SemVer). 공개 API 기준은 `package.json` `exports` 의 모든 표면 — React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
-2. `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`
-3. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성
+**태그 기반 배포** — semantic-release / changeset 미사용. 절차:
 
-**GitHub Release 노트는 Bigtablet 양식 필수** (title = 버전명만, 예: `v3.2.2`). `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체:
+1. **dev→main 릴리즈 PR(`merge: release`)에 아래 둘을 반드시 함께 포함** (별도 커밋으로 미루지 말 것):
+   - `package.json` `version` bump (SemVer). 공개 API 기준은 `package.json` `exports` 의 모든 표면 — React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+   - `CHANGELOG.md` 맨 위에 새 버전 섹션 추가 (아래 양식, semver 내림차순 유지).
+2. 리뷰어 approve 후 머지.
+3. main 에서 `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`.
+4. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성.
+
+**CHANGELOG.md 양식** — 릴리즈 노트와 동일한 Key Updates 를 미러링:
+```
+## [X.Y.Z](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/vX.Y.Z) - YYYY-MM-DD
+- 핵심 변경 1
+- 핵심 변경 2
+```
+- Key Updates 불릿만 — 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
+- 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
+
+**GitHub Release 노트는 Bigtablet 양식 필수** (title = 버전명만, 예: `v3.2.2`) — CHANGELOG 의 해당 버전 Key Updates 를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체:
 ```
 ## Design System of Bigtablet, Inc.
 
@@ -547,14 +560,6 @@ label/domain
 - 핵심 변경 1
 - 핵심 변경 2
 ```
-
-**CHANGELOG.md 는 GitHub Releases 를 미러링** — 릴리즈마다 새 버전 섹션을 파일 맨 위에 추가하고 semver 내림차순 유지:
-```
-## [X.Y.Z](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/vX.Y.Z) - YYYY-MM-DD
-- 릴리즈 노트의 Key Updates 불릿과 동일하게
-```
-- Key Updates 불릿만 — 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
-- 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
 ---
 


### PR DESCRIPTION
## 작업 개요

릴리즈 절차에 **dev→main PR 시 CHANGELOG 동반 갱신**을 명문화한다.

## 작업한 내용
- [x] CLAUDE.md `Release & Changelog` 절차 재구성 — dev→main 릴리즈 PR(`merge: release`)에 `package.json` version bump 와 `CHANGELOG.md` 새 버전 섹션을 **같은 PR 에 함께 포함**하도록 명시(별도 커밋으로 미루지 않음). 머지 후 태그 push → `release.yml` publish, GitHub Release 노트는 CHANGELOG 의 Key Updates 를 그대로 사용.

## 참고
- 문서 한 줄 규칙 추가. (#306 이 머지되며 기존 docs/semver-major 브랜치가 삭제돼, 동일 후속 커밋을 새 브랜치로 분리)