### PR TITLE
config: group react ecosystem in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,19 @@ updates:
       - dependencies
     commit-message:
       prefix: "config"
+    groups:
+      # react/react-dom 는 반드시 같은 버전이어야 함 — 한 PR 로 묶어 버전 불일치 방지
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      # Storybook 패키지 다발 — 노이즈 감소 위해 묶음
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
     ignore:
       # major 버전 업은 수동으로 검토
       - dependency-name: "*"


### PR DESCRIPTION
## 작업 개요

dependabot 의 npm 업데이트에 `groups` 를 추가해 버전 불일치를 방지한다. **자동 머지는 도입하지 않음** — PR 리뷰/머지는 수동 유지.

## 배경
- #312 는 dependabot 이 `react` 만 19.2.6→19.2.7 올리고 `react-dom` 은 안 올려, react/react-dom 버전 불일치로 **테스트 47개 스위트 전부 실패**한 사례 (→ #315 로 수동 수정).
- 근본 원인은 react 계열이 묶이지 않아 따로/부분 bump 된 것.

## 작업한 내용
- [x] `react` 그룹 — `react` / `react-dom` / `@types/react` / `@types/react-dom` 를 한 PR 로 묶어 항상 lockstep bump → mismatch 재발 방지
- [x] `storybook` 그룹 — `storybook` / `@storybook/*` 묶어 PR 노이즈 감소
- major 무시 규칙은 그대로 유지

## 참고
- dependabot 설정은 기본 브랜치(main)에서 읽히므로, develop 머지 후 다음 릴리즈로 main 에 반영되면 적용됨.
- 자동 머지(워크플로우/branch protection)는 도입하지 않음.