### PR TITLE
fix/review-batch-c

### DIFF
--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -89,6 +89,8 @@ export const Accordion = ({
 							role="region"
 							aria-labelledby={headerId}
 							aria-hidden={!isOpen}
+							// 닫힌 패널은 grid 애니메이션이라 display:none 이 아님 → inert 로 내부 포커스 차단 (WCAG 4.1.2)
+							inert={!isOpen}
 							className={cn("accordion_panel", isOpen && "accordion_panel_open")}
 						>
 							<div className="accordion_panel_wrap">

--- a/src/ui/display/list-item/index.tsx
+++ b/src/ui/display/list-item/index.tsx
@@ -69,7 +69,8 @@ export const ListItem = ({
 				if (disabled || !onClick) return;
 				if (e.key === "Enter" || e.key === " ") {
 					e.preventDefault();
-					onClick(e as unknown as React.MouseEvent<HTMLDivElement>);
+					// 실제 click 디스패치 → onClick 이 진짜 MouseEvent 로 호출됨 (가짜 캐스팅 제거)
+					e.currentTarget.click();
 				}
 			}}
 			role={onClick ? "button" : undefined}

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -83,12 +83,17 @@ export const Modal = ({
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
-	const handleEscape = React.useEffectEvent((e: KeyboardEvent) => {
-		if (e.key === "Escape") onClose?.();
+	// onClose 를 ref 로 보관 — useEffectEvent(React 19.2+) 대신 ref 패턴으로 peer react ^19 전체 호환
+	const onCloseRef = React.useRef(onClose);
+	React.useEffect(() => {
+		onCloseRef.current = onClose;
 	});
 
 	React.useEffect(() => {
 		if (!open) return;
+		const handleEscape = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onCloseRef.current?.();
+		};
 		document.addEventListener("keydown", handleEscape);
 		return () => document.removeEventListener("keydown", handleEscape);
 	}, [open]);

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -71,11 +71,26 @@ export const Tooltip = ({
 
 	const style = useSpringPresence({ visible: open, from: fromTransform });
 
-	const trigger = React.cloneElement(children as React.ReactElement<React.HTMLAttributes<HTMLElement>>, {
-		onMouseEnter: show,
-		onMouseLeave: hide,
-		onFocus: show,
-		onBlur: hide,
+	const child = children as React.ReactElement<React.HTMLAttributes<HTMLElement>>;
+	const childProps = child.props;
+	// 자식의 기존 핸들러를 보존하고 tooltip 핸들러를 합성 (덮어쓰기 방지)
+	const trigger = React.cloneElement(child, {
+		onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
+			childProps.onMouseEnter?.(e);
+			show();
+		},
+		onMouseLeave: (e: React.MouseEvent<HTMLElement>) => {
+			childProps.onMouseLeave?.(e);
+			hide();
+		},
+		onFocus: (e: React.FocusEvent<HTMLElement>) => {
+			childProps.onFocus?.(e);
+			show();
+		},
+		onBlur: (e: React.FocusEvent<HTMLElement>) => {
+			childProps.onBlur?.(e);
+			hide();
+		},
 		"aria-describedby": open ? tooltipId : undefined,
 	} as React.HTMLAttributes<HTMLElement>);
 

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -91,7 +91,10 @@ export const Tooltip = ({
 			childProps.onBlur?.(e);
 			hide();
 		},
-		"aria-describedby": open ? tooltipId : undefined,
+		// 자식의 기존 aria-describedby 보존 + tooltip id 합성 (폼 설명/에러 연결 끊김 방지)
+		"aria-describedby": open
+			? [childProps["aria-describedby"], tooltipId].filter(Boolean).join(" ")
+			: childProps["aria-describedby"],
 	} as React.HTMLAttributes<HTMLElement>);
 
 	if (disabled) return children;


### PR DESCRIPTION
## 작업 개요
코드 리뷰 후속 — 경계 명확한 a11y/안정성 fix (비파괴).

## 작업한 내용
- **Modal** — `React.useEffectEvent`(React 19.2+) → `useRef` 패턴. peer `react ^19` 의 19.0/19.1 에서 `useEffectEvent is not a function` 크래시 제거 (peer 범위 유지).
- **Tooltip** — `cloneElement` 가 자식의 기존 `onMouseEnter/Leave/Focus/Blur` 를 덮어쓰던 것 → 합성(자식 핸들러 보존 후 tooltip 동작 추가).
- **ListItem** — 키보드 활성화 시 `onClick(e as unknown as MouseEvent)` 가짜 캐스팅 제거 → `e.currentTarget.click()` 로 실제 click 디스패치(소비자가 진짜 MouseEvent 수신).
- **Accordion** — 닫힌 패널(grid 애니메이션이라 `display:none` 아님)에 `inert` 추가 → focusable-but-hidden(WCAG 4.1.2) 해소.

## 검증
- `pnpm test` 605 / `pnpm test:storybook` 264 / `pnpm build` OK (DTS 타입 통과)

## 남은 리뷰 항목 (후속)
- C 큰 것: Menu/NavBar 화살표키 네비(APG), Dropdown `aria-activedescendant`, FileInput cleanup deps
- D: ThemeProvider SSR hydration/FOUC, ref-as-prop 27개, props 네이밍 통일·react-spring peer(=major, 별도 논의)