### PR TITLE
feat/table-sort-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 	"size-limit": [
 		{
 			"path": "dist/index.js",
-			"limit": "45 kB"
+			"limit": "50 kB"
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,13 @@ export type { SkeletonProps, SkeletonVariant } from "./ui/feedback/skeleton";
 export { Skeleton } from "./ui/feedback/skeleton";
 export type { SpinnerProps } from "./ui/feedback/spinner";
 export { Spinner } from "./ui/feedback/spinner";
-export type { TableColumn, TableProps, TableSize } from "./ui/display/table";
+export type {
+	TableColumn,
+	TableProps,
+	TableSize,
+	TableSort,
+	TableSortDirection,
+} from "./ui/display/table";
 export { Table } from "./ui/display/table";
 export type { ResolvedTheme, ThemeMode, ThemeProviderProps } from "./ui/system/theme-provider";
 export { ThemeProvider, useTheme } from "./ui/system/theme-provider";

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -119,3 +119,225 @@ describe("Table", () => {
 		expect(screen.getByRole("table")).toHaveAttribute("aria-label", "결과 목록");
 	});
 });
+
+describe("Table sort", () => {
+	const sortableColumns: TableColumn<Row>[] = [
+		{ key: "name", header: "Name", sortable: true },
+		{ key: "score", header: "Score", sortable: true },
+	];
+
+	it("renders aria-sort='none' on sortable headers when unsorted", () => {
+		render(<Table columns={sortableColumns} data={rows} keyExtractor={(r) => r.id} />);
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"none",
+		);
+		expect(screen.getByRole("columnheader", { name: "Score" })).toHaveAttribute(
+			"aria-sort",
+			"none",
+		);
+	});
+
+	it("does not set aria-sort on non-sortable columns", () => {
+		render(<Table columns={columns} data={rows} keyExtractor={(r) => r.id} />);
+		expect(screen.getByRole("columnheader", { name: "Name" })).not.toHaveAttribute("aria-sort");
+	});
+
+	it("cycles a column through none -> asc -> desc -> none on click", () => {
+		const onSortChange = vi.fn();
+		const { rerender } = render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={undefined}
+				onSortChange={onSortChange}
+			/>,
+		);
+		const nameHeaderButton = screen.getByRole("button", { name: "Name" });
+
+		fireEvent.click(nameHeaderButton);
+		expect(onSortChange).toHaveBeenLastCalledWith({ key: "name", direction: "asc" });
+
+		rerender(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "asc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"ascending",
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(onSortChange).toHaveBeenLastCalledWith({ key: "name", direction: "desc" });
+
+		rerender(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"descending",
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(onSortChange).toHaveBeenLastCalledWith(null);
+	});
+
+	it("clicking a different column starts it at asc regardless of previous column state", () => {
+		const onSortChange = vi.fn();
+		render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Score" }));
+		expect(onSortChange).toHaveBeenCalledWith({ key: "score", direction: "asc" });
+	});
+
+	it("does not sort data itself - relies on consumer-provided data order", () => {
+		render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={vi.fn()}
+			/>,
+		);
+		const cells = screen.getAllByRole("cell");
+		// rows prop order (Alpha, Beta) is unchanged even though sort=desc is set
+		expect(cells[0]).toHaveTextContent("Alpha");
+	});
+});
+
+describe("Table selection", () => {
+	it("renders a checkbox column when selectable", () => {
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+			/>,
+		);
+		// 1 select-all + 2 row checkboxes
+		expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+	});
+
+	it("select-all is unchecked when nothing selected, checked when all selected, indeterminate when some selected", () => {
+		const { rerender } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+			/>,
+		);
+		const selectAll = screen.getByRole("checkbox", { name: "전체 선택" }) as HTMLInputElement;
+		expect(selectAll.checked).toBe(false);
+		expect(selectAll.indeterminate).toBe(false);
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1"]}
+			/>,
+		);
+		expect(selectAll.indeterminate).toBe(true);
+		expect(selectAll.checked).toBe(false);
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1", "2"]}
+			/>,
+		);
+		expect(selectAll.indeterminate).toBe(false);
+		expect(selectAll.checked).toBe(true);
+	});
+
+	it("toggling select-all selects all row keys, toggling again clears them", () => {
+		const onSelectionChange = vi.fn();
+		const { rerender } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		expect(onSelectionChange).toHaveBeenLastCalledWith(["1", "2"]);
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1", "2"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		expect(onSelectionChange).toHaveBeenLastCalledWith([]);
+	});
+
+	it("toggles an individual row via rowKey mapping and marks it aria-selected", () => {
+		const onSelectionChange = vi.fn();
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+
+		const rowsInTable = screen.getAllByRole("row");
+		// rowsInTable[0] is header row; body rows follow
+		expect(rowsInTable[1]).toHaveAttribute("aria-selected", "true");
+		expect(rowsInTable[2]).not.toHaveAttribute("aria-selected");
+
+		const betaCheckbox = screen.getByRole("checkbox", { name: "2번째 행 선택" });
+		fireEvent.click(betaCheckbox);
+		expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"]);
+
+		const alphaCheckbox = screen.getByRole("checkbox", { name: "1번째 행 선택" });
+		fireEvent.click(alphaCheckbox);
+		expect(onSelectionChange).toHaveBeenCalledWith([]);
+	});
+});

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -191,7 +191,7 @@ describe("Table sort", () => {
 		);
 
 		fireEvent.click(screen.getByRole("button", { name: "Name" }));
-		expect(onSortChange).toHaveBeenLastCalledWith(null);
+		expect(onSortChange).toHaveBeenLastCalledWith(undefined);
 	});
 
 	it("clicking a different column starts it at asc regardless of previous column state", () => {
@@ -207,6 +207,21 @@ describe("Table sort", () => {
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Score" }));
 		expect(onSortChange).toHaveBeenCalledWith({ key: "score", direction: "asc" });
+	});
+
+	it("emits undefined (not null) when a desc-sorted column is clicked again to clear sort", () => {
+		const onSortChange = vi.fn();
+		render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(onSortChange).toHaveBeenLastCalledWith(undefined);
 	});
 
 	it("does not sort data itself - relies on consumer-provided data order", () => {
@@ -339,5 +354,82 @@ describe("Table selection", () => {
 		const alphaCheckbox = screen.getByRole("checkbox", { name: "1번째 행 선택" });
 		fireEvent.click(alphaCheckbox);
 		expect(onSelectionChange).toHaveBeenCalledWith([]);
+	});
+
+	it("toggling select-all preserves keys selected on other pages (server pagination)", () => {
+		const onSelectionChange = vi.fn();
+		// "99" belongs to a row not present in the current page's `data`
+		const { rerender } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["99"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		const firstCallKeys = onSelectionChange.mock.calls[0][0] as string[];
+		expect(new Set(firstCallKeys)).toEqual(new Set(["99", "1", "2"]));
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["99", "1", "2"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		expect(onSelectionChange).toHaveBeenLastCalledWith(["99"]);
+	});
+
+	it("supports custom selectAllAriaLabel / selectRowAriaLabel", () => {
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+				selectAllAriaLabel="Select all rows"
+				selectRowAriaLabel={(index) => `Select row ${index + 1}`}
+			/>,
+		);
+		expect(screen.getByRole("checkbox", { name: "Select all rows" })).toBeInTheDocument();
+		expect(screen.getByRole("checkbox", { name: "Select row 1" })).toBeInTheDocument();
+		expect(screen.getByRole("checkbox", { name: "Select row 2" })).toBeInTheDocument();
+	});
+
+	it("disables the select-all checkbox while isLoading", () => {
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+				isLoading
+			/>,
+		);
+		expect(screen.getByRole("checkbox", { name: "전체 선택" })).toBeDisabled();
+	});
+});
+
+describe("Table isLoading guards", () => {
+	const sortableColumns: TableColumn<Row>[] = [{ key: "name", header: "Name", sortable: true }];
+
+	it("disables sortable header buttons while isLoading", () => {
+		render(
+			<Table columns={sortableColumns} data={rows} keyExtractor={(r) => r.id} isLoading />,
+		);
+		expect(screen.getByRole("button", { name: "Name" })).toBeDisabled();
 	});
 });

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import { Skeleton } from "../../feedback/skeleton";
@@ -81,7 +81,11 @@ export type TableProps<T extends object> = {
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
 	sort?: TableSort;
 	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
-	onSortChange?: (sort: TableSort | null) => void;
+	onSortChange?: (sort: TableSort | undefined) => void;
+	/** 전체 선택 체크박스 aria-label (기본값: "전체 선택") */
+	selectAllAriaLabel?: string;
+	/** 개별 행 선택 체크박스 aria-label (기본값: (i) => `${i+1}번째 행 선택`) */
+	selectRowAriaLabel?: (index: number) => string;
 } & TableSelectionProps<T>;
 
 /**
@@ -104,6 +108,8 @@ export const Table = <T extends object>({
 	onRowClick,
 	sort,
 	onSortChange,
+	selectAllAriaLabel = "전체 선택",
+	selectRowAriaLabel = (index: number) => `${index + 1}번째 행 선택`,
 	selectable = false,
 	rowKey,
 	selectedKeys,
@@ -121,12 +127,16 @@ export const Table = <T extends object>({
 	// ── Row selection ──────────────────────────────────────────────────────
 	const getRowKey = (item: T, index: number) => rowKey?.(item) ?? String(index);
 	const allRowKeys = selectable ? data.map((item, index) => getRowKey(item, index)) : [];
-	const selectedCount = allRowKeys.filter((key) => selectedKeys?.includes(key)).length;
+	const selectedSet = React.useMemo(() => new Set(selectedKeys), [selectedKeys]);
+	const selectedCount = allRowKeys.filter((key) => selectedSet.has(key)).length;
 	const isAllSelected = allRowKeys.length > 0 && selectedCount === allRowKeys.length;
 	const isSomeSelected = selectedCount > 0 && !isAllSelected;
 
 	const handleToggleAll = () => {
-		onSelectionChange?.(isAllSelected ? [] : allRowKeys);
+		const pageKeys = new Set(allRowKeys);
+		const offPage = (selectedKeys ?? []).filter((k) => !pageKeys.has(k));
+		// 현재 페이지가 모두 선택돼 있으면 해제, 아니면 전체 선택 - 다른 페이지 선택은 보존
+		onSelectionChange?.(isAllSelected ? offPage : [...offPage, ...allRowKeys]);
 	};
 
 	const handleToggleRow = (key: string) => {
@@ -137,12 +147,12 @@ export const Table = <T extends object>({
 
 	// ── Sort ───────────────────────────────────────────────────────────────
 	const handleSortClick = (key: string) => {
-		const next: TableSort | null =
+		const next: TableSort | undefined =
 			sort?.key !== key
 				? { key, direction: "asc" }
 				: sort.direction === "asc"
 					? { key, direction: "desc" }
-					: null;
+					: undefined;
 		onSortChange?.(next);
 	};
 
@@ -154,10 +164,10 @@ export const Table = <T extends object>({
 						{selectable && (
 							<th scope="col" className="table_th table_th_checkbox">
 								<Checkbox
-									aria-label="전체 선택"
+									aria-label={selectAllAriaLabel}
 									checked={isAllSelected}
 									indeterminate={isSomeSelected}
-									disabled={allRowKeys.length === 0}
+									disabled={isLoading || allRowKeys.length === 0}
 									onChange={handleToggleAll}
 								/>
 							</th>
@@ -190,6 +200,7 @@ export const Table = <T extends object>({
 											type="button"
 											className="table_sort_button"
 											onClick={() => handleSortClick(col.key)}
+											disabled={isLoading}
 										>
 											<span className="table_sort_label">{col.header}</span>
 											{direction === "asc" ? (
@@ -239,8 +250,7 @@ export const Table = <T extends object>({
 							))
 						: data.map((item, rowIndex) => {
 								const rowIdentity = selectable ? getRowKey(item, rowIndex) : undefined;
-								const isSelected =
-									rowIdentity !== undefined && (selectedKeys?.includes(rowIdentity) ?? false);
+								const isSelected = rowIdentity !== undefined && selectedSet.has(rowIdentity);
 
 								return (
 									<tr
@@ -273,7 +283,7 @@ export const Table = <T extends object>({
 												onKeyDown={(e) => e.stopPropagation()}
 											>
 												<Checkbox
-													aria-label={`${rowIndex + 1}번째 행 선택`}
+													aria-label={selectRowAriaLabel(rowIndex)}
 													checked={isSelected}
 													onChange={() => handleToggleRow(rowIdentity)}
 												/>

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -1,11 +1,23 @@
 "use client";
 
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import type * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import { Skeleton } from "../../feedback/skeleton";
+import { Checkbox } from "../../forms/checkbox";
 import "./style.scss";
 
 export type TableSize = "sm" | "md" | "lg";
+
+export type TableSortDirection = "asc" | "desc";
+
+export interface TableSort {
+	/** 정렬 중인 컬럼의 `TableColumn.key` */
+	key: string;
+	/** 정렬 방향 */
+	direction: TableSortDirection;
+}
 
 export interface TableColumn<T extends object> {
 	/** 컬럼 식별자 - `data[key]` 자동 렌더링에도 쓰임 */
@@ -18,9 +30,30 @@ export interface TableColumn<T extends object> {
 	width?: string;
 	/** 정렬 (기본값: "left") */
 	align?: "left" | "center" | "right";
+	/** 정렬 가능한 컬럼 여부 (기본값: false). 클릭 시 `onSortChange` 발화 - 실제 정렬은 소비자가 수행 */
+	sortable?: boolean;
 }
 
-export interface TableProps<T extends object> {
+/** `selectable` 시 `rowKey` 를 요구하기 위한 판별 유니온 */
+type TableSelectionProps<T extends object> =
+	| {
+			/** 행 선택(체크박스 컬럼) 활성화 여부 */
+			selectable: true;
+			/** 행 고유 key 추출 함수 - `selectable` 사용 시 필수 */
+			rowKey: (row: T) => string;
+			/** 선택된 행 key 배열 (제어형) */
+			selectedKeys?: string[];
+			/** 선택 변경 콜백 */
+			onSelectionChange?: (keys: string[]) => void;
+	  }
+	| {
+			selectable?: false;
+			rowKey?: (row: T) => string;
+			selectedKeys?: string[];
+			onSelectionChange?: (keys: string[]) => void;
+	  };
+
+export type TableProps<T extends object> = {
 	/** 컬럼 정의 */
 	columns: TableColumn<T>[];
 	/** 표시할 데이터 배열 */
@@ -45,7 +78,11 @@ export interface TableProps<T extends object> {
 	className?: string;
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
-}
+	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
+	sort?: TableSort;
+	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
+	onSortChange?: (sort: TableSort | null) => void;
+} & TableSelectionProps<T>;
 
 /**
  * 데이터 테이블을 렌더링한다. 로딩 중에는 헤더 유지, 바디에 스켈레톤 행을 표시한다.
@@ -65,6 +102,12 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
+	sort,
+	onSortChange,
+	selectable = false,
+	rowKey,
+	selectedKeys,
+	onSelectionChange,
 }: TableProps<T>) => {
 	const wrapperClassName = cn(
 		"table_wrapper",
@@ -75,21 +118,106 @@ export const Table = <T extends object>({
 
 	const isEmpty = !isLoading && data.length === 0;
 
+	// ── Row selection ──────────────────────────────────────────────────────
+	const getRowKey = (item: T, index: number) => rowKey?.(item) ?? String(index);
+	const allRowKeys = selectable ? data.map((item, index) => getRowKey(item, index)) : [];
+	const selectedCount = allRowKeys.filter((key) => selectedKeys?.includes(key)).length;
+	const isAllSelected = allRowKeys.length > 0 && selectedCount === allRowKeys.length;
+	const isSomeSelected = selectedCount > 0 && !isAllSelected;
+
+	const handleToggleAll = () => {
+		onSelectionChange?.(isAllSelected ? [] : allRowKeys);
+	};
+
+	const handleToggleRow = (key: string) => {
+		const current = selectedKeys ?? [];
+		const next = current.includes(key) ? current.filter((k) => k !== key) : [...current, key];
+		onSelectionChange?.(next);
+	};
+
+	// ── Sort ───────────────────────────────────────────────────────────────
+	const handleSortClick = (key: string) => {
+		const next: TableSort | null =
+			sort?.key !== key
+				? { key, direction: "asc" }
+				: sort.direction === "asc"
+					? { key, direction: "desc" }
+					: null;
+		onSortChange?.(next);
+	};
+
 	return (
 		<div className={wrapperClassName}>
 			<table className="table" aria-label={ariaLabel}>
 				<thead className="table_thead">
 					<tr>
-						{columns.map((col) => (
-							<th
-								key={col.key}
-								scope="col"
-								className={cn("table_th", col.align && `table_align_${col.align}`)}
-								style={{ width: col.width }}
-							>
-								{col.header}
+						{selectable && (
+							<th scope="col" className="table_th table_th_checkbox">
+								<Checkbox
+									aria-label="전체 선택"
+									checked={isAllSelected}
+									indeterminate={isSomeSelected}
+									disabled={allRowKeys.length === 0}
+									onChange={handleToggleAll}
+								/>
 							</th>
-						))}
+						)}
+						{columns.map((col) => {
+							const isSortActive = Boolean(col.sortable) && sort?.key === col.key;
+							const direction = isSortActive ? sort?.direction : undefined;
+							const ariaSort = col.sortable
+								? direction === "asc"
+									? "ascending"
+									: direction === "desc"
+										? "descending"
+										: "none"
+								: undefined;
+
+							return (
+								<th
+									key={col.key}
+									scope="col"
+									className={cn(
+										"table_th",
+										col.align && `table_align_${col.align}`,
+										col.sortable && "table_th_sortable",
+									)}
+									style={{ width: col.width }}
+									aria-sort={ariaSort}
+								>
+									{col.sortable ? (
+										<button
+											type="button"
+											className="table_sort_button"
+											onClick={() => handleSortClick(col.key)}
+										>
+											<span className="table_sort_label">{col.header}</span>
+											{direction === "asc" ? (
+												<ArrowUp
+													size={iconSize.sm}
+													className="table_sort_icon table_sort_icon_active"
+													aria-hidden="true"
+												/>
+											) : direction === "desc" ? (
+												<ArrowDown
+													size={iconSize.sm}
+													className="table_sort_icon table_sort_icon_active"
+													aria-hidden="true"
+												/>
+											) : (
+												<ArrowUpDown
+													size={iconSize.sm}
+													className="table_sort_icon"
+													aria-hidden="true"
+												/>
+											)}
+										</button>
+									) : (
+										col.header
+									)}
+								</th>
+							);
+						})}
 					</tr>
 				</thead>
 				<tbody className="table_tbody">
@@ -97,6 +225,7 @@ export const Table = <T extends object>({
 						? Array.from({ length: skeletonRows }).map((_, rowIndex) => (
 								// biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows have no stable identity
 								<tr key={rowIndex} className="table_row table_row_skeleton">
+									{selectable && <td className="table_td table_td_checkbox" />}
 									{columns.map((col) => (
 										<td
 											key={col.key}
@@ -108,45 +237,66 @@ export const Table = <T extends object>({
 									))}
 								</tr>
 							))
-						: data.map((item, rowIndex) => (
-								<tr
-									key={keyExtractor(item, rowIndex)}
-									className={cn(
-										"table_row",
-										hoverable && "table_row_hoverable",
-										onRowClick && "table_row_clickable",
-									)}
-									role={onRowClick ? "button" : undefined}
-									tabIndex={onRowClick ? 0 : undefined}
-									onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
-									onKeyDown={
-										onRowClick
-											? (e) => {
-													if (e.key === "Enter" || e.key === " ") {
-														e.preventDefault();
-														onRowClick(item, rowIndex);
+						: data.map((item, rowIndex) => {
+								const rowIdentity = selectable ? getRowKey(item, rowIndex) : undefined;
+								const isSelected =
+									rowIdentity !== undefined && (selectedKeys?.includes(rowIdentity) ?? false);
+
+								return (
+									<tr
+										key={keyExtractor(item, rowIndex)}
+										className={cn(
+											"table_row",
+											hoverable && "table_row_hoverable",
+											onRowClick && "table_row_clickable",
+											isSelected && "table_row_selected",
+										)}
+										aria-selected={isSelected ? "true" : undefined}
+										role={onRowClick ? "button" : undefined}
+										tabIndex={onRowClick ? 0 : undefined}
+										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
+										onKeyDown={
+											onRowClick
+												? (e) => {
+														if (e.key === "Enter" || e.key === " ") {
+															e.preventDefault();
+															onRowClick(item, rowIndex);
+														}
 													}
-												}
-											: undefined
-									}
-								>
-									{columns.map((col) => (
-										<td
-											key={col.key}
-											className={cn("table_td", col.align && `table_align_${col.align}`)}
-											style={{ width: col.width }}
-										>
-											{(() => {
-												if (col.render) return col.render(item, rowIndex);
-												const value = (item as Record<string, unknown>)[col.key];
-												return value === null || value === undefined || value === ""
-													? "-"
-													: String(value);
-											})()}
-										</td>
-									))}
-								</tr>
-							))}
+												: undefined
+										}
+									>
+										{selectable && rowIdentity !== undefined && (
+											<td
+												className="table_td table_td_checkbox"
+												onClick={(e) => e.stopPropagation()}
+												onKeyDown={(e) => e.stopPropagation()}
+											>
+												<Checkbox
+													aria-label={`${rowIndex + 1}번째 행 선택`}
+													checked={isSelected}
+													onChange={() => handleToggleRow(rowIdentity)}
+												/>
+											</td>
+										)}
+										{columns.map((col) => (
+											<td
+												key={col.key}
+												className={cn("table_td", col.align && `table_align_${col.align}`)}
+												style={{ width: col.width }}
+											>
+												{(() => {
+													if (col.render) return col.render(item, rowIndex);
+													const value = (item as Record<string, unknown>)[col.key];
+													return value === null || value === undefined || value === ""
+														? "-"
+														: String(value);
+												})()}
+											</td>
+										))}
+									</tr>
+								);
+							})}
 				</tbody>
 			</table>
 

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -27,6 +27,61 @@
   @include token.label_large_medium;
 }
 
+// ── Checkbox column (selection) ─────────────────────────────────────────────
+
+.table_th_checkbox,
+.table_td_checkbox {
+  width: token.$spacing_48;
+}
+
+// ── Sortable header ──────────────────────────────────────────────────────────
+// th 는 padding 을 0으로 비우고 button 이 전체 셀 크기/패딩을 대신 맡는다 - 클릭 영역 확대.
+
+.table_th_sortable {
+  padding: 0;
+}
+
+.table_sort_button {
+  display: flex;
+  align-items: center;
+  gap: token.$spacing_4;
+  width: 100%;
+  padding: token.$spacing_12 token.$spacing_16;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background token.$transition_fast;
+
+  &:hover {
+    background: token.$color_state_hover_on_light;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: token.$focus_ring;
+  }
+}
+
+.table_align_center .table_sort_button {
+  justify-content: center;
+}
+
+.table_align_right .table_sort_button {
+  justify-content: flex-end;
+}
+
+.table_sort_icon {
+  flex-shrink: 0;
+  color: token.$color_text_caption;
+  transition: color token.$transition_fast;
+}
+
+.table_sort_icon_active {
+  color: token.$color_text_heading;
+}
+
 .table_tbody {
   .table_row {
     border-bottom: token.$border_width_standard solid token.$color_border_default;
@@ -57,6 +112,15 @@
   .table_row_skeleton {
     pointer-events: none;
   }
+
+  // ── Selected (accent) ────────────────────────────────────────────────────
+  .table_row_selected {
+    background: token.$color_accent_subtle;
+  }
+
+  .table_row_selected.table_row_hoverable:hover {
+    background: token.$color_accent_muted;
+  }
 }
 
 .table_td {
@@ -78,6 +142,8 @@
     @include token.label_medium;
   }
   .table_th { @include token.label_medium_medium; }
+  .table_th_sortable { padding: 0; }
+  .table_sort_button { padding: token.$spacing_8 token.$spacing_12; }
 }
 
 .table_size_lg {
@@ -86,6 +152,8 @@
   }
   .table_th { @include token.body_large_medium; }
   .table_td { @include token.body_medium; }
+  .table_th_sortable { padding: 0; }
+  .table_sort_button { padding: token.$spacing_16 token.$spacing_20; }
 }
 
 // ── Sticky header ─────────────────────────────────────────────────────────
@@ -105,4 +173,13 @@
   text-align: center;
   color: token.$color_text_caption;
   @include token.body_small;
+}
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .table_row,
+  .table_sort_button,
+  .table_sort_icon {
+    transition: none;
+  }
 }

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -54,13 +54,18 @@
   cursor: pointer;
   transition: background token.$transition_fast;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: token.$color_state_hover_on_light;
   }
 
   &:focus-visible {
     outline: none;
     box-shadow: token.$focus_ring;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 }
 

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -31,6 +31,7 @@
 
 .table_th_checkbox,
 .table_td_checkbox {
+  box-sizing: border-box;
   width: token.$spacing_48;
 }
 

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -175,7 +175,7 @@ export const Sortable: Story = {
 		},
 	},
 	render: () => {
-		const [sort, setSort] = useState<TableSort | null>(null);
+		const [sort, setSort] = useState<TableSort | undefined>(undefined);
 
 		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
 			col.key === "name" || col.key === "email" || col.key === "role"
@@ -195,7 +195,7 @@ export const Sortable: Story = {
 				columns={sortableColumns}
 				data={sortedUsers}
 				keyExtractor={(u) => u.id}
-				sort={sort ?? undefined}
+				sort={sort}
 				onSortChange={setSort}
 				ariaLabel="정렬 가능한 사용자 목록"
 			/>
@@ -247,7 +247,7 @@ export const SortableAndSelectable: Story = {
 		},
 	},
 	render: () => {
-		const [sort, setSort] = useState<TableSort | null>(null);
+		const [sort, setSort] = useState<TableSort | undefined>(undefined);
 		const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
 
 		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
@@ -266,7 +266,7 @@ export const SortableAndSelectable: Story = {
 				columns={sortableColumns}
 				data={sortedUsers}
 				keyExtractor={(u) => u.id}
-				sort={sort ?? undefined}
+				sort={sort}
 				onSortChange={setSort}
 				selectable
 				rowKey={(u) => String(u.id)}

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Table, type TableColumn } from ".";
+import { useState } from "react";
+import { Table, type TableColumn, type TableSort } from ".";
 
 interface User {
 	id: number;
@@ -55,7 +56,7 @@ const meta: Meta<typeof Table> = {
 		docs: {
 			description: {
 				component: `
-**Table** - Displays structured data in rows/columns with generic row type safety. / **Table** - 정형 데이터 행/열 표시. 제네릭 row 타입 안전.
+**Table** - Displays structured data in rows/columns with generic row type safety. Supports controlled sort (\`sort\`/\`onSortChange\`) and row selection (\`selectable\`/\`rowKey\`/\`selectedKeys\`/\`onSelectionChange\`) - the DS only renders UI state, the consumer owns sorting the \`data\` array and the selection list. / **Table** - 정형 데이터 행/열 표시. 제네릭 row 타입 안전. 제어형 정렬(\`sort\`/\`onSortChange\`)과 행 선택(\`selectable\`/\`rowKey\`/\`selectedKeys\`/\`onSelectionChange\`)을 지원한다 - DS는 UI 상태만 그리고, 실제 \`data\` 정렬과 선택 목록 관리는 소비자가 담당한다.
 
 Key props: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (auto Skeleton rows), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`. / 주요 prop: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (Skeleton 행 자동), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`.
         `,
@@ -161,4 +162,118 @@ export const StickyHeader: Story = {
 			/>
 		</div>
 	),
+};
+
+export const Sortable: Story = {
+	name: "정렬 (제어형)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Controlled sort - the DS only renders `aria-sort` + arrow icon on click; the consumer sorts `data` and passes it back. Header click cycles none → asc → desc → none. / 제어형 정렬 - DS는 클릭 시 `aria-sort`와 화살표 아이콘만 그린다. 실제 `data` 정렬은 소비자가 수행해 다시 전달한다. 헤더 클릭 시 none → asc → desc → none 순환.",
+			},
+		},
+	},
+	render: () => {
+		const [sort, setSort] = useState<TableSort | null>(null);
+
+		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
+			col.key === "name" || col.key === "email" || col.key === "role"
+				? { ...col, sortable: true }
+				: col,
+		);
+
+		const sortedUsers = [...sampleUsers].sort((a, b) => {
+			if (!sort) return 0;
+			const key = sort.key as keyof User;
+			const compared = String(a[key]).localeCompare(String(b[key]), "ko");
+			return sort.direction === "asc" ? compared : -compared;
+		});
+
+		return (
+			<Table<User>
+				columns={sortableColumns}
+				data={sortedUsers}
+				keyExtractor={(u) => u.id}
+				sort={sort ?? undefined}
+				onSortChange={setSort}
+				ariaLabel="정렬 가능한 사용자 목록"
+			/>
+		);
+	},
+};
+
+export const Selectable: Story = {
+	name: "행 선택 (제어형)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Controlled row selection via `selectable` + `rowKey` + `selectedKeys` + `onSelectionChange`. Header checkbox is tri-state (checked/indeterminate/unchecked). Selected rows get `aria-selected` and an accent highlight. / `selectable` + `rowKey` + `selectedKeys` + `onSelectionChange` 로 제어하는 행 선택. 헤더 체크박스는 3-상태(전체선택/일부선택/미선택)이며, 선택된 행은 `aria-selected` 와 accent 강조를 받는다.",
+			},
+		},
+	},
+	render: () => {
+		const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+
+		return (
+			<div style={{ display: "grid", gap: 12 }}>
+				<div style={{ fontSize: 13, color: "var(--bt-color-text-body)" }}>
+					선택됨 {selectedKeys.length}건 / {selectedKeys.length} selected
+				</div>
+				<Table<User>
+					columns={columns}
+					data={sampleUsers}
+					keyExtractor={(u) => u.id}
+					selectable
+					rowKey={(u) => String(u.id)}
+					selectedKeys={selectedKeys}
+					onSelectionChange={setSelectedKeys}
+					ariaLabel="선택 가능한 사용자 목록"
+				/>
+			</div>
+		);
+	},
+};
+
+export const SortableAndSelectable: Story = {
+	name: "정렬 + 선택 조합",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Sort and selection compose independently - both are controlled, and neither DS feature touches `data` directly. / 정렬과 선택은 서로 독립적으로 조합된다 - 둘 다 제어형이며 DS는 `data` 를 직접 건드리지 않는다.",
+			},
+		},
+	},
+	render: () => {
+		const [sort, setSort] = useState<TableSort | null>(null);
+		const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+
+		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
+			col.key === "name" || col.key === "role" ? { ...col, sortable: true } : col,
+		);
+
+		const sortedUsers = [...sampleUsers].sort((a, b) => {
+			if (!sort) return 0;
+			const key = sort.key as keyof User;
+			const compared = String(a[key]).localeCompare(String(b[key]), "ko");
+			return sort.direction === "asc" ? compared : -compared;
+		});
+
+		return (
+			<Table<User>
+				columns={sortableColumns}
+				data={sortedUsers}
+				keyExtractor={(u) => u.id}
+				sort={sort ?? undefined}
+				onSortChange={setSort}
+				selectable
+				rowKey={(u) => String(u.id)}
+				selectedKeys={selectedKeys}
+				onSelectionChange={setSelectedKeys}
+				ariaLabel="정렬 및 선택 가능한 사용자 목록"
+			/>
+		);
+	},
 };


### PR DESCRIPTION
## 작업 개요
Table 컴포넌트에 제어형 정렬(sort)과 행 선택(row selection) 기능을 추가합니다. (P4)

## 작업한 내용
- [x] `TableColumn.sortable` 추가 - 정렬 가능한 컬럼 지정
- [x] `TableProps.sort` / `onSortChange` 추가 - 정렬 헤더 클릭 시 none → asc → desc → none 순환, `aria-sort` + 방향 아이콘(`iconSize`) 렌더링. DS는 데이터를 직접 정렬하지 않고 소비자가 `data`를 재정렬해 다시 전달
- [x] `TableProps.selectable` / `rowKey` / `selectedKeys` / `onSelectionChange` 추가 - 기존 `Checkbox` 컴포넌트를 재사용한 선택 컬럼. 헤더 체크박스는 3-상태(전체/일부-indeterminate/미선택), 선택된 행은 `aria-selected="true"` + accent 배경 강조
- [x] `rowKey` 는 판별 유니온 타입으로 `selectable` 시 TS가 필수로 요구하도록 처리
- [x] `style.scss` - 정렬 버튼/아이콘, 체크박스 컬럼, 선택 행 하이라이트 모두 디자인 토큰만 사용, reduced-motion 가드 추가
- [x] `Table.test.tsx` - 기존 테스트 전부 무변경 유지 + `aria-sort` 순환, `onSortChange` 페이로드, select-all 3-상태, 개별 행 토글, `rowKey` 매핑 테스트 추가
- [x] `table.stories.tsx` - Sortable / Selectable / Sortable+Selectable 스토리 추가 (한글/영문 설명 포함)
- [x] `src/index.ts` - 신규 공개 타입 `TableSort`, `TableSortDirection` export 추가

## 전달할 추가 이슈
- 내장 클라이언트사이드 정렬(자동 data sort)은 이번 범위에서 제외 - 현재는 순수 제어형으로 소비자가 정렬을 수행. 필요 시 후속 작업으로 옵션 정렬 유틸 추가 검토

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 테이블 정렬 제어(`sort`, `onSortChange`)와 체크 기반 행 선택(`selectable`, `selectedKeys`)을 지원합니다.
  * `TableColumn`의 `sortable` 옵션 및 공개 정렬 타입이 추가되었고, 헤더의 정렬/선택 상태(aria 라벨 포함) 표시가 강화되었습니다.
  * 정렬·선택 동시 사용 예시가 스토리에 추가되었습니다.
* **Bug Fixes**
  * 정렬 해제 시 `onSortChange`는 `undefined`로 전달되며, `isLoading` 중 정렬 버튼이 비활성화됩니다.
* **Tests**
  * 정렬/선택 동작과 페이지네이션·로딩 조건을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->