### PR TITLE
merge: release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
               - 'src/styles/**'
               - 'src/utils/**'
               - 'src/index.ts'
-              - 'src/next.ts'
               - 'src/test/**'
               - 'tsup.config.ts'
               - 'vitest.config.ts'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes
+          VERSION=${TAG#v}
+          # CHANGELOG.md 의 해당 버전 Key Updates 를 릴리즈 노트로 사용 (Bigtablet 양식 SSOT).
+          # --generate-notes 자동 PR 목록은 양식에 안 맞아 사용하지 않는다.
+          NOTES=$(awk -v v="$VERSION" '
+            index($0, "## [" v "]") == 1 { f=1; next }
+            f && /^## \[/ { exit }
+            f { print }
+          ' CHANGELOG.md)
+          [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ] && NOTES="- 자세한 변경은 CHANGELOG.md 참고"
+          BODY=$(printf '## Design System of Bigtablet, Inc.\n\n#### Key Updates\n%s' "$NOTES")
+          gh release create "$TAG" --title "$TAG" --notes "$BODY"

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,9 @@
 import type { Decorator, Preview } from "@storybook/react";
 import { createElement as h, Fragment } from "react";
+// 컴포넌트가 참조하는 --bt-color-* / focus-ring / elevation CSS 변수 정의.
+// theme.scss 는 scss/token 진입점에서 분리돼 있어(소비자는 style.css 로 받음),
+// Storybook preview 에도 직접 import 해줘야 컴포넌트 색/다크모드가 적용된다.
+import "../src/styles/theme.scss";
 
 /**
  * Theme decorator — globals.theme 값에 따라 document.documentElement에 data-theme 적용.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - react-spring 기반 진입/퇴출 애니메이션 — Modal, Toast, Tooltip, Menu 적용
 - Vanilla JS 패키지 완성 — Thymeleaf/JSP/PHP 환경 지원
 - `useSpringPresence` hook 공개 — 커스텀 overlay 애니메이션 지원
+- 추가 컴포넌트: Accordion · Table · Breadcrumb · EmptyState + 레이아웃 프리미티브(Container · Stack · Grid · Section)
 
 ## [2.5.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v2.5.0) - 2026-05-18
 
@@ -145,6 +146,7 @@
 
 - GitHub Pages Storybook 배포 — 클라이언트 사이드 비밀번호 보호 적용
 - Chip `aria-expanded` 및 TextField clear button 접근성 개선
+- `IconButton` 컴포넌트 추가
 
 ## [1.24.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v1.24.2) - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.3.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.3.0) - 2026-06-25
+
+- `ref` 전달(React 19 ref-as-prop) 지원 — Button · IconButton · Card · Container · Stack · Grid · Section
+- 변경 콜백 네이밍을 Radix식 `on*Change` 패밀리로 통일 (`onValueChange` / `onCheckedChange` / `onPageChange`) — 기존 prop 은 `@deprecated` alias 로 호환 유지
+- 접근성: Menu · NavBar 화살표키 네비게이션(WAI-ARIA APG), Tooltip `aria-describedby` 합성, ThemeProvider SSR hydration mismatch 수정
+- Chip tone · 통계 카드 트렌드 WCAG AA(4.5:1) 대비 충족, Storybook 에 테마 CSS 변수 로드(Divider 등 표시 수정)
+- TS 컬러 토큰을 AA 값으로 SCSS 와 동기화, `next` peer 범위를 `>=15`(React 19 호환)로 정정
+- FileInput objectURL 정리 안정화, Modal Escape 핸들러 React 19 전 버전 호환
+- undici dev 의존성 보안 패치 (`>=7.28.0`, 경보 6건 해소)
+
 ## [3.2.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.2.2) - 2026-06-18
 
 - caption 텍스트 색을 WCAG AA(4.5:1) 충족값으로 조정하고, axe `color-contrast` 검사를 재활성화해 전 컴포넌트 대비를 CI 가 가드

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,11 +193,12 @@ WCAG 2.1 SC 2.3.3 - `prefers-reduced-motion: reduce` 사용자 위해 모든 컴
 `unmount` 시점에 exit animation을 위해 `useSpringPresence` hook 사용 (`src/utils/use-spring-presence.ts`). Modal/Toast/Tooltip/Menu 패턴.
 
 ```tsx
+import { animated } from "@react-spring/web";
 import { useSpringPresence } from "../../utils";
 
-const { shouldRender, style } = useSpringPresence({ open });
-if (!shouldRender) return null;
-return <div style={style}>...</div>;
+// visible=false 가 되면 exit 애니메이션 후 onExitComplete 발화 → 부모에서 unmount.
+const style = useSpringPresence({ visible: open, onExitComplete: () => setMounted(false) });
+return <animated.div style={style}>...</animated.div>;
 ```
 
 #### 6. 금지 사항

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.2.2",
+	"version": "3.3.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	"packageManager": "pnpm@10.20.0",
 	"peerDependencies": {
 		"lucide-react": ">=0.552.0",
-		"next": ">=16",
+		"next": ">=13",
 		"react": "^19",
 		"react-dom": "^19"
 	},
@@ -124,6 +124,10 @@
 		{
 			"path": "dist/vanilla/bigtablet.min.js",
 			"limit": "5 kB"
+		},
+		{
+			"path": "dist/index.css",
+			"limit": "130 kB"
 		}
 	],
 	"pnpm": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
 			"postcss": "^8.5.10",
 			"esbuild": "^0.28.1",
 			"js-yaml": "^4.2.0",
-			"@vitest/browser": "^4.1.8"
+			"@vitest/browser": "^4.1.8",
+			"undici": "^7.28.0"
 		}
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	"packageManager": "pnpm@10.20.0",
 	"peerDependencies": {
 		"lucide-react": ">=0.552.0",
-		"next": ">=13",
+		"next": ">=15",
 		"react": "^19",
 		"react-dom": "^19"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   esbuild: ^0.28.1
   js-yaml: ^4.2.0
   '@vitest/browser': ^4.1.8
+  undici: ^7.28.0
 
 importers:
 
@@ -3213,8 +3214,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.4.0:
@@ -5323,7 +5324,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6239,7 +6240,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.4.0: {}
 

--- a/scripts/copy-scss.sh
+++ b/scripts/copy-scss.sh
@@ -10,6 +10,8 @@ if [ ! -f "$SRC/token.scss" ]; then
   exit 1
 fi
 
+# 과거 도메인 폴더가 빈 채로 잔류하지 않도록 매 빌드마다 정리(결정적 출력)
+rm -rf "$OUT"
 mkdir -p "$OUT"
 cp "$SRC/token.scss" "$OUT/token.scss"
 

--- a/src/stories/cookbook/data.stories.tsx
+++ b/src/stories/cookbook/data.stories.tsx
@@ -336,11 +336,11 @@ export const StatCards: Story = {
 									padding: "2px 8px",
 									borderRadius: 999,
 									background: stat.positive
-										? "color-mix(in srgb, var(--bt-color-status-success) 18%, transparent)"
-										: "color-mix(in srgb, var(--bt-color-status-error) 18%, transparent)",
+										? "var(--bt-color-status-success-container)"
+										: "var(--bt-color-status-error-container)",
 									color: stat.positive
-										? "var(--bt-color-status-success)"
-										: "var(--bt-color-status-error)",
+										? "var(--bt-color-status-success-on-container)"
+										: "var(--bt-color-status-error-on-container)",
 								}}
 							>
 								{stat.positive ? <TrendingUp size={12} /> : <TrendingDown size={12} />}

--- a/src/styles/colors/index.ts
+++ b/src/styles/colors/index.ts
@@ -18,10 +18,14 @@ export const baseColors = {
 	neutral925: "#141414",
 	neutral950: "#0A0A0A",
 
-	statusError: "#EF4444",
-	statusSuccess: "#10B981",
-	statusWarning: "#F59E0B",
-	statusInfo: "#3B82F6",
+	// caption 전용 AA 값 (neutral_500 과 분리 — SCSS _index.scss 와 동일)
+	textCaptionLight: "#6F6F6F",
+
+	// status — SCSS _index.scss 와 동일한 AA 통과(red/green/amber/blue-700) 값
+	statusError: "#B91C1C",
+	statusSuccess: "#047857",
+	statusWarning: "#B45309",
+	statusInfo: "#1D4ED8",
 
 	alphaBlack5: "rgba(0, 0, 0, 0.05)",
 	alphaBlack8: "rgba(0, 0, 0, 0.08)",
@@ -44,7 +48,7 @@ export const colors = {
 	text: {
 		heading: baseColors.neutral900,
 		body: baseColors.neutral700,
-		caption: baseColors.neutral500,
+		caption: baseColors.textCaptionLight,
 		brand: baseColors.brandPrimary,
 		inverse: baseColors.neutral0,
 		disabled: baseColors.alphaBlack38,

--- a/src/ui/display/accordion/Accordion.test.tsx
+++ b/src/ui/display/accordion/Accordion.test.tsx
@@ -74,4 +74,12 @@ describe("Accordion", () => {
 		fireEvent.click(screen.getByText("Title A"));
 		expect(onChange).toHaveBeenCalledWith(["a"]);
 	});
+
+	it("fires onValueChange (canonical)", () => {
+		const onValueChange = vi.fn();
+		render(<Accordion items={items} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByText("Title A"));
+		expect(onValueChange).toHaveBeenCalledWith(["a"]);
+	});
+
 });

--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -89,6 +89,8 @@ export const Accordion = ({
 							role="region"
 							aria-labelledby={headerId}
 							aria-hidden={!isOpen}
+							// 닫힌 패널은 grid 애니메이션이라 display:none 이 아님 → inert 로 내부 포커스 차단 (WCAG 4.1.2)
+							inert={!isOpen}
 							className={cn("accordion_panel", isOpen && "accordion_panel_open")}
 						>
 							<div className="accordion_panel_wrap">

--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -21,7 +21,9 @@ export interface AccordionProps extends Omit<React.HTMLAttributes<HTMLDivElement
 	defaultOpenKeys?: string[];
 	/** 제어형: 펼쳐진 키들 */
 	openKeys?: string[];
-	/** 펼침/접힘 콜백 */
+	/** 펼침/접힘 콜백 (canonical). 열린 키 배열 전달 */
+	onValueChange?: (openKeys: string[]) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
 	onChange?: (openKeys: string[]) => void;
 }
 
@@ -38,6 +40,7 @@ export const Accordion = ({
 	multiple = false,
 	defaultOpenKeys = [],
 	openKeys: controlledKeys,
+	onValueChange,
 	onChange,
 	className,
 	...props
@@ -54,7 +57,7 @@ export const Accordion = ({
 				? [...open, key]
 				: [key];
 		if (!isControlled) setInternalKeys(next);
-		onChange?.(next);
+		(onValueChange ?? onChange)?.(next);
 	};
 
 	return (

--- a/src/ui/display/card/Card.test.tsx
+++ b/src/ui/display/card/Card.test.tsx
@@ -151,4 +151,11 @@ describe("Card", () => {
 		expect(card).not.toHaveClass("card_interactive");
 		expect(card.querySelector(".card_footer")).not.toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Card ref={(el) => { node = el; }}>X</Card>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/display/card/index.tsx
+++ b/src/ui/display/card/index.tsx
@@ -32,6 +32,8 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 	footer?: React.ReactNode;
 	/** footer 정렬 (기본값: "end") */
 	footerAlign?: CardFooterAlign;
+	/** 루트 div 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLDivElement>;
 }
 
 /**
@@ -50,6 +52,7 @@ export const Card = ({
 	interactive = false,
 	footer,
 	footerAlign = "end",
+	ref,
 	className,
 	children,
 	...props
@@ -64,7 +67,7 @@ export const Card = ({
 	);
 
 	return (
-		<div className={cardClassName} {...props}>
+		<div ref={ref} className={cardClassName} {...props}>
 			{heading ? <HeadingTag className="card_title">{heading}</HeadingTag> : null}
 			<div className="card_body">{children}</div>
 			{footer ? (

--- a/src/ui/display/chip/style.scss
+++ b/src/ui/display/chip/style.scss
@@ -181,28 +181,30 @@
         .chip_content { color: token.$color_accent_default; }
     }
 
+    // status tone 은 Badge soft 와 동일한 container/on_container AA 쌍 사용
+    // (color-mix(12~14%) 틴트 위 raw status 텍스트는 4.15~4.24 로 4.5:1 미달이었음)
     &_tone_info {
-        background: color-mix(in srgb, token.$color_status_info 12%, transparent);
+        background: token.$color_status_info_container;
 
-        .chip_content { color: token.$color_status_info; }
+        .chip_content { color: token.$color_status_info_on_container; }
     }
 
     &_tone_success {
-        background: color-mix(in srgb, token.$color_status_success 12%, transparent);
+        background: token.$color_status_success_container;
 
-        .chip_content { color: token.$color_status_success; }
+        .chip_content { color: token.$color_status_success_on_container; }
     }
 
     &_tone_warning {
-        background: color-mix(in srgb, token.$color_status_warning 14%, transparent);
+        background: token.$color_status_warning_container;
 
-        .chip_content { color: token.$color_status_warning; }
+        .chip_content { color: token.$color_status_warning_on_container; }
     }
 
     &_tone_error {
-        background: color-mix(in srgb, token.$color_status_error 12%, transparent);
+        background: token.$color_status_error_container;
 
-        .chip_content { color: token.$color_status_error; }
+        .chip_content { color: token.$color_status_error_on_container; }
     }
 
     // ── Size variants (default = 32px) ────────────────────────────────────

--- a/src/ui/display/list-item/index.tsx
+++ b/src/ui/display/list-item/index.tsx
@@ -69,7 +69,8 @@ export const ListItem = ({
 				if (disabled || !onClick) return;
 				if (e.key === "Enter" || e.key === " ") {
 					e.preventDefault();
-					onClick(e as unknown as React.MouseEvent<HTMLDivElement>);
+					// 실제 click 디스패치 → onClick 이 진짜 MouseEvent 로 호출됨 (가짜 캐스팅 제거)
+					e.currentTarget.click();
 				}
 			}}
 			role={onClick ? "button" : undefined}

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -143,8 +143,11 @@ export const ToastProvider = ({
 		setToasts((prev) => prev.filter((t) => t.id !== id));
 	}, []);
 
+	// addToast 는 stable(useCallback) — value 객체만 메모이즈해 소비자 불필요 리렌더 방지
+	const contextValue = React.useMemo(() => ({ addToast }), [addToast]);
+
 	return (
-		<ToastContext.Provider value={{ addToast }}>
+		<ToastContext.Provider value={contextValue}>
 			{children}
 			{isMounted &&
 				createPortal(

--- a/src/ui/forms/date-picker/DatePicker.test.tsx
+++ b/src/ui/forms/date-picker/DatePicker.test.tsx
@@ -170,4 +170,14 @@ describe("DatePicker", () => {
 		);
 		expect(screen.getByText("오늘까지 선택 가능")).toBeInTheDocument();
 	});
+
+	it("calls onValueChange (canonical) when year is selected", () => {
+		const onValueChange = vi.fn();
+		render(<DatePicker mode="year-month" startYear={2020} endYear={2025} onValueChange={onValueChange} />);
+		const buttons = screen.getAllByRole("button");
+		fireEvent.click(buttons[0]);
+		fireEvent.click(screen.getByText("2024"));
+		expect(onValueChange).toHaveBeenCalledWith("2024-01");
+	});
+
 });

--- a/src/ui/forms/date-picker/index.tsx
+++ b/src/ui/forms/date-picker/index.tsx
@@ -13,8 +13,10 @@ export interface DatePickerProps {
 	label?: string;
 	/** 제어형 날짜 값 ("YYYY-MM" 또는 "YYYY-MM-DD" 형식) */
 	value?: string;
-	/** 날짜 변경 시 호출되는 콜백. `mode` 값에 따라 "YYYY-MM" 또는 "YYYY-MM-DD" 형식의 문자열이 전달됩니다. */
-	onChange: (value: string) => void;
+	/** 날짜 변경 콜백 (canonical). `mode` 값에 따라 "YYYY-MM" 또는 "YYYY-MM-DD" 형식의 문자열이 전달됩니다. */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (value: string) => void;
 	/** 선택 모드 (기본값: "year-month-day") */
 	mode?: DatePickerMode;
 	/** 연도 선택 범위 시작 (기본값: 1950) */
@@ -72,6 +74,7 @@ const range = (start: number, end: number) =>
 export const DatePicker = ({
 	label,
 	value,
+	onValueChange,
 	onChange,
 	mode = "year-month-day",
 	startYear = 1950,
@@ -184,14 +187,15 @@ export const DatePicker = ({
 
 	const emit = React.useCallback(
 		(yy: number, mm: number, dd?: number) => {
+			const cb = onValueChange ?? onChange;
 			if (mode === "year-month") {
-				onChange(`${yy}-${pad(mm)}`);
+				cb?.(`${yy}-${pad(mm)}`);
 				return;
 			}
 			const safeDay = Math.min(dd ?? 1, getDaysInMonth(yy, mm));
-			onChange(`${yy}-${pad(mm)}-${pad(safeDay)}`);
+			cb?.(`${yy}-${pad(mm)}-${pad(safeDay)}`);
 		},
-		[mode, onChange],
+		[mode, onValueChange, onChange],
 	);
 
 	// ── 핸들러: 연/월 변경 시 하위 값 자동 보정 ──────────────────────────
@@ -271,7 +275,7 @@ export const DatePicker = ({
 					placeholder={yearLabel}
 					options={yearOptions}
 					value={year ? String(year) : null}
-					onChange={handleYearChange}
+					onValueChange={handleYearChange}
 					disabled={disabled}
 				/>
 
@@ -282,7 +286,7 @@ export const DatePicker = ({
 					placeholder={monthLabel}
 					options={monthOptions}
 					value={month ? String(month) : null}
-					onChange={handleMonthChange}
+					onValueChange={handleMonthChange}
 					disabled={disabled || !year}
 				/>
 
@@ -294,7 +298,7 @@ export const DatePicker = ({
 						placeholder={dayLabel}
 						options={dayOptions}
 						value={day ? String(day) : null}
-						onChange={handleDayChange}
+						onValueChange={handleDayChange}
 						disabled={disabled || !month}
 					/>
 				)}

--- a/src/ui/forms/date-picker/index.tsx
+++ b/src/ui/forms/date-picker/index.tsx
@@ -8,15 +8,11 @@ import "./style.scss";
 type DatePickerMode = "year-month" | "year-month-day";
 type SelectableRange = "all" | "until-today";
 
-export interface DatePickerProps {
+interface DatePickerBaseProps {
 	/** 데이트 피커 위에 표시할 라벨 텍스트 */
 	label?: string;
 	/** 제어형 날짜 값 ("YYYY-MM" 또는 "YYYY-MM-DD" 형식) */
 	value?: string;
-	/** 날짜 변경 콜백 (canonical). `mode` 값에 따라 "YYYY-MM" 또는 "YYYY-MM-DD" 형식의 문자열이 전달됩니다. */
-	onValueChange?: (value: string) => void;
-	/** @deprecated `onValueChange` 를 사용하세요. */
-	onChange?: (value: string) => void;
 	/** 선택 모드 (기본값: "year-month-day") */
 	mode?: DatePickerMode;
 	/** 연도 선택 범위 시작 (기본값: 1950) */
@@ -53,6 +49,14 @@ export interface DatePickerProps {
 	 */
 	selectableRangeUntilTodaySrText?: string;
 }
+
+// DatePicker 는 controlled 전용(내부 value 상태 없음) → 콜백이 최소 하나는 필요.
+// canonical `onValueChange` 권장, 구 `onChange` 도 허용(@deprecated). 둘 중 하나는 필수.
+type DatePickerCallbacks =
+	| { onValueChange: (value: string) => void; onChange?: (value: string) => void }
+	| { onValueChange?: (value: string) => void; onChange: (value: string) => void };
+
+export type DatePickerProps = DatePickerBaseProps & DatePickerCallbacks;
 
 /** 숫자를 두 자리 문자열로 보정한다. */
 const pad = (n: number) => String(n).padStart(2, "0");

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -481,4 +481,13 @@ describe("Dropdown", () => {
 		// value="999" 는 옵션에 없음 - placeholder가 보여야 함
 		expect(screen.getByText("Select…")).toBeInTheDocument();
 	});
+
+	it("calls onValueChange (canonical) on select", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.click(screen.getByText("Option 1"));
+		expect(onValueChange).toHaveBeenCalledWith("1", options[0]);
+	});
+
 });

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -42,7 +42,9 @@ export interface DropdownProps {
 	options: DropdownOption[];
 	/** 제어형 선택 값 */
 	value?: string | null;
-	/** 값 변경 시 호출되는 콜백. 선택된 값과 전체 옵션 객체를 인자로 전달합니다. */
+	/** 값 변경 콜백 (canonical). 선택된 값과 전체 옵션 객체를 전달합니다. */
+	onValueChange?: (value: string | null, option?: DropdownOption | null) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
 	onChange?: (value: string | null, option?: DropdownOption | null) => void;
 	/** 비제어형 초기 선택 값 */
 	defaultValue?: string | null;
@@ -78,6 +80,7 @@ export const Dropdown = ({
 	placeholder = "Select…",
 	options,
 	value,
+	onValueChange,
 	onChange,
 	defaultValue = null,
 	disabled,
@@ -109,9 +112,9 @@ export const Dropdown = ({
 		(next: string | null) => {
 			const option = options.find((o) => o.value === next) ?? null;
 			if (!isControlled) setInternalValue(next);
-			onChange?.(next, option);
+			(onValueChange ?? onChange)?.(next, option);
 		},
-		[isControlled, onChange, options],
+		[isControlled, onValueChange, onChange, options],
 	);
 
 	useEffect(() => {

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -94,14 +94,17 @@ export const FileInput = ({
 		onFiles?.(null);
 	};
 
-	// cleanup on unmount
+	// unmount 시에만 마지막 URL 정리. 변경 시 revoke 는 handleChange/handleRemove 가 담당하므로
+	// deps 를 [previewUrls] 로 두면 변경마다 cleanup 이 돌아 이중 revoke 가 된다 → ref 로 최신값 추적.
+	const previewUrlsRef = React.useRef<string[]>([]);
+	previewUrlsRef.current = previewUrls;
 	React.useEffect(() => {
 		return () => {
-			for (const url of previewUrls) {
+			for (const url of previewUrlsRef.current) {
 				URL.revokeObjectURL(url);
 			}
 		};
-	}, [previewUrls]);
+	}, []);
 
 	const hasImage = previewUrls.length > 0;
 	const rootClassName = cn(

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -58,10 +58,9 @@ export const FileInput = ({
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const files = e.currentTarget.files;
-		onFiles?.(files);
-		// 사용자가 onChange 도 넘긴 경우 함께 호출 (back-compat)
-		onChange?.(e);
 
+		// preview URL 생성 + ref 갱신을 onFiles/onChange 호출보다 먼저 — 부모가 onFiles 안에서
+		// 동기 unmount 해도 ref 가 새 URL 을 이미 담고 있어 unmount cleanup 이 정리할 수 있도록.
 		if (showPreview && files) {
 			for (const url of previewUrls) {
 				URL.revokeObjectURL(url);
@@ -84,6 +83,10 @@ export const FileInput = ({
 			setPreviewUrls([]);
 			previewUrlsRef.current = [];
 		}
+
+		onFiles?.(files);
+		// 사용자가 onChange 도 넘긴 경우 함께 호출 (back-compat)
+		onChange?.(e);
 	};
 
 	const handleRemove = (e: React.MouseEvent) => {

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -97,7 +97,10 @@ export const FileInput = ({
 	// unmount 시에만 마지막 URL 정리. 변경 시 revoke 는 handleChange/handleRemove 가 담당하므로
 	// deps 를 [previewUrls] 로 두면 변경마다 cleanup 이 돌아 이중 revoke 가 된다 → ref 로 최신값 추적.
 	const previewUrlsRef = React.useRef<string[]>([]);
-	previewUrlsRef.current = previewUrls;
+	// 최신 previewUrls 를 effect 에서 동기화 — render phase 에서 ref 직접 수정 금지(concurrent/strict 안전)
+	React.useEffect(() => {
+		previewUrlsRef.current = previewUrls;
+	}, [previewUrls]);
 	React.useEffect(() => {
 		return () => {
 			for (const url of previewUrlsRef.current) {

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -49,6 +49,9 @@ export const FileInput = ({
 	const helperId = React.useId();
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const [previewUrls, setPreviewUrls] = React.useState<string[]>([]);
+	// 최신 objectURL 목록을 동기적으로 추적 — unmount(특히 onFiles 안에서 부모가 동기 unmount 하는
+	// 경우)에도 새로 만든 URL 까지 정리되도록 handleChange/handleRemove 에서 즉시 갱신.
+	const previewUrlsRef = React.useRef<string[]>([]);
 
 	const isPreviewVariant = variant === "preview";
 	const showPreview = isPreviewVariant || preview;
@@ -73,11 +76,13 @@ export const FileInput = ({
 				}
 			}
 			setPreviewUrls(urls);
+			previewUrlsRef.current = urls;
 		} else {
 			for (const url of previewUrls) {
 				URL.revokeObjectURL(url);
 			}
 			setPreviewUrls([]);
+			previewUrlsRef.current = [];
 		}
 	};
 
@@ -88,19 +93,14 @@ export const FileInput = ({
 			URL.revokeObjectURL(url);
 		}
 		setPreviewUrls([]);
+		previewUrlsRef.current = [];
 		if (inputRef.current) {
 			inputRef.current.value = "";
 		}
 		onFiles?.(null);
 	};
 
-	// unmount 시에만 마지막 URL 정리. 변경 시 revoke 는 handleChange/handleRemove 가 담당하므로
-	// deps 를 [previewUrls] 로 두면 변경마다 cleanup 이 돌아 이중 revoke 가 된다 → ref 로 최신값 추적.
-	const previewUrlsRef = React.useRef<string[]>([]);
-	// 최신 previewUrls 를 effect 에서 동기화 — render phase 에서 ref 직접 수정 금지(concurrent/strict 안전)
-	React.useEffect(() => {
-		previewUrlsRef.current = previewUrls;
-	}, [previewUrls]);
+	// unmount 시 남은 objectURL 정리 (변경 시 revoke 는 handleChange/handleRemove 가 담당)
 	React.useEffect(() => {
 		return () => {
 			for (const url of previewUrlsRef.current) {

--- a/src/ui/forms/otp-input/OtpInput.test.tsx
+++ b/src/ui/forms/otp-input/OtpInput.test.tsx
@@ -399,4 +399,12 @@ describe("OtpInput", () => {
 			expect(onChange).not.toHaveBeenCalled();
 		});
 	});
+
+	it("calls onValueChange (canonical) when digit entered", () => {
+		const onValueChange = vi.fn();
+		render(<OtpInput length={6} value="" onValueChange={onValueChange} ariaLabel="OTP" />);
+		fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "5" } });
+		expect(onValueChange).toHaveBeenCalledWith("5");
+	});
+
 });

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -9,7 +9,9 @@ export interface OtpInputProps {
 	length?: 4 | 6;
 	/** 제어형 값 */
 	value?: string;
-	/** 값 변경 콜백 */
+	/** 값 변경 콜백 (canonical) */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
 	onChange?: (value: string) => void;
 	/** 에러 상태 */
 	error?: boolean;
@@ -34,6 +36,7 @@ export interface OtpInputProps {
 export const OtpInput = ({
 	length = 6,
 	value = "",
+	onValueChange,
 	onChange,
 	error = false,
 	disabled = false,
@@ -61,7 +64,7 @@ export const OtpInput = ({
 	};
 
 	const updateValue = (newDigits: string[]) => {
-		onChange?.(newDigits.join(""));
+		(onValueChange ?? onChange)?.(newDigits.join(""));
 	};
 
 	const handleChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/forms/textarea/Textarea.test.tsx
+++ b/src/ui/forms/textarea/Textarea.test.tsx
@@ -121,4 +121,12 @@ describe("Textarea", () => {
 		expect(onChange).toHaveBeenLastCalledWith("한");
 	});
 
+
+	it("calls onValueChange (canonical) on input", () => {
+		const onValueChange = vi.fn();
+		render(<Textarea label="내용" onValueChange={onValueChange} />);
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "hello" } });
+		expect(onValueChange).toHaveBeenCalledWith("hello");
+	});
+
 });

--- a/src/ui/forms/textarea/index.tsx
+++ b/src/ui/forms/textarea/index.tsx
@@ -26,7 +26,9 @@ export interface TextareaProps
 	error?: boolean;
 	/** 컨테이너 전체 너비 차지 여부 */
 	fullWidth?: boolean;
-	/** 값 변경 시 호출되는 콜백. 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	/** 값 변경 콜백 (canonical). 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. (Next 서버액션 전달용으로 `Action` 접미사가 필요하면 그대로 사용 가능) */
 	onChangeAction?: (value: string) => void;
 	/**
 	 * IME 조합 중 콜백 전략 (기본값: "delayed").
@@ -81,6 +83,7 @@ export const Textarea = ({
 	fullWidth,
 	size = "md",
 	className,
+	onValueChange,
 	onChangeAction,
 	imeStrategy = "delayed",
 	value,
@@ -174,7 +177,7 @@ export const Textarea = ({
 		setInnerValue(nextValue);
 		if (nextValue !== lastEmittedValueRef.current) {
 			lastEmittedValueRef.current = nextValue;
-			onChangeAction?.(nextValue);
+			(onValueChange ?? onChangeAction)?.(nextValue);
 		}
 	};
 
@@ -215,7 +218,7 @@ export const Textarea = ({
 								setInnerValue(rawValue);
 								if (imeStrategy === "immediate" && rawValue !== lastEmittedValueRef.current) {
 									lastEmittedValueRef.current = rawValue;
-									onChangeAction?.(rawValue);
+									(onValueChange ?? onChangeAction)?.(rawValue);
 								}
 								return;
 							}

--- a/src/ui/forms/textfield/TextField.test.tsx
+++ b/src/ui/forms/textfield/TextField.test.tsx
@@ -125,4 +125,12 @@ describe("TextField", () => {
 
 		expect(handleChange).toHaveBeenCalledWith("ABC");
 	});
+
+	it("calls onValueChange (canonical) on input", () => {
+		const handleChange = vi.fn();
+		render(<TextField onValueChange={handleChange} />);
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "test@example.com" } });
+		expect(handleChange).toHaveBeenCalledWith("test@example.com");
+	});
+
 });

--- a/src/ui/forms/textfield/index.tsx
+++ b/src/ui/forms/textfield/index.tsx
@@ -38,7 +38,9 @@ export interface TextFieldProps
 	clearable?: boolean;
 	/** 컨테이너 전체 너비 차지 여부 */
 	fullWidth?: boolean;
-	/** 값 변경 시 호출되는 콜백. 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	/** 값 변경 콜백 (canonical). 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
+	onValueChange?: (value: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. (Next 서버액션 전달용으로 `Action` 접미사가 필요하면 그대로 사용 가능) */
 	onChangeAction?: (value: string) => void;
 	/**
 	 * IME 조합 중 콜백 전략 (기본값: "delayed").
@@ -77,6 +79,7 @@ export const TextField = ({
 	fullWidth,
 	size = "md",
 	className,
+	onValueChange,
 	onChangeAction,
 	imeStrategy = "delayed",
 	value,
@@ -119,10 +122,10 @@ export const TextField = ({
 			setInnerValue(nextValue);
 			if (nextValue !== lastEmittedValueRef.current) {
 				lastEmittedValueRef.current = nextValue;
-				onChangeAction?.(nextValue);
+				(onValueChange ?? onChangeAction)?.(nextValue);
 			}
 		},
-		[onChangeAction],
+		[onValueChange, onChangeAction],
 	);
 
 	const handleClear = useCallback(() => {
@@ -198,7 +201,7 @@ export const TextField = ({
 									// immediate: 조합 중에도 외부 구독 즉시 반영 (raw value).
 									if (imeStrategy === "immediate" && rawValue !== lastEmittedValueRef.current) {
 										lastEmittedValueRef.current = rawValue;
-										onChangeAction?.(rawValue);
+										(onValueChange ?? onChangeAction)?.(rawValue);
 									}
 									return;
 								}

--- a/src/ui/forms/toggle/Toggle.test.tsx
+++ b/src/ui/forms/toggle/Toggle.test.tsx
@@ -81,4 +81,12 @@ describe("Toggle", () => {
 		// Controlled: aria-checked stays at the prop value (false)
 		expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
 	});
+
+	it("calls onCheckedChange (canonical) on click", () => {
+		const onCheckedChange = vi.fn();
+		render(<Toggle ariaLabel="Toggle" onCheckedChange={onCheckedChange} />);
+		fireEvent.click(screen.getByRole("switch"));
+		expect(onCheckedChange).toHaveBeenCalledWith(true);
+	});
+
 });

--- a/src/ui/forms/toggle/index.tsx
+++ b/src/ui/forms/toggle/index.tsx
@@ -10,7 +10,9 @@ export interface ToggleProps
 	checked?: boolean;
 	/** 비제어형 초기 토글 상태 */
 	defaultChecked?: boolean;
-	/** 상태 변경 시 호출되는 콜백 */
+	/** 상태 변경 콜백 (canonical) */
+	onCheckedChange?: (checked: boolean) => void;
+	/** @deprecated `onCheckedChange` 를 사용하세요. */
 	onChange?: (checked: boolean) => void;
 	/** 토글 크기 (기본값: "sm") */
 	size?: "sm" | "md";
@@ -31,6 +33,7 @@ export interface ToggleProps
 export const Toggle = ({
 	checked,
 	defaultChecked,
+	onCheckedChange,
 	onChange,
 	size = "sm",
 	disabled,
@@ -51,7 +54,7 @@ export const Toggle = ({
 		if (disabled) return;
 		const next = !isOn;
 		if (!isControlled) setInnerChecked(next);
-		onChange?.(next);
+		(onCheckedChange ?? onChange)?.(next);
 	};
 
 	const rootClassName = cn(

--- a/src/ui/general/button/Button.test.tsx
+++ b/src/ui/general/button/Button.test.tsx
@@ -77,4 +77,11 @@ describe("Button", () => {
 		render(<Button>Button</Button>);
 		expect(screen.getByRole("button")).not.toHaveClass("button_full_width");
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLButtonElement | null = null;
+		render(<Button ref={(el) => { node = el; }}>X</Button>);
+		expect(node).toBeInstanceOf(HTMLButtonElement);
+	});
+
 });

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -25,6 +25,8 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 	 * filled: 빨간 bg, outline: 빨간 텍스트/border, tonal: 빨간 wash.
 	 */
 	danger?: boolean;
+	/** 루트 button 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLButtonElement>;
 }
 
 /**
@@ -42,6 +44,7 @@ export const Button = ({
 	radius,
 	danger = false,
 	type = "button",
+	ref,
 	className,
 	children,
 	...props
@@ -57,7 +60,7 @@ export const Button = ({
 	);
 
 	return (
-		<button type={type} className={buttonClassName} {...props}>
+		<button ref={ref} type={type} className={buttonClassName} {...props}>
 			{leadingIcon && (
 				<span className="button_icon" aria-hidden="true">
 					{leadingIcon}

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -41,6 +41,7 @@ export const Button = ({
 	fullWidth = false,
 	radius,
 	danger = false,
+	type = "button",
 	className,
 	children,
 	...props
@@ -56,7 +57,7 @@ export const Button = ({
 	);
 
 	return (
-		<button className={buttonClassName} {...props}>
+		<button type={type} className={buttonClassName} {...props}>
 			{leadingIcon && (
 				<span className="button_icon" aria-hidden="true">
 					{leadingIcon}

--- a/src/ui/general/icon-button/IconButton.test.tsx
+++ b/src/ui/general/icon-button/IconButton.test.tsx
@@ -68,4 +68,11 @@ describe("IconButton", () => {
 		render(<IconButton icon={<TestIcon />} aria-label="action" className="custom-class" />);
 		expect(screen.getByRole("button")).toHaveClass("custom-class");
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLButtonElement | null = null;
+		render(<IconButton icon={<i />} aria-label="x" ref={(el) => { node = el; }} />);
+		expect(node).toBeInstanceOf(HTMLButtonElement);
+	});
+
 });

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -26,6 +26,7 @@ export const IconButton = ({
 	variant = "standard",
 	size = "md",
 	icon,
+	type = "button",
 	className,
 	...props
 }: IconButtonProps) => {
@@ -37,7 +38,7 @@ export const IconButton = ({
 	);
 
 	return (
-		<button className={buttonClassName} {...props}>
+		<button type={type} className={buttonClassName} {...props}>
 			<span className="icon_button_icon" aria-hidden="true">
 				{icon}
 			</span>

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -14,6 +14,8 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
 	size?: IconButtonSize;
 	/** 표시할 아이콘 */
 	icon: React.ReactNode;
+	/** 루트 button 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLButtonElement>;
 }
 
 /**
@@ -27,6 +29,7 @@ export const IconButton = ({
 	size = "md",
 	icon,
 	type = "button",
+	ref,
 	className,
 	...props
 }: IconButtonProps) => {
@@ -38,7 +41,7 @@ export const IconButton = ({
 	);
 
 	return (
-		<button type={type} className={buttonClassName} {...props}>
+		<button ref={ref} type={type} className={buttonClassName} {...props}>
 			<span className="icon_button_icon" aria-hidden="true">
 				{icon}
 			</span>

--- a/src/ui/layout/container/Container.test.tsx
+++ b/src/ui/layout/container/Container.test.tsx
@@ -34,7 +34,7 @@ describe("Container", () => {
 	});
 
 	it("forwards ref to the root element", () => {
-		let node: HTMLDivElement | null = null;
+		let node: HTMLElement | null = null;
 		render(<Container ref={(el) => { node = el; }}>X</Container>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});

--- a/src/ui/layout/container/Container.test.tsx
+++ b/src/ui/layout/container/Container.test.tsx
@@ -32,4 +32,11 @@ describe("Container", () => {
 		const { container } = render(<Container className="custom" />);
 		expect(container.firstChild).toHaveClass("custom");
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Container ref={(el) => { node = el; }}>X</Container>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/layout/container/index.tsx
+++ b/src/ui/layout/container/index.tsx
@@ -17,6 +17,8 @@ export interface ContainerProps extends React.HTMLAttributes<HTMLDivElement> {
 	center?: boolean;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -35,12 +37,14 @@ export const Container = ({
 	size = "xl",
 	center = true,
 	as: Tag = "div",
+	ref,
 	className,
 	children,
 	...props
 }: ContainerProps) => {
 	return (
 		<Tag
+			ref={ref}
 			className={cn("container", `container_size_${size}`, center && "container_center", className)}
 			{...props}
 		>

--- a/src/ui/layout/grid/Grid.test.tsx
+++ b/src/ui/layout/grid/Grid.test.tsx
@@ -56,7 +56,7 @@ describe("Grid", () => {
 	});
 
 	it("forwards ref to the root element", () => {
-		let node: HTMLDivElement | null = null;
+		let node: HTMLElement | null = null;
 		render(<Grid ref={(el) => { node = el; }}>X</Grid>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});

--- a/src/ui/layout/grid/Grid.test.tsx
+++ b/src/ui/layout/grid/Grid.test.tsx
@@ -54,4 +54,11 @@ describe("Grid", () => {
 		const { container } = render(<Grid as="ul" />);
 		expect(container.querySelector("ul")).toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Grid ref={(el) => { node = el; }}>X</Grid>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/layout/grid/index.tsx
+++ b/src/ui/layout/grid/index.tsx
@@ -31,6 +31,8 @@ export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
 	singleColOnMobile?: boolean;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -58,6 +60,7 @@ export const Grid = ({
 	colGap,
 	singleColOnMobile = true,
 	as: Tag = "div",
+	ref,
 	className,
 	children,
 	style,
@@ -70,6 +73,7 @@ export const Grid = ({
 
 	return (
 		<Tag
+			ref={ref}
 			className={cn("grid_layout", singleColOnMobile && "grid_layout_mobile_single", className)}
 			style={
 				{

--- a/src/ui/layout/section/Section.test.tsx
+++ b/src/ui/layout/section/Section.test.tsx
@@ -37,4 +37,11 @@ describe("Section", () => {
 		expect(container.querySelector("div")).toBeInTheDocument();
 		expect(container.querySelector("section")).not.toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLElement | null = null;
+		render(<Section ref={(el) => { node = el; }}>X</Section>);
+		expect(node).toBeInstanceOf(HTMLElement);
+	});
+
 });

--- a/src/ui/layout/section/index.tsx
+++ b/src/ui/layout/section/index.tsx
@@ -22,6 +22,8 @@ export interface SectionProps extends React.HTMLAttributes<HTMLElement> {
 	bg?: SectionBg;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -41,12 +43,14 @@ export const Section = ({
 	spacing = "md",
 	bg = "default",
 	as: Tag = "section",
+	ref,
 	className,
 	children,
 	...props
 }: SectionProps) => {
 	return (
 		<Tag
+			ref={ref}
 			className={cn(
 				"section",
 				`section_spacing_${spacing}`,

--- a/src/ui/layout/stack/Stack.test.tsx
+++ b/src/ui/layout/stack/Stack.test.tsx
@@ -49,4 +49,11 @@ describe("Stack", () => {
 		const { container } = render(<Stack as="ul" />);
 		expect(container.querySelector("ul")).toBeInTheDocument();
 	});
+
+	it("forwards ref to the root element", () => {
+		let node: HTMLDivElement | null = null;
+		render(<Stack ref={(el) => { node = el; }}>X</Stack>);
+		expect(node).toBeInstanceOf(HTMLDivElement);
+	});
+
 });

--- a/src/ui/layout/stack/Stack.test.tsx
+++ b/src/ui/layout/stack/Stack.test.tsx
@@ -51,7 +51,7 @@ describe("Stack", () => {
 	});
 
 	it("forwards ref to the root element", () => {
-		let node: HTMLDivElement | null = null;
+		let node: HTMLElement | null = null;
 		render(<Stack ref={(el) => { node = el; }}>X</Stack>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});

--- a/src/ui/layout/stack/index.tsx
+++ b/src/ui/layout/stack/index.tsx
@@ -29,6 +29,8 @@ export interface StackProps extends React.HTMLAttributes<HTMLDivElement> {
 	wrap?: StackWrap;
 	/** 렌더링할 HTML 요소 */
 	as?: React.ElementType;
+	/** 루트 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -55,6 +57,7 @@ export const Stack = ({
 	justify,
 	wrap,
 	as: Tag = "div",
+	ref,
 	className,
 	children,
 	style,
@@ -62,6 +65,7 @@ export const Stack = ({
 }: StackProps) => {
 	return (
 		<Tag
+			ref={ref}
 			className={cn(
 				"stack",
 				`stack_${direction}`,

--- a/src/ui/navigation/menu/Menu.test.tsx
+++ b/src/ui/navigation/menu/Menu.test.tsx
@@ -394,4 +394,17 @@ describe("Menu", () => {
 		expect(trigger).toHaveFocus();
 	});
 
+
+	it("does not bubble handled keys to parent (stopPropagation)", () => {
+		const parentKeyDown = vi.fn();
+		render(
+			<div onKeyDown={parentKeyDown}>
+				<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />
+			</div>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+		expect(parentKeyDown).not.toHaveBeenCalled();
+	});
+
 });

--- a/src/ui/navigation/menu/Menu.test.tsx
+++ b/src/ui/navigation/menu/Menu.test.tsx
@@ -305,4 +305,93 @@ describe("Menu", () => {
 		unmount();
 		expect(() => fireEvent.keyDown(document, { key: "Escape" })).not.toThrow();
 	});
+
+	it("focuses first enabled item when opened (APG menu button)", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getAllByRole("menuitem")[0]).toHaveFocus();
+	});
+
+	it("moves focus with ArrowDown / ArrowUp (wraps)", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const menu = screen.getByRole("menu");
+		const items = screen.getAllByRole("menuitem");
+		fireEvent.keyDown(menu, { key: "ArrowDown" });
+		expect(items[1]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "ArrowDown" });
+		expect(items[0]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "ArrowUp" });
+		expect(items[1]).toHaveFocus();
+	});
+
+	it("Home / End jump to first / last item", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+					{ key: "c", label: "C" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const menu = screen.getByRole("menu");
+		const items = screen.getAllByRole("menuitem");
+		fireEvent.keyDown(menu, { key: "End" });
+		expect(items[2]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "Home" });
+		expect(items[0]).toHaveFocus();
+	});
+
+	it("skips disabled items during arrow navigation", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B", disabled: true },
+					{ key: "c", label: "C" },
+				]}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const menu = screen.getByRole("menu");
+		const items = screen.getAllByRole("menuitem");
+		expect(items[0]).toHaveFocus();
+		fireEvent.keyDown(menu, { key: "ArrowDown" });
+		expect(items[2]).toHaveFocus();
+	});
+
+	it("Escape closes and returns focus to the trigger", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Open" });
+		fireEvent.click(trigger);
+		fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+		expect(trigger).toHaveFocus();
+	});
+
 });

--- a/src/ui/navigation/menu/Menu.test.tsx
+++ b/src/ui/navigation/menu/Menu.test.tsx
@@ -407,4 +407,17 @@ describe("Menu", () => {
 		expect(parentKeyDown).not.toHaveBeenCalled();
 	});
 
+
+	it("lets Tab bubble to parent (focus-trap compatibility)", () => {
+		const parentKeyDown = vi.fn();
+		render(
+			<div onKeyDown={parentKeyDown}>
+				<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />
+			</div>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		fireEvent.keyDown(screen.getByRole("menu"), { key: "Tab" });
+		expect(parentKeyDown).toHaveBeenCalled();
+	});
+
 });

--- a/src/ui/navigation/menu/Menu.test.tsx
+++ b/src/ui/navigation/menu/Menu.test.tsx
@@ -420,4 +420,22 @@ describe("Menu", () => {
 		expect(parentKeyDown).toHaveBeenCalled();
 	});
 
+
+	it("focuses first item even when the trigger had focus before opening", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+				]}
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Open" });
+		trigger.focus();
+		expect(trigger).toHaveFocus();
+		fireEvent.click(trigger);
+		expect(screen.getAllByRole("menuitem")[0]).toHaveFocus();
+	});
+
 });

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -43,6 +43,7 @@ export interface MenuProps {
 export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 	const [open, setOpen] = React.useState(false);
 	const wrapperRef = React.useRef<HTMLSpanElement>(null);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
 	const menuId = React.useId();
 
 	const style = useSpringPresence({ visible: open, from: "translateY(-4px)" });
@@ -63,6 +64,56 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 		};
 	}, [open]);
 
+	// 열릴 때 첫 활성 아이템에 포커스 (WAI-ARIA menu button 패턴). 이미 메뉴 내부에 포커스가
+	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음.
+	React.useEffect(() => {
+		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		const first = items.findIndex((it) => !it.disabled);
+		if (first >= 0) itemRefs.current[first]?.focus();
+	}, [open, items]);
+
+	// 화살표/Home/End 로 메뉴 아이템 간 roving 포커스
+	const moveFocus = (dir: 1 | -1 | "first" | "last") => {
+		const enabled = items.flatMap((it, i) => (it.disabled ? [] : [i]));
+		if (enabled.length === 0) return;
+		if (dir === "first") return void itemRefs.current[enabled[0]]?.focus();
+		if (dir === "last") return void itemRefs.current[enabled[enabled.length - 1]]?.focus();
+		const pos = enabled.findIndex((i) => itemRefs.current[i] === document.activeElement);
+		const next =
+			pos < 0 ? (dir === 1 ? 0 : enabled.length - 1) : (pos + dir + enabled.length) % enabled.length;
+		itemRefs.current[enabled[next]]?.focus();
+	};
+
+	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				moveFocus(1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				moveFocus(-1);
+				break;
+			case "Home":
+				e.preventDefault();
+				moveFocus("first");
+				break;
+			case "End":
+				e.preventDefault();
+				moveFocus("last");
+				break;
+			case "Escape":
+				e.preventDefault();
+				setOpen(false);
+				// trigger 로 포커스 복귀
+				wrapperRef.current?.querySelector<HTMLElement>("[aria-haspopup]")?.focus();
+				break;
+			case "Tab":
+				setOpen(false);
+				break;
+		}
+	};
+
 	const triggerWithProps = React.cloneElement(
 		trigger as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
 		{
@@ -82,12 +133,17 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 					role="menu"
 					style={style}
 					className={cn("menu", `menu_align_${align}`)}
+					onKeyDown={handleMenuKeyDown}
 				>
-					{items.map((item) => (
+					{items.map((item, index) => (
 						<button
 							key={item.key}
+							ref={(el) => {
+								itemRefs.current[index] = el;
+							}}
 							type="button"
 							role="menuitem"
+							tabIndex={-1}
 							disabled={item.disabled}
 							className={cn(
 								"menu_item",

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -64,10 +64,11 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 		};
 	}, [open]);
 
-	// 열릴 때 첫 활성 아이템에 포커스 (WAI-ARIA menu button 패턴). 이미 메뉴 내부에 포커스가
-	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음.
+	// 열릴 때 첫 활성 아이템에 포커스 (WAI-ARIA menu button 패턴). 이미 메뉴 "아이템"에 포커스가
+	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음 — trigger 포커스는 내부로 치지 않아
+	// 트리거 클릭으로 열 때 첫 항목 포커스를 보장한다.
 	React.useEffect(() => {
-		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
 		const first = items.findIndex((it) => !it.disabled);
 		if (first >= 0) itemRefs.current[first]?.focus();
 	}, [open, items]);

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -85,6 +85,10 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 	};
 
 	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		// 메뉴가 처리하는 키는 상위로 전파 차단 — 예: Modal 안의 Menu 에서 Esc 가 둘 다 닫히는 것 방지
+		if (["ArrowDown", "ArrowUp", "Home", "End", "Escape", "Tab"].includes(e.key)) {
+			e.stopPropagation();
+		}
 		switch (e.key) {
 			case "ArrowDown":
 				e.preventDefault();

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -85,8 +85,9 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 	};
 
 	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		// 메뉴가 처리하는 키는 상위로 전파 차단 — 예: Modal 안의 Menu 에서 Esc 가 둘 다 닫히는 것 방지
-		if (["ArrowDown", "ArrowUp", "Home", "End", "Escape", "Tab"].includes(e.key)) {
+		// 메뉴 내부에서 소비하는 키만 상위로 전파 차단 — 예: Modal 안의 Menu 에서 Esc 가 둘 다 닫히는 것 방지.
+		// Tab 은 제외 — 부모 focus trap(Modal 등)이 Tab 을 감지해 포커스를 가둬야 하므로 전파시킨다.
+		if (["ArrowDown", "ArrowUp", "Home", "End", "Escape"].includes(e.key)) {
 			e.stopPropagation();
 		}
 		switch (e.key) {

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -68,7 +68,10 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음 — trigger 포커스는 내부로 치지 않아
 	// 트리거 클릭으로 열 때 첫 항목 포커스를 보장한다.
 	React.useEffect(() => {
-		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
+		const active = document.activeElement;
+		// active 가 실제 메뉴 아이템일 때만 가로채지 않음. null/trigger 는 첫 항목 포커스를 진행
+		// (itemRefs 에 null 이 섞여 있어도 includes(null) 오탐이 나지 않도록 active truthy 체크).
+		if (!open || (active && itemRefs.current.includes(active as HTMLButtonElement))) return;
 		const first = items.findIndex((it) => !it.disabled);
 		if (first >= 0) itemRefs.current[first]?.focus();
 	}, [open, items]);

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { NavBar, NavLink } from "./index";
 
 describe("NavBar", () => {
@@ -36,4 +36,50 @@ describe("NavBar", () => {
 		const { container } = render(<NavBar sticky>test</NavBar>);
 		expect(container.firstChild).toHaveClass("nav_bar_sticky");
 	});
+
+	describe("LocaleSwitcher", () => {
+		const makeLocale = (onChange = vi.fn()) => ({
+			current: "ko",
+			options: [
+				{ value: "ko", label: "한국어" },
+				{ value: "en", label: "English" },
+			],
+			onChange,
+		});
+
+		it("opens menu with options on trigger click", () => {
+			render(<NavBar locale={makeLocale()} />);
+			fireEvent.click(screen.getByRole("button"));
+			expect(screen.getByRole("menu")).toBeInTheDocument();
+			expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+		});
+
+		it("calls onChange and closes on option select", () => {
+			const onChange = vi.fn();
+			render(<NavBar locale={makeLocale(onChange)} />);
+			fireEvent.click(screen.getByRole("button"));
+			fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+			expect(onChange).toHaveBeenCalledWith("en");
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+		});
+
+		it("focuses first item on open and moves with ArrowDown", () => {
+			render(<NavBar locale={makeLocale()} />);
+			fireEvent.click(screen.getByRole("button"));
+			const items = screen.getAllByRole("menuitem");
+			expect(items[0]).toHaveFocus();
+			fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
+			expect(items[1]).toHaveFocus();
+		});
+
+		it("Escape closes and returns focus to the trigger", () => {
+			render(<NavBar locale={makeLocale()} />);
+			const trigger = screen.getByRole("button");
+			fireEvent.click(trigger);
+			fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+			expect(trigger).toHaveFocus();
+		});
+	});
+
 });

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -82,4 +82,24 @@ describe("NavBar", () => {
 		});
 	});
 
+
+	it("LocaleSwitcher calls onValueChange (canonical) on select", () => {
+		const onValueChange = vi.fn();
+		render(
+			<NavBar
+				locale={{
+					current: "ko",
+					options: [
+						{ value: "ko", label: "한국어" },
+						{ value: "en", label: "English" },
+					],
+					onValueChange,
+				}}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+		expect(onValueChange).toHaveBeenCalledWith("en");
+	});
+
 });

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -215,8 +215,8 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	};
 
 	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
-		// 처리하는 키는 상위로 전파 차단 (NavBar 가 키 핸들러를 가진 컨테이너 안에 있을 때 충돌 방지)
-		if (["ArrowDown", "ArrowUp", "Home", "End", "Escape", "Tab"].includes(e.key)) {
+		// 내부에서 소비하는 키만 상위로 전파 차단. Tab 은 제외 — 부모 focus trap 이 감지해야 하므로 전파시킨다.
+		if (["ArrowDown", "ArrowUp", "Home", "End", "Escape"].includes(e.key)) {
 			e.stopPropagation();
 		}
 		switch (e.key) {

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -19,8 +19,10 @@ export interface NavBarLocaleConfig {
 	current: string;
 	/** 가능한 옵션 */
 	options: NavBarLocaleOption[];
-	/** locale 변경 콜백 */
-	onChange: (next: string) => void;
+	/** locale 변경 콜백 (canonical) */
+	onValueChange?: (next: string) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (next: string) => void;
 	/** 표시 라벨 - 기본은 옵션의 label, 미지정 시 short code 표시 */
 	hideLabel?: boolean;
 }
@@ -242,7 +244,7 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	};
 
 	const handleSelect = (value: string) => {
-		locale.onChange(value);
+		(locale.onValueChange ?? locale.onChange)?.(value);
 		setOpen(false);
 	};
 

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -215,6 +215,10 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	};
 
 	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
+		// 처리하는 키는 상위로 전파 차단 (NavBar 가 키 핸들러를 가진 컨테이너 안에 있을 때 충돌 방지)
+		if (["ArrowDown", "ArrowUp", "Home", "End", "Escape", "Tab"].includes(e.key)) {
+			e.stopPropagation();
+		}
 		switch (e.key) {
 			case "ArrowDown":
 				e.preventDefault();

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -174,6 +174,7 @@ export const NavBar = ({
 const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	const [open, setOpen] = useState(false);
 	const wrapperRef = useRef<HTMLDivElement>(null);
+	const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 	const menuId = useId();
 
 	const currentOption = locale.options.find((o) => o.value === locale.current);
@@ -193,6 +194,52 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 			document.removeEventListener("keydown", escHandler);
 		};
 	}, [open]);
+
+	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 내부 포커스면 가로채지 않음.
+	useEffect(() => {
+		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		itemRefs.current[0]?.focus();
+	}, [open]);
+
+	// 화살표/Home/End roving 포커스 + Esc 닫고 trigger 복귀
+	const moveFocus = (dir: 1 | -1 | "first" | "last") => {
+		const n = locale.options.length;
+		if (n === 0) return;
+		if (dir === "first") return void itemRefs.current[0]?.focus();
+		if (dir === "last") return void itemRefs.current[n - 1]?.focus();
+		const pos = itemRefs.current.indexOf(document.activeElement as HTMLButtonElement | null);
+		const next = pos < 0 ? (dir === 1 ? 0 : n - 1) : (pos + dir + n) % n;
+		itemRefs.current[next]?.focus();
+	};
+
+	const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				moveFocus(1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				moveFocus(-1);
+				break;
+			case "Home":
+				e.preventDefault();
+				moveFocus("first");
+				break;
+			case "End":
+				e.preventDefault();
+				moveFocus("last");
+				break;
+			case "Escape":
+				e.preventDefault();
+				setOpen(false);
+				wrapperRef.current?.querySelector<HTMLElement>("[aria-haspopup]")?.focus();
+				break;
+			case "Tab":
+				setOpen(false);
+				break;
+		}
+	};
 
 	const handleSelect = (value: string) => {
 		locale.onChange(value);
@@ -218,12 +265,21 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 				<ChevronDown size={14} aria-hidden="true" className="nav_bar_locale_chevron" />
 			</button>
 			{open && (
-				<ul id={menuId} role="menu" className="nav_bar_locale_menu">
-					{locale.options.map((opt) => (
+				<ul
+					id={menuId}
+					role="menu"
+					className="nav_bar_locale_menu"
+					onKeyDown={handleMenuKeyDown}
+				>
+					{locale.options.map((opt, index) => (
 						<li key={opt.value} role="none">
 							<button
+								ref={(el) => {
+									itemRefs.current[index] = el;
+								}}
 								type="button"
 								role="menuitem"
+								tabIndex={-1}
 								className={cn(
 									"nav_bar_locale_item",
 									opt.value === locale.current && "nav_bar_locale_item_active",

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { ChevronDown, Globe } from "lucide-react";
-import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type * as React from "react";
-import { cn } from "../../../utils";
+import { cn, useSafeLayoutEffect } from "../../../utils";
 import "./style.scss";
 
 export type NavBarVariant = "default" | "transparent" | "accent";
@@ -89,7 +89,7 @@ export const NavBar = ({
 	const [indicator, setIndicator] = useState<{ left: number; width: number } | null>(null);
 	const [hasMounted, setHasMounted] = useState(false);
 
-	useLayoutEffect(() => {
+	useSafeLayoutEffect(() => {
 		const links = linksRef.current;
 		if (!links) return;
 

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -197,9 +197,10 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 		};
 	}, [open]);
 
-	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 내부 포커스면 가로채지 않음.
+	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 메뉴 "아이템"에 포커스가 있을 때만
+	// 가로채지 않음 — trigger 포커스는 내부로 치지 않아 클릭으로 열 때 첫 항목 포커스를 보장.
 	useEffect(() => {
-		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
 		itemRefs.current[0]?.focus();
 	}, [open]);
 

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -200,7 +200,9 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 메뉴 "아이템"에 포커스가 있을 때만
 	// 가로채지 않음 — trigger 포커스는 내부로 치지 않아 클릭으로 열 때 첫 항목 포커스를 보장.
 	useEffect(() => {
-		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
+		const active = document.activeElement;
+		// active 가 실제 메뉴 아이템일 때만 가로채지 않음 (null/trigger 는 첫 항목 포커스 진행).
+		if (!open || (active && itemRefs.current.includes(active as HTMLButtonElement))) return;
 		itemRefs.current[0]?.focus();
 	}, [open]);
 

--- a/src/ui/navigation/pagination/Pagination.test.tsx
+++ b/src/ui/navigation/pagination/Pagination.test.tsx
@@ -77,4 +77,12 @@ describe("Pagination", () => {
 		render(<Pagination page={3} totalPages={5} onChange={() => {}} />);
 		expect(screen.getByText("3")).toHaveClass("pagination_active");
 	});
+
+	it("calls onPageChange (canonical) when clicking previous", () => {
+		const onPageChange = vi.fn();
+		render(<Pagination page={5} totalPages={10} onPageChange={onPageChange} />);
+		fireEvent.click(screen.getByLabelText("Previous page"));
+		expect(onPageChange).toHaveBeenCalledWith(4);
+	});
+
 });

--- a/src/ui/navigation/pagination/index.tsx
+++ b/src/ui/navigation/pagination/index.tsx
@@ -9,8 +9,10 @@ export interface PaginationProps {
 	page: number;
 	/** 전체 페이지 수 */
 	totalPages: number;
-	/** 페이지 변경 시 호출되는 콜백 */
-	onChange: (page: number) => void;
+	/** 페이지 변경 콜백 (canonical) */
+	onPageChange?: (page: number) => void;
+	/** @deprecated `onPageChange` 를 사용하세요. */
+	onChange?: (page: number) => void;
 	/** 이전 페이지 버튼 aria-label (기본값: "Previous page") */
 	prevLabel?: string;
 	/** 다음 페이지 버튼 aria-label (기본값: "Next page") */
@@ -77,10 +79,12 @@ const getPaginationItems = (page: number, totalPages: number) => {
 export const Pagination = ({
 	page,
 	totalPages,
+	onPageChange,
 	onChange,
 	prevLabel = "Previous page",
 	nextLabel = "Next page",
 }: PaginationProps) => {
+	const emit = onPageChange ?? onChange;
 	const prevDisabled = page <= 1;
 	const nextDisabled = page >= totalPages;
 
@@ -91,7 +95,7 @@ export const Pagination = ({
 			<button
 				type="button"
 				className="pagination_item"
-				onClick={() => onChange(page - 1)}
+				onClick={() => emit?.(page - 1)}
 				disabled={prevDisabled}
 				aria-label={prevLabel}
 			>
@@ -118,7 +122,7 @@ export const Pagination = ({
 							<button
 								type="button"
 								className={buttonClassName}
-								onClick={() => onChange(it)}
+								onClick={() => emit?.(it)}
 								aria-current={isActive ? "page" : undefined}
 							>
 								{it}
@@ -131,7 +135,7 @@ export const Pagination = ({
 			<button
 				type="button"
 				className="pagination_item"
-				onClick={() => onChange(page + 1)}
+				onClick={() => emit?.(page + 1)}
 				disabled={nextDisabled}
 				aria-label={nextLabel}
 			>

--- a/src/ui/navigation/pagination/index.tsx
+++ b/src/ui/navigation/pagination/index.tsx
@@ -4,20 +4,23 @@ import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
-export interface PaginationProps {
+interface PaginationBaseProps {
 	/** 현재 페이지 번호 (1-based) */
 	page: number;
 	/** 전체 페이지 수 */
 	totalPages: number;
-	/** 페이지 변경 콜백 (canonical) */
-	onPageChange?: (page: number) => void;
-	/** @deprecated `onPageChange` 를 사용하세요. */
-	onChange?: (page: number) => void;
 	/** 이전 페이지 버튼 aria-label (기본값: "Previous page") */
 	prevLabel?: string;
 	/** 다음 페이지 버튼 aria-label (기본값: "Next page") */
 	nextLabel?: string;
 }
+
+// Pagination 은 controlled 전용 → 콜백 최소 하나 필수. canonical `onPageChange` 권장, 구 `onChange` 허용(@deprecated).
+type PaginationCallbacks =
+	| { onPageChange: (page: number) => void; onChange?: (page: number) => void }
+	| { onPageChange?: (page: number) => void; onChange: (page: number) => void };
+
+export type PaginationProps = PaginationBaseProps & PaginationCallbacks;
 
 /**
  * 시작-끝 범위의 숫자 배열을 만든다.

--- a/src/ui/navigation/tabs/index.tsx
+++ b/src/ui/navigation/tabs/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "../../../utils";
+import { cn, useSafeLayoutEffect } from "../../../utils";
 import "./style.scss";
 
 export type TabsVariant = "line" | "fills";
@@ -101,7 +101,7 @@ export const TabList = ({ ariaLabel, className, children, ...props }: TabListPro
 	const [hasMounted, setHasMounted] = React.useState(false);
 
 	// active tab 위치 추적 - sliding indicator (line=underline / fills=filled box)
-	React.useLayoutEffect(() => {
+	useSafeLayoutEffect(() => {
 		const list = listRef.current;
 		if (!list) return;
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -75,7 +75,7 @@ describe("Modal", () => {
 			</Modal>,
 		);
 
-		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
@@ -151,7 +151,7 @@ describe("Modal", () => {
 				Content
 			</Modal>,
 		);
-		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -75,7 +75,7 @@ describe("Modal", () => {
 			</Modal>,
 		);
 
-		fireEvent.keyDown(document, { key: "Escape" });
+		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -143,4 +143,16 @@ describe("Modal", () => {
 		expect(document.body.style.overflow).toBe("hidden");
 		expect(document.body.dataset.openModals).toBe("1");
 	});
+
+	it("calls onClose once on Escape from inside the modal (no duplicate handler)", () => {
+		const handleClose = vi.fn();
+		render(
+			<Modal open onClose={handleClose}>
+				Content
+			</Modal>,
+		);
+		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
 });

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -138,10 +138,8 @@ export const Modal = ({
 			aria-modal="true"
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
+			// Escape 는 document keydown 리스너가 단독 처리 (여기서도 onClose 하면 이중 호출됨)
 			onClick={() => closeOnOverlay && onClose?.()}
-			onKeyDown={(e) => {
-				if (e.key === "Escape") onClose?.();
-			}}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -83,12 +83,17 @@ export const Modal = ({
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
-	const handleEscape = React.useEffectEvent((e: KeyboardEvent) => {
-		if (e.key === "Escape") onClose?.();
+	// onClose 를 ref 로 보관 — useEffectEvent(React 19.2+) 대신 ref 패턴으로 peer react ^19 전체 호환
+	const onCloseRef = React.useRef(onClose);
+	React.useEffect(() => {
+		onCloseRef.current = onClose;
 	});
 
 	React.useEffect(() => {
 		if (!open) return;
+		const handleEscape = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onCloseRef.current?.();
+		};
 		document.addEventListener("keydown", handleEscape);
 		return () => document.removeEventListener("keydown", handleEscape);
 	}, [open]);

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -83,21 +83,6 @@ export const Modal = ({
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
-	// onClose 를 ref 로 보관 — useEffectEvent(React 19.2+) 대신 ref 패턴으로 peer react ^19 전체 호환
-	const onCloseRef = React.useRef(onClose);
-	React.useEffect(() => {
-		onCloseRef.current = onClose;
-	});
-
-	React.useEffect(() => {
-		if (!open) return;
-		const handleEscape = (e: KeyboardEvent) => {
-			if (e.key === "Escape") onCloseRef.current?.();
-		};
-		document.addEventListener("keydown", handleEscape);
-		return () => document.removeEventListener("keydown", handleEscape);
-	}, [open]);
-
 	// 바디 스크롤 잠금(중첩 모달 지원)
 	React.useEffect(() => {
 		if (!open) return;
@@ -138,8 +123,16 @@ export const Modal = ({
 			aria-modal="true"
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
-			// Escape 는 document keydown 리스너가 단독 처리 (여기서도 onClose 하면 이중 호출됨)
 			onClick={() => closeOnOverlay && onClose?.()}
+			// Escape 는 여기서 단독 처리 + stopPropagation — 중첩 모달에서 가장 안쪽만 닫히도록
+			// (document 전역 리스너로 처리하면 열린 모든 모달이 동시에 닫힘). panel onKeyDown 이
+			// Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
+			onKeyDown={(e) => {
+				if (e.key === "Escape") {
+					e.stopPropagation();
+					onClose?.();
+				}
+			}}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -71,11 +71,26 @@ export const Tooltip = ({
 
 	const style = useSpringPresence({ visible: open, from: fromTransform });
 
-	const trigger = React.cloneElement(children as React.ReactElement<React.HTMLAttributes<HTMLElement>>, {
-		onMouseEnter: show,
-		onMouseLeave: hide,
-		onFocus: show,
-		onBlur: hide,
+	const child = children as React.ReactElement<React.HTMLAttributes<HTMLElement>>;
+	const childProps = child.props;
+	// 자식의 기존 핸들러를 보존하고 tooltip 핸들러를 합성 (덮어쓰기 방지)
+	const trigger = React.cloneElement(child, {
+		onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
+			childProps.onMouseEnter?.(e);
+			show();
+		},
+		onMouseLeave: (e: React.MouseEvent<HTMLElement>) => {
+			childProps.onMouseLeave?.(e);
+			hide();
+		},
+		onFocus: (e: React.FocusEvent<HTMLElement>) => {
+			childProps.onFocus?.(e);
+			show();
+		},
+		onBlur: (e: React.FocusEvent<HTMLElement>) => {
+			childProps.onBlur?.(e);
+			hide();
+		},
 		"aria-describedby": open ? tooltipId : undefined,
 	} as React.HTMLAttributes<HTMLElement>);
 

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -91,7 +91,10 @@ export const Tooltip = ({
 			childProps.onBlur?.(e);
 			hide();
 		},
-		"aria-describedby": open ? tooltipId : undefined,
+		// 자식의 기존 aria-describedby 보존 + tooltip id 합성 (폼 설명/에러 연결 끊김 방지)
+		"aria-describedby": open
+			? [childProps["aria-describedby"], tooltipId].filter(Boolean).join(" ")
+			: childProps["aria-describedby"],
 	} as React.HTMLAttributes<HTMLElement>);
 
 	if (disabled) return children;

--- a/src/ui/system/theme-provider/index.tsx
+++ b/src/ui/system/theme-provider/index.tsx
@@ -57,11 +57,6 @@ function readStored(key: string | null): ThemeMode | null {
 	return null;
 }
 
-function resolveSystem(): ResolvedTheme {
-	if (!isClient) return "light";
-	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
 /**
  * Bigtablet DS 테마 컨텍스트를 제공한다.
  * `data-theme` attribute를 root element에 적용해서 CSS 변수 레이어를 전환한다.
@@ -79,14 +74,22 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
 	targetSelector,
 	children,
 }) => {
-	const [mode, setModeState] = React.useState<ThemeMode>(() => {
-		return readStored(storageKey) ?? defaultMode;
-	});
+	// SSR/CSR 첫 렌더를 deterministic 하게 — server 와 동일한 기본값으로 시작해 hydration mismatch 방지.
+	// 저장된 mode / 시스템 다크 설정은 mount 후 effect 에서 1회 동기화한다.
+	// (테마 깜빡임을 완전히 없애려면 hydration 전에 inline <script> 로 document.documentElement 의
+	//  data-theme 를 직접 세팅하는 것을 권장 — next-themes 와 동일한 패턴)
+	const [mode, setModeState] = React.useState<ThemeMode>(defaultMode);
+	const [systemDark, setSystemDark] = React.useState<boolean>(false);
 
-	const [systemDark, setSystemDark] = React.useState<boolean>(() => {
-		if (!isClient) return false;
-		return window.matchMedia("(prefers-color-scheme: dark)").matches;
-	});
+	// mount 후 저장값 + 시스템 설정 동기화 (storageKey 변경 시에만 재실행 — body 는 storageKey 외
+	// 모듈 상수/안정 setter 만 참조하므로 deps 완전)
+	React.useEffect(() => {
+		const stored = readStored(storageKey);
+		if (stored) setModeState(stored);
+		if (isClient) {
+			setSystemDark(window.matchMedia("(prefers-color-scheme: dark)").matches);
+		}
+	}, [storageKey]);
 
 	// prefers-color-scheme 변경 감지
 	React.useEffect(() => {

--- a/src/ui/system/theme-provider/index.tsx
+++ b/src/ui/system/theme-provider/index.tsx
@@ -84,12 +84,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
 	// mount 후 저장값 + 시스템 설정 동기화 (storageKey 변경 시에만 재실행 — body 는 storageKey 외
 	// 모듈 상수/안정 setter 만 참조하므로 deps 완전)
 	React.useEffect(() => {
-		const stored = readStored(storageKey);
-		if (stored) setModeState(stored);
+		// storageKey 가 바뀌면 새 키의 저장값으로 동기화. 저장값이 없으면 defaultMode 로 리셋
+		// (이전 키의 테마가 남지 않도록).
+		setModeState(readStored(storageKey) ?? defaultMode);
 		if (isClient) {
 			setSystemDark(window.matchMedia("(prefers-color-scheme: dark)").matches);
 		}
-	}, [storageKey]);
+	}, [storageKey, defaultMode]);
 
 	// prefers-color-scheme 변경 감지
 	React.useEffect(() => {


### PR DESCRIPTION
## Release v3.3.0

develop → main 릴리즈. **minor** (ref-as-prop · on*Change alias 등 공개 API 추가, 전부 비파괴).

### Key Updates
- `ref` 전달(React 19 ref-as-prop) 지원 — Button · IconButton · Card · Container · Stack · Grid · Section
- 변경 콜백 네이밍을 Radix식 `on*Change` 패밀리로 통일 (`onValueChange` / `onCheckedChange` / `onPageChange`) — 기존 prop 은 `@deprecated` alias 로 호환 유지
- 접근성: Menu · NavBar 화살표키 네비게이션(WAI-ARIA APG), Tooltip `aria-describedby` 합성, ThemeProvider SSR hydration mismatch 수정
- Chip tone · 통계 카드 트렌드 WCAG AA(4.5:1) 대비 충족, Storybook 에 테마 CSS 변수 로드(Divider 등 표시 수정)
- TS 컬러 토큰을 AA 값으로 SCSS 와 동기화, `next` peer 범위를 `>=15`(React 19 호환)로 정정
- FileInput objectURL 정리 안정화, Modal Escape 핸들러 React 19 전 버전 호환
- undici dev 의존성 보안 패치 (`>=7.28.0`, 경보 6건 해소)

### 포함 PR
#321 #322 #323 #324 #325 #326 #327 #328 #329 (+ #330 릴리즈 prep)

### 릴리즈 절차 (머지 후)
1. 리뷰어 approve → 머지
2. main 에서 `git tag -a v3.3.0 -m "v3.3.0"` → `git push origin v3.3.0`
3. `release.yml` 이 `npm publish --provenance` + GitHub Release 자동 생성

`package.json` 3.2.2 → 3.3.0, `CHANGELOG.md` 3.3.0 섹션 포함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 여러 컴포넌트에서 새 표준 값 변경 콜백과 ref 전달 지원이 추가되었습니다.
  * 메뉴/내비게이션에 키보드 포커스 이동, Escape 닫기, 첫 항목 자동 포커스가 강화되었습니다.

* **Bug Fixes**
  * 모달 Escape 동작과 툴팁의 기존 설명 연결이 더 안정적으로 유지됩니다.
  * 파일 미리보기 정리, 테마 초기 렌더 동기화, 닫힌 패널의 포커스 차단이 개선되었습니다.

* **Chores**
  * 릴리즈 노트/변경 기록과 빌드·테스트 관련 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->