### PR TITLE
release/v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.3.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.3.0) - 2026-06-25
+
+- `ref` 전달(React 19 ref-as-prop) 지원 — Button · IconButton · Card · Container · Stack · Grid · Section
+- 변경 콜백 네이밍을 Radix식 `on*Change` 패밀리로 통일 (`onValueChange` / `onCheckedChange` / `onPageChange`) — 기존 prop 은 `@deprecated` alias 로 호환 유지
+- 접근성: Menu · NavBar 화살표키 네비게이션(WAI-ARIA APG), Tooltip `aria-describedby` 합성, ThemeProvider SSR hydration mismatch 수정
+- Chip tone · 통계 카드 트렌드 WCAG AA(4.5:1) 대비 충족, Storybook 에 테마 CSS 변수 로드(Divider 등 표시 수정)
+- TS 컬러 토큰을 AA 값으로 SCSS 와 동기화, `next` peer 범위를 `>=15`(React 19 호환)로 정정
+- FileInput objectURL 정리 안정화, Modal Escape 핸들러 React 19 전 버전 호환
+- undici dev 의존성 보안 패치 (`>=7.28.0`, 경보 6건 해소)
+
 ## [3.2.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.2.2) - 2026-06-18
 
 - caption 텍스트 색을 WCAG AA(4.5:1) 충족값으로 조정하고, axe `color-contrast` 검사를 재활성화해 전 컴포넌트 대비를 CI 가 가드

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.2.2",
+	"version": "3.3.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## 작업 개요
v3.3.0 릴리즈 prep — `package.json` version bump (3.2.2 → 3.3.0, **minor**: ref-as-prop + on*Change alias 등 공개 API 추가) + `CHANGELOG.md` 3.3.0 섹션. dev→main 릴리즈 PR 직전 단계.