### PR TITLE
config/undici-security

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
 			"postcss": "^8.5.10",
 			"esbuild": "^0.28.1",
 			"js-yaml": "^4.2.0",
-			"@vitest/browser": "^4.1.8"
+			"@vitest/browser": "^4.1.8",
+			"undici": "^7.28.0"
 		}
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   esbuild: ^0.28.1
   js-yaml: ^4.2.0
   '@vitest/browser': ^4.1.8
+  undici: ^7.28.0
 
 importers:
 
@@ -3213,8 +3214,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.4.0:
@@ -5323,7 +5324,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6239,7 +6240,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.4.0: {}
 


### PR DESCRIPTION
## 작업 개요

Dependabot 보안 경보 6건(undici) 해소. undici `7.25.0` (jsdom→vitest 경유 **transitive devDependency**) 이 6개 GHSA 에 노출 — pnpm override 로 패치 버전 `>=7.28.0` 고정.

| # | 심각도 | 요약 |
|---|---|---|
| #77 | High | SOCKS5 proxy pool reuse → cross-origin request routing |
| #75 | High | SOCKS5 ProxyAgent requestTls drop → TLS 검증 우회 |
| #76 | Moderate | shared cache whitespace bypass → cross-user 정보 노출 |
| #80 | Moderate | Set-Cookie percent-decoding → HTTP header injection |
| #81 | Low | permissive substring → SameSite 다운그레이드 |
| #78 | Low | keep-alive socket reuse → response queue poisoning |

## 작업한 내용
- [x] `pnpm.overrides` 에 `"undici": "^7.28.0"` 추가 (전부 `>=7.28.0` 에서 패치됨)
- [x] `pnpm install` → undici 7.25.0 → **7.28.0** (jsdom 29 는 `^7.25.0` 요구 → 호환)
- [x] `pnpm audit` → **No known vulnerabilities**
- [x] unit 630 pass (jsdom 런타임 정상)

## 영향 범위
- **dev/CI 전용**. 배포 패키지는 `dist/` 만 포함하고 undici 를 번들하지 않음 → npm 소비자 영향 없음. 경보 정리 + dev 환경 위생 목적.