### PR TITLE
fix/release-review

### DIFF
--- a/src/ui/forms/date-picker/index.tsx
+++ b/src/ui/forms/date-picker/index.tsx
@@ -8,15 +8,11 @@ import "./style.scss";
 type DatePickerMode = "year-month" | "year-month-day";
 type SelectableRange = "all" | "until-today";
 
-export interface DatePickerProps {
+interface DatePickerBaseProps {
 	/** 데이트 피커 위에 표시할 라벨 텍스트 */
 	label?: string;
 	/** 제어형 날짜 값 ("YYYY-MM" 또는 "YYYY-MM-DD" 형식) */
 	value?: string;
-	/** 날짜 변경 콜백 (canonical). `mode` 값에 따라 "YYYY-MM" 또는 "YYYY-MM-DD" 형식의 문자열이 전달됩니다. */
-	onValueChange?: (value: string) => void;
-	/** @deprecated `onValueChange` 를 사용하세요. */
-	onChange?: (value: string) => void;
 	/** 선택 모드 (기본값: "year-month-day") */
 	mode?: DatePickerMode;
 	/** 연도 선택 범위 시작 (기본값: 1950) */
@@ -53,6 +49,14 @@ export interface DatePickerProps {
 	 */
 	selectableRangeUntilTodaySrText?: string;
 }
+
+// DatePicker 는 controlled 전용(내부 value 상태 없음) → 콜백이 최소 하나는 필요.
+// canonical `onValueChange` 권장, 구 `onChange` 도 허용(@deprecated). 둘 중 하나는 필수.
+type DatePickerCallbacks =
+	| { onValueChange: (value: string) => void; onChange?: (value: string) => void }
+	| { onValueChange?: (value: string) => void; onChange: (value: string) => void };
+
+export type DatePickerProps = DatePickerBaseProps & DatePickerCallbacks;
 
 /** 숫자를 두 자리 문자열로 보정한다. */
 const pad = (n: number) => String(n).padStart(2, "0");

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -58,10 +58,9 @@ export const FileInput = ({
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const files = e.currentTarget.files;
-		onFiles?.(files);
-		// 사용자가 onChange 도 넘긴 경우 함께 호출 (back-compat)
-		onChange?.(e);
 
+		// preview URL 생성 + ref 갱신을 onFiles/onChange 호출보다 먼저 — 부모가 onFiles 안에서
+		// 동기 unmount 해도 ref 가 새 URL 을 이미 담고 있어 unmount cleanup 이 정리할 수 있도록.
 		if (showPreview && files) {
 			for (const url of previewUrls) {
 				URL.revokeObjectURL(url);
@@ -84,6 +83,10 @@ export const FileInput = ({
 			setPreviewUrls([]);
 			previewUrlsRef.current = [];
 		}
+
+		onFiles?.(files);
+		// 사용자가 onChange 도 넘긴 경우 함께 호출 (back-compat)
+		onChange?.(e);
 	};
 
 	const handleRemove = (e: React.MouseEvent) => {

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -49,6 +49,9 @@ export const FileInput = ({
 	const helperId = React.useId();
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const [previewUrls, setPreviewUrls] = React.useState<string[]>([]);
+	// 최신 objectURL 목록을 동기적으로 추적 — unmount(특히 onFiles 안에서 부모가 동기 unmount 하는
+	// 경우)에도 새로 만든 URL 까지 정리되도록 handleChange/handleRemove 에서 즉시 갱신.
+	const previewUrlsRef = React.useRef<string[]>([]);
 
 	const isPreviewVariant = variant === "preview";
 	const showPreview = isPreviewVariant || preview;
@@ -73,11 +76,13 @@ export const FileInput = ({
 				}
 			}
 			setPreviewUrls(urls);
+			previewUrlsRef.current = urls;
 		} else {
 			for (const url of previewUrls) {
 				URL.revokeObjectURL(url);
 			}
 			setPreviewUrls([]);
+			previewUrlsRef.current = [];
 		}
 	};
 
@@ -88,19 +93,14 @@ export const FileInput = ({
 			URL.revokeObjectURL(url);
 		}
 		setPreviewUrls([]);
+		previewUrlsRef.current = [];
 		if (inputRef.current) {
 			inputRef.current.value = "";
 		}
 		onFiles?.(null);
 	};
 
-	// unmount 시에만 마지막 URL 정리. 변경 시 revoke 는 handleChange/handleRemove 가 담당하므로
-	// deps 를 [previewUrls] 로 두면 변경마다 cleanup 이 돌아 이중 revoke 가 된다 → ref 로 최신값 추적.
-	const previewUrlsRef = React.useRef<string[]>([]);
-	// 최신 previewUrls 를 effect 에서 동기화 — render phase 에서 ref 직접 수정 금지(concurrent/strict 안전)
-	React.useEffect(() => {
-		previewUrlsRef.current = previewUrls;
-	}, [previewUrls]);
+	// unmount 시 남은 objectURL 정리 (변경 시 revoke 는 handleChange/handleRemove 가 담당)
 	React.useEffect(() => {
 		return () => {
 			for (const url of previewUrlsRef.current) {

--- a/src/ui/navigation/menu/Menu.test.tsx
+++ b/src/ui/navigation/menu/Menu.test.tsx
@@ -420,4 +420,22 @@ describe("Menu", () => {
 		expect(parentKeyDown).toHaveBeenCalled();
 	});
 
+
+	it("focuses first item even when the trigger had focus before opening", () => {
+		render(
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[
+					{ key: "a", label: "A" },
+					{ key: "b", label: "B" },
+				]}
+			/>,
+		);
+		const trigger = screen.getByRole("button", { name: "Open" });
+		trigger.focus();
+		expect(trigger).toHaveFocus();
+		fireEvent.click(trigger);
+		expect(screen.getAllByRole("menuitem")[0]).toHaveFocus();
+	});
+
 });

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -64,10 +64,11 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 		};
 	}, [open]);
 
-	// 열릴 때 첫 활성 아이템에 포커스 (WAI-ARIA menu button 패턴). 이미 메뉴 내부에 포커스가
-	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음.
+	// 열릴 때 첫 활성 아이템에 포커스 (WAI-ARIA menu button 패턴). 이미 메뉴 "아이템"에 포커스가
+	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음 — trigger 포커스는 내부로 치지 않아
+	// 트리거 클릭으로 열 때 첫 항목 포커스를 보장한다.
 	React.useEffect(() => {
-		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
 		const first = items.findIndex((it) => !it.disabled);
 		if (first >= 0) itemRefs.current[first]?.focus();
 	}, [open, items]);

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -68,7 +68,10 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 	// 있으면(사용자 네비 중·items 재생성 re-run) 가로채지 않음 — trigger 포커스는 내부로 치지 않아
 	// 트리거 클릭으로 열 때 첫 항목 포커스를 보장한다.
 	React.useEffect(() => {
-		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
+		const active = document.activeElement;
+		// active 가 실제 메뉴 아이템일 때만 가로채지 않음. null/trigger 는 첫 항목 포커스를 진행
+		// (itemRefs 에 null 이 섞여 있어도 includes(null) 오탐이 나지 않도록 active truthy 체크).
+		if (!open || (active && itemRefs.current.includes(active as HTMLButtonElement))) return;
 		const first = items.findIndex((it) => !it.disabled);
 		if (first >= 0) itemRefs.current[first]?.focus();
 	}, [open, items]);

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -197,9 +197,10 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 		};
 	}, [open]);
 
-	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 내부 포커스면 가로채지 않음.
+	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 메뉴 "아이템"에 포커스가 있을 때만
+	// 가로채지 않음 — trigger 포커스는 내부로 치지 않아 클릭으로 열 때 첫 항목 포커스를 보장.
 	useEffect(() => {
-		if (!open || wrapperRef.current?.contains(document.activeElement)) return;
+		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
 		itemRefs.current[0]?.focus();
 	}, [open]);
 

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -200,7 +200,9 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	// 열릴 때 첫 아이템 포커스 (WAI-ARIA menu button). 이미 메뉴 "아이템"에 포커스가 있을 때만
 	// 가로채지 않음 — trigger 포커스는 내부로 치지 않아 클릭으로 열 때 첫 항목 포커스를 보장.
 	useEffect(() => {
-		if (!open || itemRefs.current.includes(document.activeElement as HTMLButtonElement)) return;
+		const active = document.activeElement;
+		// active 가 실제 메뉴 아이템일 때만 가로채지 않음 (null/trigger 는 첫 항목 포커스 진행).
+		if (!open || (active && itemRefs.current.includes(active as HTMLButtonElement))) return;
 		itemRefs.current[0]?.focus();
 	}, [open]);
 

--- a/src/ui/navigation/pagination/index.tsx
+++ b/src/ui/navigation/pagination/index.tsx
@@ -4,20 +4,23 @@ import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
-export interface PaginationProps {
+interface PaginationBaseProps {
 	/** 현재 페이지 번호 (1-based) */
 	page: number;
 	/** 전체 페이지 수 */
 	totalPages: number;
-	/** 페이지 변경 콜백 (canonical) */
-	onPageChange?: (page: number) => void;
-	/** @deprecated `onPageChange` 를 사용하세요. */
-	onChange?: (page: number) => void;
 	/** 이전 페이지 버튼 aria-label (기본값: "Previous page") */
 	prevLabel?: string;
 	/** 다음 페이지 버튼 aria-label (기본값: "Next page") */
 	nextLabel?: string;
 }
+
+// Pagination 은 controlled 전용 → 콜백 최소 하나 필수. canonical `onPageChange` 권장, 구 `onChange` 허용(@deprecated).
+type PaginationCallbacks =
+	| { onPageChange: (page: number) => void; onChange?: (page: number) => void }
+	| { onPageChange?: (page: number) => void; onChange: (page: number) => void };
+
+export type PaginationProps = PaginationBaseProps & PaginationCallbacks;
 
 /**
  * 시작-끝 범위의 숫자 배열을 만든다.

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -75,7 +75,7 @@ describe("Modal", () => {
 			</Modal>,
 		);
 
-		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
@@ -151,7 +151,7 @@ describe("Modal", () => {
 				Content
 			</Modal>,
 		);
-		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -75,7 +75,7 @@ describe("Modal", () => {
 			</Modal>,
 		);
 
-		fireEvent.keyDown(document, { key: "Escape" });
+		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -143,4 +143,16 @@ describe("Modal", () => {
 		expect(document.body.style.overflow).toBe("hidden");
 		expect(document.body.dataset.openModals).toBe("1");
 	});
+
+	it("calls onClose once on Escape from inside the modal (no duplicate handler)", () => {
+		const handleClose = vi.fn();
+		render(
+			<Modal open onClose={handleClose}>
+				Content
+			</Modal>,
+		);
+		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
 });

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -138,10 +138,8 @@ export const Modal = ({
 			aria-modal="true"
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
+			// Escape 는 document keydown 리스너가 단독 처리 (여기서도 onClose 하면 이중 호출됨)
 			onClick={() => closeOnOverlay && onClose?.()}
-			onKeyDown={(e) => {
-				if (e.key === "Escape") onClose?.();
-			}}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -83,21 +83,6 @@ export const Modal = ({
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
-	// onClose 를 ref 로 보관 — useEffectEvent(React 19.2+) 대신 ref 패턴으로 peer react ^19 전체 호환
-	const onCloseRef = React.useRef(onClose);
-	React.useEffect(() => {
-		onCloseRef.current = onClose;
-	});
-
-	React.useEffect(() => {
-		if (!open) return;
-		const handleEscape = (e: KeyboardEvent) => {
-			if (e.key === "Escape") onCloseRef.current?.();
-		};
-		document.addEventListener("keydown", handleEscape);
-		return () => document.removeEventListener("keydown", handleEscape);
-	}, [open]);
-
 	// 바디 스크롤 잠금(중첩 모달 지원)
 	React.useEffect(() => {
 		if (!open) return;
@@ -138,8 +123,16 @@ export const Modal = ({
 			aria-modal="true"
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
-			// Escape 는 document keydown 리스너가 단독 처리 (여기서도 onClose 하면 이중 호출됨)
 			onClick={() => closeOnOverlay && onClose?.()}
+			// Escape 는 여기서 단독 처리 + stopPropagation — 중첩 모달에서 가장 안쪽만 닫히도록
+			// (document 전역 리스너로 처리하면 열린 모든 모달이 동시에 닫힘). panel onKeyDown 이
+			// Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
+			onKeyDown={(e) => {
+				if (e.key === "Escape") {
+					e.stopPropagation();
+					onClose?.();
+				}
+			}}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/system/theme-provider/index.tsx
+++ b/src/ui/system/theme-provider/index.tsx
@@ -84,12 +84,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
 	// mount 후 저장값 + 시스템 설정 동기화 (storageKey 변경 시에만 재실행 — body 는 storageKey 외
 	// 모듈 상수/안정 setter 만 참조하므로 deps 완전)
 	React.useEffect(() => {
-		const stored = readStored(storageKey);
-		if (stored) setModeState(stored);
+		// storageKey 가 바뀌면 새 키의 저장값으로 동기화. 저장값이 없으면 defaultMode 로 리셋
+		// (이전 키의 테마가 남지 않도록).
+		setModeState(readStored(storageKey) ?? defaultMode);
 		if (isClient) {
 			setSystemDark(window.matchMedia("(prefers-color-scheme: dark)").matches);
 		}
-	}, [storageKey]);
+	}, [storageKey, defaultMode]);
 
 	// prefers-color-scheme 변경 감지
 	React.useEffect(() => {


### PR DESCRIPTION
## 작업 개요
릴리즈 PR #331 의 coderabbit 리뷰(CHANGES_REQUESTED, 8건) 반영. 전부 develop 의 실재 버그/계약 문제로 검증 후 수정.

## 작업한 내용
- [x] **Menu / NavBar 초기 포커스** (Major): open 시 포커스 가드가 wrapper 전체(trigger 포함)를 검사해, trigger 클릭으로 열면 첫 항목 포커스가 빠지던 문제 → item ref 기준으로 변경
- [x] **Modal Escape 이중 onClose** (Major): overlay `onKeyDown` Escape 제거 (document 리스너가 단독 처리) → onClose 1회만
- [x] **FileInput objectURL 누수** (Minor): `previewUrlsRef` 를 effect 가 아니라 handler 에서 동기 갱신 → onFiles 안에서 동기 unmount 돼도 새 URL 정리됨
- [x] **DatePicker / Pagination 콜백 계약** (Major): controlled 전용이라 콜백 최소 1개 필수 → `onValueChange | onChange` 유니온 타입으로 복원 (both-optional 제거)
- [x] **ThemeProvider** (Minor): storageKey 변경 + 저장값 없을 때 defaultMode 로 리셋
- [x] 회귀 테스트: Modal Escape 1회, Menu trigger 포커스 후 open 시 첫 항목 포커스

검증: unit 634 · storybook(axe) 264 · build(DTS) green. 8개 thread reply+resolve 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 모달에서 Escape 키를 눌렀을 때 닫기 동작이 중복 호출되지 않도록 개선했습니다.
  * 메뉴와 언어 선택 메뉴를 열 때, 이미 메뉴 항목에 포커스가 있으면 포커스를 불필요하게 다시 이동하지 않도록 조정했습니다.
  * 테마 저장값이 없거나 저장 키가 바뀌면 기본 테마로 올바르게 초기화되도록 수정했습니다.

* **New Features**
  * 날짜 선택 및 페이지네이션 컴포넌트의 입력 방식이 더 엄격해져, 필수 콜백이 없으면 사용을 방지합니다.

* **Tests**
  * 메뉴 포커스 동작과 모달 Escape 처리에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->