### PR TITLE
docs/release-note-format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,5 +54,5 @@ jobs:
             f { print }
           ' CHANGELOG.md)
           [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ] && NOTES="- 자세한 변경은 CHANGELOG.md 참고"
-          BODY=$(printf '## Bigtablet Design System Web\n#### 주요 업데이트\n%s' "$NOTES")
+          BODY=$(printf '## Design System of Bigtablet, Inc.\n#### 주요 업데이트\n%s' "$NOTES")
           gh release create "$TAG" --title "$TAG" --notes "$BODY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           TAG=${GITHUB_REF#refs/tags/}
           VERSION=${TAG#v}
-          # CHANGELOG.md 의 해당 버전 Key Updates 를 릴리즈 노트로 사용 (Bigtablet 양식 SSOT).
+          # CHANGELOG.md 의 해당 버전 주요 업데이트 를 릴리즈 노트로 사용 (조직 공통 양식 SSOT, 한글).
           # --generate-notes 자동 PR 목록은 양식에 안 맞아 사용하지 않는다.
           NOTES=$(awk -v v="$VERSION" '
             index($0, "## [" v "]") == 1 { f=1; next }
@@ -54,5 +54,5 @@ jobs:
             f { print }
           ' CHANGELOG.md)
           [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ] && NOTES="- 자세한 변경은 CHANGELOG.md 참고"
-          BODY=$(printf '## Design System of Bigtablet, Inc.\n\n#### Key Updates\n%s' "$NOTES")
+          BODY=$(printf '## Bigtablet Design System Web\n#### 주요 업데이트\n%s' "$NOTES")
           gh release create "$TAG" --title "$TAG" --notes "$BODY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,7 +541,7 @@ label/domain
 3. main 에서 `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`.
 4. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성.
 
-**CHANGELOG.md 양식** — 릴리즈 노트와 동일한 주요 업데이트 를 미러링:
+**CHANGELOG.md 양식** — 릴리즈 노트와 동일한 주요 업데이트를 미러링:
 ```
 ## [X.Y.Z](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/vX.Y.Z) - YYYY-MM-DD
 - 핵심 변경 1
@@ -550,14 +550,14 @@ label/domain
 - 주요 업데이트 불릿만 — 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
 - 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
-**GitHub Release 노트는 조직 공통 양식 필수** — 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG 의 해당 버전 주요 업데이트 를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (제목 = `Design System of Bigtablet, Inc.`, `##` 제목과 `####` 사이 빈 줄 없음):
+**GitHub Release 노트는 조직 공통 양식 필수** — 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG 의 해당 버전 주요 업데이트를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (제목 = `Design System of Bigtablet, Inc.`, `##` 제목과 `####` 사이 빈 줄 없음):
 ```
 ## Design System of Bigtablet, Inc.
 #### 주요 업데이트
 - 핵심 변경 1
 - 핵심 변경 2
 ```
-> 태그/버전 규칙은 조직 [버저닝 원칙](https://app.notion.com/p/Version-Convention-25eef4b5605c805aa8a6fc929b5ec848?pvs=21) 을 따른다.
+> 태그/버전 규칙은 조직 [버저닝 원칙](https://app.notion.com/p/Version-Convention-25eef4b5605c805aa8a6fc929b5ec848?pvs=21)을 따른다.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,9 +550,9 @@ label/domain
 - 주요 업데이트 불릿만 — 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
 - 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
-**GitHub Release 노트는 조직 공통 양식 필수** — 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG 의 해당 버전 주요 업데이트 를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (저장소명 = `Bigtablet Design System Web`, `##` 제목과 `####` 사이 빈 줄 없음):
+**GitHub Release 노트는 조직 공통 양식 필수** — 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG 의 해당 버전 주요 업데이트 를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (제목 = `Design System of Bigtablet, Inc.`, `##` 제목과 `####` 사이 빈 줄 없음):
 ```
-## Bigtablet Design System Web
+## Design System of Bigtablet, Inc.
 #### 주요 업데이트
 - 핵심 변경 1
 - 핵심 변경 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,23 +541,23 @@ label/domain
 3. main 에서 `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`.
 4. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성.
 
-**CHANGELOG.md 양식** — 릴리즈 노트와 동일한 Key Updates 를 미러링:
+**CHANGELOG.md 양식** — 릴리즈 노트와 동일한 주요 업데이트 를 미러링:
 ```
 ## [X.Y.Z](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/vX.Y.Z) - YYYY-MM-DD
 - 핵심 변경 1
 - 핵심 변경 2
 ```
-- Key Updates 불릿만 — 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
+- 주요 업데이트 불릿만 — 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
 - 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
-**GitHub Release 노트는 Bigtablet 양식 필수** (title = 버전명만, 예: `v3.2.2`) — CHANGELOG 의 해당 버전 Key Updates 를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체:
+**GitHub Release 노트는 조직 공통 양식 필수** — 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG 의 해당 버전 주요 업데이트 를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (저장소명 = `Bigtablet Design System Web`, `##` 제목과 `####` 사이 빈 줄 없음):
 ```
-## Design System of Bigtablet, Inc.
-
-#### Key Updates
+## Bigtablet Design System Web
+#### 주요 업데이트
 - 핵심 변경 1
 - 핵심 변경 2
 ```
+> 태그/버전 규칙은 조직 [버저닝 원칙](https://app.notion.com/p/Version-Convention-25eef4b5605c805aa8a6fc929b5ec848?pvs=21) 을 따른다.
 
 ---
 


### PR DESCRIPTION
## 작업 개요
릴리즈 노트 섹션 헤더를 조직 공통 양식(한글)으로 통일.

## 변경
- **`release.yml`**: 릴리즈 노트 본문 헤더 `#### Key Updates` → **`#### 주요 업데이트`**, 제목/헤더 사이 빈 줄 제거. 제목은 기존 `## Design System of Bigtablet, Inc.` 유지.
- **`CLAUDE.md`**: 릴리즈 노트 양식 문서 갱신 (한글 원칙·`주요 업데이트`) + 조직 버저닝 원칙 링크.

최종 양식:
```
## Design System of Bigtablet, Inc.
#### 주요 업데이트
- ...
```

## 참고
- 배포된 릴리즈 노트 **전체(103개, v1.0.0~v3.3.0)** 헤더를 `주요 업데이트` 로 일괄 반영 완료 (제목은 `Design System of Bigtablet, Inc.` 유지).