### PR TITLE
merge: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ## [3.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.0) - 2026-07-09
 
+- Dropdown `searchable`(검색 필터) + `multiple`(다중 선택) opt-in 추가 - 한글 IME 조합 대응, 선택 요약 텍스트 커스터마이즈(`selectedSummary`)
+- Table 정렬(controlled `sort` / `onSortChange`) + 행 선택(`selectable` / `selectedKeys` / `onSelectionChange`) 추가 - 전체선택 3-state, off-page 선택 보존
+- Drawer 신규 컴포넌트 - left/right/bottom 슬라이드 오버레이 (Modal 인프라 재사용, 포커스 트랩·스크롤 잠금·방향별 애니메이션)
 - `iconSize` 토큰 export 추가 (xs~xl 스케일) - 컴포넌트 내부 아이콘 사이즈 하드코딩 제거
+- Modal · Drawer 포커스 트랩이 "닫힌 채 마운트 후 열림" controlled 패턴에서 활성화되지 않던 버그 수정
 - 마이그레이션 가이드 `docs/MIGRATION.md` + 테마 가이드 `docs/THEMING.md` 문서 추가
 - 문서 정합화: `docs/COMPONENTS.md` 를 v3.3.0 canonical prop 이름으로 갱신, 릴리즈 노트 양식 통일, em-dash 등 타이포 정리
 - (개발) Claude PR 리뷰 워크플로 도입, dev 의존성 보안/버전 업데이트

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 ## [3.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.0) - 2026-07-09
 
 - Dropdown `searchable`(검색 필터) + `multiple`(다중 선택) opt-in 추가 - 한글 IME 조합 대응, 선택 요약 텍스트 커스터마이즈(`selectedSummary`)
-- Table 정렬(controlled `sort` / `onSortChange`) + 행 선택(`selectable` / `selectedKeys` / `onSelectionChange`) 추가 - 전체선택 3-state, off-page 선택 보존
+- Table 정렬(제어형 `sort` / `onSortChange`) + 행 선택(`selectable` / `selectedKeys` / `onSelectionChange`) 추가 - 전체 선택 3-state, 다른 페이지의 선택 상태 보존
 - Drawer 신규 컴포넌트 - left/right/bottom 슬라이드 오버레이 (Modal 인프라 재사용, 포커스 트랩·스크롤 잠금·방향별 애니메이션)
 - `iconSize` 토큰 export 추가 (xs~xl 스케일) - 컴포넌트 내부 아이콘 사이즈 하드코딩 제거
-- Modal · Drawer 포커스 트랩이 "닫힌 채 마운트 후 열림" controlled 패턴에서 활성화되지 않던 버그 수정
+- Modal · Drawer 포커스 트랩이 "닫힌 채 마운트 후 열림" 제어형(controlled) 패턴에서 활성화되지 않던 버그 수정
 - 마이그레이션 가이드 `docs/MIGRATION.md` + 테마 가이드 `docs/THEMING.md` 문서 추가
 - 문서 정합화: `docs/COMPONENTS.md` 를 v3.3.0 canonical prop 이름으로 갱신, 릴리즈 노트 양식 통일, em-dash 등 타이포 정리
 - (개발) Claude PR 리뷰 워크플로 도입, dev 의존성 보안/버전 업데이트

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -38,6 +38,7 @@ Bigtablet Design System의 모든 React 컴포넌트 문서입니다.
   - [Breadcrumb](#breadcrumb)
 - [Overlay](#overlay)
   - [Modal](#modal)
+  - [Drawer](#drawer)
   - [Tooltip](#tooltip)
   - [Menu](#menu)
   - [Popover](#popover)
@@ -1429,6 +1430,45 @@ const [isOpen, setIsOpen] = useState(false);
 | `title` | `ReactNode` | - | 제목 |
 | `width` | `number \| string` | `520` | 모달 너비 |
 | `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
+
+---
+
+### Drawer
+
+화면 가장자리(left/right/bottom)에서 미끄러져 들어오는 패널. 필터, 상세 보기, 모바일 내비게이션, 하단 시트에 적합. Modal 과 동일하게 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금을 자동 처리한다.
+
+```tsx
+import { Drawer } from '@bigtablet/design-system';
+
+const [isOpen, setIsOpen] = useState(false);
+
+<button onClick={() => setIsOpen(true)}>드로어 열기</button>
+
+<Drawer
+  open={isOpen}
+  onClose={() => setIsOpen(false)}
+  placement="right"
+  size={360}
+  title="설정"
+  footer={<button onClick={() => setIsOpen(false)}>저장</button>}
+>
+  <p>드로어 내용입니다.</p>
+</Drawer>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | required | 열림 상태 |
+| `onClose` | `() => void` | - | 닫기 핸들러 |
+| `placement` | `'left' \| 'right' \| 'bottom'` | `'right'` | 슬라이드 방향 |
+| `size` | `number \| string` | `360` | 패널 크기 - left/right 는 너비, bottom 은 높이 (number ⇒ px) |
+| `title` | `ReactNode` | - | 헤더 제목 (있으면 `aria-labelledby` 자동 연결) |
+| `footer` | `ReactNode` | - | 하단 액션 영역. 미지정 시 footer 영역 미표시 |
+| `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
+| `showCloseIcon` | `boolean` | `true` | 우상단 X 닫기 아이콘 표시 |
+| `closeLabel` | `string` | `'닫기'` | X 닫기 버튼 접근성 레이블 |
+
+> 방향별 슬라이드 진입/퇴출은 `react-spring` 으로 처리하며 `prefers-reduced-motion: reduce` 시 즉시 표시된다. `placement="top"` 과 배경 상호작용(non-modal) 변형은 현재 범위 밖.
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1467,6 +1467,7 @@ const [isOpen, setIsOpen] = useState(false);
 | `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
 | `showCloseIcon` | `boolean` | `true` | 우상단 X 닫기 아이콘 표시 |
 | `closeLabel` | `string` | `'닫기'` | X 닫기 버튼 접근성 레이블 |
+| `ariaLabel` | `string` | `'Dialog'` | `title` 없을 때 dialog 접근성 레이블 |
 
 > 방향별 슬라이드 진입/퇴출은 `react-spring` 으로 처리하며 `prefers-reduced-motion: reduce` 시 즉시 표시된다. `placement="top"` 과 배경 상호작용(non-modal) 변형은 현재 범위 밖.
 

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 	"size-limit": [
 		{
 			"path": "dist/index.js",
-			"limit": "45 kB"
+			"limit": "50 kB"
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,13 @@ export type { SkeletonProps, SkeletonVariant } from "./ui/feedback/skeleton";
 export { Skeleton } from "./ui/feedback/skeleton";
 export type { SpinnerProps } from "./ui/feedback/spinner";
 export { Spinner } from "./ui/feedback/spinner";
-export type { TableColumn, TableProps, TableSize } from "./ui/display/table";
+export type {
+	TableColumn,
+	TableProps,
+	TableSize,
+	TableSort,
+	TableSortDirection,
+} from "./ui/display/table";
 export { Table } from "./ui/display/table";
 export type { ResolvedTheme, ThemeMode, ThemeProviderProps } from "./ui/system/theme-provider";
 export { ThemeProvider, useTheme } from "./ui/system/theme-provider";

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,6 @@ export type {
 	TabsVariant,
 } from "./ui/navigation/tabs";
 export { Tab, TabList, TabPanel, Tabs } from "./ui/navigation/tabs";
-export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
-export { Drawer } from "./ui/overlay/drawer";
 export type { PopoverPlacement, PopoverProps } from "./ui/overlay/popover";
 export { Popover } from "./ui/overlay/popover";
 export type { TooltipPlacement, TooltipProps } from "./ui/overlay/tooltip";
@@ -88,6 +86,8 @@ export type { DatePickerProps } from "./ui/forms/date-picker";
 export { DatePicker } from "./ui/forms/date-picker";
 export type { DividerProps } from "./ui/display/divider";
 export { Divider } from "./ui/display/divider";
+export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
+export { Drawer } from "./ui/overlay/drawer";
 export type { DropdownOption, DropdownProps, DropdownSize } from "./ui/forms/dropdown";
 export { Dropdown } from "./ui/forms/dropdown";
 export type { FileInputProps } from "./ui/forms/file";

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ export type {
 	TabsVariant,
 } from "./ui/navigation/tabs";
 export { Tab, TabList, TabPanel, Tabs } from "./ui/navigation/tabs";
+export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
+export { Drawer } from "./ui/overlay/drawer";
 export type { PopoverPlacement, PopoverProps } from "./ui/overlay/popover";
 export { Popover } from "./ui/overlay/popover";
 export type { TooltipPlacement, TooltipProps } from "./ui/overlay/tooltip";

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -463,7 +463,8 @@ describe("Table isLoading guards", () => {
 			/>,
 		);
 		const row = container.querySelector(".table_row");
+		// role="button" 은 aria-selected 와 무효 조합이라 제거하되, 키보드 진입용 tabindex 는 유지
 		expect(row).not.toHaveAttribute("role", "button");
-		expect(row).not.toHaveAttribute("tabindex");
+		expect(row).toHaveAttribute("tabindex", "0");
 	});
 });

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -119,3 +119,225 @@ describe("Table", () => {
 		expect(screen.getByRole("table")).toHaveAttribute("aria-label", "결과 목록");
 	});
 });
+
+describe("Table sort", () => {
+	const sortableColumns: TableColumn<Row>[] = [
+		{ key: "name", header: "Name", sortable: true },
+		{ key: "score", header: "Score", sortable: true },
+	];
+
+	it("renders aria-sort='none' on sortable headers when unsorted", () => {
+		render(<Table columns={sortableColumns} data={rows} keyExtractor={(r) => r.id} />);
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"none",
+		);
+		expect(screen.getByRole("columnheader", { name: "Score" })).toHaveAttribute(
+			"aria-sort",
+			"none",
+		);
+	});
+
+	it("does not set aria-sort on non-sortable columns", () => {
+		render(<Table columns={columns} data={rows} keyExtractor={(r) => r.id} />);
+		expect(screen.getByRole("columnheader", { name: "Name" })).not.toHaveAttribute("aria-sort");
+	});
+
+	it("cycles a column through none -> asc -> desc -> none on click", () => {
+		const onSortChange = vi.fn();
+		const { rerender } = render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={undefined}
+				onSortChange={onSortChange}
+			/>,
+		);
+		const nameHeaderButton = screen.getByRole("button", { name: "Name" });
+
+		fireEvent.click(nameHeaderButton);
+		expect(onSortChange).toHaveBeenLastCalledWith({ key: "name", direction: "asc" });
+
+		rerender(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "asc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"ascending",
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(onSortChange).toHaveBeenLastCalledWith({ key: "name", direction: "desc" });
+
+		rerender(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"descending",
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(onSortChange).toHaveBeenLastCalledWith(null);
+	});
+
+	it("clicking a different column starts it at asc regardless of previous column state", () => {
+		const onSortChange = vi.fn();
+		render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Score" }));
+		expect(onSortChange).toHaveBeenCalledWith({ key: "score", direction: "asc" });
+	});
+
+	it("does not sort data itself - relies on consumer-provided data order", () => {
+		render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={vi.fn()}
+			/>,
+		);
+		const cells = screen.getAllByRole("cell");
+		// rows prop order (Alpha, Beta) is unchanged even though sort=desc is set
+		expect(cells[0]).toHaveTextContent("Alpha");
+	});
+});
+
+describe("Table selection", () => {
+	it("renders a checkbox column when selectable", () => {
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+			/>,
+		);
+		// 1 select-all + 2 row checkboxes
+		expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+	});
+
+	it("select-all is unchecked when nothing selected, checked when all selected, indeterminate when some selected", () => {
+		const { rerender } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+			/>,
+		);
+		const selectAll = screen.getByRole("checkbox", { name: "전체 선택" }) as HTMLInputElement;
+		expect(selectAll.checked).toBe(false);
+		expect(selectAll.indeterminate).toBe(false);
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1"]}
+			/>,
+		);
+		expect(selectAll.indeterminate).toBe(true);
+		expect(selectAll.checked).toBe(false);
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1", "2"]}
+			/>,
+		);
+		expect(selectAll.indeterminate).toBe(false);
+		expect(selectAll.checked).toBe(true);
+	});
+
+	it("toggling select-all selects all row keys, toggling again clears them", () => {
+		const onSelectionChange = vi.fn();
+		const { rerender } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		expect(onSelectionChange).toHaveBeenLastCalledWith(["1", "2"]);
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1", "2"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		expect(onSelectionChange).toHaveBeenLastCalledWith([]);
+	});
+
+	it("toggles an individual row via rowKey mapping and marks it aria-selected", () => {
+		const onSelectionChange = vi.fn();
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["1"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+
+		const rowsInTable = screen.getAllByRole("row");
+		// rowsInTable[0] is header row; body rows follow
+		expect(rowsInTable[1]).toHaveAttribute("aria-selected", "true");
+		expect(rowsInTable[2]).not.toHaveAttribute("aria-selected");
+
+		const betaCheckbox = screen.getByRole("checkbox", { name: "2번째 행 선택" });
+		fireEvent.click(betaCheckbox);
+		expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"]);
+
+		const alphaCheckbox = screen.getByRole("checkbox", { name: "1번째 행 선택" });
+		fireEvent.click(alphaCheckbox);
+		expect(onSelectionChange).toHaveBeenCalledWith([]);
+	});
+});

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -191,7 +191,7 @@ describe("Table sort", () => {
 		);
 
 		fireEvent.click(screen.getByRole("button", { name: "Name" }));
-		expect(onSortChange).toHaveBeenLastCalledWith(null);
+		expect(onSortChange).toHaveBeenLastCalledWith(undefined);
 	});
 
 	it("clicking a different column starts it at asc regardless of previous column state", () => {
@@ -207,6 +207,21 @@ describe("Table sort", () => {
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Score" }));
 		expect(onSortChange).toHaveBeenCalledWith({ key: "score", direction: "asc" });
+	});
+
+	it("emits undefined (not null) when a desc-sorted column is clicked again to clear sort", () => {
+		const onSortChange = vi.fn();
+		render(
+			<Table
+				columns={sortableColumns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				sort={{ key: "name", direction: "desc" }}
+				onSortChange={onSortChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Name" }));
+		expect(onSortChange).toHaveBeenLastCalledWith(undefined);
 	});
 
 	it("does not sort data itself - relies on consumer-provided data order", () => {
@@ -339,5 +354,82 @@ describe("Table selection", () => {
 		const alphaCheckbox = screen.getByRole("checkbox", { name: "1번째 행 선택" });
 		fireEvent.click(alphaCheckbox);
 		expect(onSelectionChange).toHaveBeenCalledWith([]);
+	});
+
+	it("toggling select-all preserves keys selected on other pages (server pagination)", () => {
+		const onSelectionChange = vi.fn();
+		// "99" belongs to a row not present in the current page's `data`
+		const { rerender } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["99"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		const firstCallKeys = onSelectionChange.mock.calls[0][0] as string[];
+		expect(new Set(firstCallKeys)).toEqual(new Set(["99", "1", "2"]));
+
+		rerender(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={["99", "1", "2"]}
+				onSelectionChange={onSelectionChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("checkbox", { name: "전체 선택" }));
+		expect(onSelectionChange).toHaveBeenLastCalledWith(["99"]);
+	});
+
+	it("supports custom selectAllAriaLabel / selectRowAriaLabel", () => {
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+				selectAllAriaLabel="Select all rows"
+				selectRowAriaLabel={(index) => `Select row ${index + 1}`}
+			/>,
+		);
+		expect(screen.getByRole("checkbox", { name: "Select all rows" })).toBeInTheDocument();
+		expect(screen.getByRole("checkbox", { name: "Select row 1" })).toBeInTheDocument();
+		expect(screen.getByRole("checkbox", { name: "Select row 2" })).toBeInTheDocument();
+	});
+
+	it("disables the select-all checkbox while isLoading", () => {
+		render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+				isLoading
+			/>,
+		);
+		expect(screen.getByRole("checkbox", { name: "전체 선택" })).toBeDisabled();
+	});
+});
+
+describe("Table isLoading guards", () => {
+	const sortableColumns: TableColumn<Row>[] = [{ key: "name", header: "Name", sortable: true }];
+
+	it("disables sortable header buttons while isLoading", () => {
+		render(
+			<Table columns={sortableColumns} data={rows} keyExtractor={(r) => r.id} isLoading />,
+		);
+		expect(screen.getByRole("button", { name: "Name" })).toBeDisabled();
 	});
 });

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -432,4 +432,38 @@ describe("Table isLoading guards", () => {
 		);
 		expect(screen.getByRole("button", { name: "Name" })).toBeDisabled();
 	});
+
+	it("does not crash when selectedKeys is null", () => {
+		expect(() =>
+			render(
+				<Table
+					columns={columns}
+					data={rows}
+					keyExtractor={(r) => r.id}
+					selectable
+					rowKey={(r) => String(r.id)}
+					selectedKeys={null as unknown as string[]}
+					onSelectionChange={() => {}}
+				/>,
+			),
+		).not.toThrow();
+	});
+
+	it("keeps native row semantics (no button role) when selectable and clickable", () => {
+		const { container } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				onRowClick={() => {}}
+				selectable
+				rowKey={(r) => String(r.id)}
+				selectedKeys={[]}
+				onSelectionChange={() => {}}
+			/>,
+		);
+		const row = container.querySelector(".table_row");
+		expect(row).not.toHaveAttribute("role", "button");
+		expect(row).not.toHaveAttribute("tabindex");
+	});
 });

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -127,7 +127,7 @@ export const Table = <T extends object>({
 	// ── Row selection ──────────────────────────────────────────────────────
 	const getRowKey = (item: T, index: number) => rowKey?.(item) ?? String(index);
 	const allRowKeys = selectable ? data.map((item, index) => getRowKey(item, index)) : [];
-	const selectedSet = React.useMemo(() => new Set(selectedKeys), [selectedKeys]);
+	const selectedSet = React.useMemo(() => new Set(selectedKeys ?? []), [selectedKeys]);
 	const selectedCount = allRowKeys.filter((key) => selectedSet.has(key)).length;
 	const isAllSelected = allRowKeys.length > 0 && selectedCount === allRowKeys.length;
 	const isSomeSelected = selectedCount > 0 && !isAllSelected;
@@ -262,8 +262,8 @@ export const Table = <T extends object>({
 											isSelected && "table_row_selected",
 										)}
 										aria-selected={isSelected ? "true" : undefined}
-										role={onRowClick ? "button" : undefined}
-										tabIndex={onRowClick ? 0 : undefined}
+										role={onRowClick && !selectable ? "button" : undefined}
+										tabIndex={onRowClick && !selectable ? 0 : undefined}
 										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
 										onKeyDown={
 											onRowClick

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import { Skeleton } from "../../feedback/skeleton";
@@ -81,7 +81,11 @@ export type TableProps<T extends object> = {
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
 	sort?: TableSort;
 	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
-	onSortChange?: (sort: TableSort | null) => void;
+	onSortChange?: (sort: TableSort | undefined) => void;
+	/** 전체 선택 체크박스 aria-label (기본값: "전체 선택") */
+	selectAllAriaLabel?: string;
+	/** 개별 행 선택 체크박스 aria-label (기본값: (i) => `${i+1}번째 행 선택`) */
+	selectRowAriaLabel?: (index: number) => string;
 } & TableSelectionProps<T>;
 
 /**
@@ -104,6 +108,8 @@ export const Table = <T extends object>({
 	onRowClick,
 	sort,
 	onSortChange,
+	selectAllAriaLabel = "전체 선택",
+	selectRowAriaLabel = (index: number) => `${index + 1}번째 행 선택`,
 	selectable = false,
 	rowKey,
 	selectedKeys,
@@ -121,12 +127,16 @@ export const Table = <T extends object>({
 	// ── Row selection ──────────────────────────────────────────────────────
 	const getRowKey = (item: T, index: number) => rowKey?.(item) ?? String(index);
 	const allRowKeys = selectable ? data.map((item, index) => getRowKey(item, index)) : [];
-	const selectedCount = allRowKeys.filter((key) => selectedKeys?.includes(key)).length;
+	const selectedSet = React.useMemo(() => new Set(selectedKeys), [selectedKeys]);
+	const selectedCount = allRowKeys.filter((key) => selectedSet.has(key)).length;
 	const isAllSelected = allRowKeys.length > 0 && selectedCount === allRowKeys.length;
 	const isSomeSelected = selectedCount > 0 && !isAllSelected;
 
 	const handleToggleAll = () => {
-		onSelectionChange?.(isAllSelected ? [] : allRowKeys);
+		const pageKeys = new Set(allRowKeys);
+		const offPage = (selectedKeys ?? []).filter((k) => !pageKeys.has(k));
+		// 현재 페이지가 모두 선택돼 있으면 해제, 아니면 전체 선택 - 다른 페이지 선택은 보존
+		onSelectionChange?.(isAllSelected ? offPage : [...offPage, ...allRowKeys]);
 	};
 
 	const handleToggleRow = (key: string) => {
@@ -137,12 +147,12 @@ export const Table = <T extends object>({
 
 	// ── Sort ───────────────────────────────────────────────────────────────
 	const handleSortClick = (key: string) => {
-		const next: TableSort | null =
+		const next: TableSort | undefined =
 			sort?.key !== key
 				? { key, direction: "asc" }
 				: sort.direction === "asc"
 					? { key, direction: "desc" }
-					: null;
+					: undefined;
 		onSortChange?.(next);
 	};
 
@@ -154,10 +164,10 @@ export const Table = <T extends object>({
 						{selectable && (
 							<th scope="col" className="table_th table_th_checkbox">
 								<Checkbox
-									aria-label="전체 선택"
+									aria-label={selectAllAriaLabel}
 									checked={isAllSelected}
 									indeterminate={isSomeSelected}
-									disabled={allRowKeys.length === 0}
+									disabled={isLoading || allRowKeys.length === 0}
 									onChange={handleToggleAll}
 								/>
 							</th>
@@ -190,6 +200,7 @@ export const Table = <T extends object>({
 											type="button"
 											className="table_sort_button"
 											onClick={() => handleSortClick(col.key)}
+											disabled={isLoading}
 										>
 											<span className="table_sort_label">{col.header}</span>
 											{direction === "asc" ? (
@@ -239,8 +250,7 @@ export const Table = <T extends object>({
 							))
 						: data.map((item, rowIndex) => {
 								const rowIdentity = selectable ? getRowKey(item, rowIndex) : undefined;
-								const isSelected =
-									rowIdentity !== undefined && (selectedKeys?.includes(rowIdentity) ?? false);
+								const isSelected = rowIdentity !== undefined && selectedSet.has(rowIdentity);
 
 								return (
 									<tr
@@ -273,7 +283,7 @@ export const Table = <T extends object>({
 												onKeyDown={(e) => e.stopPropagation()}
 											>
 												<Checkbox
-													aria-label={`${rowIndex + 1}번째 행 선택`}
+													aria-label={selectRowAriaLabel(rowIndex)}
 													checked={isSelected}
 													onChange={() => handleToggleRow(rowIdentity)}
 												/>

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -263,7 +263,7 @@ export const Table = <T extends object>({
 										)}
 										aria-selected={isSelected ? "true" : undefined}
 										role={onRowClick && !selectable ? "button" : undefined}
-										tabIndex={onRowClick && !selectable ? 0 : undefined}
+										tabIndex={onRowClick ? 0 : undefined}
 										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
 										onKeyDown={
 											onRowClick

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -1,11 +1,23 @@
 "use client";
 
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import type * as React from "react";
+import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
 import { Skeleton } from "../../feedback/skeleton";
+import { Checkbox } from "../../forms/checkbox";
 import "./style.scss";
 
 export type TableSize = "sm" | "md" | "lg";
+
+export type TableSortDirection = "asc" | "desc";
+
+export interface TableSort {
+	/** 정렬 중인 컬럼의 `TableColumn.key` */
+	key: string;
+	/** 정렬 방향 */
+	direction: TableSortDirection;
+}
 
 export interface TableColumn<T extends object> {
 	/** 컬럼 식별자 - `data[key]` 자동 렌더링에도 쓰임 */
@@ -18,9 +30,30 @@ export interface TableColumn<T extends object> {
 	width?: string;
 	/** 정렬 (기본값: "left") */
 	align?: "left" | "center" | "right";
+	/** 정렬 가능한 컬럼 여부 (기본값: false). 클릭 시 `onSortChange` 발화 - 실제 정렬은 소비자가 수행 */
+	sortable?: boolean;
 }
 
-export interface TableProps<T extends object> {
+/** `selectable` 시 `rowKey` 를 요구하기 위한 판별 유니온 */
+type TableSelectionProps<T extends object> =
+	| {
+			/** 행 선택(체크박스 컬럼) 활성화 여부 */
+			selectable: true;
+			/** 행 고유 key 추출 함수 - `selectable` 사용 시 필수 */
+			rowKey: (row: T) => string;
+			/** 선택된 행 key 배열 (제어형) */
+			selectedKeys?: string[];
+			/** 선택 변경 콜백 */
+			onSelectionChange?: (keys: string[]) => void;
+	  }
+	| {
+			selectable?: false;
+			rowKey?: (row: T) => string;
+			selectedKeys?: string[];
+			onSelectionChange?: (keys: string[]) => void;
+	  };
+
+export type TableProps<T extends object> = {
 	/** 컬럼 정의 */
 	columns: TableColumn<T>[];
 	/** 표시할 데이터 배열 */
@@ -45,7 +78,11 @@ export interface TableProps<T extends object> {
 	className?: string;
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
-}
+	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
+	sort?: TableSort;
+	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
+	onSortChange?: (sort: TableSort | null) => void;
+} & TableSelectionProps<T>;
 
 /**
  * 데이터 테이블을 렌더링한다. 로딩 중에는 헤더 유지, 바디에 스켈레톤 행을 표시한다.
@@ -65,6 +102,12 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
+	sort,
+	onSortChange,
+	selectable = false,
+	rowKey,
+	selectedKeys,
+	onSelectionChange,
 }: TableProps<T>) => {
 	const wrapperClassName = cn(
 		"table_wrapper",
@@ -75,21 +118,106 @@ export const Table = <T extends object>({
 
 	const isEmpty = !isLoading && data.length === 0;
 
+	// ── Row selection ──────────────────────────────────────────────────────
+	const getRowKey = (item: T, index: number) => rowKey?.(item) ?? String(index);
+	const allRowKeys = selectable ? data.map((item, index) => getRowKey(item, index)) : [];
+	const selectedCount = allRowKeys.filter((key) => selectedKeys?.includes(key)).length;
+	const isAllSelected = allRowKeys.length > 0 && selectedCount === allRowKeys.length;
+	const isSomeSelected = selectedCount > 0 && !isAllSelected;
+
+	const handleToggleAll = () => {
+		onSelectionChange?.(isAllSelected ? [] : allRowKeys);
+	};
+
+	const handleToggleRow = (key: string) => {
+		const current = selectedKeys ?? [];
+		const next = current.includes(key) ? current.filter((k) => k !== key) : [...current, key];
+		onSelectionChange?.(next);
+	};
+
+	// ── Sort ───────────────────────────────────────────────────────────────
+	const handleSortClick = (key: string) => {
+		const next: TableSort | null =
+			sort?.key !== key
+				? { key, direction: "asc" }
+				: sort.direction === "asc"
+					? { key, direction: "desc" }
+					: null;
+		onSortChange?.(next);
+	};
+
 	return (
 		<div className={wrapperClassName}>
 			<table className="table" aria-label={ariaLabel}>
 				<thead className="table_thead">
 					<tr>
-						{columns.map((col) => (
-							<th
-								key={col.key}
-								scope="col"
-								className={cn("table_th", col.align && `table_align_${col.align}`)}
-								style={{ width: col.width }}
-							>
-								{col.header}
+						{selectable && (
+							<th scope="col" className="table_th table_th_checkbox">
+								<Checkbox
+									aria-label="전체 선택"
+									checked={isAllSelected}
+									indeterminate={isSomeSelected}
+									disabled={allRowKeys.length === 0}
+									onChange={handleToggleAll}
+								/>
 							</th>
-						))}
+						)}
+						{columns.map((col) => {
+							const isSortActive = Boolean(col.sortable) && sort?.key === col.key;
+							const direction = isSortActive ? sort?.direction : undefined;
+							const ariaSort = col.sortable
+								? direction === "asc"
+									? "ascending"
+									: direction === "desc"
+										? "descending"
+										: "none"
+								: undefined;
+
+							return (
+								<th
+									key={col.key}
+									scope="col"
+									className={cn(
+										"table_th",
+										col.align && `table_align_${col.align}`,
+										col.sortable && "table_th_sortable",
+									)}
+									style={{ width: col.width }}
+									aria-sort={ariaSort}
+								>
+									{col.sortable ? (
+										<button
+											type="button"
+											className="table_sort_button"
+											onClick={() => handleSortClick(col.key)}
+										>
+											<span className="table_sort_label">{col.header}</span>
+											{direction === "asc" ? (
+												<ArrowUp
+													size={iconSize.sm}
+													className="table_sort_icon table_sort_icon_active"
+													aria-hidden="true"
+												/>
+											) : direction === "desc" ? (
+												<ArrowDown
+													size={iconSize.sm}
+													className="table_sort_icon table_sort_icon_active"
+													aria-hidden="true"
+												/>
+											) : (
+												<ArrowUpDown
+													size={iconSize.sm}
+													className="table_sort_icon"
+													aria-hidden="true"
+												/>
+											)}
+										</button>
+									) : (
+										col.header
+									)}
+								</th>
+							);
+						})}
 					</tr>
 				</thead>
 				<tbody className="table_tbody">
@@ -97,6 +225,7 @@ export const Table = <T extends object>({
 						? Array.from({ length: skeletonRows }).map((_, rowIndex) => (
 								// biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows have no stable identity
 								<tr key={rowIndex} className="table_row table_row_skeleton">
+									{selectable && <td className="table_td table_td_checkbox" />}
 									{columns.map((col) => (
 										<td
 											key={col.key}
@@ -108,45 +237,66 @@ export const Table = <T extends object>({
 									))}
 								</tr>
 							))
-						: data.map((item, rowIndex) => (
-								<tr
-									key={keyExtractor(item, rowIndex)}
-									className={cn(
-										"table_row",
-										hoverable && "table_row_hoverable",
-										onRowClick && "table_row_clickable",
-									)}
-									role={onRowClick ? "button" : undefined}
-									tabIndex={onRowClick ? 0 : undefined}
-									onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
-									onKeyDown={
-										onRowClick
-											? (e) => {
-													if (e.key === "Enter" || e.key === " ") {
-														e.preventDefault();
-														onRowClick(item, rowIndex);
+						: data.map((item, rowIndex) => {
+								const rowIdentity = selectable ? getRowKey(item, rowIndex) : undefined;
+								const isSelected =
+									rowIdentity !== undefined && (selectedKeys?.includes(rowIdentity) ?? false);
+
+								return (
+									<tr
+										key={keyExtractor(item, rowIndex)}
+										className={cn(
+											"table_row",
+											hoverable && "table_row_hoverable",
+											onRowClick && "table_row_clickable",
+											isSelected && "table_row_selected",
+										)}
+										aria-selected={isSelected ? "true" : undefined}
+										role={onRowClick ? "button" : undefined}
+										tabIndex={onRowClick ? 0 : undefined}
+										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
+										onKeyDown={
+											onRowClick
+												? (e) => {
+														if (e.key === "Enter" || e.key === " ") {
+															e.preventDefault();
+															onRowClick(item, rowIndex);
+														}
 													}
-												}
-											: undefined
-									}
-								>
-									{columns.map((col) => (
-										<td
-											key={col.key}
-											className={cn("table_td", col.align && `table_align_${col.align}`)}
-											style={{ width: col.width }}
-										>
-											{(() => {
-												if (col.render) return col.render(item, rowIndex);
-												const value = (item as Record<string, unknown>)[col.key];
-												return value === null || value === undefined || value === ""
-													? "-"
-													: String(value);
-											})()}
-										</td>
-									))}
-								</tr>
-							))}
+												: undefined
+										}
+									>
+										{selectable && rowIdentity !== undefined && (
+											<td
+												className="table_td table_td_checkbox"
+												onClick={(e) => e.stopPropagation()}
+												onKeyDown={(e) => e.stopPropagation()}
+											>
+												<Checkbox
+													aria-label={`${rowIndex + 1}번째 행 선택`}
+													checked={isSelected}
+													onChange={() => handleToggleRow(rowIdentity)}
+												/>
+											</td>
+										)}
+										{columns.map((col) => (
+											<td
+												key={col.key}
+												className={cn("table_td", col.align && `table_align_${col.align}`)}
+												style={{ width: col.width }}
+											>
+												{(() => {
+													if (col.render) return col.render(item, rowIndex);
+													const value = (item as Record<string, unknown>)[col.key];
+													return value === null || value === undefined || value === ""
+														? "-"
+														: String(value);
+												})()}
+											</td>
+										))}
+									</tr>
+								);
+							})}
 				</tbody>
 			</table>
 

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -66,7 +66,7 @@
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 0.5;
+    opacity: token.$opacity_38;
   }
 }
 

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -27,6 +27,61 @@
   @include token.label_large_medium;
 }
 
+// ── Checkbox column (selection) ─────────────────────────────────────────────
+
+.table_th_checkbox,
+.table_td_checkbox {
+  width: token.$spacing_48;
+}
+
+// ── Sortable header ──────────────────────────────────────────────────────────
+// th 는 padding 을 0으로 비우고 button 이 전체 셀 크기/패딩을 대신 맡는다 - 클릭 영역 확대.
+
+.table_th_sortable {
+  padding: 0;
+}
+
+.table_sort_button {
+  display: flex;
+  align-items: center;
+  gap: token.$spacing_4;
+  width: 100%;
+  padding: token.$spacing_12 token.$spacing_16;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background token.$transition_fast;
+
+  &:hover {
+    background: token.$color_state_hover_on_light;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: token.$focus_ring;
+  }
+}
+
+.table_align_center .table_sort_button {
+  justify-content: center;
+}
+
+.table_align_right .table_sort_button {
+  justify-content: flex-end;
+}
+
+.table_sort_icon {
+  flex-shrink: 0;
+  color: token.$color_text_caption;
+  transition: color token.$transition_fast;
+}
+
+.table_sort_icon_active {
+  color: token.$color_text_heading;
+}
+
 .table_tbody {
   .table_row {
     border-bottom: token.$border_width_standard solid token.$color_border_default;
@@ -57,6 +112,15 @@
   .table_row_skeleton {
     pointer-events: none;
   }
+
+  // ── Selected (accent) ────────────────────────────────────────────────────
+  .table_row_selected {
+    background: token.$color_accent_subtle;
+  }
+
+  .table_row_selected.table_row_hoverable:hover {
+    background: token.$color_accent_muted;
+  }
 }
 
 .table_td {
@@ -78,6 +142,8 @@
     @include token.label_medium;
   }
   .table_th { @include token.label_medium_medium; }
+  .table_th_sortable { padding: 0; }
+  .table_sort_button { padding: token.$spacing_8 token.$spacing_12; }
 }
 
 .table_size_lg {
@@ -86,6 +152,8 @@
   }
   .table_th { @include token.body_large_medium; }
   .table_td { @include token.body_medium; }
+  .table_th_sortable { padding: 0; }
+  .table_sort_button { padding: token.$spacing_16 token.$spacing_20; }
 }
 
 // ── Sticky header ─────────────────────────────────────────────────────────
@@ -105,4 +173,13 @@
   text-align: center;
   color: token.$color_text_caption;
   @include token.body_small;
+}
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .table_row,
+  .table_sort_button,
+  .table_sort_icon {
+    transition: none;
+  }
 }

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -54,13 +54,18 @@
   cursor: pointer;
   transition: background token.$transition_fast;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: token.$color_state_hover_on_light;
   }
 
   &:focus-visible {
     outline: none;
     box-shadow: token.$focus_ring;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 }
 

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -31,6 +31,7 @@
 
 .table_th_checkbox,
 .table_td_checkbox {
+  box-sizing: border-box;
   width: token.$spacing_48;
 }
 

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -175,7 +175,7 @@ export const Sortable: Story = {
 		},
 	},
 	render: () => {
-		const [sort, setSort] = useState<TableSort | null>(null);
+		const [sort, setSort] = useState<TableSort | undefined>(undefined);
 
 		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
 			col.key === "name" || col.key === "email" || col.key === "role"
@@ -195,7 +195,7 @@ export const Sortable: Story = {
 				columns={sortableColumns}
 				data={sortedUsers}
 				keyExtractor={(u) => u.id}
-				sort={sort ?? undefined}
+				sort={sort}
 				onSortChange={setSort}
 				ariaLabel="정렬 가능한 사용자 목록"
 			/>
@@ -247,7 +247,7 @@ export const SortableAndSelectable: Story = {
 		},
 	},
 	render: () => {
-		const [sort, setSort] = useState<TableSort | null>(null);
+		const [sort, setSort] = useState<TableSort | undefined>(undefined);
 		const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
 
 		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
@@ -266,7 +266,7 @@ export const SortableAndSelectable: Story = {
 				columns={sortableColumns}
 				data={sortedUsers}
 				keyExtractor={(u) => u.id}
-				sort={sort ?? undefined}
+				sort={sort}
 				onSortChange={setSort}
 				selectable
 				rowKey={(u) => String(u.id)}

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Table, type TableColumn } from ".";
+import { useState } from "react";
+import { Table, type TableColumn, type TableSort } from ".";
 
 interface User {
 	id: number;
@@ -55,7 +56,7 @@ const meta: Meta<typeof Table> = {
 		docs: {
 			description: {
 				component: `
-**Table** - Displays structured data in rows/columns with generic row type safety. / **Table** - 정형 데이터 행/열 표시. 제네릭 row 타입 안전.
+**Table** - Displays structured data in rows/columns with generic row type safety. Supports controlled sort (\`sort\`/\`onSortChange\`) and row selection (\`selectable\`/\`rowKey\`/\`selectedKeys\`/\`onSelectionChange\`) - the DS only renders UI state, the consumer owns sorting the \`data\` array and the selection list. / **Table** - 정형 데이터 행/열 표시. 제네릭 row 타입 안전. 제어형 정렬(\`sort\`/\`onSortChange\`)과 행 선택(\`selectable\`/\`rowKey\`/\`selectedKeys\`/\`onSelectionChange\`)을 지원한다 - DS는 UI 상태만 그리고, 실제 \`data\` 정렬과 선택 목록 관리는 소비자가 담당한다.
 
 Key props: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (auto Skeleton rows), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`. / 주요 prop: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (Skeleton 행 자동), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`.
         `,
@@ -161,4 +162,118 @@ export const StickyHeader: Story = {
 			/>
 		</div>
 	),
+};
+
+export const Sortable: Story = {
+	name: "정렬 (제어형)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Controlled sort - the DS only renders `aria-sort` + arrow icon on click; the consumer sorts `data` and passes it back. Header click cycles none → asc → desc → none. / 제어형 정렬 - DS는 클릭 시 `aria-sort`와 화살표 아이콘만 그린다. 실제 `data` 정렬은 소비자가 수행해 다시 전달한다. 헤더 클릭 시 none → asc → desc → none 순환.",
+			},
+		},
+	},
+	render: () => {
+		const [sort, setSort] = useState<TableSort | null>(null);
+
+		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
+			col.key === "name" || col.key === "email" || col.key === "role"
+				? { ...col, sortable: true }
+				: col,
+		);
+
+		const sortedUsers = [...sampleUsers].sort((a, b) => {
+			if (!sort) return 0;
+			const key = sort.key as keyof User;
+			const compared = String(a[key]).localeCompare(String(b[key]), "ko");
+			return sort.direction === "asc" ? compared : -compared;
+		});
+
+		return (
+			<Table<User>
+				columns={sortableColumns}
+				data={sortedUsers}
+				keyExtractor={(u) => u.id}
+				sort={sort ?? undefined}
+				onSortChange={setSort}
+				ariaLabel="정렬 가능한 사용자 목록"
+			/>
+		);
+	},
+};
+
+export const Selectable: Story = {
+	name: "행 선택 (제어형)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Controlled row selection via `selectable` + `rowKey` + `selectedKeys` + `onSelectionChange`. Header checkbox is tri-state (checked/indeterminate/unchecked). Selected rows get `aria-selected` and an accent highlight. / `selectable` + `rowKey` + `selectedKeys` + `onSelectionChange` 로 제어하는 행 선택. 헤더 체크박스는 3-상태(전체선택/일부선택/미선택)이며, 선택된 행은 `aria-selected` 와 accent 강조를 받는다.",
+			},
+		},
+	},
+	render: () => {
+		const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+
+		return (
+			<div style={{ display: "grid", gap: 12 }}>
+				<div style={{ fontSize: 13, color: "var(--bt-color-text-body)" }}>
+					선택됨 {selectedKeys.length}건 / {selectedKeys.length} selected
+				</div>
+				<Table<User>
+					columns={columns}
+					data={sampleUsers}
+					keyExtractor={(u) => u.id}
+					selectable
+					rowKey={(u) => String(u.id)}
+					selectedKeys={selectedKeys}
+					onSelectionChange={setSelectedKeys}
+					ariaLabel="선택 가능한 사용자 목록"
+				/>
+			</div>
+		);
+	},
+};
+
+export const SortableAndSelectable: Story = {
+	name: "정렬 + 선택 조합",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Sort and selection compose independently - both are controlled, and neither DS feature touches `data` directly. / 정렬과 선택은 서로 독립적으로 조합된다 - 둘 다 제어형이며 DS는 `data` 를 직접 건드리지 않는다.",
+			},
+		},
+	},
+	render: () => {
+		const [sort, setSort] = useState<TableSort | null>(null);
+		const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+
+		const sortableColumns: TableColumn<User>[] = columns.map((col) =>
+			col.key === "name" || col.key === "role" ? { ...col, sortable: true } : col,
+		);
+
+		const sortedUsers = [...sampleUsers].sort((a, b) => {
+			if (!sort) return 0;
+			const key = sort.key as keyof User;
+			const compared = String(a[key]).localeCompare(String(b[key]), "ko");
+			return sort.direction === "asc" ? compared : -compared;
+		});
+
+		return (
+			<Table<User>
+				columns={sortableColumns}
+				data={sortedUsers}
+				keyExtractor={(u) => u.id}
+				sort={sort ?? undefined}
+				onSortChange={setSort}
+				selectable
+				rowKey={(u) => String(u.id)}
+				selectedKeys={selectedKeys}
+				onSelectionChange={setSelectedKeys}
+				ariaLabel="정렬 및 선택 가능한 사용자 목록"
+			/>
+		);
+	},
 };

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -690,4 +690,15 @@ describe("Dropdown", () => {
 		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
 		expect(screen.getByText("Option 2")).toBeInTheDocument();
 	});
+
+	it("exposes combobox a11y on the search input pointing at the active option", () => {
+		render(<Dropdown options={options} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		const input = screen.getByRole("combobox");
+		expect(input).toHaveAttribute("aria-autocomplete", "list");
+		expect(input).toHaveAttribute("aria-expanded", "true");
+		const activeId = input.getAttribute("aria-activedescendant");
+		expect(activeId).toBeTruthy();
+		expect(document.getElementById(activeId as string)).toHaveAttribute("role", "option");
+	});
 });

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -490,4 +490,175 @@ describe("Dropdown", () => {
 		expect(onValueChange).toHaveBeenCalledWith("1", options[0]);
 	});
 
+	// ── searchable ──────────────────────────────────────────────────────────────
+
+	it("renders a search input at the top of the panel when searchable", () => {
+		render(<Dropdown options={options} searchable searchPlaceholder="Find…" />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByPlaceholderText("Find…")).toBeInTheDocument();
+	});
+
+	it("does not render a search input when not searchable", () => {
+		render(<Dropdown options={options} />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.queryByPlaceholderText("검색…")).not.toBeInTheDocument();
+	});
+
+	it("filters options case- and whitespace-insensitively by label", () => {
+		render(<Dropdown options={options} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.change(screen.getByPlaceholderText("검색…"), { target: { value: "  OPTION2 " } });
+		expect(screen.getByText("Option 2")).toBeInTheDocument();
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+		expect(screen.queryByText("Option 3")).not.toBeInTheDocument();
+	});
+
+	it("shows emptyText when the filter yields no options", () => {
+		render(<Dropdown options={options} searchable emptyText="No results" />);
+		fireEvent.click(screen.getByRole("button"));
+		fireEvent.change(screen.getByPlaceholderText("검색…"), { target: { value: "zzz" } });
+		expect(screen.getByText("No results")).toBeInTheDocument();
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+	});
+
+	it("defers filtering until composition ends (Korean IME)", () => {
+		const imeOptions = [
+			{ value: "seoul", label: "서울" },
+			{ value: "busan", label: "부산" },
+		];
+		render(<Dropdown options={imeOptions} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		fireEvent.compositionStart(search);
+		// 조합 중: 표시는 갱신되지만 필터는 아직 적용되지 않아야 함
+		fireEvent.change(search, { target: { value: "서" } });
+		expect(screen.getByText("서울")).toBeInTheDocument();
+		expect(screen.getByText("부산")).toBeInTheDocument();
+
+		// 조합 종료: 이제 필터 적용
+		fireEvent.compositionEnd(search, { target: { value: "서울" } });
+		expect(screen.getByText("서울")).toBeInTheDocument();
+		expect(screen.queryByText("부산")).not.toBeInTheDocument();
+	});
+
+	it("keeps active option in range after the filter reduces the list", () => {
+		const searchOptions = [
+			{ value: "a", label: "Alpha" },
+			{ value: "b", label: "Bravo" },
+			{ value: "c", label: "Charlie" },
+		];
+		render(<Dropdown options={searchOptions} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		fireEvent.keyDown(search, { key: "ArrowDown" }); // active -> Bravo
+		fireEvent.keyDown(search, { key: "ArrowDown" }); // active -> Charlie (idx 2)
+
+		fireEvent.change(search, { target: { value: "Bravo" } }); // 남는 옵션은 Bravo 뿐
+		const bravo = screen.getByText("Bravo").closest("[role='option']");
+		expect(bravo).toHaveClass("is_active");
+	});
+
+	it("selects active option with Enter from the search input (single)", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown options={options} searchable onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+		fireEvent.change(search, { target: { value: "Option 2" } });
+		fireEvent.keyDown(search, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("2", options[1]);
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	it("closes on Escape from the search input", () => {
+		render(<Dropdown options={options} searchable />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+		fireEvent.keyDown(search, { key: "Escape" });
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	// ── multiple ──────────────────────────────────────────────────────────────
+
+	it("toggles selection and keeps the list open in multiple mode", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown multiple options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+
+		fireEvent.click(screen.getByText("Option 1"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["1"], [options[0]]);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByText("Option 2"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["1", "2"], [options[0], options[1]]);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		// 다시 클릭하면 토글 해제
+		fireEvent.click(screen.getByText("Option 1"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["2"], [options[1]]);
+	});
+
+	it("shows N개 선택 summary in multiple mode", () => {
+		render(<Dropdown multiple options={options} defaultValue={["1", "2"]} placeholder="선택" />);
+		expect(screen.getByText("2개 선택")).toBeInTheDocument();
+	});
+
+	it("shows placeholder when nothing is selected in multiple mode", () => {
+		render(<Dropdown multiple options={options} placeholder="항목 선택" />);
+		expect(screen.getByText("항목 선택")).toBeInTheDocument();
+	});
+
+	it("renders a left check mark on selected options in multiple mode", () => {
+		render(<Dropdown multiple options={options} defaultValue={["1"]} />);
+		fireEvent.click(screen.getByRole("button"));
+		const opt1 = screen.getByText("Option 1").closest("[role='option']");
+		expect(opt1?.querySelector(".dropdown_option_check svg")).toBeInTheDocument();
+		const opt2 = screen.getByText("Option 2").closest("[role='option']");
+		expect(opt2?.querySelector(".dropdown_option_check svg")).not.toBeInTheDocument();
+	});
+
+	it("sets aria-multiselectable on the listbox in multiple mode", () => {
+		render(<Dropdown multiple options={options} />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByRole("listbox")).toHaveAttribute("aria-multiselectable", "true");
+	});
+
+	it("does not set aria-multiselectable in single mode", () => {
+		render(<Dropdown options={options} />);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByRole("listbox")).not.toHaveAttribute("aria-multiselectable");
+	});
+
+	it("toggles with Enter from the search input in multiple mode (stays open)", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown multiple searchable options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+		fireEvent.change(search, { target: { value: "Option 1" } });
+		fireEvent.keyDown(search, { key: "Enter" });
+		expect(onValueChange).toHaveBeenLastCalledWith(["1"], [options[0]]);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+	});
+
+	// ── searchable + multiple combined ──────────────────────────────────────────
+
+	it("keeps the active filter after selecting in searchable + multiple mode", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown multiple searchable options={options} onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		fireEvent.change(search, { target: { value: "Option 2" } });
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByText("Option 2"));
+		expect(onValueChange).toHaveBeenLastCalledWith(["2"], [options[1]]);
+
+		// 리스트 유지 + 필터 유지 (Option 1 여전히 숨김)
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+		expect(screen.queryByText("Option 1")).not.toBeInTheDocument();
+		expect(screen.getByText("Option 2")).toBeInTheDocument();
+	});
 });

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -580,6 +580,23 @@ describe("Dropdown", () => {
 		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 	});
 
+	it("ignores Enter during IME composition, then selects on a normal Enter", () => {
+		const onValueChange = vi.fn();
+		render(<Dropdown options={options} searchable onValueChange={onValueChange} />);
+		fireEvent.click(screen.getByRole("button"));
+		const search = screen.getByPlaceholderText("검색…");
+
+		// 조합 중 Enter (한글 확정) - 선택/토글·닫기 발생하지 않아야 함
+		fireEvent.keyDown(search, { key: "Enter", isComposing: true });
+		expect(onValueChange).not.toHaveBeenCalled();
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		// 조합이 끝난 뒤의 일반 Enter - 이제 활성 옵션 선택
+		fireEvent.keyDown(search, { key: "Enter" });
+		expect(onValueChange).toHaveBeenCalledWith("1", options[0]);
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
 	// ── multiple ──────────────────────────────────────────────────────────────
 
 	it("toggles selection and keeps the list open in multiple mode", () => {
@@ -603,6 +620,18 @@ describe("Dropdown", () => {
 	it("shows N개 선택 summary in multiple mode", () => {
 		render(<Dropdown multiple options={options} defaultValue={["1", "2"]} placeholder="선택" />);
 		expect(screen.getByText("2개 선택")).toBeInTheDocument();
+	});
+
+	it("uses a custom selectedSummary in multiple mode", () => {
+		render(
+			<Dropdown
+				multiple
+				options={options}
+				defaultValue={["1", "2"]}
+				selectedSummary={(n) => `${n} selected`}
+			/>,
+		);
+		expect(screen.getByText("2 selected")).toBeInTheDocument();
 	});
 
 	it("shows placeholder when nothing is selected in multiple mode", () => {

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -10,6 +10,19 @@ const basicOptions: DropdownOption[] = [
 	{ value: "disabled", label: "Disabled option", disabled: true },
 ];
 
+const fruitOptions: DropdownOption[] = [
+	{ value: "apple", label: "Apple" },
+	{ value: "banana", label: "Banana" },
+	{ value: "blueberry", label: "Blueberry" },
+	{ value: "cherry", label: "Cherry" },
+	{ value: "grape", label: "Grape" },
+	{ value: "mango", label: "Mango" },
+	{ value: "orange", label: "Orange" },
+	{ value: "peach", label: "Peach" },
+	{ value: "pear", label: "Pear" },
+	{ value: "strawberry", label: "Strawberry" },
+];
+
 const meta: Meta<typeof Dropdown> = {
 	title: "Components/Forms/Dropdown",
 	component: Dropdown,
@@ -18,6 +31,10 @@ const meta: Meta<typeof Dropdown> = {
 		size: { control: "select", options: ["sm", "md", "lg"] },
 		disabled: { control: "boolean" },
 		fullWidth: { control: "boolean" },
+		searchable: { control: "boolean" },
+		multiple: { control: "boolean" },
+		searchPlaceholder: { control: "text" },
+		emptyText: { control: "text" },
 		options: { table: { disable: true } },
 		onChange: { control: false },
 		value: { control: false },
@@ -38,6 +55,8 @@ const meta: Meta<typeof Dropdown> = {
 Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
 \`DropdownOption\` fields: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`. / \`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
 Keyboard: ↑↓/Enter/Esc/Home/End. / 키보드: ↑↓/Enter/Esc/Home/End.
+
+Opt-in: \`searchable\` adds a label filter (case/whitespace-insensitive, Korean IME safe), \`multiple\` enables multi-select (toggle, list stays open, "N개 선택" summary). / opt-in: \`searchable\` 은 라벨 필터(대소문자·공백 무시, 한글 IME 안전), \`multiple\` 은 다중 선택(토글, 리스트 유지, "N개 선택" 요약)을 켭니다.
 				`,
 			},
 		},
@@ -91,6 +110,92 @@ export const Controlled: Story = {
 				<Dropdown {...args} value={value} onChange={setValue} />
 				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 					선택: <strong>{String(value)}</strong>
+				</div>
+			</div>
+		);
+	},
+};
+
+export const Searchable: Story = {
+	name: "Searchable (label filter)",
+	args: {
+		label: "Fruit",
+		options: fruitOptions,
+		placeholder: "Choose a fruit",
+		searchable: true,
+		searchPlaceholder: "Search fruit…",
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Type to filter options by label (case- and whitespace-insensitive). Korean IME composition is committed on composition end so the list does not thrash mid-typing. / 라벨로 옵션을 필터링합니다(대소문자·공백 무시). 한글 IME 는 조합 완료 시점에 반영되어 조합 중 리스트가 흔들리지 않습니다.",
+			},
+		},
+	},
+};
+
+export const Multiple: Story = {
+	name: "Multiple (multi-select)",
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		docs: {
+			description: {
+				story:
+					'Clicking an option toggles it and the list stays open. Selected options show a left check mark; the control shows an "N개 선택" summary. / 옵션을 클릭하면 토글되고 리스트는 열린 채 유지됩니다. 선택 항목은 왼쪽 체크 표시가 붙고, 컨트롤에는 "N개 선택" 요약이 표시됩니다.',
+			},
+		},
+	},
+	render: (args) => {
+		const [values, setValues] = React.useState<string[]>(["apple", "cherry"]);
+		return (
+			<div style={{ width: 320 }}>
+				<Dropdown
+					{...args}
+					multiple
+					options={fruitOptions}
+					label="Fruit"
+					placeholder="Choose fruits"
+					value={values}
+					onValueChange={setValues}
+				/>
+				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
+					선택: <strong>{values.join(", ") || "(없음)"}</strong>
+				</div>
+			</div>
+		);
+	},
+};
+
+export const SearchableMultiple: Story = {
+	name: "Searchable + Multiple",
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		docs: {
+			description: {
+				story:
+					"Search and multi-select combine: selecting an option while a filter is active keeps the filter so you can keep picking from the narrowed list. / 검색과 다중 선택 조합: 필터가 걸린 상태에서 항목을 선택해도 필터가 유지되어 좁혀진 목록에서 계속 고를 수 있습니다.",
+			},
+		},
+	},
+	render: (args) => {
+		const [values, setValues] = React.useState<string[]>([]);
+		return (
+			<div style={{ width: 320 }}>
+				<Dropdown
+					{...args}
+					multiple
+					searchable
+					options={fruitOptions}
+					label="Fruit"
+					placeholder="Choose fruits"
+					searchPlaceholder="Search fruit…"
+					emptyText="No matching fruit"
+					value={values}
+					onValueChange={setValues}
+				/>
+				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
+					선택: <strong>{values.join(", ") || "(없음)"}</strong>
 				</div>
 			</div>
 		);

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -235,7 +235,9 @@ export const Dropdown = (props: DropdownProps) => {
 				setIsOpen(true);
 				return;
 			}
-			let i = activeIndex;
+			// activeIndex === -1(활성 없음)에서 첫 입력은 아래=첫 항목, 위=마지막 항목으로 진입해야 한다.
+			// 시드를 보정하지 않으면 위 방향에서 (-1-1+len)%len = len-2 로 마지막을 건너뛴다.
+			let i = activeIndex === -1 ? (dir === 1 ? -1 : 0) : activeIndex;
 			const len = visibleOptions.length;
 			for (let step = 0; step < len; step++) {
 				i = (i + dir + len) % len;
@@ -427,6 +429,15 @@ export const Dropdown = (props: DropdownProps) => {
 								placeholder={searchPlaceholder}
 								aria-label={searchPlaceholder}
 								autoComplete="off"
+								role="combobox"
+								aria-autocomplete="list"
+								aria-expanded={isOpen}
+								aria-controls={`${dropdownId}_listbox`}
+								aria-activedescendant={
+									activeIndex >= 0 && visibleOptions[activeIndex]
+										? `${dropdownId}_option_${visibleOptions[activeIndex].value}`
+										: undefined
+								}
 								value={searchText}
 								onChange={(e) => {
 									const v = e.target.value;
@@ -464,6 +475,7 @@ export const Dropdown = (props: DropdownProps) => {
 										<Fragment key={opt.value}>
 											{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by parent listbox button - options are non-focusable role=option per WAI-ARIA listbox pattern */}
 											<div
+												id={`${dropdownId}_option_${opt.value}`}
 												role="option"
 												tabIndex={-1}
 												aria-selected={selected}

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -235,9 +235,13 @@ export const Dropdown = (props: DropdownProps) => {
 				setIsOpen(true);
 				return;
 			}
-			// activeIndex === -1(활성 없음)에서 첫 입력은 아래=첫 항목, 위=마지막 항목으로 진입해야 한다.
-			// 시드를 보정하지 않으면 위 방향에서 (-1-1+len)%len = len-2 로 마지막을 건너뛴다.
-			let i = activeIndex === -1 ? (dir === 1 ? -1 : 0) : activeIndex;
+			let i = activeIndex;
+			if (i === -1) {
+				// 활성 없음에서 첫 입력: 아래(dir=1)면 -1 유지 → 첫 step 이 0(첫 항목),
+				// 위(dir=-1)면 0 으로 두어 → 첫 step 이 len-1(마지막 항목).
+				// 보정하지 않으면 위 방향에서 (-1-1+len)%len = len-2 로 마지막을 건너뛴다.
+				i = dir === 1 ? -1 : 0;
+			}
 			const len = visibleOptions.length;
 			for (let step = 0; step < len; step++) {
 				i = (i + dir + len) % len;
@@ -435,7 +439,7 @@ export const Dropdown = (props: DropdownProps) => {
 								aria-controls={`${dropdownId}_listbox`}
 								aria-activedescendant={
 									activeIndex >= 0 && visibleOptions[activeIndex]
-										? `${dropdownId}_option_${visibleOptions[activeIndex].value}`
+										? `${dropdownId}_option_${activeIndex}`
 										: undefined
 								}
 								value={searchText}
@@ -475,7 +479,7 @@ export const Dropdown = (props: DropdownProps) => {
 										<Fragment key={opt.value}>
 											{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by parent listbox button - options are non-focusable role=option per WAI-ARIA listbox pattern */}
 											<div
-												id={`${dropdownId}_option_${opt.value}`}
+												id={`${dropdownId}_option_${i}`}
 												role="option"
 												tabIndex={-1}
 												aria-selected={selected}

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -1,20 +1,12 @@
 "use client";
 
 import { animated } from "@react-spring/web";
-import * as React from "react";
-import {
-	Fragment,
-	useCallback,
-	useEffect,
-	useId,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { Check, ChevronDown, Search } from "lucide-react";
+import type * as React from "react";
+import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { iconSize } from "../../../styles/icon";
 import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
-import { Check, ChevronDown } from "lucide-react";
 
 export type DropdownSize = "sm" | "md" | "lg";
 
@@ -32,7 +24,8 @@ export interface DropdownOption {
 	showDivider?: boolean;
 }
 
-export interface DropdownProps {
+/** single/multiple 공통 속성 */
+interface DropdownCommonProps {
 	/** 드롭다운 요소의 id (미입력 시 자동 생성) */
 	id?: string;
 	/** 드롭다운 위에 표시할 플로팅 라벨 텍스트 */
@@ -41,14 +34,6 @@ export interface DropdownProps {
 	placeholder?: string;
 	/** 표시할 옵션 목록 */
 	options: DropdownOption[];
-	/** 제어형 선택 값 */
-	value?: string | null;
-	/** 값 변경 콜백 (canonical). 선택된 값과 전체 옵션 객체를 전달합니다. */
-	onValueChange?: (value: string | null, option?: DropdownOption | null) => void;
-	/** @deprecated `onValueChange` 를 사용하세요. */
-	onChange?: (value: string | null, option?: DropdownOption | null) => void;
-	/** 비제어형 초기 선택 값 */
-	defaultValue?: string | null;
 	/** 비활성화 여부 */
 	disabled?: boolean;
 	/** 드롭다운 크기 (기본값: "md") */
@@ -67,55 +52,165 @@ export interface DropdownProps {
 	 * @deprecated textAlign은 더 이상 지원되지 않습니다.
 	 */
 	textAlign?: "left" | "center";
+	/**
+	 * 검색 가능 여부. 활성화 시 열린 패널 상단에 검색 입력이 표시되고, 옵션 `label` 부분 일치로 필터링됩니다.
+	 * (기본값: false)
+	 */
+	searchable?: boolean;
+	/** 검색 입력의 placeholder (기본값: "검색…") */
+	searchPlaceholder?: string;
+	/** 필터 결과가 0개일 때 표시할 텍스트 (기본값: "결과 없음") */
+	emptyText?: string;
 }
+
+/** 단일 선택 (기본) */
+export interface DropdownSingleProps extends DropdownCommonProps {
+	/** 다중 선택 모드 (기본값: false) */
+	multiple?: false;
+	/** 제어형 선택 값 */
+	value?: string | null;
+	/** 값 변경 콜백 (canonical). 선택된 값과 전체 옵션 객체를 전달합니다. */
+	onValueChange?: (value: string | null, option?: DropdownOption | null) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (value: string | null, option?: DropdownOption | null) => void;
+	/** 비제어형 초기 선택 값 */
+	defaultValue?: string | null;
+}
+
+/** 다중 선택 */
+export interface DropdownMultipleProps extends DropdownCommonProps {
+	/** 다중 선택 모드 */
+	multiple: true;
+	/** 제어형 선택 값 목록 */
+	value?: string[];
+	/** 값 변경 콜백 (canonical). 선택된 값 목록과 옵션 객체 목록을 전달합니다. */
+	onValueChange?: (values: string[], options: DropdownOption[]) => void;
+	/** @deprecated `onValueChange` 를 사용하세요. */
+	onChange?: (values: string[], options: DropdownOption[]) => void;
+	/** 비제어형 초기 선택 값 목록 */
+	defaultValue?: string[];
+}
+
+export type DropdownProps = DropdownSingleProps | DropdownMultipleProps;
+
+/** 검색 매칭용 정규화 - 대소문자·공백 무시 */
+const normalizeForSearch = (s: string) => s.toLowerCase().replace(/\s+/g, "");
 
 /**
  * 드롭다운 컴포넌트를 렌더링한다.
- * 제어형/비제어형 상태를 지원하며, 키보드/마우스 상호작용과 플로팅 라벨을 관리한다.
+ * 제어형/비제어형 상태를 지원하며, 키보드/마우스 상호작용과 정적 라벨을 관리한다.
+ * `searchable` 로 라벨 부분 일치 검색을, `multiple` 로 다중 선택을 opt-in 할 수 있다.
  * @param props 드롭다운 속성
  * @returns 렌더링된 드롭다운 UI
  */
-export const Dropdown = ({
-	id,
-	label,
-	placeholder = "Select…",
-	options,
-	value,
-	onValueChange,
-	onChange,
-	defaultValue = null,
-	disabled,
-	size = "md",
-	className,
-}: DropdownProps) => {
+export const Dropdown = (props: DropdownProps) => {
+	const {
+		id,
+		label,
+		placeholder = "Select…",
+		options,
+		disabled,
+		size = "md",
+		className,
+		searchable = false,
+		searchPlaceholder = "검색…",
+		emptyText = "결과 없음",
+	} = props;
+
+	const multiple = props.multiple === true;
+
 	const internalId = useId();
 	const dropdownId = id ?? internalId;
 
-	const isControlled = value !== undefined;
-	const [internalValue, setInternalValue] = useState<string | null>(defaultValue);
-	const currentValue = isControlled ? (value ?? null) : internalValue;
+	const isControlled = props.value !== undefined;
+
+	// 단일/다중 각각 별도 내부 상태 (mode 는 런타임에 바뀌지 않는다고 가정)
+	const [internalSingle, setInternalSingle] = useState<string | null>(() =>
+		props.multiple === true ? null : ((props.defaultValue as string | null | undefined) ?? null),
+	);
+	const [internalMulti, setInternalMulti] = useState<string[]>(() =>
+		props.multiple === true ? ((props.defaultValue as string[] | undefined) ?? []) : [],
+	);
 
 	const [isOpen, setIsOpen] = useState(false);
 	const [activeIndex, setActiveIndex] = useState(-1);
 	const [dropUp, setDropUp] = useState(false);
 
+	// 검색 상태 - searchText 는 표시용(IME 조합 중에도 즉시 반영), committedQuery 는 필터용(조합 완료 시 반영)
+	const [searchText, setSearchText] = useState("");
+	const [committedQuery, setCommittedQuery] = useState("");
+	const isComposingRef = useRef(false);
+
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const controlRef = useRef<HTMLButtonElement>(null);
+	const searchRef = useRef<HTMLInputElement>(null);
 
-	const currentOption = useMemo(
-		() => options.find((o) => o.value === currentValue) ?? null,
-		[options, currentValue],
-	);
+	// 현재 선택값 - 항상 배열로 정규화 (single 은 길이 0~1)
+	const selectedValues = useMemo<string[]>(() => {
+		if (multiple) {
+			const v = isControlled ? (props.value as string[] | undefined) : internalMulti;
+			return v ?? [];
+		}
+		const v = isControlled ? (props.value as string | null | undefined) : internalSingle;
+		return v != null ? [v] : [];
+	}, [multiple, isControlled, props.value, internalMulti, internalSingle]);
 
-	// 라벨은 항상 보이는 정적 라벨 (notched outline + always visible)
+	// 검색 필터 적용된 노출 옵션. searchable 아니거나 쿼리 없으면 전체.
+	const visibleOptions = useMemo<DropdownOption[]>(() => {
+		if (!searchable) return options;
+		const q = normalizeForSearch(committedQuery);
+		if (q === "") return options;
+		return options.filter((o) => normalizeForSearch(o.label).includes(q));
+	}, [options, searchable, committedQuery]);
 
-	const setValue = useCallback(
+	// ── 선택 처리 ──────────────────────────────────────────────────────────
+
+	const selectSingle = useCallback(
 		(next: string | null) => {
 			const option = options.find((o) => o.value === next) ?? null;
-			if (!isControlled) setInternalValue(next);
-			(onValueChange ?? onChange)?.(next, option);
+			if (!isControlled) setInternalSingle(next);
+			if (props.multiple !== true) {
+				(props.onValueChange ?? props.onChange)?.(next, option);
+			}
 		},
-		[isControlled, onValueChange, onChange, options],
+		[isControlled, options, props.multiple, props.onValueChange, props.onChange],
+	);
+
+	const toggleMultiple = useCallback(
+		(opt: DropdownOption) => {
+			const exists = selectedValues.includes(opt.value);
+			const nextValues = exists
+				? selectedValues.filter((v) => v !== opt.value)
+				: [...selectedValues, opt.value];
+			const nextOptions = nextValues
+				.map((v) => options.find((o) => o.value === v))
+				.filter((o): o is DropdownOption => Boolean(o));
+			if (!isControlled) setInternalMulti(nextValues);
+			if (props.multiple === true) {
+				(props.onValueChange ?? props.onChange)?.(nextValues, nextOptions);
+			}
+		},
+		[selectedValues, options, isControlled, props.multiple, props.onValueChange, props.onChange],
+	);
+
+	const closePanel = useCallback(() => {
+		setIsOpen(false);
+		// searchable 은 포커스가 검색 입력에 있으므로 닫을 때 트리거로 되돌린다.
+		if (searchable) controlRef.current?.focus();
+	}, [searchable]);
+
+	const selectOption = useCallback(
+		(opt: DropdownOption) => {
+			if (opt.disabled) return;
+			if (multiple) {
+				// 다중: 토글 후 리스트/필터 유지 (닫지 않음)
+				toggleMultiple(opt);
+			} else {
+				selectSingle(opt.value);
+				closePanel();
+			}
+		},
+		[multiple, toggleMultiple, selectSingle, closePanel],
 	);
 
 	useEffect(() => {
@@ -128,33 +223,34 @@ export const Dropdown = ({
 		return () => document.removeEventListener("mousedown", handleOutsideClick);
 	}, []);
 
-	const moveActive = (dir: 1 | -1) => {
-		if (options.length === 0) return;
-		if (!isOpen) {
-			setIsOpen(true);
-			return;
-		}
-		let i = activeIndex;
-		const len = options.length;
-		for (let step = 0; step < len; step++) {
-			i = (i + dir + len) % len;
-			if (!options[i].disabled) {
-				setActiveIndex(i);
-				break;
+	// ── 키보드 네비게이션 (visibleOptions 기준) ─────────────────────────────
+
+	const moveActive = useCallback(
+		(dir: 1 | -1) => {
+			if (visibleOptions.length === 0) return;
+			if (!isOpen) {
+				setIsOpen(true);
+				return;
 			}
-		}
-	};
+			let i = activeIndex;
+			const len = visibleOptions.length;
+			for (let step = 0; step < len; step++) {
+				i = (i + dir + len) % len;
+				if (!visibleOptions[i].disabled) {
+					setActiveIndex(i);
+					break;
+				}
+			}
+		},
+		[visibleOptions, isOpen, activeIndex],
+	);
 
-	const commitActive = () => {
-		if (activeIndex < 0 || activeIndex >= options.length) return;
-		const opt = options[activeIndex];
-		if (!opt.disabled) {
-			setValue(opt.value);
-			setIsOpen(false);
-		}
-	};
+	const commitActive = useCallback(() => {
+		if (activeIndex < 0 || activeIndex >= visibleOptions.length) return;
+		selectOption(visibleOptions[activeIndex]);
+	}, [activeIndex, visibleOptions, selectOption]);
 
-	const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+	const onControlKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
 		if (disabled) return;
 		switch (e.key) {
 			case " ":
@@ -174,13 +270,13 @@ export const Dropdown = ({
 			case "Home":
 				e.preventDefault();
 				setIsOpen(true);
-				setActiveIndex(options.findIndex((o) => !o.disabled));
+				setActiveIndex(visibleOptions.findIndex((o) => !o.disabled));
 				break;
 			case "End":
 				e.preventDefault();
 				setIsOpen(true);
-				for (let i = options.length - 1; i >= 0; i--) {
-					if (!options[i].disabled) {
+				for (let i = visibleOptions.length - 1; i >= 0; i--) {
+					if (!visibleOptions[i].disabled) {
 						setActiveIndex(i);
 						break;
 					}
@@ -193,18 +289,54 @@ export const Dropdown = ({
 		}
 	};
 
+	// 검색 입력 내 키보드 - ↑/↓ 이동, Enter 선택/토글, Esc 닫기. Home/End 는 커서 이동에 양보.
+	const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				moveActive(1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				moveActive(-1);
+				break;
+			case "Enter":
+				e.preventDefault();
+				commitActive();
+				break;
+			case "Escape":
+				e.preventDefault();
+				closePanel();
+				break;
+		}
+	};
+
+	// open / 필터 변경 / options 변경 시 activeIndex 재계산해 범위 내로 유지.
+	// selectedValues 는 의도적으로 제외 - 다중 토글마다 active 가 리셋되지 않게.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: selectedValues 제외는 의도적 (다중 토글 시 active 유지)
 	useEffect(() => {
 		if (!isOpen) return;
-		const matchedIndex = options.findIndex((o) => o.value === currentValue && !o.disabled);
-		setActiveIndex(
-			matchedIndex >= 0
-				? matchedIndex
-				: Math.max(
-						0,
-						options.findIndex((o) => !o.disabled),
-					),
+		const selectedIdx = visibleOptions.findIndex(
+			(o) => selectedValues.includes(o.value) && !o.disabled,
 		);
-	}, [isOpen, options, currentValue]);
+		setActiveIndex(selectedIdx >= 0 ? selectedIdx : visibleOptions.findIndex((o) => !o.disabled));
+	}, [isOpen, visibleOptions]);
+
+	// 패널을 닫으면 검색 상태 초기화 (다음 열림 시 fresh)
+	useEffect(() => {
+		if (!isOpen) {
+			setSearchText("");
+			setCommittedQuery("");
+			isComposingRef.current = false;
+		}
+	}, [isOpen]);
+
+	// searchable 패널이 열리면 검색 입력에 포커스
+	useEffect(() => {
+		if (isOpen && searchable) {
+			searchRef.current?.focus();
+		}
+	}, [isOpen, searchable]);
 
 	useEffect(() => {
 		if (!isOpen || !controlRef.current) return;
@@ -216,6 +348,21 @@ export const Dropdown = ({
 		const MIN_BELOW = 120;
 		setDropUp(spaceBelow < MIN_BELOW && spaceAbove > spaceBelow);
 	}, [isOpen]);
+
+	// ── 표시 값 계산 ────────────────────────────────────────────────────────
+
+	const currentOption = multiple
+		? null
+		: (options.find((o) => o.value === selectedValues[0]) ?? null);
+	const hasSelection = selectedValues.length > 0;
+	const showValue = multiple ? hasSelection : currentOption != null;
+	const controlText = multiple
+		? hasSelection
+			? `${selectedValues.length}개 선택`
+			: placeholder
+		: currentOption
+			? currentOption.label
+			: placeholder;
 
 	const rootClassName = cn("dropdown", `dropdown_size_${size}`, className);
 	const fieldsetClassName = cn("dropdown_fieldset", { is_open: isOpen, is_disabled: disabled });
@@ -231,10 +378,7 @@ export const Dropdown = ({
 	});
 
 	return (
-		<div
-			ref={wrapperRef}
-			className={rootClassName}
-		>
+		<div ref={wrapperRef} className={rootClassName}>
 			{label && (
 				<label htmlFor={dropdownId} className="dropdown_label">
 					{label}
@@ -251,71 +395,106 @@ export const Dropdown = ({
 					aria-expanded={isOpen}
 					aria-controls={`${dropdownId}_listbox`}
 					onClick={() => !disabled && setIsOpen((o) => !o)}
-					onKeyDown={onKeyDown}
+					onKeyDown={onControlKeyDown}
 					disabled={disabled}
 				>
-					<span className={currentOption ? "dropdown_value" : "dropdown_placeholder"}>
-						{currentOption ? currentOption.label : placeholder}
+					<span className={showValue ? "dropdown_value" : "dropdown_placeholder"}>
+						{controlText}
 					</span>
-					<span
-						className={cn("dropdown_icon", { dropdown_icon_open: isOpen })}
-						aria-hidden="true"
-					>
+					<span className={cn("dropdown_icon", { dropdown_icon_open: isOpen })} aria-hidden="true">
 						<ChevronDown size={iconSize.lg} />
 					</span>
 				</button>
 			</div>
 
 			{isOpen && (
-				<animated.div
-					id={`${dropdownId}_listbox`}
-					role="listbox"
-					className={listClassName}
-					style={listStyle}
-				>
-					{options.map((opt, i) => {
-						const selected = currentValue === opt.value;
-						const active = i === activeIndex;
+				<animated.div className={listClassName} style={listStyle}>
+					{searchable && (
+						<div className="dropdown_search">
+							<span className="dropdown_search_icon" aria-hidden="true">
+								<Search size={iconSize.sm} />
+							</span>
+							<input
+								ref={searchRef}
+								type="text"
+								className="dropdown_search_input"
+								placeholder={searchPlaceholder}
+								aria-label={searchPlaceholder}
+								autoComplete="off"
+								value={searchText}
+								onChange={(e) => {
+									const v = e.target.value;
+									setSearchText(v);
+									// 조합 중에는 필터 갱신 보류 (mid-composition 리스트 thrash 방지)
+									if (!isComposingRef.current) setCommittedQuery(v);
+								}}
+								onCompositionStart={() => {
+									isComposingRef.current = true;
+								}}
+								onCompositionEnd={(e) => {
+									isComposingRef.current = false;
+									const v = e.currentTarget.value;
+									setSearchText(v);
+									setCommittedQuery(v);
+								}}
+								onKeyDown={onSearchKeyDown}
+							/>
+						</div>
+					)}
 
-						return (
-							<Fragment key={opt.value}>
-								{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by parent listbox button - options are non-focusable role=option per WAI-ARIA listbox pattern */}
-								<div
-									role="option"
-									tabIndex={-1}
-									aria-selected={selected}
-									aria-disabled={opt.disabled ? true : undefined}
-									className={cn("dropdown_option", {
-										is_selected: selected,
-										is_active: active,
-										is_disabled: opt.disabled,
-									})}
-									onMouseEnter={() => !opt.disabled && setActiveIndex(i)}
-									onClick={() => {
-										if (opt.disabled) return;
-										setValue(opt.value);
-										setIsOpen(false);
-									}}
-								>
-									{opt.leadingIcon && (
-										<span className="dropdown_option_icon">{opt.leadingIcon}</span>
-									)}
-									<span className="dropdown_option_content">
-										<span className="dropdown_option_label">{opt.label}</span>
-										{opt.supportingText && (
-											<span className="dropdown_option_supporting">{opt.supportingText}</span>
-										)}
-									</span>
-									{(selected || opt.trailingIcon) && (
-										<span className="dropdown_option_trailing">
-											{opt.trailingIcon ?? <Check size={iconSize.sm} aria-hidden="true" />}
-										</span>
-									)}
-								</div>
-								{opt.showDivider && <hr className="dropdown_option_divider" />}
-							</Fragment>
-						);
-					})}
+					<div
+						id={`${dropdownId}_listbox`}
+						role="listbox"
+						className="dropdown_options"
+						aria-multiselectable={multiple || undefined}
+					>
+						{visibleOptions.length === 0
+							? searchable && <div className="dropdown_empty">{emptyText}</div>
+							: visibleOptions.map((opt, i) => {
+									const selected = selectedValues.includes(opt.value);
+									const active = i === activeIndex;
+
+									return (
+										<Fragment key={opt.value}>
+											{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by parent listbox button - options are non-focusable role=option per WAI-ARIA listbox pattern */}
+											<div
+												role="option"
+												tabIndex={-1}
+												aria-selected={selected}
+												aria-disabled={opt.disabled ? true : undefined}
+												className={cn("dropdown_option", {
+													is_selected: selected,
+													is_active: active,
+													is_disabled: opt.disabled,
+												})}
+												onMouseEnter={() => !opt.disabled && setActiveIndex(i)}
+												onClick={() => selectOption(opt)}
+											>
+												{multiple && (
+													<span className="dropdown_option_check" aria-hidden="true">
+														{selected && <Check size={iconSize.sm} />}
+													</span>
+												)}
+												{opt.leadingIcon && (
+													<span className="dropdown_option_icon">{opt.leadingIcon}</span>
+												)}
+												<span className="dropdown_option_content">
+													<span className="dropdown_option_label">{opt.label}</span>
+													{opt.supportingText && (
+														<span className="dropdown_option_supporting">{opt.supportingText}</span>
+													)}
+												</span>
+												{(opt.trailingIcon || (!multiple && selected)) && (
+													<span className="dropdown_option_trailing">
+														{opt.trailingIcon ?? <Check size={iconSize.sm} aria-hidden="true" />}
+													</span>
+												)}
+											</div>
+											{opt.showDivider && <hr className="dropdown_option_divider" />}
+										</Fragment>
+									);
+								})}
+					</div>
 				</animated.div>
 			)}
 		</div>

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -61,6 +61,8 @@ interface DropdownCommonProps {
 	searchPlaceholder?: string;
 	/** 필터 결과가 0개일 때 표시할 텍스트 (기본값: "결과 없음") */
 	emptyText?: string;
+	/** 멀티 선택 요약 텍스트 (기본값: "N개 선택") */
+	selectedSummary?: (count: number) => string;
 }
 
 /** 단일 선택 (기본) */
@@ -115,6 +117,7 @@ export const Dropdown = (props: DropdownProps) => {
 		searchable = false,
 		searchPlaceholder = "검색…",
 		emptyText = "결과 없음",
+		selectedSummary = (count: number) => `${count}개 선택`,
 	} = props;
 
 	const multiple = props.multiple === true;
@@ -291,6 +294,8 @@ export const Dropdown = (props: DropdownProps) => {
 
 	// 검색 입력 내 키보드 - ↑/↓ 이동, Enter 선택/토글, Esc 닫기. Home/End 는 커서 이동에 양보.
 	const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		// IME 조합 중 Enter 는 조합 확정용 - 선택/토글·네비게이션·닫기 트리거 금지
+		if (e.nativeEvent.isComposing) return;
 		switch (e.key) {
 			case "ArrowDown":
 				e.preventDefault();
@@ -351,14 +356,15 @@ export const Dropdown = (props: DropdownProps) => {
 
 	// ── 표시 값 계산 ────────────────────────────────────────────────────────
 
-	const currentOption = multiple
-		? null
-		: (options.find((o) => o.value === selectedValues[0]) ?? null);
+	const currentOption = useMemo(
+		() => (multiple ? null : (options.find((o) => o.value === selectedValues[0]) ?? null)),
+		[multiple, options, selectedValues],
+	);
 	const hasSelection = selectedValues.length > 0;
 	const showValue = multiple ? hasSelection : currentOption != null;
 	const controlText = multiple
 		? hasSelection
-			? `${selectedValues.length}개 선택`
+			? selectedSummary(selectedValues.length)
 			: placeholder
 		: currentOption
 			? currentOption.label

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -171,6 +171,7 @@
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_lg; // 컨트롤과 동일 radius
     box-shadow: token.$elevation_level1; // 좀 더 가볍게
+    overflow: hidden; // radius 안쪽으로 자식(검색바/스크롤) 클립
 
     [data-theme="dark"] & {
       background: token.$color_bg_solid_dim;
@@ -181,11 +182,6 @@
       }
     }
 
-    max-height: 18rem;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: token.$spacing_4 0;
-
     will-change: transform, opacity;
 
     &_up {
@@ -194,6 +190,63 @@
       margin-top: 0;
       margin-bottom: token.$spacing_4;
     }
+  }
+
+  // ── Search (검색 입력 - searchable) ────────────────────────────────────────
+  // 패널 상단 고정. 옵션 스크롤과 분리되도록 &_options 에만 스크롤을 둔다.
+
+  &_search {
+    display: flex;
+    align-items: center;
+    gap: token.$spacing_8;
+    padding: token.$spacing_8 token.$spacing_12;
+    border-bottom: token.$border_width_standard solid token.$color_border_default;
+  }
+
+  &_search_icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: token.$color_text_body;
+  }
+
+  &_search_input {
+    flex: 1 1 auto;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: token.$color_text_heading;
+    border-radius: token.$radius_sm;
+    @include token.body_small;
+    transition: box-shadow token.$transition_fast;
+
+    &::placeholder {
+      color: token.$color_text_body;
+    }
+
+    &:focus-visible {
+      box-shadow: token.$focus_ring;
+    }
+  }
+
+  // ── Options scroll container (role=listbox) ─────────────────────────────────
+
+  &_options {
+    max-height: 18rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: token.$spacing_4 0;
+  }
+
+  // ── Empty state (필터 결과 0개) ─────────────────────────────────────────────
+
+  &_empty {
+    padding: token.$spacing_12 token.$spacing_16;
+    @include token.body_small;
+    color: token.$color_text_caption;
+    text-align: center;
   }
 
   // ── Option ────────────────────────────────────────────────────────────────────
@@ -240,6 +293,16 @@
       cursor: not-allowed;
       color: token.$color_text_caption;
     }
+  }
+
+  // 다중 선택: 왼쪽 체크 슬롯. 미선택 시에도 폭 유지해 정렬 안정.
+  &_option_check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: token.$spacing_16;
+    color: token.$color_accent_default;
   }
 
   &_option_icon {
@@ -295,4 +358,5 @@
 // ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
 @media (prefers-reduced-motion: reduce) {
   .dropdown_icon { transition: none; }
+  .dropdown_search_input { transition: none; }
 }

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -208,6 +208,15 @@ describe("Drawer", () => {
 		expect(dialog).toHaveAttribute("aria-label", "Dialog");
 	});
 
+	it("uses ariaLabel for the dialog when provided without a title", () => {
+		render(
+			<Drawer open onClose={() => {}} ariaLabel="필터 패널">
+				Content
+			</Drawer>,
+		);
+		expect(screen.getByRole("dialog")).toHaveAttribute("aria-label", "필터 패널");
+	});
+
 	// ── Body scroll lock ───────────────────────────────────────────────────
 
 	it("locks body scroll while open and restores on close", () => {
@@ -222,6 +231,46 @@ describe("Drawer", () => {
 			<Drawer open={false} onClose={() => {}}>
 				Content
 			</Drawer>,
+		);
+		expect(document.body.style.overflow).not.toBe("hidden");
+	});
+
+	it("keeps body scroll locked until the last overlay closes (shared counter)", () => {
+		const { rerender } = render(
+			<>
+				<Drawer open onClose={() => {}}>
+					Outer
+				</Drawer>
+				<Drawer open onClose={() => {}}>
+					Inner
+				</Drawer>
+			</>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		// 안쪽만 닫힘 - 바깥이 아직 열려 있으므로 잠금 유지 (카운터 1)
+		rerender(
+			<>
+				<Drawer open onClose={() => {}}>
+					Outer
+				</Drawer>
+				<Drawer open={false} onClose={() => {}}>
+					Inner
+				</Drawer>
+			</>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		// 마지막까지 닫히면 원래 overflow 복원 (카운터 0)
+		rerender(
+			<>
+				<Drawer open={false} onClose={() => {}}>
+					Outer
+				</Drawer>
+				<Drawer open={false} onClose={() => {}}>
+					Inner
+				</Drawer>
+			</>,
 		);
 		expect(document.body.style.overflow).not.toBe("hidden");
 	});

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -194,6 +194,22 @@ describe("Drawer", () => {
 		expect(panel?.contains(document.activeElement)).toBe(true);
 	});
 
+	it("activates the focus trap when toggled open after mounting closed", () => {
+		// 닫힌 채로 마운트 → open=true 로 전환하는 일반적인 controlled 패턴에서도 트랩이 걸려야 함
+		const { rerender } = render(
+			<Drawer open={false} onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		rerender(
+			<Drawer open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	// ── Accessibility ────────────────────────────────────────────────────────
 
 	it("has dialog role and modal accessibility attributes", () => {

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -1,0 +1,268 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Drawer } from "./index";
+
+describe("Drawer", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("renders when open", () => {
+		render(
+			<Drawer open onClose={() => {}}>
+				Drawer content
+			</Drawer>,
+		);
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByText("Drawer content")).toBeInTheDocument();
+	});
+
+	it("does not render when closed", () => {
+		render(
+			<Drawer open={false} onClose={() => {}}>
+				Drawer content
+			</Drawer>,
+		);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("renders title inside header with linked aria-labelledby", () => {
+		render(
+			<Drawer open onClose={() => {}} title="Drawer Title">
+				Content
+			</Drawer>,
+		);
+		const dialog = screen.getByRole("dialog");
+		const heading = screen.getByText("Drawer Title");
+		expect(heading).toBeInTheDocument();
+		expect(dialog).toHaveAttribute("aria-labelledby", heading.getAttribute("id"));
+	});
+
+	// ── Placement ────────────────────────────────────────────────────────────
+
+	it("defaults to the right placement", () => {
+		render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		expect(screen.getByRole("dialog")).toHaveClass("drawer_placement_right");
+	});
+
+	it.each(["left", "right", "bottom"] as const)(
+		"applies the placement class for %s",
+		(placement) => {
+			render(
+				<Drawer open onClose={() => {}} placement={placement}>
+					Content
+				</Drawer>,
+			);
+			expect(screen.getByRole("dialog")).toHaveClass(`drawer_placement_${placement}`);
+		},
+	);
+
+	// ── Size ───────────────────────────────────────────────────────────────
+
+	it("applies numeric size as px width for left/right", () => {
+		render(
+			<Drawer open onClose={() => {}} placement="right" size={420}>
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveStyle({ width: "420px" });
+	});
+
+	it("applies string size verbatim", () => {
+		render(
+			<Drawer open onClose={() => {}} placement="left" size="50vw">
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveStyle({ width: "50vw" });
+	});
+
+	it("applies size as height for bottom placement", () => {
+		render(
+			<Drawer open onClose={() => {}} placement="bottom" size={300}>
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveStyle({ height: "300px" });
+	});
+
+	// ── Overlay / close ──────────────────────────────────────────────────────
+
+	it("calls onClose when overlay is clicked", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose}>
+				Content
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByRole("dialog"));
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not close on overlay click when closeOnOverlay is false", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose} closeOnOverlay={false}>
+				Content
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByRole("dialog"));
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	it("does not close when clicking inside the panel", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose}>
+				<button type="button">Inside button</button>
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByText("Inside button"));
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	it("renders the close icon button and calls onClose when clicked", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose} closeLabel="Close drawer">
+				Content
+			</Drawer>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Close drawer" }));
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides the close icon when showCloseIcon is false", () => {
+		render(
+			<Drawer open onClose={() => {}} showCloseIcon={false}>
+				Content
+			</Drawer>,
+		);
+		expect(screen.queryByRole("button", { name: "닫기" })).not.toBeInTheDocument();
+	});
+
+	// ── Escape ────────────────────────────────────────────────────────────
+
+	it("closes on Escape and calls onClose once", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose}>
+				Content
+			</Drawer>,
+		);
+		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("Escape closes only the topmost drawer when nested (stopPropagation)", () => {
+		const outerClose = vi.fn();
+		const innerClose = vi.fn();
+		render(
+			<Drawer open onClose={outerClose} title="Outer">
+				<Drawer open onClose={innerClose} title="Inner">
+					<button type="button">Inner content</button>
+				</Drawer>
+			</Drawer>,
+		);
+
+		// getAllByRole("document") in DOM order: [outer panel, inner panel]
+		const panels = screen.getAllByRole("document");
+		expect(panels).toHaveLength(2);
+		fireEvent.keyDown(panels[1], { key: "Escape" });
+
+		expect(innerClose).toHaveBeenCalledTimes(1);
+		expect(outerClose).not.toHaveBeenCalled();
+	});
+
+	// ── Focus trap ────────────────────────────────────────────────────────
+
+	it("moves focus into the panel when opened (focus trap active)", () => {
+		render(
+			<Drawer open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).not.toBeNull();
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
+	// ── Accessibility ────────────────────────────────────────────────────────
+
+	it("has dialog role and modal accessibility attributes", () => {
+		render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).toHaveAttribute("aria-modal", "true");
+		// title 이 없으면 aria-label fallback
+		expect(dialog).toHaveAttribute("aria-label", "Dialog");
+	});
+
+	// ── Body scroll lock ───────────────────────────────────────────────────
+
+	it("locks body scroll while open and restores on close", () => {
+		const { rerender } = render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		rerender(
+			<Drawer open={false} onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		expect(document.body.style.overflow).not.toBe("hidden");
+	});
+
+	// ── Reduced motion ───────────────────────────────────────────────────────
+
+	it("renders without motion when prefers-reduced-motion is set", () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+
+		render(
+			<Drawer open onClose={() => {}} placement="right" title="Reduced">
+				Content
+			</Drawer>,
+		);
+
+		// reduced-motion 에서도 정상 렌더 + 패널이 최종(휴지) 위치에 즉시 도달
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toBeInTheDocument();
+		expect(panel).toHaveStyle({ transform: "translateX(0%)" });
+	});
+
+	// ── className passthrough ─────────────────────────────────────────────
+
+	it("applies custom className to the panel", () => {
+		render(
+			<Drawer open onClose={() => {}} className="custom-drawer">
+				Content
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).toHaveClass("custom-drawer");
+	});
+});

--- a/src/ui/overlay/drawer/drawer.stories.tsx
+++ b/src/ui/overlay/drawer/drawer.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "../../general/button";
+import { Drawer } from ".";
+
+const meta: Meta<typeof Drawer> = {
+	title: "Components/Overlay/Drawer",
+	component: Drawer,
+	tags: ["autodocs"],
+	argTypes: {
+		placement: {
+			control: "radio",
+			options: ["left", "right", "bottom"],
+			description: "슬라이드 방향 / Slide direction",
+		},
+		size: {
+			control: "text",
+			description: "패널 크기 - left/right 는 너비, bottom 은 높이 / Panel size (width for left/right, height for bottom)",
+		},
+		closeOnOverlay: {
+			control: "boolean",
+			description: "배경(오버레이)을 클릭했을 때 닫을지 여부 / Close on overlay click",
+		},
+		showCloseIcon: {
+			control: "boolean",
+			description: "우상단 X 닫기 아이콘 표시 여부 / Show close icon",
+		},
+	},
+	args: {
+		placement: "right",
+		size: 360,
+		closeOnOverlay: true,
+		showCloseIcon: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component: `
+**Drawer** - Panel that slides in from a screen edge. Automatic focus trap + Esc to close + background scroll lock. / 화면 가장자리에서 미끄러져 들어오는 패널. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금 자동.
+
+Key props: \`open\`, \`onClose\`, \`placement\` ("left" | "right" | "bottom"), \`size\`, \`title\`, \`footer\`, \`closeOnOverlay\`. / 주요 prop: \`open\`, \`onClose\`, \`placement\`, \`size\`, \`title\`, \`footer\`, \`closeOnOverlay\`.
+        `,
+			},
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+export const Right: Story = {
+	name: "Right (기본)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Default drawer sliding in from the right - the most common side-panel pattern for filters, details, or settings. / 우측에서 들어오는 기본 드로어 - 필터/상세/설정에 가장 흔한 사이드 패널 패턴.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>드로어 열기</Button>
+				<Drawer {...args} open={open} onClose={() => setOpen(false)} title="설정 / Settings">
+					<p style={{ margin: 0 }}>
+						오른쪽에서 미끄러져 들어오는 패널입니다. 폼, 목록, 상세 정보를 자유롭게 배치할 수 있습니다.
+					</p>
+				</Drawer>
+			</div>
+		);
+	},
+};
+
+export const Left: Story = {
+	name: "Left (내비게이션)",
+	args: { placement: "left", size: 300 },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Left drawer - typical for mobile navigation menus. / 좌측 드로어 - 모바일 내비게이션 메뉴에 자주 쓰입니다.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>메뉴 열기</Button>
+				<Drawer {...args} open={open} onClose={() => setOpen(false)} title="메뉴 / Menu">
+					<nav style={{ display: "grid", gap: 12 }}>
+						<a href="#home">홈 / Home</a>
+						<a href="#orders">주문 / Orders</a>
+						<a href="#settings">설정 / Settings</a>
+					</nav>
+				</Drawer>
+			</div>
+		);
+	},
+};
+
+export const Bottom: Story = {
+	name: "Bottom (시트)",
+	args: { placement: "bottom", size: 320 },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Bottom sheet - slides up from the bottom, common on touch devices. / 하단 시트 - 아래에서 위로 올라오며 터치 기기에서 흔합니다.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>시트 열기</Button>
+				<Drawer {...args} open={open} onClose={() => setOpen(false)} title="공유 / Share">
+					<p style={{ margin: 0 }}>
+						하단에서 올라오는 시트입니다. 짧은 액션 목록이나 옵션 선택에 적합합니다.
+					</p>
+				</Drawer>
+			</div>
+		);
+	},
+};
+
+export const WithFooter: Story = {
+	name: "With footer (액션)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Drawer with a footer action area - confirm/cancel or save patterns. / footer 액션 영역이 있는 드로어 - 확인/취소 또는 저장 패턴.",
+			},
+		},
+	},
+	render: (args) => {
+		const [open, setOpen] = useState(false);
+		return (
+			<div style={{ padding: 24 }}>
+				<Button onClick={() => setOpen(true)}>편집 드로어 열기</Button>
+				<Drawer
+					{...args}
+					open={open}
+					onClose={() => setOpen(false)}
+					title="프로필 편집 / Edit profile"
+					footer={
+						<>
+							<Button variant="outline" onClick={() => setOpen(false)}>
+								취소 / Cancel
+							</Button>
+							<Button onClick={() => setOpen(false)}>저장 / Save</Button>
+						</>
+					}
+				>
+					<p style={{ margin: 0 }}>
+						본문은 스크롤되고 footer 는 항상 하단에 고정됩니다. 긴 폼에 적합합니다.
+					</p>
+				</Drawer>
+			</div>
+		);
+	},
+};

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { animated, useSpring } from "@react-spring/web";
+import { X } from "lucide-react";
+import * as React from "react";
+import { iconSize } from "../../../styles/icon";
+import { cn, useFocusTrap, useReducedMotion, useSpringPresence } from "../../../utils";
+import "./style.scss";
+
+/** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
+export type DrawerPlacement = "left" | "right" | "bottom";
+
+export interface DrawerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+	/** 드로어 열림 여부 */
+	open: boolean;
+	/** 드로어 닫기 콜백 */
+	onClose?: () => void;
+	/** 슬라이드 방향 (기본값: "right") */
+	placement?: DrawerPlacement;
+	/** 패널 크기 - left/right 는 너비, bottom 은 높이 (기본값: 360). number ⇒ px */
+	size?: number | string;
+	/** 드로어 제목 (헤더 h2, heading_small_bold) */
+	title?: React.ReactNode;
+	/** 하단 액션 영역 (Button들). 미지정 시 footer 영역 자체가 안 보임 */
+	footer?: React.ReactNode;
+	/** 오버레이 클릭 시 닫기 여부 (기본값: true) */
+	closeOnOverlay?: boolean;
+	/** 우상단 X 닫기 아이콘 표시 여부 (기본값: true) */
+	showCloseIcon?: boolean;
+	/** X 닫기 버튼 접근성 레이블 (기본값: "닫기") */
+	closeLabel?: string;
+}
+
+// placement 별 진입 시작(=퇴출 도착) transform. 방향 축과 단위(%)를 진입/퇴출 양쪽에서
+// 일치시켜야 react-spring 문자열 보간이 올바른 축으로 슬라이드한다.
+const SLIDE_FROM: Record<DrawerPlacement, string> = {
+	left: "translateX(-100%)",
+	right: "translateX(100%)",
+	bottom: "translateY(100%)",
+};
+
+/**
+ * 화면 가장자리에서 미끄러져 들어오는 패널(Drawer)을 렌더링한다.
+ * react-spring 기반 방향별 슬라이드 진입/퇴출 + 포커스 트랩 + 바디 스크롤 잠금.
+ *
+ * @param props 드로어 속성
+ * @returns 열림 상태일 때 렌더링된 드로어, 닫힘 상태면 null
+ */
+export const Drawer = ({
+	open,
+	onClose,
+	placement = "right",
+	size = 360,
+	title,
+	footer,
+	closeOnOverlay = true,
+	showCloseIcon = true,
+	closeLabel = "닫기",
+	children,
+	className,
+	...props
+}: DrawerProps) => {
+	const panelRef = React.useRef<HTMLDivElement>(null);
+	const titleId = React.useId();
+	const [shouldRender, setShouldRender] = React.useState(open);
+	const reduced = useReducedMotion();
+
+	// 포커스 트랩
+	useFocusTrap(panelRef, open);
+
+	// 진입 시 마운트 보장
+	React.useEffect(() => {
+		if (open) setShouldRender(true);
+	}, [open]);
+
+	// 오버레이 opacity 페이드 + presence 라이프사이클(퇴출 완료 후 unmount).
+	// 오버레이는 이동하지 않으므로 transform 을 translateY(0px) 로 고정한다.
+	const overlayStyle = useSpringPresence({
+		visible: open,
+		from: "translateY(0px)",
+		onExitComplete: () => setShouldRender(false),
+	});
+
+	// 패널 슬라이드 - 진입/퇴출 모두 placement 축을 따라 동일 template 로 보간(정확한 reverse).
+	const slideFrom = SLIDE_FROM[placement];
+	const slideRest = placement === "bottom" ? "translateY(0%)" : "translateX(0%)";
+	const panelStyle = useSpring({
+		from: { transform: slideFrom },
+		to: { transform: open ? slideRest : slideFrom },
+		immediate: reduced,
+		config: { tension: 280, friction: 28, clamp: !open },
+	});
+
+	// 바디 스크롤 잠금 (Modal 과 동일 mechanism - 카운터 없이 저장/설정/복원)
+	React.useEffect(() => {
+		if (!open) return;
+
+		const body = document.body;
+		body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
+		body.style.overflow = "hidden";
+
+		return () => {
+			body.style.overflow = body.dataset.originalOverflow || "";
+			delete body.dataset.originalOverflow;
+		};
+	}, [open]);
+
+	if (!shouldRender) return null;
+
+	const hasTitle = !!title;
+	const sizeValue = typeof size === "number" ? `${size}px` : size;
+	const panelSizeStyle = placement === "bottom" ? { height: sizeValue } : { width: sizeValue };
+
+	return (
+		<animated.div
+			className={cn("drawer", `drawer_placement_${placement}`)}
+			style={overlayStyle}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby={hasTitle ? titleId : undefined}
+			aria-label={!hasTitle ? "Dialog" : undefined}
+			onClick={() => closeOnOverlay && onClose?.()}
+			// Escape 는 여기서 단독 처리 + stopPropagation - 중첩 오버레이에서 가장 위(topmost)만
+			// 닫히도록 (document 전역 리스너로 처리하면 열린 모든 오버레이가 동시에 닫힘).
+			// panel onKeyDown 이 Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
+			onKeyDown={(e) => {
+				if (e.key === "Escape") {
+					e.stopPropagation();
+					onClose?.();
+				}
+			}}
+		>
+			<animated.div
+				ref={panelRef}
+				className={cn("drawer_panel", className)}
+				style={{ ...panelStyle, ...panelSizeStyle }}
+				role="document"
+				onClick={(e) => e.stopPropagation()}
+				onKeyDown={(e) => {
+					if (e.key !== "Escape") e.stopPropagation();
+				}}
+				{...props}
+			>
+				{showCloseIcon && onClose && (
+					<button
+						type="button"
+						className="drawer_close"
+						onClick={onClose}
+						aria-label={closeLabel}
+					>
+						<X size={iconSize.md} aria-hidden="true" />
+					</button>
+				)}
+				{title && (
+					<div className="drawer_header">
+						<h2 id={titleId} className="drawer_title">
+							{title}
+						</h2>
+					</div>
+				)}
+				{children && <div className="drawer_body">{children}</div>}
+				{footer && <div className="drawer_footer">{footer}</div>}
+			</animated.div>
+		</animated.div>
+	);
+};
+
+Drawer.displayName = "Drawer";

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -71,10 +71,11 @@ export const Drawer = ({
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
 
-	// 진입 시 마운트 보장
-	React.useEffect(() => {
-		if (open) setShouldRender(true);
-	}, [open]);
+	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
+	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
+	// true 가 안 돼 exit 애니메이션이 누락될 수 있다. React "render 중 상태 조정" 패턴 — setState 는 이
+	// 컴포넌트 자신만 대상으로 하고 조건이 곧 거짓이 되어 무한 루프가 없다.
+	if (open && !shouldRender) setShouldRender(true);
 
 	// 오버레이 opacity 페이드 + presence 라이프사이클(퇴출 완료 후 unmount).
 	// 오버레이는 이동하지 않으므로 transform 을 translateY(0px) 로 고정한다.

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -29,6 +29,8 @@ export interface DrawerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
 	showCloseIcon?: boolean;
 	/** X 닫기 버튼 접근성 레이블 (기본값: "닫기") */
 	closeLabel?: string;
+	/** 드로어 접근성 레이블 (title 없을 때 사용, 기본값: "Dialog") */
+	ariaLabel?: string;
 }
 
 // placement 별 진입 시작(=퇴출 도착) transform. 방향 축과 단위(%)를 진입/퇴출 양쪽에서
@@ -56,6 +58,7 @@ export const Drawer = ({
 	closeOnOverlay = true,
 	showCloseIcon = true,
 	closeLabel = "닫기",
+	ariaLabel,
 	children,
 	className,
 	...props
@@ -91,17 +94,33 @@ export const Drawer = ({
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
-	// 바디 스크롤 잠금 (Modal 과 동일 mechanism - 카운터 없이 저장/설정/복원)
+	// 바디 스크롤 잠금 - Modal 과 동일한 data-open-modals 카운터 공유.
+	// Modal/Drawer 를 동시에 열거나 중첩해도 카운터가 0 이 될 때만 원래 overflow 를 복원해
+	// 스크롤 잠금 오작동/원래 스타일 유실을 막는다.
 	React.useEffect(() => {
 		if (!open) return;
 
 		const body = document.body;
-		body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
-		body.style.overflow = "hidden";
+		const openModals = parseInt(body.dataset.openModals || "0", 10);
+
+		if (openModals === 0) {
+			body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
+			body.style.overflow = "hidden";
+		}
+
+		body.dataset.openModals = String(openModals + 1);
 
 		return () => {
-			body.style.overflow = body.dataset.originalOverflow || "";
-			delete body.dataset.originalOverflow;
+			const currentOpenModals = parseInt(body.dataset.openModals || "1", 10);
+			const nextOpenModals = currentOpenModals - 1;
+
+			if (nextOpenModals === 0) {
+				body.style.overflow = body.dataset.originalOverflow || "";
+				delete body.dataset.openModals;
+				delete body.dataset.originalOverflow;
+			} else {
+				body.dataset.openModals = String(nextOpenModals);
+			}
 		};
 	}, [open]);
 
@@ -117,8 +136,8 @@ export const Drawer = ({
 			style={overlayStyle}
 			role="dialog"
 			aria-modal="true"
-			aria-labelledby={hasTitle ? titleId : undefined}
-			aria-label={!hasTitle ? "Dialog" : undefined}
+			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
+			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
 			onClick={() => closeOnOverlay && onClose?.()}
 			// Escape 는 여기서 단독 처리 + stopPropagation - 중첩 오버레이에서 가장 위(topmost)만
 			// 닫히도록 (document 전역 리스너로 처리하면 열린 모든 오버레이가 동시에 닫힘).

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -124,7 +124,11 @@ export const Drawer = ({
 		};
 	}, [open]);
 
-	if (!shouldRender) return null;
+	// open 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
+	// panelRef.current 가 이미 붙어 있어 포커스 트랩이 정상 활성화된다. shouldRender 만 보면
+	// 마운트가 한 렌더 늦어(effect 로 세팅) 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션
+	// 동안 마운트 유지용.
+	if (!open && !shouldRender) return null;
 
 	const hasTitle = !!title;
 	const sizeValue = typeof size === "number" ? `${size}px` : size;

--- a/src/ui/overlay/drawer/style.scss
+++ b/src/ui/overlay/drawer/style.scss
@@ -45,8 +45,8 @@
     position: absolute;
     top: token.$spacing_12;
     right: token.$spacing_12;
-    width: 32px;
-    height: 32px;
+    width: token.$tap_target_dense;
+    height: token.$tap_target_dense;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/ui/overlay/drawer/style.scss
+++ b/src/ui/overlay/drawer/style.scss
@@ -1,0 +1,118 @@
+@use "src/styles/token" as token;
+
+.drawer {
+  position: fixed;
+  top: 0; right: 0; bottom: 0; left: 0;
+  display: flex;
+  background: token.$color_bg_overlay;
+  z-index: token.$z_level2; // Modal 과 동일 레이어
+  will-change: opacity;
+
+  // ── Placement (패널을 가장자리에 정렬) ─────────────────────────────────
+  &_placement_left  { justify-content: flex-start; }
+  &_placement_right { justify-content: flex-end; }
+  &_placement_bottom {
+    align-items: flex-end;
+    justify-content: stretch;
+  }
+
+  // ── Panel ──────────────────────────────────────────────────────────────
+  &_panel {
+    position: relative; // close button 의 absolute 기준
+    display: flex;
+    flex-direction: column;
+    background: token.$color_bg_solid;
+    box-shadow: token.$elevation_level3;
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden; // body 영역만 스크롤
+    will-change: transform;
+  }
+
+  &_placement_left &_panel,
+  &_placement_right &_panel {
+    height: 100%;
+  }
+
+  &_placement_bottom &_panel {
+    width: 100%;
+    border-top-left-radius: token.$radius_lg;
+    border-top-right-radius: token.$radius_lg;
+  }
+
+  // ── Close (우상단 X 아이콘 버튼) ───────────────────────────────────────
+  &_close {
+    position: absolute;
+    top: token.$spacing_12;
+    right: token.$spacing_12;
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: token.$color_text_caption;
+    border-radius: token.$radius_md;
+    cursor: pointer;
+    transition:
+      background token.$transition_fast,
+      color token.$transition_fast;
+
+    &:hover {
+      background: token.$color_state_hover_on_light;
+      color: token.$color_text_heading;
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: token.$focus_ring;
+    }
+  }
+
+  // ── Header (title) ─────────────────────────────────────────────────────
+  &_header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    padding: token.$spacing_20 token.$spacing_24;
+    padding-right: token.$spacing_48; // 우상단 close 버튼과 겹침 방지
+    border-bottom: token.$border_width_standard solid token.$color_border_subtle;
+  }
+
+  &_title {
+    margin: 0;
+    color: token.$color_text_heading;
+    @include token.heading_small_bold;
+  }
+
+  // ── Body (자유 children) ───────────────────────────────────────────────
+  &_body {
+    flex: 1 1 auto;
+    min-height: 0; // flex item 이 넘칠 때 내부 스크롤 허용
+    overflow-y: auto;
+    padding: token.$spacing_24;
+    color: token.$color_text_body;
+    @include token.body_medium;
+  }
+
+  // ── Footer (액션 영역) ─────────────────────────────────────────────────
+  &_footer {
+    flex: 0 0 auto;
+    display: flex;
+    gap: token.$spacing_8;
+    justify-content: flex-end;
+    padding: token.$spacing_16 token.$spacing_24;
+    border-top: token.$border_width_standard solid token.$color_border_subtle;
+  }
+}
+
+// Reduced motion (WCAG 2.3.3) - JS 스프링은 immediate 로 처리, CSS transition 은 여기서 제거
+@media (prefers-reduced-motion: reduce) {
+  .drawer,
+  .drawer_panel,
+  .drawer_close {
+    transition: none;
+    animation: none;
+  }
+}

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -144,6 +144,22 @@ describe("Modal", () => {
 		expect(document.body.dataset.openModals).toBe("1");
 	});
 
+	it("activates the focus trap when toggled open after mounting closed", () => {
+		// 닫힌 채로 마운트 → open=true 로 전환하는 일반적인 controlled 패턴에서도 트랩이 걸려야 함
+		const { rerender } = render(
+			<Modal open={false} onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Modal>,
+		);
+		rerender(
+			<Modal open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Modal>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".modal_panel");
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	it("calls onClose once on Escape from inside the modal (no duplicate handler)", () => {
 		const handleClose = vi.fn();
 		render(

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -112,7 +112,10 @@ export const Modal = ({
 		};
 	}, [open]);
 
-	if (!shouldRender) return null;
+	// open 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
+	// panelRef.current 가 이미 붙어 있어 포커스 트랩이 정상 활성화된다. shouldRender 만 보면
+	// 마운트가 한 렌더 늦어 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
+	if (!open && !shouldRender) return null;
 
 	const hasTitle = !!title;
 

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -63,10 +63,11 @@ export const Modal = ({
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
 
-	// 진입 시 마운트 보장
-	React.useEffect(() => {
-		if (open) setShouldRender(true);
-	}, [open]);
+	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
+	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
+	// true 가 안 돼 exit 애니메이션이 누락될 수 있다. React "render 중 상태 조정" 패턴 — setState 는 이
+	// 컴포넌트 자신만 대상으로 하고 조건이 곧 거짓이 되어 무한 루프가 없다.
+	if (open && !shouldRender) setShouldRender(true);
 
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({


### PR DESCRIPTION
## 릴리즈 개요
**v3.4.0** — 컴포넌트 3종 추가 + 오버레이 포커스 트랩 버그 수정. `develop → main` 배포용 PR.

> 머지 후 main 에서 `v3.4.0` 태그를 발행(`git tag -a v3.4.0` 후 태그 push)하면 `release.yml` 이 npm publish(`--provenance`) + GitHub Release 를 자동 생성한다. (아직 v3.4.0 태그 미발행 → 이번이 첫 3.4.0 릴리즈)

## 주요 업데이트 (v3.4.0)
- Dropdown `searchable`(검색) + `multiple`(다중 선택) opt-in 추가 — 한글 IME 대응, `selectedSummary` 커스터마이즈
- Table 정렬(제어형 `sort`/`onSortChange`) + 행 선택(`selectable`/`selectedKeys`/`onSelectionChange`) 추가 — 전체 선택 3-state, 다른 페이지 선택 보존
- Drawer 신규 컴포넌트 — left/right/bottom 슬라이드 오버레이 (Modal 인프라 재사용)
- `iconSize` 토큰 export 추가 (xs~xl)
- Modal · Drawer 포커스 트랩이 "닫힌 채 마운트 후 열림" 제어형 패턴에서 활성화되지 않던 버그 수정
- 문서: `docs/MIGRATION.md` · `docs/THEMING.md` 추가, `docs/COMPONENTS.md` canonical prop 갱신, Claude PR 리뷰 워크플로 도입

## 릴리즈 체크리스트
- [x] `package.json` version = `3.4.0` (직전 릴리즈 v3.3.0 → minor: 새 export·prop·토큰 추가)
- [x] `CHANGELOG.md` 3.4.0 섹션 반영 (#354)
- [ ] 리뷰어 approve 후 머지
- [ ] main 에서 `v3.4.0` 태그 발행 → 배포


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Dropdown에서 검색 필터, 다중 선택, 선택 요약 커스터마이즈를 지원합니다.
  * Table에 제어형 정렬과 행 선택을 추가했습니다. 전체 선택 및 페이지 간 선택 상태도 지원합니다.
  * 좌·우·하단에서 열리는 Drawer 컴포넌트를 추가했습니다.

* **버그 수정**
  * Modal과 Drawer를 닫힌 상태로 마운트한 뒤 열 때 포커스 트랩이 정상 활성화됩니다.

* **접근성**
  * 한글 IME 검색 입력, 키보드 조작, 포커스 트랩, 스크롤 잠금 및 모션 감소 설정을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->