### PR TITLE
merge: release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - name: Update npm to latest (OIDC Trusted Publisher)
-        run: npm install -g npm@latest
+      - name: Pin npm to 11.x (OIDC Trusted Publisher; npm@12 ships broken sigstore)
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## 릴리즈 개요
**v3.4.0 재배포 복구 (2차)** — `release.yml` npm 고정(`npm@11`)을 main 에 반영. 머지 후 `v3.4.0` 태그를 새 main HEAD 로 재생성하면 재배포된다.

## 포함 변경
- `release.yml` `npm install -g npm@latest` → `npm install -g npm@11` — `npm@12.0.0` 전역 설치본에 `sigstore` 모듈이 빠져 `npm publish --provenance` 가 `MODULE_NOT_FOUND` 로 실패하던 문제 복구. `npm@11`(>=11.5.1)은 OIDC trusted publishing + provenance 정상, 직전 성공 릴리즈(v3.3.0) 상태와 동일.

## 참고
- 버전(`3.4.0`) · 컴포넌트 · `CHANGELOG` 는 이전 릴리즈 PR(#355)에서 이미 main 반영됨. **이 PR 은 CI 수정만, 패키지 산출물 불변.**
- 직전 재실행: Node 24 · npm 설치 · build 는 통과, publish 단계에서 sigstore 누락으로 실패 → npm 미발행.
