### PR TITLE
feat/ref-forwarding

### DIFF
--- a/src/ui/display/card/Card.test.tsx
+++ b/src/ui/display/card/Card.test.tsx
@@ -151,4 +151,11 @@ describe("Card", () => {
 		expect(card).not.toHaveClass("card_interactive");
 		expect(card.querySelector(".card_footer")).not.toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Card ref={(el) => { node = el; }}>X</Card>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/display/card/index.tsx
+++ b/src/ui/display/card/index.tsx
@@ -32,6 +32,8 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	footer?: React.ReactNode;
 	/** footer 정렬 (기본값: "end") */
 	footerAlign?: CardFooterAlign;
+	/** 루트 div 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLDivElement>;
 }
 
 /**
@@ -50,6 +52,7 @@ export const Card = ({
 	interactive = false,
 	footer,
 	footerAlign = "end",
+	ref,
 	className,
 	children,
 	...props
@@ -64,7 +67,7 @@ export const Card = ({
 	);
 
 	return (
-		<div className={cardClassName} {...props}>
+		<div ref={ref} className={cardClassName} {...props}>
 			{heading ? <HeadingTag className="card_title">{heading}</HeadingTag> : null}
 			<div className="card_body">{children}</div>
 			{footer ? (

--- a/src/ui/general/button/Button.test.tsx
+++ b/src/ui/general/button/Button.test.tsx
@@ -77,4 +77,11 @@ describe("Button", () => {
 		render(<Button>Button</Button>);
 		expect(screen.getByRole("button")).not.toHaveClass("button_full_width");
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLButtonElement | null = null;
+		render(<Button ref={(el) => { node = el; }}>X</Button>);
+		expect(node).toBeInstanceOf(HTMLButtonElement);
+	});
+
 });

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -25,6 +25,8 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 	 * filled: 빨간 bg, outline: 빨간 텍스트/border, tonal: 빨간 wash.
 	 */
 	danger?: boolean;
+	/** 루트 button 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLButtonElement>;
 }
 
 /**
@@ -42,6 +44,7 @@ export const Button = ({
 	radius,
 	danger = false,
 	type = "button",
+	ref,
 	className,
 	children,
 	...props
@@ -57,7 +60,7 @@ export const Button = ({
 	);
 
 	return (
-		<button type={type} className={buttonClassName} {...props}>
+		<button ref={ref} type={type} className={buttonClassName} {...props}>
 			{leadingIcon && (
 				<span className="button_icon" aria-hidden="true">
 					{leadingIcon}

--- a/src/ui/general/icon-button/IconButton.test.tsx
+++ b/src/ui/general/icon-button/IconButton.test.tsx
@@ -68,4 +68,11 @@ describe("IconButton", () => {
 		render(<IconButton icon={<TestIcon />} aria-label="action" className="custom-class" />);
 		expect(screen.getByRole("button")).toHaveClass("custom-class");
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLButtonElement | null = null;
+		render(<IconButton icon={<i />} aria-label="x" ref={(el) => { node = el; }} />);
+		expect(node).toBeInstanceOf(HTMLButtonElement);
+	});
+
 });

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -14,6 +14,8 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
 	size?: IconButtonSize;
 	/** 표시할 아이콘 */
 	icon: React.ReactNode;
+	/** 루트 button 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLButtonElement>;
 }
 
 /**
@@ -27,6 +29,7 @@ export const IconButton = ({
 	size = "md",
 	icon,
 	type = "button",
+	ref,
 	className,
 	...props
 }: IconButtonProps) => {
@@ -38,7 +41,7 @@ export const IconButton = ({
 	);
 
 	return (
-		<button type={type} className={buttonClassName} {...props}>
+		<button ref={ref} type={type} className={buttonClassName} {...props}>
 			<span className="icon_button_icon" aria-hidden="true">
 				{icon}
 			</span>

--- a/src/ui/layout/container/Container.test.tsx
+++ b/src/ui/layout/container/Container.test.tsx
@@ -34,7 +34,7 @@ describe("Container", () => {
 	});
 
 	it("forwards ref to the root element", () => {
-		let node: HTMLDivElement | null = null;
+		let node: HTMLElement | null = null;
 		render(<Container ref={(el) => { node = el; }}>X</Container>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});

--- a/src/ui/layout/container/Container.test.tsx
+++ b/src/ui/layout/container/Container.test.tsx
@@ -32,4 +32,11 @@ describe("Container", () => {
 		const { container } = render(<Container className="custom" />);
 		expect(container.firstChild).toHaveClass("custom");
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Container ref={(el) => { node = el; }}>X</Container>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/layout/container/index.tsx
+++ b/src/ui/layout/container/index.tsx
@@ -17,6 +17,8 @@ export interface ContainerProps extends React.HTMLAttributes<HTMLDivElement> {
 	center?: boolean;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -35,12 +37,14 @@ export const Container = ({
 	size = "xl",
 	center = true,
 	as: Tag = "div",
+	ref,
 	className,
 	children,
 	...props
 }: ContainerProps) => {
 	return (
 		<Tag
+			ref={ref}
 			className={cn("container", `container_size_${size}`, center && "container_center", className)}
 			{...props}
 		>

--- a/src/ui/layout/grid/Grid.test.tsx
+++ b/src/ui/layout/grid/Grid.test.tsx
@@ -56,7 +56,7 @@ describe("Grid", () => {
 	});
 
 	it("forwards ref to the root element", () => {
-		let node: HTMLDivElement | null = null;
+		let node: HTMLElement | null = null;
 		render(<Grid ref={(el) => { node = el; }}>X</Grid>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});

--- a/src/ui/layout/grid/Grid.test.tsx
+++ b/src/ui/layout/grid/Grid.test.tsx
@@ -54,4 +54,11 @@ describe("Grid", () => {
 		const { container } = render(<Grid as="ul" />);
 		expect(container.querySelector("ul")).toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Grid ref={(el) => { node = el; }}>X</Grid>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/layout/grid/index.tsx
+++ b/src/ui/layout/grid/index.tsx
@@ -31,6 +31,8 @@ export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
 	singleColOnMobile?: boolean;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -58,6 +60,7 @@ export const Grid = ({
 	colGap,
 	singleColOnMobile = true,
 	as: Tag = "div",
+	ref,
 	className,
 	children,
 	style,
@@ -70,6 +73,7 @@ export const Grid = ({
 
 	return (
 		<Tag
+			ref={ref}
 			className={cn("grid_layout", singleColOnMobile && "grid_layout_mobile_single", className)}
 			style={
 				{

--- a/src/ui/layout/section/Section.test.tsx
+++ b/src/ui/layout/section/Section.test.tsx
@@ -37,4 +37,11 @@ describe("Section", () => {
 		expect(container.querySelector("div")).toBeInTheDocument();
 		expect(container.querySelector("section")).not.toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLElement | null = null;
+		render(<Section ref={(el) => { node = el; }}>X</Section>);
+		expect(node).toBeInstanceOf(HTMLElement);
+	});
+
 });

--- a/src/ui/layout/section/index.tsx
+++ b/src/ui/layout/section/index.tsx
@@ -22,6 +22,8 @@ export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
 	bg?: SectionBg;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -41,12 +43,14 @@ export const Section = ({
 	spacing = "md",
 	bg = "default",
 	as: Tag = "section",
+	ref,
 	className,
 	children,
 	...props
 }: SectionProps) => {
 	return (
 		<Tag
+			ref={ref}
 			className={cn(
 				"section",
 				`section_spacing_${spacing}`,

--- a/src/ui/layout/stack/Stack.test.tsx
+++ b/src/ui/layout/stack/Stack.test.tsx
@@ -49,4 +49,11 @@ describe("Stack", () => {
 		const { container } = render(<Stack as="ul" />);
 		expect(container.querySelector("ul")).toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Stack ref={(el) => { node = el; }}>X</Stack>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/layout/stack/Stack.test.tsx
+++ b/src/ui/layout/stack/Stack.test.tsx
@@ -51,7 +51,7 @@ describe("Stack", () => {
 	});
 
 	it("forwards ref to the root element", () => {
-		let node: HTMLDivElement | null = null;
+		let node: HTMLElement | null = null;
 		render(<Stack ref={(el) => { node = el; }}>X</Stack>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});

--- a/src/ui/layout/stack/index.tsx
+++ b/src/ui/layout/stack/index.tsx
@@ -29,6 +29,8 @@ export interface StackProps extends React.HTMLAttributes<HTMLDivElement> {
 	wrap?: StackWrap;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -55,6 +57,7 @@ export const Stack = ({
 	justify,
 	wrap,
 	as: Tag = "div",
+	ref,
 	className,
 	children,
 	style,
@@ -62,6 +65,7 @@ export const Stack = ({
 }: StackProps) => {
 	return (
 		<Tag
+			ref={ref}
 			className={cn(
 				"stack",
 				`stack_${direction}`,


### PR DESCRIPTION
## 작업 개요

외부 코드 리뷰 후속 (F 비파괴) — React 19 ref-as-prop 으로 고가치 컴포넌트에 `ref` 전달 지원 추가. **additive / 비파괴 (minor)**.

## 작업한 내용
- [x] `ref` prop 추가 (루트 요소로 전달):
  - general: **Button**, **IconButton** (→ `<button>`)
  - display: **Card** (→ `<div>`)
  - layout: **Container · Stack · Grid · Section** (다형성 `as` → 렌더된 `<Tag>` 로 전달, `React.Ref<HTMLElement>`)
- [x] 컴포넌트별 ref 전달 테스트 +7 (callback ref → 루트 element instance 검증)

검증: unit 621 pass · storybook(axe) 264 pass · build(DTS) green.

## 범위 결정 (YAGNI)
- leaf/presentational (Divider · Skeleton · Badge · Chip · Avatar 등)은 consumer ref 수요가 드물어 **제외**. 필요 시 후속 추가.
- form input 5종(TextField/Textarea/Checkbox/Radio/Toggle)은 이미 ref 전달 중. RadioGroup/FileInput 은 내부 ref 합성 필요라 별도 검토.

## 전달할 추가 이슈
- 나머지 컴포넌트 ref 전면 적용은 수요 확인 후. props 네이밍 통일 / react-spring peer 승격은 major(4.0.0) 사안으로 별도.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 여러 UI 컴포넌트에서 루트 요소에 `ref`를 직접 연결할 수 있게 지원이 추가되었습니다.
  * 카드, 버튼, 아이콘 버튼, 컨테이너, 그리드, 섹션, 스택 등에서 외부에서 DOM 요소를 더 쉽게 참조할 수 있습니다.

* **Tests**
  * 각 컴포넌트의 `ref` 전달 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->