### PR TITLE
docs/structure-refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ This file helps Claude (and other AI assistants) understand the Bigtablet Design
 - **Package Manager**: pnpm@10.20.0 (enforced)
 - **Exports** (`package.json` `exports`):
   - React / Next.js (`.`) - 컴포넌트가 빌드 시 `"use client"` 자동 주입되어 Next App Router 와 호환 (별도 `/next` entry 없음)
-  - Vanilla JS (`/vanilla`) - for Thymeleaf, JSP, PHP, etc.
-  - SCSS 토큰 (`/scss/token`), CSS (`/style.css`)
+  - Vanilla JS (`./vanilla`) - for Thymeleaf, JSP, PHP, etc.
+  - SCSS 토큰 (`./scss/token`), CSS (`./style.css`)
 
 ## Quick Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,10 @@ This file helps Claude (and other AI assistants) understand the Bigtablet Design
 - **Package**: `@bigtablet/design-system` (v1.15.0)
 - **Type**: React 19 component library with TypeScript + Vanilla JS
 - **Package Manager**: pnpm@10.20.0 (enforced)
-- **Exports**:
-  - Pure React (`/`)
-  - Next.js (`/next`)
+- **Exports** (`package.json` `exports`):
+  - React / Next.js (`.`) - 컴포넌트가 빌드 시 `"use client"` 자동 주입되어 Next App Router 와 호환 (별도 `/next` entry 없음)
   - Vanilla JS (`/vanilla`) - for Thymeleaf, JSP, PHP, etc.
+  - SCSS 토큰 (`/scss/token`), CSS (`/style.css`)
 
 ## Quick Commands
 
@@ -26,29 +26,26 @@ pnpm test:storybook # Run a11y tests via Storybook + Playwright
 
 ```
 src/
-├── styles/
-│   ├── token.scss       # SCSS barrel (@forward all domains)
+├── index.ts             # 진입점 (React/Next.js 공용 — 빌드 시 "use client" 자동 주입)
+├── styles/              # 도메인별 디자인 토큰 (각 폴더 _index.scss + index.ts)
+│   ├── token.scss       # SCSS barrel (@forward all domains) — 소비자 @use 진입점
 │   ├── tokens.json      # Designer JSON tokens
-│   ├── colors/          # _index.scss + index.ts per domain
-│   ├── spacing/
-│   ├── typography/
-│   ├── radius/
-│   ├── elevation/
-│   ├── motion/
-│   ├── breakpoints/
-│   ├── opacity/
-│   ├── border-width/
-│   ├── z-index/
-│   ├── skeleton/
-│   ├── a11y/
+│   ├── theme.scss       # :root / [data-theme="dark"] / @media CSS 변수 (style.css 에 포함)
+│   ├── global.css
+│   ├── colors/  spacing/  typography/  radius/  elevation/  motion/
+│   ├── breakpoints/  opacity/  border-width/  z-index/  skeleton/  a11y/
 │   └── layout/          # SCSS only (no TS)
-├── ui/                  # Flat component folders (no category subdirs)
-├── vanilla/       # Vanilla JS package (HTML/CSS/JS)
-│   ├── bigtablet.scss    # All component styles + CSS custom properties
-│   ├── bigtablet.js      # JS utilities (Select, Modal, Alert, etc.)
-│   └── examples/         # HTML usage examples
-├── index.ts       # Pure React entry point
-└── next.ts        # Next.js entry point (reserved for future Next.js-specific exports)
+├── ui/                  # 8 카테고리 폴더 하위에 컴포넌트 폴더
+│   ├── display/  feedback/  forms/  general/
+│   └── layout/  navigation/  overlay/  system/
+├── utils/               # cn + 훅 (use-focus-trap, use-reduced-motion, use-spring-presence/hover, use-safe-layout-effect)
+├── stories/             # Storybook 문서 (foundation / getting-started / cookbook / examples)
+├── test/                # setup.ts (Vitest)
+├── types/               # scss.d.ts
+└── vanilla/             # Vanilla JS 패키지 (HTML/CSS/JS)
+    ├── bigtablet.scss   # 컴포넌트 스타일 + CSS custom properties
+    ├── bigtablet.js     # JS 유틸 (Select, Modal, Alert, etc.)
+    └── examples/        # HTML 사용 예시
 ```
 
 ## Key Conventions
@@ -213,10 +210,10 @@ return <div style={style}>...</div>;
 
 ## Important Files
 
-- `tsup.config.ts` - Build config (dual bundles for React/Next.js + Vanilla)
+- `tsup.config.ts` - Build config (2 bundles: React `index.ts` + Vanilla `bigtablet.js`)
 - `.github/workflows/release.yml` - 태그 기반 배포 (`v*` 태그 → npm publish + GitHub Release)
-- `scripts/copy-scss.mjs` - Copies SCSS to dist
-- `scripts/build-vanilla.mjs` - Builds Vanilla CSS/JS
+- `scripts/copy-scss.sh` - Copies SCSS to dist
+- `scripts/build-vanilla.sh` - Builds Vanilla CSS/JS
 - `.github/workflows/ci.yml` - CI/CD pipeline (test + coverage)
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,7 +251,7 @@ export default defineConfig([
         entry: { index: "src/index.ts" },
         format: ["esm"],
         dts: true,
-        external: ["react", "react-dom"],
+        external: ["react", "react-dom", "lucide-react", "react-toastify", "react-markdown", "remark-gfm"],
     },
     // Vanilla JS 번들 (IIFE, 전역 Bigtablet)
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,73 +9,47 @@ Bigtablet Design System의 프로젝트 구조 및 아키텍처 문서입니다.
 ```
 bigtablet-design-system/
 ├── src/
+│   ├── index.ts             # React/Next.js 공용 진입점 (빌드 시 "use client" 자동 주입)
+│   │
 │   ├── styles/              # 도메인별 디자인 토큰 (각 폴더에 _index.scss + index.ts)
-│   │   ├── token.scss       # SCSS barrel (@forward all domains)
+│   │   ├── token.scss       # SCSS barrel (@forward all domains) — 소비자 @use 진입점
 │   │   ├── tokens.json      # 디자이너 JSON 토큰
-│   │   ├── colors/
-│   │   ├── spacing/
-│   │   ├── typography/
-│   │   ├── radius/
-│   │   ├── shadows/
-│   │   ├── motion/
-│   │   ├── breakpoints/
-│   │   ├── opacity/
-│   │   ├── border-width/
-│   │   ├── z-index/
-│   │   ├── skeleton/
-│   │   ├── a11y/
+│   │   ├── theme.scss       # :root / [data-theme="dark"] / @media CSS 변수 (style.css 에 포함)
+│   │   ├── global.css
+│   │   ├── colors/  spacing/  typography/  radius/  elevation/  motion/
+│   │   ├── breakpoints/  opacity/  border-width/  z-index/  skeleton/  a11y/
 │   │   └── layout/          # SCSS only
 │   │
-│   ├── ui/                  # UI 컴포넌트 (플랫 구조)
-│   │   ├── alert/
-│   │   ├── button/
-│   │   ├── card/
-│   │   ├── checkbox/
-│   │   ├── chip/
-│   │   ├── date-picker/
-│   │   ├── divider/
-│   │   ├── fab/
-│   │   ├── file/
-│   │   ├── icon-button/
-│   │   ├── linear-progress/
-│   │   ├── list-item/
-│   │   ├── modal/
-│   │   ├── pagination/
-│   │   ├── radio/
-│   │   ├── dropdown/
-│   │   ├── select/              # deprecated - re-exports Dropdown
-│   │   ├── spinner/
-│   │   ├── switch/
-│   │   ├── textfield/
-│   │   ├── toast/
-│   │   └── top-loading/
+│   ├── ui/                  # UI 컴포넌트 — 8 카테고리 폴더 하위에 컴포넌트
+│   │   ├── display/         # accordion avatar badge card chip divider hero icon list-item media-card table
+│   │   ├── feedback/        # alert empty-state error-state linear-progress skeleton spinner toast top-loading
+│   │   ├── forms/           # checkbox date-picker dropdown file otp-input radio radio-group textarea textfield toggle
+│   │   ├── general/         # button icon-button
+│   │   ├── layout/          # container grid section stack
+│   │   ├── navigation/      # bottom-nav breadcrumb menu nav-bar pagination sidebar tabs
+│   │   ├── overlay/         # modal popover tooltip
+│   │   └── system/          # theme-provider
 │   │
-│   ├── utils/               # 유틸리티 함수
-│   │   ├── cn.ts            # className 유틸리티
-│   │   ├── use-focus-trap.ts  # Focus trap hook
+│   ├── utils/               # cn + 훅
+│   │   ├── cn.ts
+│   │   ├── use-focus-trap.ts
+│   │   ├── use-reduced-motion.ts
+│   │   ├── use-spring-presence.ts  /  use-spring-hover.ts
+│   │   ├── use-safe-layout-effect.ts
 │   │   └── index.ts
 │   │
-│   ├── vanilla/             # Vanilla JS 패키지
-│   │   ├── bigtablet.scss
-│   │   ├── bigtablet.js
-│   │   └── examples/
-│   │
-│   ├── index.ts             # Pure React 진입점
-│   └── next.ts              # Next.js 진입점
+│   ├── stories/             # Storybook 문서 (foundation / getting-started / cookbook / examples)
+│   ├── test/                # setup.ts (Vitest)
+│   ├── types/               # scss.d.ts
+│   └── vanilla/             # Vanilla JS 패키지
+│       ├── bigtablet.scss
+│       ├── bigtablet.js
+│       └── examples/
 │
-├── docs/                    # 문서
-│   ├── COMPONENTS.md
-│   ├── VANILLA.md
-│   ├── ARCHITECTURE.md
-│   ├── CONTRIBUTING.md
-│   └── TESTING.md
-│
-├── .github/
-│   └── workflows/
-│       └── ci.yml           # CI/CD 파이프라인
-│
+├── docs/                    # 문서 (COMPONENTS, VANILLA, ARCHITECTURE, CONTRIBUTING, TESTING, AGENT_GUIDE)
+├── .github/workflows/       # ci.yml (CI), release.yml (태그 배포)
 ├── .storybook/              # Storybook 설정
-├── scripts/                 # 빌드 스크립트
+├── scripts/                 # 빌드 스크립트 (copy-scss.sh, build-vanilla.sh, ...)
 ├── tsup.config.ts           # 빌드 설정
 ├── vitest.config.ts         # 테스트 설정
 └── package.json
@@ -195,26 +169,17 @@ cn(styles.button, styles[`size_${size}`], className);
 
 ## 진입점 (Entry Points)
 
-### Pure React (`/`)
+### React / Next.js (`.`)
 
 ```ts
-// src/index.ts
+// src/index.ts — 모든 컴포넌트·훅·유틸 re-export
 export * from "./ui/general/button";
-export * from "./ui/dropdown";
-export * from "./ui/select";    // deprecated alias
-export * from "./ui/form/textfield";
+export * from "./ui/forms/textfield";
+export { cn, useReducedMotion } from "./utils";
 // ... 모든 컴포넌트 export
 ```
 
-### Next.js (`/next`)
-
-```ts
-// src/next.ts
-// Next.js-specific components
-// Currently all components are framework-agnostic.
-// This entry point is reserved for future Next.js-specific exports.
-export {};
-```
+별도 `/next` entry 는 없다. 컴포넌트가 `"use client"` 로 마킹되고(빌드 시 tsup 가 `dist/index.js` 선두에 자동 주입) `next` 가 optional peer dependency 라, 동일한 `.` export 로 Next.js App Router 에서 그대로 동작한다.
 
 ### Vanilla JS (`/vanilla`)
 
@@ -281,35 +246,32 @@ $transition_base: 0.2s ease-in-out;
 import { defineConfig } from "tsup";
 
 export default defineConfig([
-    // React 번들
+    // React 번들 (Next.js 공용) — 빌드 후 dist/index.js 선두에 "use client" 주입
     {
-        entry: ["src/index.ts"],
-        format: ["cjs", "esm"],
+        entry: { index: "src/index.ts" },
+        format: ["esm"],
         dts: true,
         external: ["react", "react-dom"],
     },
-    // Next.js 번들
+    // Vanilla JS 번들 (IIFE, 전역 Bigtablet)
     {
-        entry: ["src/next.ts"],
-        format: ["cjs", "esm"],
-        dts: true,
-        external: ["react", "react-dom", "next"],
+        entry: { "vanilla/bigtablet": "src/vanilla/bigtablet.js" },
+        format: ["iife"],
+        globalName: "Bigtablet",
     },
 ]);
 ```
+
+별도 Next.js 번들은 없다 (React 번들이 `"use client"` 마킹으로 Next 호환). SCSS 복사·Vanilla CSS 빌드는 `pnpm build` 가 `scripts/copy-scss.sh` · `scripts/build-vanilla.sh` 로 처리.
 
 ### 빌드 출력
 
 ```
 dist/
-├── index.js           # CJS (React)
-├── index.mjs          # ESM (React)
+├── index.js           # ESM (React/Next.js)
 ├── index.d.ts         # TypeScript 타입
-├── next.js            # CJS (Next.js)
-├── next.mjs           # ESM (Next.js)
-├── next.d.ts          # TypeScript 타입
-├── style.css          # 통합 스타일
-├── scss/              # SCSS 토큰
+├── index.css          # 통합 스타일 (= style.css, theme.scss CSS 변수 포함)
+├── styles/token.scss  # SCSS 토큰 (/scss/token)
 └── vanilla/           # Vanilla JS 패키지
     ├── bigtablet.css
     ├── bigtablet.min.css

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
 	],
 	"sideEffects": [
 		"**/*.css",
-		"**/*.scss",
-		"./dist/next.css"
+		"**/*.scss"
 	],
 	"scripts": {
 		"build": "tsup && pnpm run copy:scss && pnpm run build:vanilla",


### PR DESCRIPTION
## 작업 개요

구조/빌드/exports 문서가 실제 레포와 어긋나 있어 정합화한다. (순수 문서 + 죽은 참조 1줄 정리, 코드 동작 변경 없음)

## 배경
- `/next`·`src/next.ts`·tsup Next 번들은 commit `dfe9c7e`("remove dead next.ts bundle")에서 이미 제거됨. 문서와 `package.json` sideEffects 에만 잔재가 남아있었음.
- Next.js 는 별도 `/next` 없이 메인 `.` export 로 지원 (빌드 시 `"use client"` 자동 주입).

## 작업한 내용
**CLAUDE.md**
- [x] Exports: `/next` 제거 → `.`(React/Next) · `/vanilla` · `/scss/token` · `/style.css`
- [x] Architecture 다이어그램: `ui/` "flat" → 8 카테고리, `next.ts` 제거, `utils`/`stories`/`test`/`types` 추가, `styles` 에 `theme.scss`/`global.css` 추가
- [x] Important Files: tsup "dual React/Next" → "React+Vanilla 2 번들", `scripts/*.mjs` → `.sh`

**docs/ARCHITECTURE.md**
- [x] 구조 다이어그램 전면 정합화 (구식 flat ui 목록 → 8 카테고리 실제 컴포넌트, `shadows/`→`elevation/`, next.ts 제거, stories/test/types/theme.scss/global.css 추가, utils 훅 5종)
- [x] Entry Points: `/next` 섹션 삭제 → `.` 단일 진입점(Next 호환) 설명
- [x] tsup 설정/`dist` 출력 블록: cjs+esm+next → 실제 (ESM React + IIFE Vanilla, next 산출물 제거)

**package.json**
- [x] `sideEffects` 의 고아 참조 `./dist/next.css` 제거

## 검증
- `pnpm build` 통과, `dist` 에 `next.*` 없음, sideEffects = `["**/*.css","**/*.scss"]`
- 다이어그램 디렉토리 ↔ 실제 `ls src/`·`ls src/ui/`·`ls src/styles/` 1:1 매칭
- 잔재 grep(`next.ts`/`flat`/`shadows`/`.mjs`/`dual bundle`) 0 (남은 `/next` 매치는 "entry 없음" 설명문)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 프로젝트 진입점 및 패키지 노출 방식에 대한 설명이 명확히 업데이트됨
  * 프로젝트 구조 및 아키텍처 문서가 리정리되어 스타일 토큰 구조와 UI 컴포넌트 분류 방식이 개선됨

* **Chores**
  * 빌드 설정 및 번들 구성 관련 문서 안내가 현행화됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->