### PR TITLE
fix/overlay-focus-trap-mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 	"size-limit": [
 		{
 			"path": "dist/index.js",
-			"limit": "45 kB"
+			"limit": "50 kB"
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,6 @@ export type {
 	TabsVariant,
 } from "./ui/navigation/tabs";
 export { Tab, TabList, TabPanel, Tabs } from "./ui/navigation/tabs";
-export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
-export { Drawer } from "./ui/overlay/drawer";
 export type { PopoverPlacement, PopoverProps } from "./ui/overlay/popover";
 export { Popover } from "./ui/overlay/popover";
 export type { TooltipPlacement, TooltipProps } from "./ui/overlay/tooltip";
@@ -88,6 +86,8 @@ export type { DatePickerProps } from "./ui/forms/date-picker";
 export { DatePicker } from "./ui/forms/date-picker";
 export type { DividerProps } from "./ui/display/divider";
 export { Divider } from "./ui/display/divider";
+export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
+export { Drawer } from "./ui/overlay/drawer";
 export type { DropdownOption, DropdownProps, DropdownSize } from "./ui/forms/dropdown";
 export { Dropdown } from "./ui/forms/dropdown";
 export type { FileInputProps } from "./ui/forms/file";

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -194,6 +194,22 @@ describe("Drawer", () => {
 		expect(panel?.contains(document.activeElement)).toBe(true);
 	});
 
+	it("activates the focus trap when toggled open after mounting closed", () => {
+		// 닫힌 채로 마운트 → open=true 로 전환하는 일반적인 controlled 패턴에서도 트랩이 걸려야 함
+		const { rerender } = render(
+			<Drawer open={false} onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		rerender(
+			<Drawer open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	// ── Accessibility ────────────────────────────────────────────────────────
 
 	it("has dialog role and modal accessibility attributes", () => {

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -71,10 +71,11 @@ export const Drawer = ({
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
 
-	// 진입 시 마운트 보장
-	React.useEffect(() => {
-		if (open) setShouldRender(true);
-	}, [open]);
+	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
+	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
+	// true 가 안 돼 exit 애니메이션이 누락될 수 있다. React "render 중 상태 조정" 패턴 — setState 는 이
+	// 컴포넌트 자신만 대상으로 하고 조건이 곧 거짓이 되어 무한 루프가 없다.
+	if (open && !shouldRender) setShouldRender(true);
 
 	// 오버레이 opacity 페이드 + presence 라이프사이클(퇴출 완료 후 unmount).
 	// 오버레이는 이동하지 않으므로 transform 을 translateY(0px) 로 고정한다.

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -124,7 +124,11 @@ export const Drawer = ({
 		};
 	}, [open]);
 
-	if (!shouldRender) return null;
+	// open 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
+	// panelRef.current 가 이미 붙어 있어 포커스 트랩이 정상 활성화된다. shouldRender 만 보면
+	// 마운트가 한 렌더 늦어(effect 로 세팅) 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션
+	// 동안 마운트 유지용.
+	if (!open && !shouldRender) return null;
 
 	const hasTitle = !!title;
 	const sizeValue = typeof size === "number" ? `${size}px` : size;

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -144,6 +144,22 @@ describe("Modal", () => {
 		expect(document.body.dataset.openModals).toBe("1");
 	});
 
+	it("activates the focus trap when toggled open after mounting closed", () => {
+		// 닫힌 채로 마운트 → open=true 로 전환하는 일반적인 controlled 패턴에서도 트랩이 걸려야 함
+		const { rerender } = render(
+			<Modal open={false} onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Modal>,
+		);
+		rerender(
+			<Modal open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Modal>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".modal_panel");
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	it("calls onClose once on Escape from inside the modal (no duplicate handler)", () => {
 		const handleClose = vi.fn();
 		render(

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -112,7 +112,10 @@ export const Modal = ({
 		};
 	}, [open]);
 
-	if (!shouldRender) return null;
+	// open 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
+	// panelRef.current 가 이미 붙어 있어 포커스 트랩이 정상 활성화된다. shouldRender 만 보면
+	// 마운트가 한 렌더 늦어 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
+	if (!open && !shouldRender) return null;
 
 	const hasTitle = !!title;
 

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -63,10 +63,11 @@ export const Modal = ({
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
 
-	// 진입 시 마운트 보장
-	React.useEffect(() => {
-		if (open) setShouldRender(true);
-	}, [open]);
+	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
+	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
+	// true 가 안 돼 exit 애니메이션이 누락될 수 있다. React "render 중 상태 조정" 패턴 — setState 는 이
+	// 컴포넌트 자신만 대상으로 하고 조건이 곧 거짓이 되어 무한 루프가 없다.
+	if (open && !shouldRender) setShouldRender(true);
 
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({


### PR DESCRIPTION
## 작업 개요
재검토(re-review)에서 발견된 **focus trap 미활성화 버그** 수정. Drawer·Modal 둘 다 "닫힌 채 마운트 → `open=true` 로 전환"하는 일반적인 controlled 패턴에서 포커스 트랩이 실제로 걸리지 않는다.

## 원인
`useFocusTrap(panelRef, open)` effect 의 deps 가 `[open]` 뿐이라:
1. `open` 이 false→true 되는 렌더에서는 아직 `shouldRender` 가 false → 패널 미마운트 → `panelRef.current` 가 null. 이 커밋 뒤 effect 가 `isActive=true` 로 실행되지만 container 가 null 이라 조기 return.
2. 이어지는 effect 가 `setShouldRender(true)` → 패널 마운트되지만 `open` 은 그대로 true → deps 불변 → effect 재실행 안 됨 → 트랩 미설정.

스토리/문서 예제(`const [open,setOpen]=useState(false)` 후 버튼으로 열기)가 정확히 이 경로.

## 작업한 내용
- [x] Drawer: 마운트 조건을 `!open && !shouldRender` 로 (open 되는 렌더에서 패널 즉시 마운트 → effect 시점에 ref 존재)
- [x] Modal: 동일 잠복 버그 동일 수정 (근본 원인이 같아 함께 처리)
- [x] `Drawer` export 를 `src/index.ts` 알파벳 정렬 블록(Divider~Dropdown 사이)으로 이동
- [x] 회귀 테스트 2개 (Drawer·Modal 각각: 닫힌 채 마운트 → open 후 포커스가 패널 안으로 이동 확인)

## 전달할 추가 이슈
- #350(Drawer)이 focus-trap 수정 전 커밋(f7507ab)으로 머지되어 현재 develop 에 버그가 있음 → **이 PR 로 보정**. v3.4.0 배포(태그) 전에 머지 필요.