### PR TITLE
feat/drawer

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -38,6 +38,7 @@ Bigtablet Design System의 모든 React 컴포넌트 문서입니다.
   - [Breadcrumb](#breadcrumb)
 - [Overlay](#overlay)
   - [Modal](#modal)
+  - [Drawer](#drawer)
   - [Tooltip](#tooltip)
   - [Menu](#menu)
   - [Popover](#popover)
@@ -1429,6 +1430,45 @@ const [isOpen, setIsOpen] = useState(false);
 | `title` | `ReactNode` | - | 제목 |
 | `width` | `number \| string` | `520` | 모달 너비 |
 | `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
+
+---
+
+### Drawer
+
+화면 가장자리(left/right/bottom)에서 미끄러져 들어오는 패널. 필터, 상세 보기, 모바일 내비게이션, 하단 시트에 적합. Modal 과 동일하게 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금을 자동 처리한다.
+
+```tsx
+import { Drawer } from '@bigtablet/design-system';
+
+const [isOpen, setIsOpen] = useState(false);
+
+<button onClick={() => setIsOpen(true)}>드로어 열기</button>
+
+<Drawer
+  open={isOpen}
+  onClose={() => setIsOpen(false)}
+  placement="right"
+  size={360}
+  title="설정"
+  footer={<button onClick={() => setIsOpen(false)}>저장</button>}
+>
+  <p>드로어 내용입니다.</p>
+</Drawer>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | required | 열림 상태 |
+| `onClose` | `() => void` | - | 닫기 핸들러 |
+| `placement` | `'left' \| 'right' \| 'bottom'` | `'right'` | 슬라이드 방향 |
+| `size` | `number \| string` | `360` | 패널 크기 - left/right 는 너비, bottom 은 높이 (number ⇒ px) |
+| `title` | `ReactNode` | - | 헤더 제목 (있으면 `aria-labelledby` 자동 연결) |
+| `footer` | `ReactNode` | - | 하단 액션 영역. 미지정 시 footer 영역 미표시 |
+| `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
+| `showCloseIcon` | `boolean` | `true` | 우상단 X 닫기 아이콘 표시 |
+| `closeLabel` | `string` | `'닫기'` | X 닫기 버튼 접근성 레이블 |
+
+> 방향별 슬라이드 진입/퇴출은 `react-spring` 으로 처리하며 `prefers-reduced-motion: reduce` 시 즉시 표시된다. `placement="top"` 과 배경 상호작용(non-modal) 변형은 현재 범위 밖.
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1467,6 +1467,7 @@ const [isOpen, setIsOpen] = useState(false);
 | `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
 | `showCloseIcon` | `boolean` | `true` | 우상단 X 닫기 아이콘 표시 |
 | `closeLabel` | `string` | `'닫기'` | X 닫기 버튼 접근성 레이블 |
+| `ariaLabel` | `string` | `'Dialog'` | `title` 없을 때 dialog 접근성 레이블 |
 
 > 방향별 슬라이드 진입/퇴출은 `react-spring` 으로 처리하며 `prefers-reduced-motion: reduce` 시 즉시 표시된다. `placement="top"` 과 배경 상호작용(non-modal) 변형은 현재 범위 밖.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ export type {
 	TabsVariant,
 } from "./ui/navigation/tabs";
 export { Tab, TabList, TabPanel, Tabs } from "./ui/navigation/tabs";
+export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
+export { Drawer } from "./ui/overlay/drawer";
 export type { PopoverPlacement, PopoverProps } from "./ui/overlay/popover";
 export { Popover } from "./ui/overlay/popover";
 export type { TooltipPlacement, TooltipProps } from "./ui/overlay/tooltip";

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -208,6 +208,15 @@ describe("Drawer", () => {
 		expect(dialog).toHaveAttribute("aria-label", "Dialog");
 	});
 
+	it("uses ariaLabel for the dialog when provided without a title", () => {
+		render(
+			<Drawer open onClose={() => {}} ariaLabel="필터 패널">
+				Content
+			</Drawer>,
+		);
+		expect(screen.getByRole("dialog")).toHaveAttribute("aria-label", "필터 패널");
+	});
+
 	// ── Body scroll lock ───────────────────────────────────────────────────
 
 	it("locks body scroll while open and restores on close", () => {
@@ -222,6 +231,46 @@ describe("Drawer", () => {
 			<Drawer open={false} onClose={() => {}}>
 				Content
 			</Drawer>,
+		);
+		expect(document.body.style.overflow).not.toBe("hidden");
+	});
+
+	it("keeps body scroll locked until the last overlay closes (shared counter)", () => {
+		const { rerender } = render(
+			<>
+				<Drawer open onClose={() => {}}>
+					Outer
+				</Drawer>
+				<Drawer open onClose={() => {}}>
+					Inner
+				</Drawer>
+			</>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		// 안쪽만 닫힘 - 바깥이 아직 열려 있으므로 잠금 유지 (카운터 1)
+		rerender(
+			<>
+				<Drawer open onClose={() => {}}>
+					Outer
+				</Drawer>
+				<Drawer open={false} onClose={() => {}}>
+					Inner
+				</Drawer>
+			</>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		// 마지막까지 닫히면 원래 overflow 복원 (카운터 0)
+		rerender(
+			<>
+				<Drawer open={false} onClose={() => {}}>
+					Outer
+				</Drawer>
+				<Drawer open={false} onClose={() => {}}>
+					Inner
+				</Drawer>
+			</>,
 		);
 		expect(document.body.style.overflow).not.toBe("hidden");
 	});

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -1,0 +1,268 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Drawer } from "./index";
+
+describe("Drawer", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("renders when open", () => {
+		render(
+			<Drawer open onClose={() => {}}>
+				Drawer content
+			</Drawer>,
+		);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByText("Drawer content")).toBeInTheDocument();
+	});
+
+	it("does not render when closed", () => {
+		render(
+			<Drawer open={false} onClose={() => {}}>
+				Drawer content
+			</Drawer>,
+		);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("renders title inside header with linked aria-labelledby", () => {
+		render(
+			<Drawer open onClose={() => {}} title="Drawer Title">
+				Content
+			</Drawer>,
+		);
+		const dialog = screen.getByRole("dialog");
+		const heading = screen.getByText("Drawer Title");
+		expect(heading).toBeInTheDocument();
+		expect(dialog).toHaveAttribute("aria-labelledby", heading.getAttribute("id"));
+	});
+
+	// ── Placement ────────────────────────────────────────────────────────────
+
+	it("defaults to the right placement", () => {
+		render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		expect(screen.getByRole("dialog")).toHaveClass("drawer_placement_right");
+	});
+
+	it.each(["left", "right", "bottom"] as const)(
+		"applies the placement class for %s",
+		(placement) => {
+			render(
+				<Drawer open onClose={() => {}} placement={placement}>
+					Content
+				</Drawer>,
+			);
+			expect(screen.getByRole("dialog")).toHaveClass(`drawer_placement_${placement}`);
+		},
+	);
+
+	// ── Size ───────────────────────────────────────────────────────────────
+
+	it("applies numeric size as px width for left/right", () => {
+		render(
+			<Drawer open onClose={() => {}} placement="right" size={420}>
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveStyle({ width: "420px" });
+	});
+
+	it("applies string size verbatim", () => {
+		render(
+			<Drawer open onClose={() => {}} placement="left" size="50vw">
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveStyle({ width: "50vw" });
+	});
+
+	it("applies size as height for bottom placement", () => {
+		render(
+			<Drawer open onClose={() => {}} placement="bottom" size={300}>
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveStyle({ height: "300px" });
+	});
+
+	// ── Overlay / close ──────────────────────────────────────────────────────
+
+	it("calls onClose when overlay is clicked", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose}>
+				Content
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByRole("dialog"));
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not close on overlay click when closeOnOverlay is false", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose} closeOnOverlay={false}>
+				Content
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByRole("dialog"));
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	it("does not close when clicking inside the panel", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose}>
+				<button type="button">Inside button</button>
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByText("Inside button"));
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	it("renders the close icon button and calls onClose when clicked", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose} closeLabel="Close drawer">
+				Content
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Close drawer" }));
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides the close icon when showCloseIcon is false", () => {
+		render(
+			<Drawer open onClose={() => {}} showCloseIcon={false}>
+				Content
+			</Drawer>,
+		);
+		expect(screen.queryByRole("button", { name: "닫기" })).not.toBeInTheDocument();
+	});
+
+	// ── Escape ────────────────────────────────────────────────────────────
+
+	it("closes on Escape and calls onClose once", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose}>
+				Content
+			</Drawer>,
+		);
+		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("Escape closes only the topmost drawer when nested (stopPropagation)", () => {
+		const outerClose = vi.fn();
+		const innerClose = vi.fn();
+		render(
+			<Drawer open onClose={outerClose} title="Outer">
+				<Drawer open onClose={innerClose} title="Inner">
+					<button type="button">Inner content</button>
+				</Drawer>
+			</Drawer>,
+		);
+
+		// getAllByRole("document") in DOM order: [outer panel, inner panel]
+		const panels = screen.getAllByRole("document");
+		expect(panels).toHaveLength(2);
+		fireEvent.keyDown(panels[1], { key: "Escape" });
+
+		expect(innerClose).toHaveBeenCalledTimes(1);
+		expect(outerClose).not.toHaveBeenCalled();
+	});
+
+	// ── Focus trap ────────────────────────────────────────────────────────
+
+	it("moves focus into the panel when opened (focus trap active)", () => {
+		render(
+			<Drawer open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).not.toBeNull();
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
+	// ── Accessibility ────────────────────────────────────────────────────────
+
+	it("has dialog role and modal accessibility attributes", () => {
+		render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).toHaveAttribute("aria-modal", "true");
+		// title 이 없으면 aria-label fallback
+		expect(dialog).toHaveAttribute("aria-label", "Dialog");
+	});
+
+	// ── Body scroll lock ───────────────────────────────────────────────────
+
+	it("locks body scroll while open and restores on close", () => {
+		const { rerender } = render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		rerender(
+			<Drawer open={false} onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		expect(document.body.style.overflow).not.toBe("hidden");
+	});
+
+	// ── Reduced motion ───────────────────────────────────────────────────────
+
+	it("renders without motion when prefers-reduced-motion is set", () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+
+		render(
+			<Drawer open onClose={() => {}} placement="right" title="Reduced">
+				Content
+			</Drawer>,
+		);
+
+		// reduced-motion 에서도 정상 렌더 + 패널이 최종(휴지) 위치에 즉시 도달
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toBeInTheDocument();
+		expect(panel).toHaveStyle({ transform: "translateX(0%)" });
+	});
+
+	// ── className passthrough ─────────────────────────────────────────────
+
+	it("applies custom className to the panel", () => {
+		render(
+			<Drawer open onClose={() => {}} className="custom-drawer">
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveClass("custom-drawer");
+	});
+});

--- a/src/ui/overlay/drawer/drawer.stories.tsx
+++ b/src/ui/overlay/drawer/drawer.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "../../general/button";
+import { Drawer } from ".";
+
+const meta: Meta<typeof Drawer> = {
+	title: "Components/Overlay/Drawer",
+	component: Drawer,
+	tags: ["autodocs"],
+	argTypes: {
+		placement: {
+			control: "radio",
+			options: ["left", "right", "bottom"],
+			description: "슬라이드 방향 / Slide direction",
+		},
+		size: {
+			control: "text",
+			description: "패널 크기 - left/right 는 너비, bottom 은 높이 / Panel size (width for left/right, height for bottom)",
+		},
+		closeOnOverlay: {
+			control: "boolean",
+			description: "배경(오버레이)을 클릭했을 때 닫을지 여부 / Close on overlay click",
+		},
+		showCloseIcon: {
+			control: "boolean",
+			description: "우상단 X 닫기 아이콘 표시 여부 / Show close icon",
+		},
+	},
+	args: {
+		placement: "right",
+		size: 360,
+		closeOnOverlay: true,
+		showCloseIcon: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: `
+**Drawer** - Panel that slides in from a screen edge. Automatic focus trap + Esc to close + background scroll lock. / 화면 가장자리에서 미끄러져 들어오는 패널. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금 자동.
+
+Key props: \`open\`, \`onClose\`, \`placement\` ("left" | "right" | "bottom"), \`size\`, \`title\`, \`footer\`, \`closeOnOverlay\`. / 주요 prop: \`open\`, \`onClose\`, \`placement\`, \`size\`, \`title\`, \`footer\`, \`closeOnOverlay\`.
+        `,
+			},
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+export const Right: Story = {
+	name: "Right (기본)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Default drawer sliding in from the right - the most common side-panel pattern for filters, details, or settings. / 우측에서 들어오는 기본 드로어 - 필터/상세/설정에 가장 흔한 사이드 패널 패턴.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>드로어 열기</Button>
+				<Drawer {...args} open={open} onClose={() => setOpen(false)} title="설정 / Settings">
+					<p style={{ margin: 0 }}>
+						오른쪽에서 미끄러져 들어오는 패널입니다. 폼, 목록, 상세 정보를 자유롭게 배치할 수 있습니다.
+					</p>
+				</Drawer>
+			</div>
+		);
+	},
+};
+
+export const Left: Story = {
+	name: "Left (내비게이션)",
+	args: { placement: "left", size: 300 },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Left drawer - typical for mobile navigation menus. / 좌측 드로어 - 모바일 내비게이션 메뉴에 자주 쓰입니다.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>메뉴 열기</Button>
+				<Drawer {...args} open={open} onClose={() => setOpen(false)} title="메뉴 / Menu">
+					<nav style={{ display: "grid", gap: 12 }}>
+						<a href="#home">홈 / Home</a>
+						<a href="#orders">주문 / Orders</a>
+						<a href="#settings">설정 / Settings</a>
+					</nav>
+				</Drawer>
+			</div>
+		);
+	},
+};
+
+export const Bottom: Story = {
+	name: "Bottom (시트)",
+	args: { placement: "bottom", size: 320 },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Bottom sheet - slides up from the bottom, common on touch devices. / 하단 시트 - 아래에서 위로 올라오며 터치 기기에서 흔합니다.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>시트 열기</Button>
+				<Drawer {...args} open={open} onClose={() => setOpen(false)} title="공유 / Share">
+					<p style={{ margin: 0 }}>
+						하단에서 올라오는 시트입니다. 짧은 액션 목록이나 옵션 선택에 적합합니다.
+					</p>
+				</Drawer>
+			</div>
+		);
+	},
+};
+
+export const WithFooter: Story = {
+	name: "With footer (액션)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Drawer with a footer action area - confirm/cancel or save patterns. / footer 액션 영역이 있는 드로어 - 확인/취소 또는 저장 패턴.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>편집 드로어 열기</Button>
+				<Drawer
+					{...args}
+					open={open}
+					onClose={() => setOpen(false)}
+					title="프로필 편집 / Edit profile"
+					footer={
+						<>
+							<Button variant="outline" onClick={() => setOpen(false)}>
+								취소 / Cancel
+							</Button>
+							<Button onClick={() => setOpen(false)}>저장 / Save</Button>
+						</>
+					}
+				>
+					<p style={{ margin: 0 }}>
+						본문은 스크롤되고 footer 는 항상 하단에 고정됩니다. 긴 폼에 적합합니다.
+					</p>
+				</Drawer>
+			</div>
+		);
+	},
+};

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { animated, useSpring } from "@react-spring/web";
+import { X } from "lucide-react";
+import * as React from "react";
+import { iconSize } from "../../../styles/icon";
+import { cn, useFocusTrap, useReducedMotion, useSpringPresence } from "../../../utils";
+import "./style.scss";
+
+/** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
+export type DrawerPlacement = "left" | "right" | "bottom";
+
+export interface DrawerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+	/** 드로어 열림 여부 */
+	open: boolean;
+	/** 드로어 닫기 콜백 */
+	onClose?: () => void;
+	/** 슬라이드 방향 (기본값: "right") */
+	placement?: DrawerPlacement;
+	/** 패널 크기 - left/right 는 너비, bottom 은 높이 (기본값: 360). number ⇒ px */
+	size?: number | string;
+	/** 드로어 제목 (헤더 h2, heading_small_bold) */
+	title?: React.ReactNode;
+	/** 하단 액션 영역 (Button들). 미지정 시 footer 영역 자체가 안 보임 */
+	footer?: React.ReactNode;
+	/** 오버레이 클릭 시 닫기 여부 (기본값: true) */
+	closeOnOverlay?: boolean;
+	/** 우상단 X 닫기 아이콘 표시 여부 (기본값: true) */
+	showCloseIcon?: boolean;
+	/** X 닫기 버튼 접근성 레이블 (기본값: "닫기") */
+	closeLabel?: string;
+}
+
+// placement 별 진입 시작(=퇴출 도착) transform. 방향 축과 단위(%)를 진입/퇴출 양쪽에서
+// 일치시켜야 react-spring 문자열 보간이 올바른 축으로 슬라이드한다.
+const SLIDE_FROM: Record<DrawerPlacement, string> = {
+	left: "translateX(-100%)",
+	right: "translateX(100%)",
+	bottom: "translateY(100%)",
+};
+
+/**
+ * 화면 가장자리에서 미끄러져 들어오는 패널(Drawer)을 렌더링한다.
+ * react-spring 기반 방향별 슬라이드 진입/퇴출 + 포커스 트랩 + 바디 스크롤 잠금.
+ *
+ * @param props 드로어 속성
+ * @returns 열림 상태일 때 렌더링된 드로어, 닫힘 상태면 null
+ */
+export const Drawer = ({
+	open,
+	onClose,
+	placement = "right",
+	size = 360,
+	title,
+	footer,
+	closeOnOverlay = true,
+	showCloseIcon = true,
+	closeLabel = "닫기",
+	children,
+	className,
+	...props
+}: DrawerProps) => {
+	const panelRef = React.useRef<HTMLDivElement>(null);
+	const titleId = React.useId();
+	const [shouldRender, setShouldRender] = React.useState(open);
+	const reduced = useReducedMotion();
+
+	// 포커스 트랩
+	useFocusTrap(panelRef, open);
+
+	// 진입 시 마운트 보장
+	React.useEffect(() => {
+		if (open) setShouldRender(true);
+	}, [open]);
+
+	// 오버레이 opacity 페이드 + presence 라이프사이클(퇴출 완료 후 unmount).
+	// 오버레이는 이동하지 않으므로 transform 을 translateY(0px) 로 고정한다.
+	const overlayStyle = useSpringPresence({
+		visible: open,
+		from: "translateY(0px)",
+		onExitComplete: () => setShouldRender(false),
+	});
+
+	// 패널 슬라이드 - 진입/퇴출 모두 placement 축을 따라 동일 template 로 보간(정확한 reverse).
+	const slideFrom = SLIDE_FROM[placement];
+	const slideRest = placement === "bottom" ? "translateY(0%)" : "translateX(0%)";
+	const panelStyle = useSpring({
+		from: { transform: slideFrom },
+		to: { transform: open ? slideRest : slideFrom },
+		immediate: reduced,
+		config: { tension: 280, friction: 28, clamp: !open },
+	});
+
+	// 바디 스크롤 잠금 (Modal 과 동일 mechanism - 카운터 없이 저장/설정/복원)
+	React.useEffect(() => {
+		if (!open) return;
+
+		const body = document.body;
+		body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
+		body.style.overflow = "hidden";
+
+		return () => {
+			body.style.overflow = body.dataset.originalOverflow || "";
+			delete body.dataset.originalOverflow;
+		};
+	}, [open]);
+
+	if (!shouldRender) return null;
+
+	const hasTitle = !!title;
+	const sizeValue = typeof size === "number" ? `${size}px` : size;
+	const panelSizeStyle = placement === "bottom" ? { height: sizeValue } : { width: sizeValue };
+
+	return (
+		<animated.div
+			className={cn("drawer", `drawer_placement_${placement}`)}
+			style={overlayStyle}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby={hasTitle ? titleId : undefined}
+			aria-label={!hasTitle ? "Dialog" : undefined}
+			onClick={() => closeOnOverlay && onClose?.()}
+			// Escape 는 여기서 단독 처리 + stopPropagation - 중첩 오버레이에서 가장 위(topmost)만
+			// 닫히도록 (document 전역 리스너로 처리하면 열린 모든 오버레이가 동시에 닫힘).
+			// panel onKeyDown 이 Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
+			onKeyDown={(e) => {
+				if (e.key === "Escape") {
+					e.stopPropagation();
+					onClose?.();
+				}
+			}}
+		>
+			<animated.div
+				ref={panelRef}
+				className={cn("drawer_panel", className)}
+				style={{ ...panelStyle, ...panelSizeStyle }}
+				role="document"
+				onClick={(e) => e.stopPropagation()}
+				onKeyDown={(e) => {
+					if (e.key !== "Escape") e.stopPropagation();
+				}}
+				{...props}
+			>
+				{showCloseIcon && onClose && (
+					<button
+						type="button"
+						className="drawer_close"
+						onClick={onClose}
+						aria-label={closeLabel}
+					>
+						<X size={iconSize.md} aria-hidden="true" />
+					</button>
+				)}
+				{title && (
+					<div className="drawer_header">
+						<h2 id={titleId} className="drawer_title">
+							{title}
+						</h2>
+					</div>
+				)}
+				{children && <div className="drawer_body">{children}</div>}
+				{footer && <div className="drawer_footer">{footer}</div>}
+			</animated.div>
+		</animated.div>
+	);
+};
+
+Drawer.displayName = "Drawer";

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -29,6 +29,8 @@ export interface DrawerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
 	showCloseIcon?: boolean;
 	/** X 닫기 버튼 접근성 레이블 (기본값: "닫기") */
 	closeLabel?: string;
+	/** 드로어 접근성 레이블 (title 없을 때 사용, 기본값: "Dialog") */
+	ariaLabel?: string;
 }
 
 // placement 별 진입 시작(=퇴출 도착) transform. 방향 축과 단위(%)를 진입/퇴출 양쪽에서
@@ -56,6 +58,7 @@ export const Drawer = ({
 	closeOnOverlay = true,
 	showCloseIcon = true,
 	closeLabel = "닫기",
+	ariaLabel,
 	children,
 	className,
 	...props
@@ -91,17 +94,33 @@ export const Drawer = ({
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
-	// 바디 스크롤 잠금 (Modal 과 동일 mechanism - 카운터 없이 저장/설정/복원)
+	// 바디 스크롤 잠금 - Modal 과 동일한 data-open-modals 카운터 공유.
+	// Modal/Drawer 를 동시에 열거나 중첩해도 카운터가 0 이 될 때만 원래 overflow 를 복원해
+	// 스크롤 잠금 오작동/원래 스타일 유실을 막는다.
 	React.useEffect(() => {
 		if (!open) return;
 
 		const body = document.body;
-		body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
-		body.style.overflow = "hidden";
+		const openModals = parseInt(body.dataset.openModals || "0", 10);
+
+		if (openModals === 0) {
+			body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
+			body.style.overflow = "hidden";
+		}
+
+		body.dataset.openModals = String(openModals + 1);
 
 		return () => {
-			body.style.overflow = body.dataset.originalOverflow || "";
-			delete body.dataset.originalOverflow;
+			const currentOpenModals = parseInt(body.dataset.openModals || "1", 10);
+			const nextOpenModals = currentOpenModals - 1;
+
+			if (nextOpenModals === 0) {
+				body.style.overflow = body.dataset.originalOverflow || "";
+				delete body.dataset.openModals;
+				delete body.dataset.originalOverflow;
+			} else {
+				body.dataset.openModals = String(nextOpenModals);
+			}
 		};
 	}, [open]);
 
@@ -117,8 +136,8 @@ export const Drawer = ({
 			style={overlayStyle}
 			role="dialog"
 			aria-modal="true"
-			aria-labelledby={hasTitle ? titleId : undefined}
-			aria-label={!hasTitle ? "Dialog" : undefined}
+			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
+			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
 			onClick={() => closeOnOverlay && onClose?.()}
 			// Escape 는 여기서 단독 처리 + stopPropagation - 중첩 오버레이에서 가장 위(topmost)만
 			// 닫히도록 (document 전역 리스너로 처리하면 열린 모든 오버레이가 동시에 닫힘).

--- a/src/ui/overlay/drawer/style.scss
+++ b/src/ui/overlay/drawer/style.scss
@@ -45,8 +45,8 @@
     position: absolute;
     top: token.$spacing_12;
     right: token.$spacing_12;
-    width: 32px;
-    height: 32px;
+    width: token.$tap_target_dense;
+    height: token.$tap_target_dense;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/ui/overlay/drawer/style.scss
+++ b/src/ui/overlay/drawer/style.scss
@@ -1,0 +1,118 @@
+@use "src/styles/token" as token;
+
+.drawer {
+  position: fixed;
+  top: 0; right: 0; bottom: 0; left: 0;
+  display: flex;
+  background: token.$color_bg_overlay;
+  z-index: token.$z_level2; // Modal 과 동일 레이어
+  will-change: opacity;
+
+  // ── Placement (패널을 가장자리에 정렬) ─────────────────────────────────
+  &_placement_left  { justify-content: flex-start; }
+  &_placement_right { justify-content: flex-end; }
+  &_placement_bottom {
+    align-items: flex-end;
+    justify-content: stretch;
+  }
+
+  // ── Panel ──────────────────────────────────────────────────────────────
+  &_panel {
+    position: relative; // close button 의 absolute 기준
+    display: flex;
+    flex-direction: column;
+    background: token.$color_bg_solid;
+    box-shadow: token.$elevation_level3;
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden; // body 영역만 스크롤
+    will-change: transform;
+  }
+
+  &_placement_left &_panel,
+  &_placement_right &_panel {
+    height: 100%;
+  }
+
+  &_placement_bottom &_panel {
+    width: 100%;
+    border-top-left-radius: token.$radius_lg;
+    border-top-right-radius: token.$radius_lg;
+  }
+
+  // ── Close (우상단 X 아이콘 버튼) ───────────────────────────────────────
+  &_close {
+    position: absolute;
+    top: token.$spacing_12;
+    right: token.$spacing_12;
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: token.$color_text_caption;
+    border-radius: token.$radius_md;
+    cursor: pointer;
+    transition:
+      background token.$transition_fast,
+      color token.$transition_fast;
+
+    &:hover {
+      background: token.$color_state_hover_on_light;
+      color: token.$color_text_heading;
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: token.$focus_ring;
+    }
+  }
+
+  // ── Header (title) ─────────────────────────────────────────────────────
+  &_header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    padding: token.$spacing_20 token.$spacing_24;
+    padding-right: token.$spacing_48; // 우상단 close 버튼과 겹침 방지
+    border-bottom: token.$border_width_standard solid token.$color_border_subtle;
+  }
+
+  &_title {
+    margin: 0;
+    color: token.$color_text_heading;
+    @include token.heading_small_bold;
+  }
+
+  // ── Body (자유 children) ───────────────────────────────────────────────
+  &_body {
+    flex: 1 1 auto;
+    min-height: 0; // flex item 이 넘칠 때 내부 스크롤 허용
+    overflow-y: auto;
+    padding: token.$spacing_24;
+    color: token.$color_text_body;
+    @include token.body_medium;
+  }
+
+  // ── Footer (액션 영역) ─────────────────────────────────────────────────
+  &_footer {
+    flex: 0 0 auto;
+    display: flex;
+    gap: token.$spacing_8;
+    justify-content: flex-end;
+    padding: token.$spacing_16 token.$spacing_24;
+    border-top: token.$border_width_standard solid token.$color_border_subtle;
+  }
+}
+
+// Reduced motion (WCAG 2.3.3) - JS 스프링은 immediate 로 처리, CSS transition 은 여기서 제거
+@media (prefers-reduced-motion: reduce) {
+  .drawer,
+  .drawer_panel,
+  .drawer_close {
+    transition: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## 작업 개요

화면 가장자리에서 미끄러져 들어오는 신규 오버레이 컴포넌트 **Drawer** 를 추가합니다 (`src/ui/overlay/drawer/`). Modal 의 인프라(포커스 트랩, 바디 스크롤 잠금, topmost-only Escape 처리)를 그대로 재사용해 일관성을 유지했습니다.

## 작업한 내용

- [x] `Drawer` 컴포넌트 구현 (`index.tsx`) - `open`, `onClose`, `placement`, `size`, `title`, `footer`, `closeOnOverlay`, `showCloseIcon`, `closeLabel` props
- [x] `placement` (`left` / `right` / `bottom`) 방향별 react-spring 슬라이드 - 진입/퇴출을 동일 축(translateX/Y)으로 보간해 정확히 역방향으로 닫힘
- [x] `size` (number ⇒ px) 를 left/right 는 너비, bottom 은 높이에 적용
- [x] 오버레이 opacity 페이드 + 퇴출 후 unmount 라이프사이클 (`useSpringPresence`)
- [x] `useFocusTrap` 포커스 트랩 + Modal 과 동일한 바디 스크롤 잠금
- [x] Escape 는 오버레이 `onKeyDown` + `stopPropagation` (중첩 시 최상단만 닫힘, #333 교훈)
- [x] `role="dialog"`, `aria-modal`, `title` 존재 시 `aria-labelledby` 자동 연결 (없으면 `aria-label` fallback)
- [x] `prefers-reduced-motion: reduce` 대응 (JS `immediate` + CSS `transition: none`)
- [x] 토큰만 사용 (elevation/z-index/spacing/radius/motion, 아이콘 크기 `iconSize.md`)
- [x] 단위 테스트 22개 (`Drawer.test.tsx`) - 렌더, placement, size, 오버레이 클릭, Escape(중첩 포함), 포커스 트랩, reduced-motion, a11y 속성
- [x] Storybook 스토리 (`drawer.stories.tsx`) - Right / Left / Bottom / With footer, KO/EN 병기
- [x] `src/index.ts` 에 `Drawer` + `DrawerProps` / `DrawerPlacement` export
- [x] `docs/COMPONENTS.md` Drawer 섹션 추가 (props table + 사용 예시)
- [x] `pnpm test` / `pnpm build` / `pnpm lint:css` 모두 통과

## 전달할 추가 이슈

- `placement="top"` 과 배경 상호작용 가능한 non-modal 변형은 이번 범위에서 제외 (필요 시 후속 작업)
- Modal 과 Drawer 를 **동시에** 열 경우 바디 스크롤 잠금 stacking 이 알려진 엣지입니다. 두 컴포넌트가 각자 `body.style.overflow` 를 독립적으로 토글하므로, 한 번에 하나의 오버레이만 여는 사용에서는 안전하지만 동시 사용 시 한쪽을 닫으면 다른 쪽이 열려 있어도 스크롤이 복원될 수 있습니다.