### PR TITLE
feat/prop-naming-unification

### DIFF
--- a/src/ui/display/accordion/Accordion.test.tsx
+++ b/src/ui/display/accordion/Accordion.test.tsx
@@ -74,4 +74,12 @@ describe("Accordion", () => {
 		fireEvent.click(screen.getByText("Title A"));
 		expect(onChange).toHaveBeenCalledWith(["a"]);
 	});
+
+	it("fires onValueChange (canonical)", () => {
+		const onValueChange = vi.fn();
+		render(<Accordion items={items} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByText("Title A"));
+		expect(onValueChange).toHaveBeenCalledWith(["a"]);
+	});
+
 });

--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -21,7 +21,9 @@ export interface AccordionProps extends Omit<React.HTMLAttributes<HTMLDivElement
 	defaultOpenKeys?: string[];
 	/** 제어형: 펼쳐진 키들 */
 	openKeys?: string[];
-	/** 펼침/접힘 콜백 */
+	/** 펼침/접힘 콜백 (canonical). 열린 키 배열 전달 */
+	onValueChange?: (openKeys: string[]) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
 	onChange?: (openKeys: string[]) => void;
 }
 
@@ -38,6 +40,7 @@ export const Accordion = ({
 	multiple = false,
 	defaultOpenKeys = [],
 	openKeys: controlledKeys,
+	onValueChange,
 	onChange,
 	className,
 	...props
@@ -54,7 +57,7 @@ export const Accordion = ({
 				? [...open, key]
 				: [key];
 		if (!isControlled) setInternalKeys(next);
-		onChange?.(next);
+		(onValueChange ?? onChange)?.(next);
 	};
 
 	return (

--- a/src/ui/forms/date-picker/DatePicker.test.tsx
+++ b/src/ui/forms/date-picker/DatePicker.test.tsx
@@ -170,4 +170,14 @@ describe("DatePicker", () => {
 		);
 		expect(screen.getByText("오늘까지 선택 가능")).toBeInTheDocument();
 	});
+
+	it("calls onValueChange (canonical) when year is selected", () => {
+		const onValueChange = vi.fn();
+		render(<DatePicker mode="year-month" startYear={2020} endYear={2025} onValueChange={onValueChange} />);
+		const buttons = screen.getAllByRole("button");
+		fireEvent.click(buttons[0]);
+		fireEvent.click(screen.getByText("2024"));
+		expect(onValueChange).toHaveBeenCalledWith("2024-01");
+	});
+
 });

--- a/src/ui/forms/date-picker/index.tsx
+++ b/src/ui/forms/date-picker/index.tsx
@@ -13,8 +13,10 @@ export interface DatePickerProps {
 	label?: string;
 	/** 제어형 날짜 값 ("YYYY-MM" 또는 "YYYY-MM-DD" 형식) */
 	value?: string;
-	/** 날짜 변경 시 호출되는 콜백. `mode` 값에 따라 "YYYY-MM" 또는 "YYYY-MM-DD" 형식의 문자열이 전달됩니다. */
-	onChange: (value: string) => void;
+	/** 날짜 변경 콜백 (canonical). `mode` 값에 따라 "YYYY-MM" 또는 "YYYY-MM-DD" 형식의 문자열이 전달됩니다. */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (value: string) => void;
 	/** 선택 모드 (기본값: "year-month-day") */
 	mode?: DatePickerMode;
 	/** 연도 선택 범위 시작 (기본값: 1950) */
@@ -72,6 +74,7 @@ const range = (start: number, end: number) =>
 export const DatePicker = ({
 	label,
 	value,
+	onValueChange,
 	onChange,
 	mode = "year-month-day",
 	startYear = 1950,
@@ -184,14 +187,15 @@ export const DatePicker = ({
 
 	const emit = React.useCallback(
 		(yy: number, mm: number, dd?: number) => {
+			const cb = onValueChange ?? onChange;
 			if (mode === "year-month") {
-				onChange(`${yy}-${pad(mm)}`);
+				cb?.(`${yy}-${pad(mm)}`);
 				return;
 			}
 			const safeDay = Math.min(dd ?? 1, getDaysInMonth(yy, mm));
-			onChange(`${yy}-${pad(mm)}-${pad(safeDay)}`);
+			cb?.(`${yy}-${pad(mm)}-${pad(safeDay)}`);
 		},
-		[mode, onChange],
+		[mode, onValueChange, onChange],
 	);
 
 	// ── 핸들러: 연/월 변경 시 하위 값 자동 보정 ──────────────────────────
@@ -271,7 +275,7 @@ export const DatePicker = ({
 					placeholder={yearLabel}
 					options={yearOptions}
 					value={year ? String(year) : null}
-					onChange={handleYearChange}
+					onValueChange={handleYearChange}
 					disabled={disabled}
 				/>
 
@@ -282,7 +286,7 @@ export const DatePicker = ({
 					placeholder={monthLabel}
 					options={monthOptions}
 					value={month ? String(month) : null}
-					onChange={handleMonthChange}
+					onValueChange={handleMonthChange}
 					disabled={disabled || !year}
 				/>
 
@@ -294,7 +298,7 @@ export const DatePicker = ({
 						placeholder={dayLabel}
 						options={dayOptions}
 						value={day ? String(day) : null}
-						onChange={handleDayChange}
+						onValueChange={handleDayChange}
 						disabled={disabled || !month}
 					/>
 				)}

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -481,4 +481,13 @@ describe("Dropdown", () => {
 		// value="999" 는 옵션에 없음 - placeholder가 보여야 함
 		expect(screen.getByText("Select…")).toBeInTheDocument();
 	});
+
+	it("calls onValueChange (canonical) on select", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.click(screen.getByText("Option 1"));
+		expect(onValueChange).toHaveBeenCalledWith("1", options[0]);
+	});
+
 });

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -42,7 +42,9 @@ export interface DropdownProps {
 	options: DropdownOption[];
 	/** 제어형 선택 값 */
 	value?: string | null;
-	/** 값 변경 시 호출되는 콜백. 선택된 값과 전체 옵션 객체를 인자로 전달합니다. */
+	/** 값 변경 콜백 (canonical). 선택된 값과 전체 옵션 객체를 전달합니다. */
+	onValueChange?: (value: string | null, option?: DropdownOption | null) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
 	onChange?: (value: string | null, option?: DropdownOption | null) => void;
 	/** 비제어형 초기 선택 값 */
 	defaultValue?: string | null;
@@ -78,6 +80,7 @@ export const Dropdown = ({
 	placeholder = "Select…",
 	options,
 	value,
+	onValueChange,
 	onChange,
 	defaultValue = null,
 	disabled,
@@ -109,9 +112,9 @@ export const Dropdown = ({
 		(next: string | null) => {
 			const option = options.find((o) => o.value === next) ?? null;
 			if (!isControlled) setInternalValue(next);
-			onChange?.(next, option);
+			(onValueChange ?? onChange)?.(next, option);
 		},
-		[isControlled, onChange, options],
+		[isControlled, onValueChange, onChange, options],
 	);
 
 	useEffect(() => {

--- a/src/ui/forms/otp-input/OtpInput.test.tsx
+++ b/src/ui/forms/otp-input/OtpInput.test.tsx
@@ -399,4 +399,12 @@ describe("OtpInput", () => {
 			expect(onChange).not.toHaveBeenCalled();
 		});
 	});
+
+	it("calls onValueChange (canonical) when digit entered", () => {
+		const onValueChange = vi.fn();
+		render(<OtpInput length={6} value="" onValueChange={onValueChange} ariaLabel="OTP" />);
+		fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "5" } });
+		expect(onValueChange).toHaveBeenCalledWith("5");
+	});
+
 });

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -9,7 +9,9 @@ export interface OtpInputProps {
 	length?: 4 | 6;
 	/** 제어형 값 */
 	value?: string;
-	/** 값 변경 콜백 */
+	/** 값 변경 콜백 (canonical) */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
 	onChange?: (value: string) => void;
 	/** 에러 상태 */
 	error?: boolean;
@@ -34,6 +36,7 @@ export interface OtpInputProps {
 export const OtpInput = ({
 	length = 6,
 	value = "",
+	onValueChange,
 	onChange,
 	error = false,
 	disabled = false,
@@ -61,7 +64,7 @@ export const OtpInput = ({
 	};
 
 	const updateValue = (newDigits: string[]) => {
-		onChange?.(newDigits.join(""));
+		(onValueChange ?? onChange)?.(newDigits.join(""));
 	};
 
 	const handleChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/forms/textarea/Textarea.test.tsx
+++ b/src/ui/forms/textarea/Textarea.test.tsx
@@ -121,4 +121,12 @@ describe("Textarea", () => {
 		expect(onChange).toHaveBeenLastCalledWith("한");
 	});
 
+
+	it("calls onValueChange (canonical) on input", () => {
+		const onValueChange = vi.fn();
+		render(<Textarea label="내용" onValueChange={onValueChange} />);
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "hello" } });
+		expect(onValueChange).toHaveBeenCalledWith("hello");
+	});
+
 });

--- a/src/ui/forms/textarea/index.tsx
+++ b/src/ui/forms/textarea/index.tsx
@@ -26,7 +26,9 @@ export interface TextareaProps
 	error?: boolean;
 	/** 컨테이너 전체 너비 차지 여부 */
 	fullWidth?: boolean;
-	/** 값 변경 시 호출되는 콜백. 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	/** 값 변경 콜백 (canonical). 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. (Next 서버액션 전달용으로 `Action` 접미사가 필요하면 그대로 사용 가능) */
 	onChangeAction?: (value: string) => void;
 	/**
 	 * IME 조합 중 콜백 전략 (기본값: "delayed").
@@ -81,6 +83,7 @@ export const Textarea = ({
 	fullWidth,
 	size = "md",
 	className,
+	onValueChange,
 	onChangeAction,
 	imeStrategy = "delayed",
 	value,
@@ -174,7 +177,7 @@ export const Textarea = ({
 		setInnerValue(nextValue);
 		if (nextValue !== lastEmittedValueRef.current) {
 			lastEmittedValueRef.current = nextValue;
-			onChangeAction?.(nextValue);
+			(onValueChange ?? onChangeAction)?.(nextValue);
 		}
 	};
 
@@ -215,7 +218,7 @@ export const Textarea = ({
 								setInnerValue(rawValue);
 								if (imeStrategy === "immediate" && rawValue !== lastEmittedValueRef.current) {
 									lastEmittedValueRef.current = rawValue;
-									onChangeAction?.(rawValue);
+									(onValueChange ?? onChangeAction)?.(rawValue);
 								}
 								return;
 							}

--- a/src/ui/forms/textfield/TextField.test.tsx
+++ b/src/ui/forms/textfield/TextField.test.tsx
@@ -125,4 +125,12 @@ describe("TextField", () => {
 
 		expect(handleChange).toHaveBeenCalledWith("ABC");
 	});
+
+	it("calls onValueChange (canonical) on input", () => {
+		const handleChange = vi.fn();
+		render(<TextField onValueChange={handleChange} />);
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "test@example.com" } });
+		expect(handleChange).toHaveBeenCalledWith("test@example.com");
+	});
+
 });

--- a/src/ui/forms/textfield/index.tsx
+++ b/src/ui/forms/textfield/index.tsx
@@ -38,7 +38,9 @@ export interface TextFieldProps
 	clearable?: boolean;
 	/** 컨테이너 전체 너비 차지 여부 */
 	fullWidth?: boolean;
-	/** 값 변경 시 호출되는 콜백. 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	/** 값 변경 콜백 (canonical). 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. (Next 서버액션 전달용으로 `Action` 접미사가 필요하면 그대로 사용 가능) */
 	onChangeAction?: (value: string) => void;
 	/**
 	 * IME 조합 중 콜백 전략 (기본값: "delayed").
@@ -77,6 +79,7 @@ export const TextField = ({
 	fullWidth,
 	size = "md",
 	className,
+	onValueChange,
 	onChangeAction,
 	imeStrategy = "delayed",
 	value,
@@ -119,10 +122,10 @@ export const TextField = ({
 			setInnerValue(nextValue);
 			if (nextValue !== lastEmittedValueRef.current) {
 				lastEmittedValueRef.current = nextValue;
-				onChangeAction?.(nextValue);
+				(onValueChange ?? onChangeAction)?.(nextValue);
 			}
 		},
-		[onChangeAction],
+		[onValueChange, onChangeAction],
 	);
 
 	const handleClear = useCallback(() => {
@@ -198,7 +201,7 @@ export const TextField = ({
 									// immediate: 조합 중에도 외부 구독 즉시 반영 (raw value).
 									if (imeStrategy === "immediate" && rawValue !== lastEmittedValueRef.current) {
 										lastEmittedValueRef.current = rawValue;
-										onChangeAction?.(rawValue);
+										(onValueChange ?? onChangeAction)?.(rawValue);
 									}
 									return;
 								}

--- a/src/ui/forms/toggle/Toggle.test.tsx
+++ b/src/ui/forms/toggle/Toggle.test.tsx
@@ -81,4 +81,12 @@ describe("Toggle", () => {
 		// Controlled: aria-checked stays at the prop value (false)
 		expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
 	});
+
+	it("calls onCheckedChange (canonical) on click", () => {
+		const onCheckedChange = vi.fn();
+		render(<Toggle ariaLabel="Toggle" onCheckedChange={onCheckedChange} />);
+		fireEvent.click(screen.getByRole("switch"));
+		expect(onCheckedChange).toHaveBeenCalledWith(true);
+	});
+
 });

--- a/src/ui/forms/toggle/index.tsx
+++ b/src/ui/forms/toggle/index.tsx
@@ -10,7 +10,9 @@ export interface ToggleProps
 	checked?: boolean;
 	/** 비제어형 초기 토글 상태 */
 	defaultChecked?: boolean;
-	/** 상태 변경 시 호출되는 콜백 */
+	/** 상태 변경 콜백 (canonical) */
+	onCheckedChange?: (checked: boolean) => void;
+	/** @deprecated `onCheckedChange` 를 사용하세요. */
 	onChange?: (checked: boolean) => void;
 	/** 토글 크기 (기본값: "sm") */
 	size?: "sm" | "md";
@@ -31,6 +33,7 @@ export interface ToggleProps
 export const Toggle = ({
 	checked,
 	defaultChecked,
+	onCheckedChange,
 	onChange,
 	size = "sm",
 	disabled,
@@ -51,7 +54,7 @@ export const Toggle = ({
 		if (disabled) return;
 		const next = !isOn;
 		if (!isControlled) setInnerChecked(next);
-		onChange?.(next);
+		(onCheckedChange ?? onChange)?.(next);
 	};
 
 	const rootClassName = cn(

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -82,4 +82,24 @@ describe("NavBar", () => {
 		});
 	});
 
+
+	it("LocaleSwitcher calls onValueChange (canonical) on select", () => {
+		const onValueChange = vi.fn();
+		render(
+			<NavBar
+				locale={{
+					current: "ko",
+					options: [
+						{ value: "ko", label: "한국어" },
+						{ value: "en", label: "English" },
+					],
+					onValueChange,
+				}}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+		expect(onValueChange).toHaveBeenCalledWith("en");
+	});
+
 });

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -19,8 +19,10 @@ export interface NavBarLocaleConfig {
 	current: string;
 	/** 가능한 옵션 */
 	options: NavBarLocaleOption[];
-	/** locale 변경 콜백 */
-	onChange: (next: string) => void;
+	/** locale 변경 콜백 (canonical) */
+	onValueChange?: (next: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (next: string) => void;
 	/** 표시 라벨 - 기본은 옵션의 label, 미지정 시 short code 표시 */
 	hideLabel?: boolean;
 }
@@ -242,7 +244,7 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	};
 
 	const handleSelect = (value: string) => {
-		locale.onChange(value);
+		(locale.onValueChange ?? locale.onChange)?.(value);
 		setOpen(false);
 	};
 

--- a/src/ui/navigation/pagination/Pagination.test.tsx
+++ b/src/ui/navigation/pagination/Pagination.test.tsx
@@ -77,4 +77,12 @@ describe("Pagination", () => {
 		render(<Pagination page={3} totalPages={5} onChange={() => {}} />);
 		expect(screen.getByText("3")).toHaveClass("pagination_active");
 	});
+
+	it("calls onPageChange (canonical) when clicking previous", () => {
+		const onPageChange = vi.fn();
+		render(<Pagination page={5} totalPages={10} onPageChange={onPageChange} />);
+		fireEvent.click(screen.getByLabelText("Previous page"));
+		expect(onPageChange).toHaveBeenCalledWith(4);
+	});
+
 });

--- a/src/ui/navigation/pagination/index.tsx
+++ b/src/ui/navigation/pagination/index.tsx
@@ -9,8 +9,10 @@ export interface PaginationProps {
 	page: number;
 	/** 전체 페이지 수 */
 	totalPages: number;
-	/** 페이지 변경 시 호출되는 콜백 */
-	onChange: (page: number) => void;
+	/** 페이지 변경 콜백 (canonical) */
+	onPageChange?: (page: number) => void;
+	/** @deprecated `onPageChange` 를 사용하세요. */
+	onChange?: (page: number) => void;
 	/** 이전 페이지 버튼 aria-label (기본값: "Previous page") */
 	prevLabel?: string;
 	/** 다음 페이지 버튼 aria-label (기본값: "Next page") */
@@ -77,10 +79,12 @@ const getPaginationItems = (page: number, totalPages: number) => {
 export const Pagination = ({
 	page,
 	totalPages,
+	onPageChange,
 	onChange,
 	prevLabel = "Previous page",
 	nextLabel = "Next page",
 }: PaginationProps) => {
+	const emit = onPageChange ?? onChange;
 	const prevDisabled = page <= 1;
 	const nextDisabled = page >= totalPages;
 
@@ -91,7 +95,7 @@ export const Pagination = ({
 			<button
 				type="button"
 				className="pagination_item"
-				onClick={() => onChange(page - 1)}
+				onClick={() => emit?.(page - 1)}
 				disabled={prevDisabled}
 				aria-label={prevLabel}
 			>
@@ -118,7 +122,7 @@ export const Pagination = ({
 							<button
 								type="button"
 								className={buttonClassName}
-								onClick={() => onChange(it)}
+								onClick={() => emit?.(it)}
 								aria-current={isActive ? "page" : undefined}
 							>
 								{it}
@@ -131,7 +135,7 @@ export const Pagination = ({
 			<button
 				type="button"
 				className="pagination_item"
-				onClick={() => onChange(page + 1)}
+				onClick={() => emit?.(page + 1)}
 				disabled={nextDisabled}
 				aria-label={nextLabel}
 			>


### PR DESCRIPTION
## 작업 개요

변경 콜백 prop 네이밍을 **Radix식 `on*Change` 패밀리**로 통일. 전부 **additive** — 구 prop 은 `@deprecated` alias 로 유지되어 그대로 동작(호출 시 canonical 우선 → `(onValueChange ?? onChange)?.()`). **비파괴 (minor)**, major 아님.

## canonical 매핑
| 컴포넌트 | canonical | 구 prop(@deprecated) |
|---|---|---|
| Dropdown · OtpInput · DatePicker · Accordion · NavBar locale | `onValueChange` | `onChange` |
| TextField · Textarea | `onValueChange` | `onChangeAction` |
| Toggle | `onCheckedChange` | `onChange` |
| Pagination | `onPageChange` | `onChange` |
| RadioGroup · Tabs | `onValueChange` ✓ (이미) | — |
| Popover | `onOpenChange` ✓ (이미) | — |

## 작업한 내용
- [x] 9개 컴포넌트에 canonical alias 추가 + 구 prop `@deprecated` 표기, 호출부 canonical 우선
- [x] DatePicker 내부 Dropdown 들도 `onValueChange` 로 구동(자기 deprecated prop 미사용)
- [x] 컴포넌트별 canonical-fires 테스트 +9. 기존 구-prop 테스트도 그대로 green = back-compat 검증

검증: unit 630 pass · storybook(axe) 264 pass · build(DTS) green · lint:css clean.

## 비고
- `FileInput.onFiles`(파일은 "value" 아님) · `Menu.onSelect`(아이템 단위)는 의미가 달라 그대로 유지.
- react-spring `dependencies`→`peer` 승격은 소비자 설치 강제(진짜 breaking)라 안 함 — 번들 dependency 로 유지가 영향 0.
- 구 prop 제거(=breaking)는 다음 major 때.