### PR TITLE
fix/release-node-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.14.0
+          node-version: 24
           cache: pnpm
 
       - name: Update npm to latest (OIDC Trusted Publisher)


### PR DESCRIPTION
## 작업 개요
v3.4.0 릴리즈 워크플로가 publish 전에 실패해 배포를 복구하기 위한 CI 수정. **npm 배포/GitHub Release 는 발생하지 않았고(실패 지점이 publish 이전), 산출물엔 영향 없음.**

## 원인
`release.yml` 의 `Update npm to latest` 단계(`npm install -g npm@latest`)가 `EBADENGINE` 으로 실패:
- `npm@latest`(12.x)는 node `>=22.22.2` 요구
- 러너 node 가 `22.14.0`(고정값)이라 미충족 → 릴리즈 abort

## 작업한 내용
- [x] `release.yml` `node-version: 22.14.0` → `24` (Node 24 LTS, `npm@latest` 요구 충족)

## 복구 절차 (이 PR 머지 후)
1. 이 PR → develop 머지
2. dev→main 반영 (release.yml 이 main 태그 커밋에 있어야 함)
3. `v3.4.0` 태그를 새 main HEAD 로 재생성 → 수정된 release.yml 로 재실행 → npm publish + GitHub Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 릴리스 자동화 환경을 최신 Node.js 24로 업데이트했습니다.
  * 기존 빌드 및 패키지 배포 절차는 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->