### PR TITLE
feat/export-use-reduced-motion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import "./styles/theme.scss";
 
 // Hooks / Utils
 
-export { cn, useFocusTrap, useSpringHover, useSpringPresence } from "./utils";
+export { cn, useFocusTrap, useReducedMotion, useSpringHover, useSpringPresence } from "./utils";
 
 // New primitives (v3.0)
 


### PR DESCRIPTION
## 작업 개요

공개 훅 export 표면을 일관화한다.

## 배경
- `src/index.ts` 가 `useFocusTrap` / `useSpringHover` / `useSpringPresence` 는 공개 export 하면서, 소비자가 직접 애니메이션 만들 때 유용한 `useReducedMotion` 만 미export 였다 (구조 점검 중 발견한 불일치).

## 작업한 내용
- [x] `useReducedMotion` 을 패키지 entry(`src/index.ts`) 배럴에 추가 — 모션 관련 훅(spring 2종 + reduced-motion) 표면 일관화. 추가 export 라 하위호환(additive, SemVer minor).
- [x] `useSafeLayoutEffect` 는 저수준 SSR layout-effect shim 이라 내부 전용 유지(공개 대상 아님).

## 검증
- `pnpm build` 통과, `dist/index.d.ts` 에 `useReducedMotion` export 확인.
- 훅 자체 회귀 테스트(`use-reduced-motion.test.ts`)는 기존 통과.

## 참고
- 신규 공개 export → 다음 릴리즈는 minor 권장 (CLAUDE.md SemVer 규칙).