### PR TITLE
docs/changelog-340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ## [3.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.0) - 2026-07-09
 
+- Dropdown `searchable`(검색 필터) + `multiple`(다중 선택) opt-in 추가 - 한글 IME 조합 대응, 선택 요약 텍스트 커스터마이즈(`selectedSummary`)
+- Table 정렬(controlled `sort` / `onSortChange`) + 행 선택(`selectable` / `selectedKeys` / `onSelectionChange`) 추가 - 전체선택 3-state, off-page 선택 보존
+- Drawer 신규 컴포넌트 - left/right/bottom 슬라이드 오버레이 (Modal 인프라 재사용, 포커스 트랩·스크롤 잠금·방향별 애니메이션)
 - `iconSize` 토큰 export 추가 (xs~xl 스케일) - 컴포넌트 내부 아이콘 사이즈 하드코딩 제거
+- Modal · Drawer 포커스 트랩이 "닫힌 채 마운트 후 열림" controlled 패턴에서 활성화되지 않던 버그 수정
 - 마이그레이션 가이드 `docs/MIGRATION.md` + 테마 가이드 `docs/THEMING.md` 문서 추가
 - 문서 정합화: `docs/COMPONENTS.md` 를 v3.3.0 canonical prop 이름으로 갱신, 릴리즈 노트 양식 통일, em-dash 등 타이포 정리
 - (개발) Claude PR 리뷰 워크플로 도입, dev 의존성 보안/버전 업데이트

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 ## [3.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.0) - 2026-07-09
 
 - Dropdown `searchable`(검색 필터) + `multiple`(다중 선택) opt-in 추가 - 한글 IME 조합 대응, 선택 요약 텍스트 커스터마이즈(`selectedSummary`)
-- Table 정렬(controlled `sort` / `onSortChange`) + 행 선택(`selectable` / `selectedKeys` / `onSelectionChange`) 추가 - 전체선택 3-state, off-page 선택 보존
+- Table 정렬(제어형 `sort` / `onSortChange`) + 행 선택(`selectable` / `selectedKeys` / `onSelectionChange`) 추가 - 전체 선택 3-state, 다른 페이지의 선택 상태 보존
 - Drawer 신규 컴포넌트 - left/right/bottom 슬라이드 오버레이 (Modal 인프라 재사용, 포커스 트랩·스크롤 잠금·방향별 애니메이션)
 - `iconSize` 토큰 export 추가 (xs~xl 스케일) - 컴포넌트 내부 아이콘 사이즈 하드코딩 제거
-- Modal · Drawer 포커스 트랩이 "닫힌 채 마운트 후 열림" controlled 패턴에서 활성화되지 않던 버그 수정
+- Modal · Drawer 포커스 트랩이 "닫힌 채 마운트 후 열림" 제어형(controlled) 패턴에서 활성화되지 않던 버그 수정
 - 마이그레이션 가이드 `docs/MIGRATION.md` + 테마 가이드 `docs/THEMING.md` 문서 추가
 - 문서 정합화: `docs/COMPONENTS.md` 를 v3.3.0 canonical prop 이름으로 갱신, 릴리즈 노트 양식 통일, em-dash 등 타이포 정리
 - (개발) Claude PR 리뷰 워크플로 도입, dev 의존성 보안/버전 업데이트


### PR DESCRIPTION
## 작업 개요
CHANGELOG 의 v3.4.0 섹션에 이후 develop 에 머지된 컴포넌트/수정이 빠져 있어 보강한다. (배포 전 릴리즈 노트 정합성 확보)

## 작업한 내용
- [x] v3.4.0 섹션에 신규/주요 항목 추가:
  - Dropdown `searchable` + `multiple`
  - Table 정렬(controlled) + 행 선택
  - Drawer 신규 컴포넌트
  - Modal · Drawer 포커스 트랩 버그 수정
- [x] 기존 iconSize/문서/워크플로 항목은 유지

## 전달할 추가 이슈
- v3.4.0 배포 시: 컴포넌트가 develop 에만 있고 main(구 #347 스냅샷)엔 없음 → 새 `merge: release` dev→main PR 후 `v3.4.0` 태그 필요. (이 CHANGELOG 가 그 릴리즈 노트 소스가 됨)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 드롭다운에서 검색 필터와 다중 선택을 사용할 수 있게 되었으며, 한글 IME 입력도 더 안정적으로 처리됩니다.
  * 선택된 항목 요약 문구를 원하는 방식으로 커스터마이즈할 수 있습니다.
  * 테이블에 정렬 제어와 행 선택 기능이 추가되었으며, 전체 선택과 일부 선택 상태를 지원합니다.
  * 좌/우/하단에서 슬라이드로 열리는 새 드로어 컴포넌트가 추가되었습니다.
  * 아이콘 크기 토큰이 여러 단계로 제공됩니다.

* **Bug Fixes**
  * 모달과 드로어가 닫힌 상태로 마운트된 뒤 열릴 때 포커스 트랩이 동작하지 않던 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->