### PR TITLE
fix: drop stale /next import paths

### DIFF
--- a/.claude/docs/design-system.md
+++ b/.claude/docs/design-system.md
@@ -20,7 +20,7 @@ Complete reference for AI assistants to generate code using the Bigtablet Design
 import { Button, TextField, Dropdown, Modal, Card } from '@bigtablet/design-system';
 import '@bigtablet/design-system/style.css';  // REQUIRED
 
-// Next.js - use this when you need Sidebar (uses next/link internally)
+// Sidebar uses next/link internally — works in Next.js App Router
 import { Sidebar, Button } from '@bigtablet/design-system';
 import '@bigtablet/design-system/style.css';  // REQUIRED
 
@@ -556,7 +556,7 @@ const [page, setPage] = useState(1);
 ### Sidebar (Next.js Only)
 
 ```tsx
-// IMPORTANT: Import from /next
+// Sidebar — main package export (Next.js App Router 호환)
 import { Sidebar } from '@bigtablet/design-system';
 import { Home, Users, Settings } from 'lucide-react';
 

--- a/.claude/docs/design-system.md
+++ b/.claude/docs/design-system.md
@@ -21,7 +21,7 @@ import { Button, TextField, Dropdown, Modal, Card } from '@bigtablet/design-syst
 import '@bigtablet/design-system/style.css';  // REQUIRED
 
 // Next.js - use this when you need Sidebar (uses next/link internally)
-import { Sidebar, Button } from '@bigtablet/design-system/next';
+import { Sidebar, Button } from '@bigtablet/design-system';
 import '@bigtablet/design-system/style.css';  // REQUIRED
 
 // Provider components - need wrapper setup
@@ -557,7 +557,7 @@ const [page, setPage] = useState(1);
 
 ```tsx
 // IMPORTANT: Import from /next
-import { Sidebar } from '@bigtablet/design-system/next';
+import { Sidebar } from '@bigtablet/design-system';
 import { Home, Users, Settings } from 'lucide-react';
 
 const items = [
@@ -890,7 +890,7 @@ function DataLoader() {
 ```tsx
 'use client';
 import { usePathname } from 'next/navigation';
-import { Sidebar } from '@bigtablet/design-system/next';
+import { Sidebar } from '@bigtablet/design-system';
 import { Home, Users } from 'lucide-react';
 
 const menuItems = [

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -100,7 +100,7 @@ info "Wrap your app with the required providers:"
 if [ "$ENV" = "nextjs" ]; then
   printf "\n"
   code "// app/layout.tsx"
-  code "import { AlertProvider, ToastProvider } from '@bigtablet/design-system/next';"
+  code "import { AlertProvider, ToastProvider } from '@bigtablet/design-system';"
   code ""
   code "export default function RootLayout({ children }) {"
   code "  return ("


### PR DESCRIPTION
## 작업 개요

PR #318 리뷰(coderabbit)에서 발견한 `/next` import 잔재 정리. `/next` entry 는 이미 제거됐는데 온보딩 스크립트·docs 예시에 import 경로가 남아있었다.

## 작업한 내용
- [x] `scripts/setup.sh` Next.js 예시 — `@bigtablet/design-system/next` → `@bigtablet/design-system` (coderabbit 지적). AlertProvider/ToastProvider 는 메인 export 에 존재.
- [x] `.claude/docs/design-system.md` import 예시 3곳 동일 정정

## 검증
- repo 전체 `design-system/next` 잔재 grep → 0 (node_modules/dist/CHANGELOG 제외)

## 참고
- #318(dev→main)에 develop 머지되면 함께 반영.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **문서**
  * 디자인 시스템 설명서의 여러 코드 예제에서 라이브러리 import 경로를 통일하여 일관성을 개선했습니다.
  * Sidebar 컴포넌트 관련 예제 및 Next.js 레이아웃 구현 가이드의 import 경로를 최신화했습니다.

* **설정**
  * 프로젝트 초기 설정 가이드 스크립트에서 제공하는 코드 예시의 import 경로를 일관되게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->