### PR TITLE
fix/review-batch-a

### DIFF
--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -143,8 +143,11 @@ export const ToastProvider = ({
 		setToasts((prev) => prev.filter((t) => t.id !== id));
 	}, []);
 
+	// addToast 는 stable(useCallback) — value 객체만 메모이즈해 소비자 불필요 리렌더 방지
+	const contextValue = React.useMemo(() => ({ addToast }), [addToast]);
+
 	return (
-		<ToastContext.Provider value={{ addToast }}>
+		<ToastContext.Provider value={contextValue}>
 			{children}
 			{isMounted &&
 				createPortal(

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -41,6 +41,7 @@ export const Button = ({
 	fullWidth = false,
 	radius,
 	danger = false,
+	type = "button",
 	className,
 	children,
 	...props
@@ -56,7 +57,7 @@ export const Button = ({
 	);
 
 	return (
-		<button className={buttonClassName} {...props}>
+		<button type={type} className={buttonClassName} {...props}>
 			{leadingIcon && (
 				<span className="button_icon" aria-hidden="true">
 					{leadingIcon}

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -26,6 +26,7 @@ export const IconButton = ({
 	variant = "standard",
 	size = "md",
 	icon,
+	type = "button",
 	className,
 	...props
 }: IconButtonProps) => {
@@ -37,7 +38,7 @@ export const IconButton = ({
 	);
 
 	return (
-		<button className={buttonClassName} {...props}>
+		<button type={type} className={buttonClassName} {...props}>
 			<span className="icon_button_icon" aria-hidden="true">
 				{icon}
 			</span>

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { ChevronDown, Globe } from "lucide-react";
-import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type * as React from "react";
-import { cn } from "../../../utils";
+import { cn, useSafeLayoutEffect } from "../../../utils";
 import "./style.scss";
 
 export type NavBarVariant = "default" | "transparent" | "accent";
@@ -89,7 +89,7 @@ export const NavBar = ({
 	const [indicator, setIndicator] = useState<{ left: number; width: number } | null>(null);
 	const [hasMounted, setHasMounted] = useState(false);
 
-	useLayoutEffect(() => {
+	useSafeLayoutEffect(() => {
 		const links = linksRef.current;
 		if (!links) return;
 

--- a/src/ui/navigation/tabs/index.tsx
+++ b/src/ui/navigation/tabs/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "../../../utils";
+import { cn, useSafeLayoutEffect } from "../../../utils";
 import "./style.scss";
 
 export type TabsVariant = "line" | "fills";
@@ -101,7 +101,7 @@ export const TabList = ({ ariaLabel, className, children, ...props }: TabListPro
 	const [hasMounted, setHasMounted] = React.useState(false);
 
 	// active tab 위치 추적 - sliding indicator (line=underline / fills=filled box)
-	React.useLayoutEffect(() => {
+	useSafeLayoutEffect(() => {
 		const list = listRef.current;
 		if (!list) return;
 


### PR DESCRIPTION
## 작업 개요

코드 리뷰 후속 — 비파괴 컴포넌트 fix (batch A 코드 파트).

## 작업한 내용
- [x] **Button / IconButton** `type` 디폴트 `"button"` — `<button {...props}>` 만이라 브라우저 기본 `submit` 으로 동작해 form 내 오submit 위험이었음. biome `useButtonType:"error"` 충족.
- [x] **Toast** Provider `value={{ addToast }}` → `useMemo` (addToast 는 이미 `useCallback` 으로 stable). `useToast` 소비 컴포넌트의 불필요 리렌더 방지.
- [x] **Tabs / NavBar** raw `React.useLayoutEffect` → 기존 `useSafeLayoutEffect` 유틸. Next App Router SSR 경고 제거.

## 검증
- `pnpm test` 605 passed / `pnpm build` OK
- `biome lint` button/icon-button 위반 0

## 참고
- batch A 나머지(ci.yml/release.yml/CHANGELOG/문서) + B(토큰 SSOT) + C(a11y) + D(분석)는 후속 PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 버튼과 아이콘 버튼의 기본 `type`이 `button`으로 명시되어, 폼 안에서 의도치 않은 제출이 발생할 가능성을 줄였습니다.
  * 네비게이션 바와 탭의 강조 표시가 더 안정적으로 갱신되도록 개선했습니다.

* **성능 개선**
  * 토스트 컨텍스트 값과 일부 레이아웃 계산을 최적화해 불필요한 리렌더와 화면 깜빡임 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->