### PR TITLE
docs/theming-hydration

### DIFF
--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -103,7 +103,10 @@ const NO_FLASH_SCRIPT = `
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ko">
+    // 인라인 스크립트가 hydration 이전에 <html> 의 data-theme 를 바꾸므로 서버 HTML 과
+    // 클라이언트 DOM 이 달라진다. suppressHydrationWarning 으로 이 최상위 노드의 불일치 경고를
+    // 무시한다 (next-themes 와 동일한 처리, 자식에는 전파되지 않음).
+    <html lang="ko" suppressHydrationWarning>
       <head>
         {/* next/script 의 beforeInteractive 는 인라인 스크립트(src 없는 스크립트)를 보장하지 않으므로
             hydration 이전 실행을 위해 head 에 일반 <script> 로 주입한다 */}

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -102,10 +102,10 @@ const NO_FLASH_SCRIPT = `
 `;
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // 인라인 스크립트가 hydration 이전에 <html> 의 data-theme 를 바꾸므로 서버 HTML 과 클라이언트
+  // DOM 이 달라진다. 아래 suppressHydrationWarning 으로 이 최상위 노드의 불일치 경고를 무시한다
+  // (next-themes 와 동일한 처리, 자식에는 전파되지 않음).
   return (
-    // 인라인 스크립트가 hydration 이전에 <html> 의 data-theme 를 바꾸므로 서버 HTML 과
-    // 클라이언트 DOM 이 달라진다. suppressHydrationWarning 으로 이 최상위 노드의 불일치 경고를
-    // 무시한다 (next-themes 와 동일한 처리, 자식에는 전파되지 않음).
     <html lang="ko" suppressHydrationWarning>
       <head>
         {/* next/script 의 beforeInteractive 는 인라인 스크립트(src 없는 스크립트)를 보장하지 않으므로


### PR DESCRIPTION
## 작업 개요
#347(dev→main) 의 gemini 리뷰 반영 - THEMING.md no-flash 스크립트 예제의 hydration 불일치 경고 처리.

## 작업한 내용
- [x] Next.js 예제 `<html>` 에 `suppressHydrationWarning` 추가 + 사유 주석 (인라인 스크립트가 hydration 이전 `data-theme` 를 바꿔 최상위 노드 불일치 발생, next-themes 동일 패턴)

Vanilla HTML 예제는 React hydration 이 없어 변경 불필요.