### PR TITLE
fix/token-ssot-sync

### DIFF
--- a/src/styles/colors/index.ts
+++ b/src/styles/colors/index.ts
@@ -18,10 +18,14 @@ export const baseColors = {
 	neutral925: "#141414",
 	neutral950: "#0A0A0A",
 
-	statusError: "#EF4444",
-	statusSuccess: "#10B981",
-	statusWarning: "#F59E0B",
-	statusInfo: "#3B82F6",
+	// caption 전용 AA 값 (neutral_500 과 분리 — SCSS _index.scss 와 동일)
+	textCaptionLight: "#6F6F6F",
+
+	// status — SCSS _index.scss 와 동일한 AA 통과(red/green/amber/blue-700) 값
+	statusError: "#B91C1C",
+	statusSuccess: "#047857",
+	statusWarning: "#B45309",
+	statusInfo: "#1D4ED8",
 
 	alphaBlack5: "rgba(0, 0, 0, 0.05)",
 	alphaBlack8: "rgba(0, 0, 0, 0.08)",
@@ -44,7 +48,7 @@ export const colors = {
 	text: {
 		heading: baseColors.neutral900,
 		body: baseColors.neutral700,
-		caption: baseColors.neutral500,
+		caption: baseColors.textCaptionLight,
 		brand: baseColors.brandPrimary,
 		inverse: baseColors.neutral0,
 		disabled: baseColors.alphaBlack38,


### PR DESCRIPTION
## 작업 개요 (Critical — 코드 리뷰)

공개 export 인 `colors`/`baseColors`(`src/index.ts`)의 status·caption 값이 구버전(접근성 미달)으로 남아 SCSS `_index.scss`·`tokens.json` 의 AA 값과 **분기**돼 있었다. 소비자가 JS 로 status/caption 색을 읽으면 실제 CSS 렌더와 다른 **AA 미달 색**을 받았고, `colors.stories` 색상 문서도 실제 컴포넌트와 불일치였다.

## 작업한 내용
- [x] `statusError` `#EF4444`→`#B91C1C`, `statusSuccess` `#10B981`→`#047857`, `statusWarning` `#F59E0B`→`#B45309`, `statusInfo` `#3B82F6`→`#1D4ED8` (전부 *-700, `#fff` 대비 5+:1) — SCSS 와 일치
- [x] `text.caption` `neutral500(#888888, 3.5:1)` → 신규 `textCaptionLight #6F6F6F`(AA, SCSS `$color_base_text_caption_light` 와 동일)

## 검증
- `pnpm test` pass / `pnpm test:storybook` 264 / `pnpm build` OK
- TS `colors` ↔ SCSS `_index.scss` status/caption 값 일치 확인

## 참고
- 근본책(tokens.json → SCSS+TS 코드젠 SSOT)은 별도 후속. 이번엔 값 동기화(correctness, 비파괴).