### PR TITLE
fix/review-batch-e

### DIFF
--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -94,14 +94,17 @@ export const FileInput = ({
 		onFiles?.(null);
 	};
 
-	// cleanup on unmount
+	// unmount 시에만 마지막 URL 정리. 변경 시 revoke 는 handleChange/handleRemove 가 담당하므로
+	// deps 를 [previewUrls] 로 두면 변경마다 cleanup 이 돌아 이중 revoke 가 된다 → ref 로 최신값 추적.
+	const previewUrlsRef = React.useRef<string[]>([]);
+	previewUrlsRef.current = previewUrls;
 	React.useEffect(() => {
 		return () => {
-			for (const url of previewUrls) {
+			for (const url of previewUrlsRef.current) {
 				URL.revokeObjectURL(url);
 			}
 		};
-	}, [previewUrls]);
+	}, []);
 
 	const hasImage = previewUrls.length > 0;
 	const rootClassName = cn(

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -97,7 +97,10 @@ export const FileInput = ({
 	// unmount 시에만 마지막 URL 정리. 변경 시 revoke 는 handleChange/handleRemove 가 담당하므로
 	// deps 를 [previewUrls] 로 두면 변경마다 cleanup 이 돌아 이중 revoke 가 된다 → ref 로 최신값 추적.
 	const previewUrlsRef = React.useRef<string[]>([]);
-	previewUrlsRef.current = previewUrls;
+	// 최신 previewUrls 를 effect 에서 동기화 — render phase 에서 ref 직접 수정 금지(concurrent/strict 안전)
+	React.useEffect(() => {
+		previewUrlsRef.current = previewUrls;
+	}, [previewUrls]);
 	React.useEffect(() => {
 		return () => {
 			for (const url of previewUrlsRef.current) {

--- a/src/ui/navigation/menu/Menu.test.tsx
+++ b/src/ui/navigation/menu/Menu.test.tsx
@@ -305,4 +305,93 @@ describe("Menu", () => {
 		unmount();
 		expect(() => fireEvent.keyDown(document, { key: "Escape" })).not.toThrow();
 	});
+
+	it("focuses first enabled item when opened (APG menu button)", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getAllByRole("menuitem")[0]).toHaveFocus();
+	});
+
+	it("moves focus with ArrowDown / ArrowUp (wraps)", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const menu = screen.getByRole("menu");
+		const items = screen.getAllByRole("menuitem");
+		fireEvent.keyDown(menu, { key: "ArrowDown" });
+		expect(items[1]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "ArrowDown" });
+		expect(items[0]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "ArrowUp" });
+		expect(items[1]).toHaveFocus();
+	});
+
+	it("Home / End jump to first / last item", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+					{ key: "c", label: "C" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const menu = screen.getByRole("menu");
+		const items = screen.getAllByRole("menuitem");
+		fireEvent.keyDown(menu, { key: "End" });
+		expect(items[2]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "Home" });
+		expect(items[0]).toHaveFocus();
+	});
+
+	it("skips disabled items during arrow navigation", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B", disabled: true },
+					{ key: "c", label: "C" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const menu = screen.getByRole("menu");
+		const items = screen.getAllByRole("menuitem");
+		expect(items[0]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "ArrowDown" });
+		expect(items[2]).toHaveFocus();
+	});
+
+	it("Escape closes and returns focus to the trigger", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Open" });
+		fireEvent.click(trigger);
+		fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+		expect(trigger).toHaveFocus();
+	});
+
 });

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -43,6 +43,7 @@ export interface MenuProps {
 export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 	const [open, setOpen] = React.useState(false);
 	const wrapperRef = React.useRef<HTMLSpanElement>(null);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
 	const menuId = React.useId();
 
 	const style = useSpringPresence({ visible: open, from: "translateY(-4px)" });
@@ -63,6 +64,56 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 		};
 	}, [open]);
 
+	// 열릴 때 첫 활성 아이템에 포커스 (WAI-ARIA menu button 패턴). 이미 메뉴 내부에 포커스가
+	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음.
+	React.useEffect(() => {
+		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		const first = items.findIndex((it) => !it.disabled);
+		if (first >= 0) itemRefs.current[first]?.focus();
+	}, [open, items]);
+
+	// 화살표/Home/End 로 메뉴 아이템 간 roving 포커스
+	const moveFocus = (dir: 1 | -1 | "first" | "last") => {
+		const enabled = items.flatMap((it, i) => (it.disabled ? [] : [i]));
+		if (enabled.length === 0) return;
+		if (dir === "first") return void itemRefs.current[enabled[0]]?.focus();
+		if (dir === "last") return void itemRefs.current[enabled[enabled.length - 1]]?.focus();
+		const pos = enabled.findIndex((i) => itemRefs.current[i] === document.activeElement);
+		const next =
+			pos < 0 ? (dir === 1 ? 0 : enabled.length - 1) : (pos + dir + enabled.length) % enabled.length;
+		itemRefs.current[enabled[next]]?.focus();
+	};
+
+	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				moveFocus(1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				moveFocus(-1);
+				break;
+			case "Home":
+				e.preventDefault();
+				moveFocus("first");
+				break;
+			case "End":
+				e.preventDefault();
+				moveFocus("last");
+				break;
+			case "Escape":
+				e.preventDefault();
+				setOpen(false);
+				// trigger 로 포커스 복귀
+				wrapperRef.current?.querySelector<HTMLElement>("[aria-haspopup]")?.focus();
+				break;
+			case "Tab":
+				setOpen(false);
+				break;
+		}
+	};
+
 	const triggerWithProps = React.cloneElement(
 		trigger as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
 		{
@@ -82,12 +133,17 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 					role="menu"
 					style={style}
 					className={cn("menu", `menu_align_${align}`)}
+					onKeyDown={handleMenuKeyDown}
 				>
-					{items.map((item) => (
+					{items.map((item, index) => (
 						<button
 							key={item.key}
+							ref={(el) => {
+								itemRefs.current[index] = el;
+							}}
 							type="button"
 							role="menuitem"
+							tabIndex={-1}
 							disabled={item.disabled}
 							className={cn(
 								"menu_item",

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { NavBar, NavLink } from "./index";
 
 describe("NavBar", () => {
@@ -36,4 +36,50 @@ describe("NavBar", () => {
 		const { container } = render(<NavBar sticky>test</NavBar>);
 		expect(container.firstChild).toHaveClass("nav_bar_sticky");
 	});
+
+	describe("LocaleSwitcher", () => {
+		const makeLocale = (onChange = vi.fn()) => ({
+			current: "ko",
+			options: [
+				{ value: "ko", label: "한국어" },
+				{ value: "en", label: "English" },
+			],
+			onChange,
+		});
+
+		it("opens menu with options on trigger click", () => {
+			render(<NavBar locale={makeLocale()} />);
+			fireEvent.click(screen.getByRole("button"));
+			expect(screen.getByRole("menu")).toBeInTheDocument();
+			expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+		});
+
+		it("calls onChange and closes on option select", () => {
+			const onChange = vi.fn();
+			render(<NavBar locale={makeLocale(onChange)} />);
+			fireEvent.click(screen.getByRole("button"));
+			fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+			expect(onChange).toHaveBeenCalledWith("en");
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+		});
+
+		it("focuses first item on open and moves with ArrowDown", () => {
+			render(<NavBar locale={makeLocale()} />);
+			fireEvent.click(screen.getByRole("button"));
+			const items = screen.getAllByRole("menuitem");
+			expect(items[0]).toHaveFocus();
+			fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+			expect(items[1]).toHaveFocus();
+		});
+
+		it("Escape closes and returns focus to the trigger", () => {
+			render(<NavBar locale={makeLocale()} />);
+			const trigger = screen.getByRole("button");
+			fireEvent.click(trigger);
+			fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+			expect(trigger).toHaveFocus();
+		});
+	});
+
 });

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -174,6 +174,7 @@ export const NavBar = ({
 const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	const [open, setOpen] = useState(false);
 	const wrapperRef = useRef<HTMLDivElement>(null);
+	const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 	const menuId = useId();
 
 	const currentOption = locale.options.find((o) => o.value === locale.current);
@@ -193,6 +194,52 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 			document.removeEventListener("keydown", escHandler);
 		};
 	}, [open]);
+
+	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 내부 포커스면 가로채지 않음.
+	useEffect(() => {
+		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		itemRefs.current[0]?.focus();
+	}, [open]);
+
+	// 화살표/Home/End roving 포커스 + Esc 닫고 trigger 복귀
+	const moveFocus = (dir: 1 | -1 | "first" | "last") => {
+		const n = locale.options.length;
+		if (n === 0) return;
+		if (dir === "first") return void itemRefs.current[0]?.focus();
+		if (dir === "last") return void itemRefs.current[n - 1]?.focus();
+		const pos = itemRefs.current.indexOf(document.activeElement as HTMLButtonElement | null);
+		const next = pos < 0 ? (dir === 1 ? 0 : n - 1) : (pos + dir + n) % n;
+		itemRefs.current[next]?.focus();
+	};
+
+	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				moveFocus(1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				moveFocus(-1);
+				break;
+			case "Home":
+				e.preventDefault();
+				moveFocus("first");
+				break;
+			case "End":
+				e.preventDefault();
+				moveFocus("last");
+				break;
+			case "Escape":
+				e.preventDefault();
+				setOpen(false);
+				wrapperRef.current?.querySelector<HTMLElement>("[aria-haspopup]")?.focus();
+				break;
+			case "Tab":
+				setOpen(false);
+				break;
+		}
+	};
 
 	const handleSelect = (value: string) => {
 		locale.onChange(value);
@@ -218,12 +265,21 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 				<ChevronDown size={14} aria-hidden="true" className="nav_bar_locale_chevron" />
 			</button>
 			{open && (
-				<ul id={menuId} role="menu" className="nav_bar_locale_menu">
-					{locale.options.map((opt) => (
+				<ul
+					id={menuId}
+					role="menu"
+					className="nav_bar_locale_menu"
+					onKeyDown={handleMenuKeyDown}
+				>
+					{locale.options.map((opt, index) => (
 						<li key={opt.value} role="none">
 							<button
+								ref={(el) => {
+									itemRefs.current[index] = el;
+								}}
 								type="button"
 								role="menuitem"
+								tabIndex={-1}
 								className={cn(
 									"nav_bar_locale_item",
 									opt.value === locale.current && "nav_bar_locale_item_active",

--- a/src/ui/system/theme-provider/index.tsx
+++ b/src/ui/system/theme-provider/index.tsx
@@ -57,11 +57,6 @@ function readStored(key: string | null): ThemeMode | null {
 	return null;
 }
 
-function resolveSystem(): ResolvedTheme {
-	if (!isClient) return "light";
-	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
 /**
  * Bigtablet DS 테마 컨텍스트를 제공한다.
  * `data-theme` attribute를 root element에 적용해서 CSS 변수 레이어를 전환한다.
@@ -79,14 +74,22 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
 	targetSelector,
 	children,
 }) => {
-	const [mode, setModeState] = React.useState<ThemeMode>(() => {
-		return readStored(storageKey) ?? defaultMode;
-	});
+	// SSR/CSR 첫 렌더를 deterministic 하게 — server 와 동일한 기본값으로 시작해 hydration mismatch 방지.
+	// 저장된 mode / 시스템 다크 설정은 mount 후 effect 에서 1회 동기화한다.
+	// (테마 깜빡임을 완전히 없애려면 hydration 전에 inline <script> 로 document.documentElement 의
+	//  data-theme 를 직접 세팅하는 것을 권장 — next-themes 와 동일한 패턴)
+	const [mode, setModeState] = React.useState<ThemeMode>(defaultMode);
+	const [systemDark, setSystemDark] = React.useState<boolean>(false);
 
-	const [systemDark, setSystemDark] = React.useState<boolean>(() => {
-		if (!isClient) return false;
-		return window.matchMedia("(prefers-color-scheme: dark)").matches;
-	});
+	// mount 후 저장값 + 시스템 설정 동기화 (storageKey 변경 시에만 재실행 — body 는 storageKey 외
+	// 모듈 상수/안정 setter 만 참조하므로 deps 완전)
+	React.useEffect(() => {
+		const stored = readStored(storageKey);
+		if (stored) setModeState(stored);
+		if (isClient) {
+			setSystemDark(window.matchMedia("(prefers-color-scheme: dark)").matches);
+		}
+	}, [storageKey]);
 
 	// prefers-color-scheme 변경 감지
 	React.useEffect(() => {


### PR DESCRIPTION
## 작업 개요

외부 코드 리뷰 후속 — 비파괴(non-breaking) a11y/SSR 개선 묶음 (E). `develop` 기반.

## 작업한 내용
- [x] **ThemeProvider SSR hydration** — `useState` 초기값을 localStorage/matchMedia 로 잡던 걸 deterministic 기본값으로 바꾸고 mount effect 에서 1회 동기화. server/client 첫 렌더 불일치(hydration mismatch) 제거. 사용 안 하던 `resolveSystem` dead code 제거.
- [x] **FileInput cleanup deps** — `useEffect` deps `[previewUrls]` 가 변경마다 cleanup 을 돌려 objectURL 이중 revoke 되던 문제를, ref 로 최신값 추적 + unmount-only cleanup 으로 수정.
- [x] **Menu 키보드 네비 (WAI-ARIA menu button)** — 열릴 때 첫 아이템 포커스, ↑/↓ roving 포커스(wrap), Home/End, disabled 아이템 skip, Esc 닫고 trigger 로 포커스 복귀.
- [x] **NavBar LocaleSwitcher 키보드 네비** — 동일 패턴 적용.
- [x] **테스트 +9** — Menu/NavBar 키보드 네비 spec 추가.

검증: unit 614 pass · storybook(axe) 264 pass · build green.

## 보류/제외 (의도)
- **Dropdown `aria-activedescendant`**: 적용하려면 control 을 `role="combobox"` 로 바꿔야 하는데(`button` role 에선 ARIA 무효) → DatePicker 등 Dropdown 기반 컴포넌트 + 모든 소비처 + 접근명(placeholder 가 더 이상 control 이름 역할 못 함)에 연쇄 영향. 기존 `aria-selected` + `aria-expanded` + full 키보드 네비로 핵심 a11y 는 이미 커버되어 **제외**.
- **ref-as-prop (~27 컴포넌트)**: 비파괴지만 별도 PR 권장.
- **props 네이밍 통일 / react-spring peer 승격**: 공개 API breaking = major(4.0.0) 사안 — 별도 논의.

## 전달할 추가 이슈
- ThemeProvider 테마 깜빡임(FOUC) 완전 제거가 필요하면 소비처에서 hydration 전 inline `<script>` 로 `data-theme` 선세팅 (next-themes 패턴) — JSDoc 에 명시함.