### PR TITLE
feat/icon-size-tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ Domain-based structure in `src/styles/` (each folder has `_index.scss` + `index.
 - `z-index/` - Layer priorities
 - `breakpoints/` - Responsive breakpoints
 - `a11y/` - Accessibility (focus rings, tap targets)
+- `icon/` - Icon sizes (xs 14px - xl 32px, lucide-react `size` prop)
 
 ### Storybook
 - Component stories: `Components/{Category}/{ComponentName}`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,7 @@ bigtablet-design-system/
 │   │   ├── global.css
 │   │   ├── colors/  spacing/  typography/  radius/  elevation/  motion/
 │   │   ├── breakpoints/  opacity/  border-width/  z-index/  skeleton/  a11y/
+│   │   ├── icon/            # 아이콘 사이즈 (xs-xl)
 │   │   └── layout/          # SCSS only
 │   │
 │   ├── ui/                  # UI 컴포넌트 — 8 카테고리 폴더 하위에 컴포넌트

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export { baseBorderWidth, borderWidth } from "./styles/border-width";
 export { breakpoints } from "./styles/breakpoints";
 export { baseColors, colors } from "./styles/colors";
 export { elevation } from "./styles/elevation";
+export { iconSize } from "./styles/icon";
 export { motion } from "./styles/motion";
 export { opacity } from "./styles/opacity";
 export { radius } from "./styles/radius";

--- a/src/styles/icon/_index.scss
+++ b/src/styles/icon/_index.scss
@@ -1,0 +1,5 @@
+$icon_size_xs: 14px;
+$icon_size_sm: 16px;
+$icon_size_md: 18px;
+$icon_size_lg: 20px;
+$icon_size_xl: 32px;

--- a/src/styles/icon/index.ts
+++ b/src/styles/icon/index.ts
@@ -1,0 +1,7 @@
+export const iconSize = {
+	xs: 14,
+	sm: 16,
+	md: 18,
+	lg: 20,
+	xl: 32,
+} as const;

--- a/src/styles/token.scss
+++ b/src/styles/token.scss
@@ -2,6 +2,7 @@
 @forward "./border-width";
 @forward "./breakpoints";
 @forward "./colors";
+@forward "./icon";
 @forward "./layout";
 @forward "./motion";
 @forward "./opacity";

--- a/src/styles/tokens.json
+++ b/src/styles/tokens.json
@@ -1155,6 +1155,28 @@
 				"$value": "1200px",
 				"$type": "dimension"
 			}
+		},
+		"icon-size": {
+			"icon-size-14": {
+				"$value": "14px",
+				"$type": "dimension"
+			},
+			"icon-size-16": {
+				"$value": "16px",
+				"$type": "dimension"
+			},
+			"icon-size-18": {
+				"$value": "18px",
+				"$type": "dimension"
+			},
+			"icon-size-20": {
+				"$value": "20px",
+				"$type": "dimension"
+			},
+			"icon-size-32": {
+				"$value": "32px",
+				"$type": "dimension"
+			}
 		}
 	}
 }

--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown } from "lucide-react";
 import * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -81,7 +82,7 @@ export const Accordion = ({
 							>
 								<span className="accordion_title">{item.title}</span>
 								<ChevronDown
-									size={20}
+									size={iconSize.lg}
 									className={cn("accordion_chevron", isOpen && "accordion_chevron_open")}
 									aria-hidden="true"
 								/>

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
 import * as React from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { createPortal } from "react-dom";
+import { iconSize } from "../../../styles/icon";
 import { cn, useFocusTrap } from "../../../utils";
 import { Button, type ButtonVariant } from "../../general/button";
 import "./style.scss";
@@ -13,10 +14,10 @@ export type AlertVariant = "info" | "success" | "warning" | "error";
 export type AlertActionsAlign = "left" | "center" | "right";
 
 const ICONS: Record<AlertVariant, React.ReactNode> = {
-	info: <Info size={20} aria-hidden="true" />,
-	success: <CheckCircle2 size={20} aria-hidden="true" />,
-	warning: <AlertTriangle size={20} aria-hidden="true" />,
-	error: <XCircle size={20} aria-hidden="true" />,
+	info: <Info size={iconSize.lg} aria-hidden="true" />,
+	success: <CheckCircle2 size={iconSize.lg} aria-hidden="true" />,
+	warning: <AlertTriangle size={iconSize.lg} aria-hidden="true" />,
+	error: <XCircle size={iconSize.lg} aria-hidden="true" />,
 };
 
 export interface AlertOptions {

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -4,6 +4,7 @@ import { animated } from "@react-spring/web";
 import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
+import { iconSize } from "../../../styles/icon";
 import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
@@ -32,11 +33,11 @@ export interface ToastProviderProps {
 }
 
 const VARIANT_ICONS: Record<ToastVariant, React.ReactElement> = {
-	success: <CheckCircle2 size={18} />,
-	error: <XCircle size={18} />,
-	warning: <AlertTriangle size={18} />,
-	info: <Info size={18} />,
-	default: <Bell size={18} />,
+	success: <CheckCircle2 size={iconSize.md} />,
+	error: <XCircle size={iconSize.md} />,
+	warning: <AlertTriangle size={iconSize.md} />,
+	info: <Info size={iconSize.md} />,
+	default: <Bell size={iconSize.md} />,
 };
 
 // ── ToastItemComponent ───────────────────────────────────────────────────────
@@ -86,7 +87,7 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 			<span className="toast_message">{item.message}</span>
 
 			<button type="button" className="toast_close" onClick={close} aria-label={closeAriaLabel}>
-				<X size={14} />
+				<X size={iconSize.xs} />
 			</button>
 
 			<div

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -11,6 +11,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
 import { Check, ChevronDown } from "lucide-react";
@@ -260,7 +261,7 @@ export const Dropdown = ({
 						className={cn("dropdown_icon", { dropdown_icon_open: isOpen })}
 						aria-hidden="true"
 					>
-						<ChevronDown size={20} />
+						<ChevronDown size={iconSize.lg} />
 					</span>
 				</button>
 			</div>
@@ -307,7 +308,7 @@ export const Dropdown = ({
 									</span>
 									{(selected || opt.trailingIcon) && (
 										<span className="dropdown_option_trailing">
-											{opt.trailingIcon ?? <Check size={16} aria-hidden="true" />}
+											{opt.trailingIcon ?? <Check size={iconSize.sm} aria-hidden="true" />}
 										</span>
 									)}
 								</div>

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -2,6 +2,7 @@
 
 import { Image as ImageIcon, X } from "lucide-react";
 import * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -150,7 +151,7 @@ export const FileInput = ({
 						/>
 					) : (
 						<span className="file_input_preview_empty">
-							<ImageIcon size={32} aria-hidden="true" />
+							<ImageIcon size={iconSize.xl} aria-hidden="true" />
 							<span className="file_input_preview_empty_text">{label}</span>
 						</span>
 					)}
@@ -168,7 +169,7 @@ export const FileInput = ({
 					onClick={handleRemove}
 					aria-label="이미지 제거"
 				>
-					<X size={14} aria-hidden="true" />
+					<X size={iconSize.xs} aria-hidden="true" />
 				</button>
 			)}
 

--- a/src/ui/forms/textfield/index.tsx
+++ b/src/ui/forms/textfield/index.tsx
@@ -3,6 +3,7 @@
 import { X } from "lucide-react";
 import * as React from "react";
 import { useCallback, useId, useRef, useState } from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -58,7 +59,7 @@ export interface TextFieldProps
 }
 
 // X 아이콘 - lucide-react
-const ClearIcon = () => <X size={20} aria-hidden="true" />;
+const ClearIcon = () => <X size={iconSize.lg} aria-hidden="true" />;
 
 /**
  * 텍스트 필드를 렌더링한다.

--- a/src/ui/navigation/breadcrumb/index.tsx
+++ b/src/ui/navigation/breadcrumb/index.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronRight } from "lucide-react";
 import * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -39,7 +40,7 @@ export const Breadcrumb = ({
 	className,
 	...props
 }: BreadcrumbProps) => {
-	const sep = separator ?? <ChevronRight size={14} aria-hidden="true" />;
+	const sep = separator ?? <ChevronRight size={iconSize.xs} aria-hidden="true" />;
 
 	return (
 		<nav aria-label="Breadcrumb" className={cn("breadcrumb", className)} {...props}>

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown, Globe } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import type * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn, useSafeLayoutEffect } from "../../../utils";
 import "./style.scss";
 
@@ -265,13 +266,17 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 				aria-controls={menuId}
 				onClick={() => setOpen((p) => !p)}
 			>
-				<Globe size={16} aria-hidden="true" />
+				<Globe size={iconSize.sm} aria-hidden="true" />
 				{!locale.hideLabel && (
 					<span className="nav_bar_locale_label">
 						{currentOption?.label ?? locale.current.toUpperCase()}
 					</span>
 				)}
-				<ChevronDown size={14} aria-hidden="true" className="nav_bar_locale_chevron" />
+				<ChevronDown
+					size={iconSize.xs}
+					aria-hidden="true"
+					className="nav_bar_locale_chevron"
+				/>
 			</button>
 			{open && (
 				<ul

--- a/src/ui/navigation/sidebar/index.tsx
+++ b/src/ui/navigation/sidebar/index.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -119,7 +120,11 @@ export const Sidebar = ({
 					aria-label={toggleLabel}
 					aria-expanded={!collapsed}
 				>
-					{collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
+					{collapsed ? (
+						<ChevronRight size={iconSize.xs} />
+					) : (
+						<ChevronLeft size={iconSize.xs} />
+					)}
 				</button>
 			)}
 		</aside>

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -3,6 +3,7 @@
 import { animated, useSpring } from "@react-spring/web";
 import { X } from "lucide-react";
 import * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn, useFocusTrap } from "../../../utils";
 import "./style.scss";
 
@@ -152,7 +153,7 @@ export const Modal = ({
 						onClick={onClose}
 						aria-label={closeLabel}
 					>
-						<X size={18} aria-hidden="true" />
+						<X size={iconSize.md} aria-hidden="true" />
 					</button>
 				)}
 				{title && (


### PR DESCRIPTION
## 작업 개요
lucide-react 아이콘 `size={N}` 하드코딩을 전수 조사해 `icon/` 디자인 토큰 도메인으로 치환했습니다.

## 작업한 내용
- [x] `src/ui/**/index.tsx` 에서 `size={[0-9]*}` 패턴 전수 조사 (JSDoc 예시 3곳 제외, 실사용 22곳 / 10개 컴포넌트 파일)
- [x] `src/styles/icon/` 신설 - `_index.scss`($icon_size_xs~xl px 변수) + `index.ts`(`iconSize` export), 기존 `radius/` 도메인 패턴과 동일 구조
- [x] `token.scss` `@forward`, `tokens.json` `icon-size` 항목, `src/index.ts` `iconSize` re-export 등록
- [x] 10개 컴포넌트(dropdown, file, textfield, sidebar, nav-bar, breadcrumb, alert, toast, accordion, modal) 22곳을 `iconSize.xx` 토큰으로 치환 - 모두 동일 px 유지 (시각 변화 0)
- [x] `CLAUDE.md`, `docs/ARCHITECTURE.md` 토큰 도메인 목록에 `icon/` 반영
- [x] 검증: `pnpm test`(634 passed) · `pnpm build`(DTS 포함 성공) · `pnpm test:storybook`(264 passed) · `pnpm lint:css`(clean) 전부 green

### 스케일 매핑
| 토큰 | px | 사용처 |
|------|-----|--------|
| `iconSize.xs` | 14 | file 삭제, toast 닫기, breadcrumb separator, nav-bar chevron, sidebar toggle |
| `iconSize.sm` | 16 | dropdown check, nav-bar globe |
| `iconSize.md` | 18 | toast variant 아이콘, modal 닫기 |
| `iconSize.lg` | 20 | dropdown chevron, textfield clear, alert 아이콘, accordion chevron |
| `iconSize.xl` | 32 | file 미리보기 빈 상태 아이콘 |

## 전달할 추가 이슈
- `src/ui/feedback/error-state/index.tsx` 의 `DEFAULT_ICON_SIZE`(48/28) 는 이번 grep 스코프(`size={[0-9]*}`, 12~32 범위) 밖이라 미포함 - 필요 시 별도 작업으로 검토