### PR TITLE
merge: release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.14.0
+          node-version: 24
           cache: pnpm
 
       - name: Update npm to latest (OIDC Trusted Publisher)


### PR DESCRIPTION
## 릴리즈 개요
**v3.4.0 배포 복구** — `release.yml` node 수정(#357)을 main 에 반영. 이 PR 머지 후 `v3.4.0` 태그를 새 main HEAD 로 재생성하면 수정된 워크플로로 재배포된다.

## 포함 변경
- `release.yml` `node-version` `22.14.0` → `24` (#357) — `npm install -g npm@latest` 가 `EBADENGINE`(npm@12 는 node ≥22.22.2 요구)으로 실패하며 v3.4.0 publish 를 abort 시키던 문제 복구

## 참고
- 버전(`3.4.0`) · 컴포넌트 · `CHANGELOG` 는 직전 v3.4.0 릴리즈 PR(#355)에서 이미 main 에 반영됨. **이 PR 은 CI 수정만 담으며 패키지 산출물은 불변.**
- 직전 릴리즈 실행은 publish 이전 단계에서 실패 → npm 미발행 · GitHub Release 미생성. 이 PR + 태그 재생성으로 재배포.
