### PR TITLE
feat/dropdown-search-multi

### DIFF
--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -490,4 +490,175 @@ describe("Dropdown", () => {
 		expect(onValueChange).toHaveBeenCalledWith("1", options[0]);
 	});
 
+	// ── searchable ──────────────────────────────────────────────────────────────
+
+	it("renders a search input at the top of the panel when searchable", () => {
+		render(<Dropdown options={options} searchable searchPlaceholder="Find…" />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByPlaceholderText("Find…")).toBeInTheDocument();
+	});
+
+	it("does not render a search input when not searchable", () => {
+		render(<Dropdown options={options} />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.queryByPlaceholderText("검색…")).not.toBeInTheDocument();
+	});
+
+	it("filters options case- and whitespace-insensitively by label", () => {
+		render(<Dropdown options={options} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.change(screen.getByPlaceholderText("검색…"), { target: { value: "  OPTION2 " } });
+		expect(screen.getByText("Option 2")).toBeInTheDocument();
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+		expect(screen.queryByText("Option 3")).not.toBeInTheDocument();
+	});
+
+	it("shows emptyText when the filter yields no options", () => {
+		render(<Dropdown options={options} searchable emptyText="No results" />);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.change(screen.getByPlaceholderText("검색…"), { target: { value: "zzz" } });
+		expect(screen.getByText("No results")).toBeInTheDocument();
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+	});
+
+	it("defers filtering until composition ends (Korean IME)", () => {
+		const imeOptions = [
+			{ value: "seoul", label: "서울" },
+			{ value: "busan", label: "부산" },
+		];
+		render(<Dropdown options={imeOptions} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		fireEvent.compositionStart(search);
+		// 조합 중: 표시는 갱신되지만 필터는 아직 적용되지 않아야 함
+		fireEvent.change(search, { target: { value: "서" } });
+		expect(screen.getByText("서울")).toBeInTheDocument();
+		expect(screen.getByText("부산")).toBeInTheDocument();
+
+		// 조합 종료: 이제 필터 적용
+		fireEvent.compositionEnd(search, { target: { value: "서울" } });
+		expect(screen.getByText("서울")).toBeInTheDocument();
+		expect(screen.queryByText("부산")).not.toBeInTheDocument();
+	});
+
+	it("keeps active option in range after the filter reduces the list", () => {
+		const searchOptions = [
+			{ value: "a", label: "Alpha" },
+			{ value: "b", label: "Bravo" },
+			{ value: "c", label: "Charlie" },
+		];
+		render(<Dropdown options={searchOptions} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		fireEvent.keyDown(search, { key: "ArrowDown" }); // active -> Bravo
+		fireEvent.keyDown(search, { key: "ArrowDown" }); // active -> Charlie (idx 2)
+
+		fireEvent.change(search, { target: { value: "Bravo" } }); // 남는 옵션은 Bravo 뿐
+		const bravo = screen.getByText("Bravo").closest("[role='option']");
+		expect(bravo).toHaveClass("is_active");
+	});
+
+	it("selects active option with Enter from the search input (single)", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown options={options} searchable onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+		fireEvent.change(search, { target: { value: "Option 2" } });
+		fireEvent.keyDown(search, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("2", options[1]);
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	it("closes on Escape from the search input", () => {
+		render(<Dropdown options={options} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+		fireEvent.keyDown(search, { key: "Escape" });
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	// ── multiple ──────────────────────────────────────────────────────────────
+
+	it("toggles selection and keeps the list open in multiple mode", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown multiple options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+
+		fireEvent.click(screen.getByText("Option 1"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["1"], [options[0]]);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByText("Option 2"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["1", "2"], [options[0], options[1]]);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		// 다시 클릭하면 토글 해제
+		fireEvent.click(screen.getByText("Option 1"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["2"], [options[1]]);
+	});
+
+	it("shows N개 선택 summary in multiple mode", () => {
+		render(<Dropdown multiple options={options} defaultValue={["1", "2"]} placeholder="선택" />);
+		expect(screen.getByText("2개 선택")).toBeInTheDocument();
+	});
+
+	it("shows placeholder when nothing is selected in multiple mode", () => {
+		render(<Dropdown multiple options={options} placeholder="항목 선택" />);
+		expect(screen.getByText("항목 선택")).toBeInTheDocument();
+	});
+
+	it("renders a left check mark on selected options in multiple mode", () => {
+		render(<Dropdown multiple options={options} defaultValue={["1"]} />);
+		fireEvent.click(screen.getByRole("button"));
+		const opt1 = screen.getByText("Option 1").closest("[role='option']");
+		expect(opt1?.querySelector(".dropdown_option_check svg")).toBeInTheDocument();
+		const opt2 = screen.getByText("Option 2").closest("[role='option']");
+		expect(opt2?.querySelector(".dropdown_option_check svg")).not.toBeInTheDocument();
+	});
+
+	it("sets aria-multiselectable on the listbox in multiple mode", () => {
+		render(<Dropdown multiple options={options} />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByRole("listbox")).toHaveAttribute("aria-multiselectable", "true");
+	});
+
+	it("does not set aria-multiselectable in single mode", () => {
+		render(<Dropdown options={options} />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByRole("listbox")).not.toHaveAttribute("aria-multiselectable");
+	});
+
+	it("toggles with Enter from the search input in multiple mode (stays open)", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown multiple searchable options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+		fireEvent.change(search, { target: { value: "Option 1" } });
+		fireEvent.keyDown(search, { key: "Enter" });
+		expect(onValueChange).toHaveBeenLastCalledWith(["1"], [options[0]]);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+	});
+
+	// ── searchable + multiple combined ──────────────────────────────────────────
+
+	it("keeps the active filter after selecting in searchable + multiple mode", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown multiple searchable options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		fireEvent.change(search, { target: { value: "Option 2" } });
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByText("Option 2"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["2"], [options[1]]);
+
+		// 리스트 유지 + 필터 유지 (Option 1 여전히 숨김)
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+		expect(screen.getByText("Option 2")).toBeInTheDocument();
+	});
 });

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -580,6 +580,23 @@ describe("Dropdown", () => {
 		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 	});
 
+	it("ignores Enter during IME composition, then selects on a normal Enter", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown options={options} searchable onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		// 조합 중 Enter (한글 확정) - 선택/토글·닫기 발생하지 않아야 함
+		fireEvent.keyDown(search, { key: "Enter", isComposing: true });
+		expect(onValueChange).not.toHaveBeenCalled();
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		// 조합이 끝난 뒤의 일반 Enter - 이제 활성 옵션 선택
+		fireEvent.keyDown(search, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("1", options[0]);
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
 	// ── multiple ──────────────────────────────────────────────────────────────
 
 	it("toggles selection and keeps the list open in multiple mode", () => {
@@ -603,6 +620,18 @@ describe("Dropdown", () => {
 	it("shows N개 선택 summary in multiple mode", () => {
 		render(<Dropdown multiple options={options} defaultValue={["1", "2"]} placeholder="선택" />);
 		expect(screen.getByText("2개 선택")).toBeInTheDocument();
+	});
+
+	it("uses a custom selectedSummary in multiple mode", () => {
+		render(
+			<Dropdown
+				multiple
+				options={options}
+				defaultValue={["1", "2"]}
+				selectedSummary={(n) => `${n} selected`}
+			/>,
+		);
+		expect(screen.getByText("2 selected")).toBeInTheDocument();
 	});
 
 	it("shows placeholder when nothing is selected in multiple mode", () => {

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -10,6 +10,19 @@ const basicOptions: DropdownOption[] = [
 	{ value: "disabled", label: "Disabled option", disabled: true },
 ];
 
+const fruitOptions: DropdownOption[] = [
+	{ value: "apple", label: "Apple" },
+	{ value: "banana", label: "Banana" },
+	{ value: "blueberry", label: "Blueberry" },
+	{ value: "cherry", label: "Cherry" },
+	{ value: "grape", label: "Grape" },
+	{ value: "mango", label: "Mango" },
+	{ value: "orange", label: "Orange" },
+	{ value: "peach", label: "Peach" },
+	{ value: "pear", label: "Pear" },
+	{ value: "strawberry", label: "Strawberry" },
+];
+
 const meta: Meta<typeof Dropdown> = {
 	title: "Components/Forms/Dropdown",
 	component: Dropdown,
@@ -18,6 +31,10 @@ const meta: Meta<typeof Dropdown> = {
 		size: { control: "select", options: ["sm", "md", "lg"] },
 		disabled: { control: "boolean" },
 		fullWidth: { control: "boolean" },
+		searchable: { control: "boolean" },
+		multiple: { control: "boolean" },
+		searchPlaceholder: { control: "text" },
+		emptyText: { control: "text" },
 		options: { table: { disable: true } },
 		onChange: { control: false },
 		value: { control: false },
@@ -38,6 +55,8 @@ const meta: Meta<typeof Dropdown> = {
 Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
 \`DropdownOption\` fields: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`. / \`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
 Keyboard: ↑↓/Enter/Esc/Home/End. / 키보드: ↑↓/Enter/Esc/Home/End.
+
+Opt-in: \`searchable\` adds a label filter (case/whitespace-insensitive, Korean IME safe), \`multiple\` enables multi-select (toggle, list stays open, "N개 선택" summary). / opt-in: \`searchable\` 은 라벨 필터(대소문자·공백 무시, 한글 IME 안전), \`multiple\` 은 다중 선택(토글, 리스트 유지, "N개 선택" 요약)을 켭니다.
 				`,
 			},
 		},
@@ -91,6 +110,92 @@ export const Controlled: Story = {
 				<Dropdown {...args} value={value} onChange={setValue} />
 				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 					선택: <strong>{String(value)}</strong>
+				</div>
+			</div>
+		);
+	},
+};
+
+export const Searchable: Story = {
+	name: "Searchable (label filter)",
+	args: {
+		label: "Fruit",
+		options: fruitOptions,
+		placeholder: "Choose a fruit",
+		searchable: true,
+		searchPlaceholder: "Search fruit…",
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Type to filter options by label (case- and whitespace-insensitive). Korean IME composition is committed on composition end so the list does not thrash mid-typing. / 라벨로 옵션을 필터링합니다(대소문자·공백 무시). 한글 IME 는 조합 완료 시점에 반영되어 조합 중 리스트가 흔들리지 않습니다.",
+			},
+		},
+	},
+};
+
+export const Multiple: Story = {
+	name: "Multiple (multi-select)",
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		docs: {
+			description: {
+				story:
+					'Clicking an option toggles it and the list stays open. Selected options show a left check mark; the control shows an "N개 선택" summary. / 옵션을 클릭하면 토글되고 리스트는 열린 채 유지됩니다. 선택 항목은 왼쪽 체크 표시가 붙고, 컨트롤에는 "N개 선택" 요약이 표시됩니다.',
+			},
+		},
+	},
+	render: (args) => {
+		const [values, setValues] = React.useState<string[]>(["apple", "cherry"]);
+		return (
+			<div style={{ width: 320 }}>
+				<Dropdown
+					{...args}
+					multiple
+					options={fruitOptions}
+					label="Fruit"
+					placeholder="Choose fruits"
+					value={values}
+					onValueChange={setValues}
+				/>
+				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
+					선택: <strong>{values.join(", ") || "(없음)"}</strong>
+				</div>
+			</div>
+		);
+	},
+};
+
+export const SearchableMultiple: Story = {
+	name: "Searchable + Multiple",
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		docs: {
+			description: {
+				story:
+					"Search and multi-select combine: selecting an option while a filter is active keeps the filter so you can keep picking from the narrowed list. / 검색과 다중 선택 조합: 필터가 걸린 상태에서 항목을 선택해도 필터가 유지되어 좁혀진 목록에서 계속 고를 수 있습니다.",
+			},
+		},
+	},
+	render: (args) => {
+		const [values, setValues] = React.useState<string[]>([]);
+		return (
+			<div style={{ width: 320 }}>
+				<Dropdown
+					{...args}
+					multiple
+					searchable
+					options={fruitOptions}
+					label="Fruit"
+					placeholder="Choose fruits"
+					searchPlaceholder="Search fruit…"
+					emptyText="No matching fruit"
+					value={values}
+					onValueChange={setValues}
+				/>
+				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
+					선택: <strong>{values.join(", ") || "(없음)"}</strong>
 				</div>
 			</div>
 		);

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -1,20 +1,12 @@
 "use client";
 
 import { animated } from "@react-spring/web";
-import * as React from "react";
-import {
-	Fragment,
-	useCallback,
-	useEffect,
-	useId,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { Check, ChevronDown, Search } from "lucide-react";
+import type * as React from "react";
+import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { iconSize } from "../../../styles/icon";
 import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
-import { Check, ChevronDown } from "lucide-react";
 
 export type DropdownSize = "sm" | "md" | "lg";
 
@@ -32,7 +24,8 @@ export interface DropdownOption {
 	showDivider?: boolean;
 }
 
-export interface DropdownProps {
+/** single/multiple 공통 속성 */
+interface DropdownCommonProps {
 	/** 드롭다운 요소의 id (미입력 시 자동 생성) */
 	id?: string;
 	/** 드롭다운 위에 표시할 플로팅 라벨 텍스트 */
@@ -41,14 +34,6 @@ export interface DropdownProps {
 	placeholder?: string;
 	/** 표시할 옵션 목록 */
 	options: DropdownOption[];
-	/** 제어형 선택 값 */
-	value?: string | null;
-	/** 값 변경 콜백 (canonical). 선택된 값과 전체 옵션 객체를 전달합니다. */
-	onValueChange?: (value: string | null, option?: DropdownOption | null) => void;
-	/** @deprecated `onValueChange` 를 사용하세요. */
-	onChange?: (value: string | null, option?: DropdownOption | null) => void;
-	/** 비제어형 초기 선택 값 */
-	defaultValue?: string | null;
 	/** 비활성화 여부 */
 	disabled?: boolean;
 	/** 드롭다운 크기 (기본값: "md") */
@@ -67,55 +52,165 @@ export interface DropdownProps {
 	 * @deprecated textAlign은 더 이상 지원되지 않습니다.
 	 */
 	textAlign?: "left" | "center";
+	/**
+	 * 검색 가능 여부. 활성화 시 열린 패널 상단에 검색 입력이 표시되고, 옵션 `label` 부분 일치로 필터링됩니다.
+	 * (기본값: false)
+	 */
+	searchable?: boolean;
+	/** 검색 입력의 placeholder (기본값: "검색…") */
+	searchPlaceholder?: string;
+	/** 필터 결과가 0개일 때 표시할 텍스트 (기본값: "결과 없음") */
+	emptyText?: string;
 }
+
+/** 단일 선택 (기본) */
+export interface DropdownSingleProps extends DropdownCommonProps {
+	/** 다중 선택 모드 (기본값: false) */
+	multiple?: false;
+	/** 제어형 선택 값 */
+	value?: string | null;
+	/** 값 변경 콜백 (canonical). 선택된 값과 전체 옵션 객체를 전달합니다. */
+	onValueChange?: (value: string | null, option?: DropdownOption | null) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (value: string | null, option?: DropdownOption | null) => void;
+	/** 비제어형 초기 선택 값 */
+	defaultValue?: string | null;
+}
+
+/** 다중 선택 */
+export interface DropdownMultipleProps extends DropdownCommonProps {
+	/** 다중 선택 모드 */
+	multiple: true;
+	/** 제어형 선택 값 목록 */
+	value?: string[];
+	/** 값 변경 콜백 (canonical). 선택된 값 목록과 옵션 객체 목록을 전달합니다. */
+	onValueChange?: (values: string[], options: DropdownOption[]) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (values: string[], options: DropdownOption[]) => void;
+	/** 비제어형 초기 선택 값 목록 */
+	defaultValue?: string[];
+}
+
+export type DropdownProps = DropdownSingleProps | DropdownMultipleProps;
+
+/** 검색 매칭용 정규화 - 대소문자·공백 무시 */
+const normalizeForSearch = (s: string) => s.toLowerCase().replace(/\s+/g, "");
 
 /**
  * 드롭다운 컴포넌트를 렌더링한다.
- * 제어형/비제어형 상태를 지원하며, 키보드/마우스 상호작용과 플로팅 라벨을 관리한다.
+ * 제어형/비제어형 상태를 지원하며, 키보드/마우스 상호작용과 정적 라벨을 관리한다.
+ * `searchable` 로 라벨 부분 일치 검색을, `multiple` 로 다중 선택을 opt-in 할 수 있다.
  * @param props 드롭다운 속성
  * @returns 렌더링된 드롭다운 UI
  */
-export const Dropdown = ({
-	id,
-	label,
-	placeholder = "Select…",
-	options,
-	value,
-	onValueChange,
-	onChange,
-	defaultValue = null,
-	disabled,
-	size = "md",
-	className,
-}: DropdownProps) => {
+export const Dropdown = (props: DropdownProps) => {
+	const {
+		id,
+		label,
+		placeholder = "Select…",
+		options,
+		disabled,
+		size = "md",
+		className,
+		searchable = false,
+		searchPlaceholder = "검색…",
+		emptyText = "결과 없음",
+	} = props;
+
+	const multiple = props.multiple === true;
+
 	const internalId = useId();
 	const dropdownId = id ?? internalId;
 
-	const isControlled = value !== undefined;
-	const [internalValue, setInternalValue] = useState<string | null>(defaultValue);
-	const currentValue = isControlled ? (value ?? null) : internalValue;
+	const isControlled = props.value !== undefined;
+
+	// 단일/다중 각각 별도 내부 상태 (mode 는 런타임에 바뀌지 않는다고 가정)
+	const [internalSingle, setInternalSingle] = useState<string | null>(() =>
+		props.multiple === true ? null : ((props.defaultValue as string | null | undefined) ?? null),
+	);
+	const [internalMulti, setInternalMulti] = useState<string[]>(() =>
+		props.multiple === true ? ((props.defaultValue as string[] | undefined) ?? []) : [],
+	);
 
 	const [isOpen, setIsOpen] = useState(false);
 	const [activeIndex, setActiveIndex] = useState(-1);
 	const [dropUp, setDropUp] = useState(false);
 
+	// 검색 상태 - searchText 는 표시용(IME 조합 중에도 즉시 반영), committedQuery 는 필터용(조합 완료 시 반영)
+	const [searchText, setSearchText] = useState("");
+	const [committedQuery, setCommittedQuery] = useState("");
+	const isComposingRef = useRef(false);
+
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const controlRef = useRef<HTMLButtonElement>(null);
+	const searchRef = useRef<HTMLInputElement>(null);
 
-	const currentOption = useMemo(
-		() => options.find((o) => o.value === currentValue) ?? null,
-		[options, currentValue],
-	);
+	// 현재 선택값 - 항상 배열로 정규화 (single 은 길이 0~1)
+	const selectedValues = useMemo<string[]>(() => {
+		if (multiple) {
+			const v = isControlled ? (props.value as string[] | undefined) : internalMulti;
+			return v ?? [];
+		}
+		const v = isControlled ? (props.value as string | null | undefined) : internalSingle;
+		return v != null ? [v] : [];
+	}, [multiple, isControlled, props.value, internalMulti, internalSingle]);
 
-	// 라벨은 항상 보이는 정적 라벨 (notched outline + always visible)
+	// 검색 필터 적용된 노출 옵션. searchable 아니거나 쿼리 없으면 전체.
+	const visibleOptions = useMemo<DropdownOption[]>(() => {
+		if (!searchable) return options;
+		const q = normalizeForSearch(committedQuery);
+		if (q === "") return options;
+		return options.filter((o) => normalizeForSearch(o.label).includes(q));
+	}, [options, searchable, committedQuery]);
 
-	const setValue = useCallback(
+	// ── 선택 처리 ──────────────────────────────────────────────────────────
+
+	const selectSingle = useCallback(
 		(next: string | null) => {
 			const option = options.find((o) => o.value === next) ?? null;
-			if (!isControlled) setInternalValue(next);
-			(onValueChange ?? onChange)?.(next, option);
+			if (!isControlled) setInternalSingle(next);
+			if (props.multiple !== true) {
+				(props.onValueChange ?? props.onChange)?.(next, option);
+			}
 		},
-		[isControlled, onValueChange, onChange, options],
+		[isControlled, options, props.multiple, props.onValueChange, props.onChange],
+	);
+
+	const toggleMultiple = useCallback(
+		(opt: DropdownOption) => {
+			const exists = selectedValues.includes(opt.value);
+			const nextValues = exists
+				? selectedValues.filter((v) => v !== opt.value)
+				: [...selectedValues, opt.value];
+			const nextOptions = nextValues
+				.map((v) => options.find((o) => o.value === v))
+				.filter((o): o is DropdownOption => Boolean(o));
+			if (!isControlled) setInternalMulti(nextValues);
+			if (props.multiple === true) {
+				(props.onValueChange ?? props.onChange)?.(nextValues, nextOptions);
+			}
+		},
+		[selectedValues, options, isControlled, props.multiple, props.onValueChange, props.onChange],
+	);
+
+	const closePanel = useCallback(() => {
+		setIsOpen(false);
+		// searchable 은 포커스가 검색 입력에 있으므로 닫을 때 트리거로 되돌린다.
+		if (searchable) controlRef.current?.focus();
+	}, [searchable]);
+
+	const selectOption = useCallback(
+		(opt: DropdownOption) => {
+			if (opt.disabled) return;
+			if (multiple) {
+				// 다중: 토글 후 리스트/필터 유지 (닫지 않음)
+				toggleMultiple(opt);
+			} else {
+				selectSingle(opt.value);
+				closePanel();
+			}
+		},
+		[multiple, toggleMultiple, selectSingle, closePanel],
 	);
 
 	useEffect(() => {
@@ -128,33 +223,34 @@ export const Dropdown = ({
 		return () => document.removeEventListener("mousedown", handleOutsideClick);
 	}, []);
 
-	const moveActive = (dir: 1 | -1) => {
-		if (options.length === 0) return;
-		if (!isOpen) {
-			setIsOpen(true);
-			return;
-		}
-		let i = activeIndex;
-		const len = options.length;
-		for (let step = 0; step < len; step++) {
-			i = (i + dir + len) % len;
-			if (!options[i].disabled) {
-				setActiveIndex(i);
-				break;
+	// ── 키보드 네비게이션 (visibleOptions 기준) ─────────────────────────────
+
+	const moveActive = useCallback(
+		(dir: 1 | -1) => {
+			if (visibleOptions.length === 0) return;
+			if (!isOpen) {
+				setIsOpen(true);
+				return;
 			}
-		}
-	};
+			let i = activeIndex;
+			const len = visibleOptions.length;
+			for (let step = 0; step < len; step++) {
+				i = (i + dir + len) % len;
+				if (!visibleOptions[i].disabled) {
+					setActiveIndex(i);
+					break;
+				}
+			}
+		},
+		[visibleOptions, isOpen, activeIndex],
+	);
 
-	const commitActive = () => {
-		if (activeIndex < 0 || activeIndex >= options.length) return;
-		const opt = options[activeIndex];
-		if (!opt.disabled) {
-			setValue(opt.value);
-			setIsOpen(false);
-		}
-	};
+	const commitActive = useCallback(() => {
+		if (activeIndex < 0 || activeIndex >= visibleOptions.length) return;
+		selectOption(visibleOptions[activeIndex]);
+	}, [activeIndex, visibleOptions, selectOption]);
 
-	const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+	const onControlKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
 		if (disabled) return;
 		switch (e.key) {
 			case " ":
@@ -174,13 +270,13 @@ export const Dropdown = ({
 			case "Home":
 				e.preventDefault();
 				setIsOpen(true);
-				setActiveIndex(options.findIndex((o) => !o.disabled));
+				setActiveIndex(visibleOptions.findIndex((o) => !o.disabled));
 				break;
 			case "End":
 				e.preventDefault();
 				setIsOpen(true);
-				for (let i = options.length - 1; i >= 0; i--) {
-					if (!options[i].disabled) {
+				for (let i = visibleOptions.length - 1; i >= 0; i--) {
+					if (!visibleOptions[i].disabled) {
 						setActiveIndex(i);
 						break;
 					}
@@ -193,18 +289,54 @@ export const Dropdown = ({
 		}
 	};
 
+	// 검색 입력 내 키보드 - ↑/↓ 이동, Enter 선택/토글, Esc 닫기. Home/End 는 커서 이동에 양보.
+	const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				moveActive(1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				moveActive(-1);
+				break;
+			case "Enter":
+				e.preventDefault();
+				commitActive();
+				break;
+			case "Escape":
+				e.preventDefault();
+				closePanel();
+				break;
+		}
+	};
+
+	// open / 필터 변경 / options 변경 시 activeIndex 재계산해 범위 내로 유지.
+	// selectedValues 는 의도적으로 제외 - 다중 토글마다 active 가 리셋되지 않게.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: selectedValues 제외는 의도적 (다중 토글 시 active 유지)
 	useEffect(() => {
 		if (!isOpen) return;
-		const matchedIndex = options.findIndex((o) => o.value === currentValue && !o.disabled);
-		setActiveIndex(
-			matchedIndex >= 0
-				? matchedIndex
-				: Math.max(
-						0,
-						options.findIndex((o) => !o.disabled),
-					),
+		const selectedIdx = visibleOptions.findIndex(
+			(o) => selectedValues.includes(o.value) && !o.disabled,
 		);
-	}, [isOpen, options, currentValue]);
+		setActiveIndex(selectedIdx >= 0 ? selectedIdx : visibleOptions.findIndex((o) => !o.disabled));
+	}, [isOpen, visibleOptions]);
+
+	// 패널을 닫으면 검색 상태 초기화 (다음 열림 시 fresh)
+	useEffect(() => {
+		if (!isOpen) {
+			setSearchText("");
+			setCommittedQuery("");
+			isComposingRef.current = false;
+		}
+	}, [isOpen]);
+
+	// searchable 패널이 열리면 검색 입력에 포커스
+	useEffect(() => {
+		if (isOpen && searchable) {
+			searchRef.current?.focus();
+		}
+	}, [isOpen, searchable]);
 
 	useEffect(() => {
 		if (!isOpen || !controlRef.current) return;
@@ -216,6 +348,21 @@ export const Dropdown = ({
 		const MIN_BELOW = 120;
 		setDropUp(spaceBelow < MIN_BELOW && spaceAbove > spaceBelow);
 	}, [isOpen]);
+
+	// ── 표시 값 계산 ────────────────────────────────────────────────────────
+
+	const currentOption = multiple
+		? null
+		: (options.find((o) => o.value === selectedValues[0]) ?? null);
+	const hasSelection = selectedValues.length > 0;
+	const showValue = multiple ? hasSelection : currentOption != null;
+	const controlText = multiple
+		? hasSelection
+			? `${selectedValues.length}개 선택`
+			: placeholder
+		: currentOption
+			? currentOption.label
+			: placeholder;
 
 	const rootClassName = cn("dropdown", `dropdown_size_${size}`, className);
 	const fieldsetClassName = cn("dropdown_fieldset", { is_open: isOpen, is_disabled: disabled });
@@ -231,10 +378,7 @@ export const Dropdown = ({
 	});
 
 	return (
-		<div
-			ref={wrapperRef}
-			className={rootClassName}
-		>
+		<div ref={wrapperRef} className={rootClassName}>
 			{label && (
 				<label htmlFor={dropdownId} className="dropdown_label">
 					{label}
@@ -251,71 +395,106 @@ export const Dropdown = ({
 					aria-expanded={isOpen}
 					aria-controls={`${dropdownId}_listbox`}
 					onClick={() => !disabled && setIsOpen((o) => !o)}
-					onKeyDown={onKeyDown}
+					onKeyDown={onControlKeyDown}
 					disabled={disabled}
 				>
-					<span className={currentOption ? "dropdown_value" : "dropdown_placeholder"}>
-						{currentOption ? currentOption.label : placeholder}
+					<span className={showValue ? "dropdown_value" : "dropdown_placeholder"}>
+						{controlText}
 					</span>
-					<span
-						className={cn("dropdown_icon", { dropdown_icon_open: isOpen })}
-						aria-hidden="true"
-					>
+					<span className={cn("dropdown_icon", { dropdown_icon_open: isOpen })} aria-hidden="true">
 						<ChevronDown size={iconSize.lg} />
 					</span>
 				</button>
 			</div>
 
 			{isOpen && (
-				<animated.div
-					id={`${dropdownId}_listbox`}
-					role="listbox"
-					className={listClassName}
-					style={listStyle}
-				>
-					{options.map((opt, i) => {
-						const selected = currentValue === opt.value;
-						const active = i === activeIndex;
+				<animated.div className={listClassName} style={listStyle}>
+					{searchable && (
+						<div className="dropdown_search">
+							<span className="dropdown_search_icon" aria-hidden="true">
+								<Search size={iconSize.sm} />
+							</span>
+							<input
+								ref={searchRef}
+								type="text"
+								className="dropdown_search_input"
+								placeholder={searchPlaceholder}
+								aria-label={searchPlaceholder}
+								autoComplete="off"
+								value={searchText}
+								onChange={(e) => {
+									const v = e.target.value;
+									setSearchText(v);
+									// 조합 중에는 필터 갱신 보류 (mid-composition 리스트 thrash 방지)
+									if (!isComposingRef.current) setCommittedQuery(v);
+								}}
+								onCompositionStart={() => {
+									isComposingRef.current = true;
+								}}
+								onCompositionEnd={(e) => {
+									isComposingRef.current = false;
+									const v = e.currentTarget.value;
+									setSearchText(v);
+									setCommittedQuery(v);
+								}}
+								onKeyDown={onSearchKeyDown}
+							/>
+						</div>
+					)}
 
-						return (
-							<Fragment key={opt.value}>
-								{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by parent listbox button - options are non-focusable role=option per WAI-ARIA listbox pattern */}
-								<div
-									role="option"
-									tabIndex={-1}
-									aria-selected={selected}
-									aria-disabled={opt.disabled ? true : undefined}
-									className={cn("dropdown_option", {
-										is_selected: selected,
-										is_active: active,
-										is_disabled: opt.disabled,
-									})}
-									onMouseEnter={() => !opt.disabled && setActiveIndex(i)}
-									onClick={() => {
-										if (opt.disabled) return;
-										setValue(opt.value);
-										setIsOpen(false);
-									}}
-								>
-									{opt.leadingIcon && (
-										<span className="dropdown_option_icon">{opt.leadingIcon}</span>
-									)}
-									<span className="dropdown_option_content">
-										<span className="dropdown_option_label">{opt.label}</span>
-										{opt.supportingText && (
-											<span className="dropdown_option_supporting">{opt.supportingText}</span>
-										)}
-									</span>
-									{(selected || opt.trailingIcon) && (
-										<span className="dropdown_option_trailing">
-											{opt.trailingIcon ?? <Check size={iconSize.sm} aria-hidden="true" />}
-										</span>
-									)}
-								</div>
-								{opt.showDivider && <hr className="dropdown_option_divider" />}
-							</Fragment>
-						);
-					})}
+					<div
+						id={`${dropdownId}_listbox`}
+						role="listbox"
+						className="dropdown_options"
+						aria-multiselectable={multiple || undefined}
+					>
+						{visibleOptions.length === 0
+							? searchable && <div className="dropdown_empty">{emptyText}</div>
+							: visibleOptions.map((opt, i) => {
+									const selected = selectedValues.includes(opt.value);
+									const active = i === activeIndex;
+
+									return (
+										<Fragment key={opt.value}>
+											{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by parent listbox button - options are non-focusable role=option per WAI-ARIA listbox pattern */}
+											<div
+												role="option"
+												tabIndex={-1}
+												aria-selected={selected}
+												aria-disabled={opt.disabled ? true : undefined}
+												className={cn("dropdown_option", {
+													is_selected: selected,
+													is_active: active,
+													is_disabled: opt.disabled,
+												})}
+												onMouseEnter={() => !opt.disabled && setActiveIndex(i)}
+												onClick={() => selectOption(opt)}
+											>
+												{multiple && (
+													<span className="dropdown_option_check" aria-hidden="true">
+														{selected && <Check size={iconSize.sm} />}
+													</span>
+												)}
+												{opt.leadingIcon && (
+													<span className="dropdown_option_icon">{opt.leadingIcon}</span>
+												)}
+												<span className="dropdown_option_content">
+													<span className="dropdown_option_label">{opt.label}</span>
+													{opt.supportingText && (
+														<span className="dropdown_option_supporting">{opt.supportingText}</span>
+													)}
+												</span>
+												{(opt.trailingIcon || (!multiple && selected)) && (
+													<span className="dropdown_option_trailing">
+														{opt.trailingIcon ?? <Check size={iconSize.sm} aria-hidden="true" />}
+													</span>
+												)}
+											</div>
+											{opt.showDivider && <hr className="dropdown_option_divider" />}
+										</Fragment>
+									);
+								})}
+					</div>
 				</animated.div>
 			)}
 		</div>

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -61,6 +61,8 @@ interface DropdownCommonProps {
 	searchPlaceholder?: string;
 	/** 필터 결과가 0개일 때 표시할 텍스트 (기본값: "결과 없음") */
 	emptyText?: string;
+	/** 멀티 선택 요약 텍스트 (기본값: "N개 선택") */
+	selectedSummary?: (count: number) => string;
 }
 
 /** 단일 선택 (기본) */
@@ -115,6 +117,7 @@ export const Dropdown = (props: DropdownProps) => {
 		searchable = false,
 		searchPlaceholder = "검색…",
 		emptyText = "결과 없음",
+		selectedSummary = (count: number) => `${count}개 선택`,
 	} = props;
 
 	const multiple = props.multiple === true;
@@ -291,6 +294,8 @@ export const Dropdown = (props: DropdownProps) => {
 
 	// 검색 입력 내 키보드 - ↑/↓ 이동, Enter 선택/토글, Esc 닫기. Home/End 는 커서 이동에 양보.
 	const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		// IME 조합 중 Enter 는 조합 확정용 - 선택/토글·네비게이션·닫기 트리거 금지
+		if (e.nativeEvent.isComposing) return;
 		switch (e.key) {
 			case "ArrowDown":
 				e.preventDefault();
@@ -351,14 +356,15 @@ export const Dropdown = (props: DropdownProps) => {
 
 	// ── 표시 값 계산 ────────────────────────────────────────────────────────
 
-	const currentOption = multiple
-		? null
-		: (options.find((o) => o.value === selectedValues[0]) ?? null);
+	const currentOption = useMemo(
+		() => (multiple ? null : (options.find((o) => o.value === selectedValues[0]) ?? null)),
+		[multiple, options, selectedValues],
+	);
 	const hasSelection = selectedValues.length > 0;
 	const showValue = multiple ? hasSelection : currentOption != null;
 	const controlText = multiple
 		? hasSelection
-			? `${selectedValues.length}개 선택`
+			? selectedSummary(selectedValues.length)
 			: placeholder
 		: currentOption
 			? currentOption.label

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -171,6 +171,7 @@
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_lg; // 컨트롤과 동일 radius
     box-shadow: token.$elevation_level1; // 좀 더 가볍게
+    overflow: hidden; // radius 안쪽으로 자식(검색바/스크롤) 클립
 
     [data-theme="dark"] & {
       background: token.$color_bg_solid_dim;
@@ -181,11 +182,6 @@
       }
     }
 
-    max-height: 18rem;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: token.$spacing_4 0;
-
     will-change: transform, opacity;
 
     &_up {
@@ -194,6 +190,63 @@
       margin-top: 0;
       margin-bottom: token.$spacing_4;
     }
+  }
+
+  // ── Search (검색 입력 - searchable) ────────────────────────────────────────
+  // 패널 상단 고정. 옵션 스크롤과 분리되도록 &_options 에만 스크롤을 둔다.
+
+  &_search {
+    display: flex;
+    align-items: center;
+    gap: token.$spacing_8;
+    padding: token.$spacing_8 token.$spacing_12;
+    border-bottom: token.$border_width_standard solid token.$color_border_default;
+  }
+
+  &_search_icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: token.$color_text_body;
+  }
+
+  &_search_input {
+    flex: 1 1 auto;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: token.$color_text_heading;
+    border-radius: token.$radius_sm;
+    @include token.body_small;
+    transition: box-shadow token.$transition_fast;
+
+    &::placeholder {
+      color: token.$color_text_body;
+    }
+
+    &:focus-visible {
+      box-shadow: token.$focus_ring;
+    }
+  }
+
+  // ── Options scroll container (role=listbox) ─────────────────────────────────
+
+  &_options {
+    max-height: 18rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: token.$spacing_4 0;
+  }
+
+  // ── Empty state (필터 결과 0개) ─────────────────────────────────────────────
+
+  &_empty {
+    padding: token.$spacing_12 token.$spacing_16;
+    @include token.body_small;
+    color: token.$color_text_caption;
+    text-align: center;
   }
 
   // ── Option ────────────────────────────────────────────────────────────────────
@@ -240,6 +293,16 @@
       cursor: not-allowed;
       color: token.$color_text_caption;
     }
+  }
+
+  // 다중 선택: 왼쪽 체크 슬롯. 미선택 시에도 폭 유지해 정렬 안정.
+  &_option_check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: token.$spacing_16;
+    color: token.$color_accent_default;
   }
 
   &_option_icon {
@@ -295,4 +358,5 @@
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
   .dropdown_icon { transition: none; }
+  .dropdown_search_input { transition: none; }
 }


### PR DESCRIPTION
## 작업 개요

Dropdown 에 opt-in `searchable`(검색 필터)와 `multiple`(다중 선택)을 추가합니다. 두 prop 모두 미지정 시 기존 동작이 100% 그대로 유지되는 additive 변경이며, DatePicker(내부적으로 Dropdown 합성)와 기존 단일 선택 API 시그니처는 그대로입니다.

- 접근성: v3.3.0 롤백 이력을 감안해 `role="combobox"` / `aria-activedescendant` 는 도입하지 않았습니다. 기존 `button` + `listbox` 구조를 유지하고, 열린 패널 상단에 검색 `<input>` 만 추가했습니다.
- 애니메이션/토큰: 모션은 composite 토큰(`$transition_fast`), 색·간격·radius 는 전부 토큰 사용, 아이콘 크기는 `iconSize` 토큰 사용. 검색 입력 focus ring 에 `prefers-reduced-motion` 대응 포함.

## 작업한 내용

- [x] `searchable` — 열린 패널 상단 검색 입력, `label` 부분 일치 필터(대소문자·공백 무시)
- [x] 한글 IME 대응 — TextField 의 composition-event 패턴 재사용, 조합 완료(compositionEnd) 시점에만 필터 반영해 조합 중 리스트 thrash 방지
- [x] `multiple` — 옵션 클릭 시 토글 + 리스트 유지, 선택 항목 좌측 체크 표시, 컨트롤 라벨은 `"N개 선택"` 텍스트 요약(0개면 placeholder)
- [x] `value` / `onValueChange` 를 `multiple` 기준 discriminated union 으로 타입화 (`multiple: true` ⇒ `string[]`, 단일 모드는 기존 `string | null` 시그니처 유지). 기존 deprecated `onChange` alias 유지
- [x] 검색 + 다중 조합 — 필터 활성 상태에서 선택해도 필터 유지
- [x] 키보드 — 검색 입력 포커스 시 ↑/↓ active 이동, Enter 선택(단일)/토글(다중), Esc 닫기. 필터로 노출 옵션 수가 바뀌면 `activeIndex` 재계산해 범위 내 유지
- [x] `multiple` 시 리스트에 `aria-multiselectable="true"`, 옵션에 `aria-selected`
- [x] `searchPlaceholder`(기본 "검색…") / `emptyText`(기본 "결과 없음") prop 추가, 필터 0건 시 빈 상태 표시
- [x] SCSS — 검색 입력/좌측 체크/빈 상태 스타일(토큰만), 검색바는 상단 고정하고 옵션 영역만 스크롤
- [x] 테스트 — 기존 테스트 전부 무수정 유지, 필터/IME 조합/다중 토글·요약/필터 후 키보드 재계산/빈 상태/조합 시나리오 추가 (Dropdown 65개, DatePicker 포함 전체 650 pass)
- [x] Storybook — Searchable / Multiple / Searchable+Multiple 스토리(KO/EN 병기) 추가
- [x] `pnpm test` / `pnpm build`(tsup 타입체크 포함) / `pnpm lint:css` 모두 통과

## 전달할 추가 이슈

- 태그 칩(선택 항목 chip) 표시 및 `maxTagCount` 는 이번 범위에서 제외(텍스트 요약만). 후속 과제로 분리 권장.
- 서버사이드 검색(`onSearchChange` 등 외부 필터 훅)은 이번 범위 제외(클라이언트 필터 전용). 필요 시 후속 additive 로 검토.