### PR TITLE
fix/release-npm-pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - name: Update npm to latest (OIDC Trusted Publisher)
-        run: npm install -g npm@latest
+      - name: Pin npm to 11.x (OIDC Trusted Publisher; npm@12 ships broken sigstore)
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## 작업 개요
v3.4.0 재배포 2차 복구. node 24 수정(#357/#358) 후 `npm publish` 단계가 `Cannot find module 'sigstore'` 로 실패 → npm 고정으로 해결.

## 원인
`npm install -g npm@latest` 가 방금 릴리즈된 `npm@12.0.0` 를 설치하는데, 이 전역 설치본에 `sigstore` 모듈이 빠져 있어 `npm publish --provenance` 가 `MODULE_NOT_FOUND` 로 죽음. (직전 성공 릴리즈 v3.3.0 때는 `npm@latest` 가 정상 11.x 였음)

## 작업한 내용
- [x] `npm install -g npm@latest` → `npm install -g npm@11` (>=11.5.1 = OIDC trusted publishing + provenance 유지, sigstore 정상)

## 복구 절차 (머지 후)
1. 이 PR → develop 머지
2. dev→main 반영
3. `v3.4.0` 태그 새 main HEAD 로 재생성 → 재배포

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 릴리스 과정에서 npm 버전을 11.x로 고정해 일관된 패키지 배포 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->