### PR TITLE
fix/review-followups

### DIFF
--- a/src/styles/layout/_index.scss
+++ b/src/styles/layout/_index.scss
@@ -50,3 +50,6 @@
     box-shadow: 0 0 30px $color;
   }
 }
+
+/* Overlay list scroll cap - dropdown/menu/select 등 오버레이 옵션 리스트의 최대 높이 */
+$overlay_list_max_height: 18rem;

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -467,4 +467,20 @@ describe("Table isLoading guards", () => {
 		expect(row).not.toHaveAttribute("role", "button");
 		expect(row).toHaveAttribute("tabindex", "0");
 	});
+
+	it("sets a clickable-row aria-label via rowClickAriaLabel", () => {
+		const { container } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				onRowClick={() => {}}
+				rowClickAriaLabel={(r) => `${r.name} 상세로 이동`}
+			/>,
+		);
+		const row = container.querySelector(".table_row");
+		expect(row).toHaveAttribute("aria-label", "Alpha 상세로 이동");
+		expect(row).not.toHaveAttribute("role", "button");
+		expect(row).toHaveAttribute("tabindex", "0");
+	});
 });

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -480,7 +480,18 @@ describe("Table isLoading guards", () => {
 		);
 		const row = container.querySelector(".table_row");
 		expect(row).toHaveAttribute("aria-label", "Alpha 상세로 이동");
-		expect(row).not.toHaveAttribute("role", "button");
+		// 비-selectable clickable 행은 role="button" 을 유지하며 aria-label 이 접근성 이름이 된다
+		expect(row).toHaveAttribute("role", "button");
+		expect(row).toHaveAttribute("tabindex", "0");
+	});
+
+	it("keeps role=button on a clickable non-selectable row even without a custom label", () => {
+		const { container } = render(
+			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} onRowClick={() => {}} />,
+		);
+		const row = container.querySelector(".table_row");
+		// 기본 인터랙티브 affordance 유지 (rowClickAriaLabel 없어도 접근성 후퇴 없음)
+		expect(row).toHaveAttribute("role", "button");
 		expect(row).toHaveAttribute("tabindex", "0");
 	});
 });

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -78,6 +78,8 @@ export type TableProps<T extends object> = {
 	className?: string;
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
+	/** clickable 행(onRowClick)의 aria-label - 스크린리더에 행의 동작을 알림 (예: (row) => `${row.name} 상세로 이동`) */
+	rowClickAriaLabel?: (item: T, index: number) => string;
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
 	sort?: TableSort;
 	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
@@ -106,6 +108,7 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
+	rowClickAriaLabel,
 	sort,
 	onSortChange,
 	selectAllAriaLabel = "전체 선택",
@@ -262,7 +265,9 @@ export const Table = <T extends object>({
 											isSelected && "table_row_selected",
 										)}
 										aria-selected={isSelected ? "true" : undefined}
-										role={onRowClick && !selectable ? "button" : undefined}
+										aria-label={
+											onRowClick && rowClickAriaLabel ? rowClickAriaLabel(item, rowIndex) : undefined
+										}
 										tabIndex={onRowClick ? 0 : undefined}
 										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
 										onKeyDown={

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -265,6 +265,10 @@ export const Table = <T extends object>({
 											isSelected && "table_row_selected",
 										)}
 										aria-selected={isSelected ? "true" : undefined}
+										// 비-selectable clickable 행엔 role="button" 으로 기본 인터랙티브 affordance 제공
+										// (aria-selected 가 없어 무효 조합 아님). selectable 행은 aria-selected 와 충돌하므로 role 생략 -
+										// 체크박스가 1차 affordance. rowClickAriaLabel 로 서술형 접근성 이름을 덧붙일 수 있다.
+										role={onRowClick && !selectable ? "button" : undefined}
 										aria-label={
 											onRowClick && rowClickAriaLabel ? rowClickAriaLabel(item, rowIndex) : undefined
 										}

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -234,7 +234,7 @@
   // ── Options scroll container (role=listbox) ─────────────────────────────────
 
   &_options {
-    max-height: 18rem;
+    max-height: token.$overlay_list_max_height;
     overflow-y: auto;
     overflow-x: hidden;
     padding: token.$spacing_4 0;

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -331,12 +331,27 @@ describe("Drawer", () => {
 		expect(panel).toHaveClass("custom-drawer");
 	});
 
-	it("forwards arbitrary props to the panel (spread order keeps them)", () => {
+	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
+		const consumerClick = vi.fn();
 		const { container } = render(
-			<Drawer open onClose={() => {}} data-testid="panel-x">
+			<Drawer
+				open
+				onClose={() => {}}
+				data-testid="panel-x"
+				style={{ backgroundColor: "rgb(255, 0, 0)" }}
+				{...({ role: "menu", onClick: consumerClick } as Record<string, unknown>)}
+			>
 				Content
 			</Drawer>,
 		);
-		expect(container.querySelector(".drawer_panel")).toHaveAttribute("data-testid", "panel-x");
+		const panel = container.querySelector(".drawer_panel") as HTMLElement;
+		// data-* 등은 통과
+		expect(panel).toHaveAttribute("data-testid", "panel-x");
+		// role/onClick 은 컴포넌트가 전유 - 소비자 값 무시(스프레드 순서 회귀 시 깨짐)
+		expect(panel).toHaveAttribute("role", "document");
+		fireEvent.click(panel);
+		expect(consumerClick).not.toHaveBeenCalled();
+		// style 은 병합 - 소비자 값 적용
+		expect(panel.style.backgroundColor).toBe("rgb(255, 0, 0)");
 	});
 });

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -330,4 +330,13 @@ describe("Drawer", () => {
 		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
 		expect(panel).toHaveClass("custom-drawer");
 	});
+
+	it("forwards arbitrary props to the panel (spread order keeps them)", () => {
+		const { container } = render(
+			<Drawer open onClose={() => {}} data-testid="panel-x">
+				Content
+			</Drawer>,
+		);
+		expect(container.querySelector(".drawer_panel")).toHaveAttribute("data-testid", "panel-x");
+	});
 });

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -10,7 +10,10 @@ import "./style.scss";
 /** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
 export type DrawerPlacement = "left" | "right" | "bottom";
 
-export interface DrawerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+// onClick/onKeyDown/role 은 오버레이 동작(stopPropagation·Escape·role="document")을 위해
+// 컴포넌트가 전유하므로 타입에서 제외한다. style/className 은 병합되어 소비자 값도 반영된다.
+export interface DrawerProps
+	extends Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "onClick" | "onKeyDown" | "role"> {
 	/** 드로어 열림 여부 */
 	open: boolean;
 	/** 드로어 닫기 콜백 */
@@ -161,7 +164,7 @@ export const Drawer = ({
 				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
 				{...props}
 				className={cn("drawer_panel", className)}
-				style={{ ...panelStyle, ...panelSizeStyle }}
+				style={{ ...props.style, ...panelStyle, ...panelSizeStyle }}
 				role="document"
 				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -156,6 +156,10 @@ export const Drawer = ({
 		>
 			<animated.div
 				ref={panelRef}
+				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
+				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				{...props}
 				className={cn("drawer_panel", className)}
 				style={{ ...panelStyle, ...panelSizeStyle }}
 				role="document"
@@ -163,7 +167,6 @@ export const Drawer = ({
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}
-				{...props}
 			>
 				{showCloseIcon && onClose && (
 					<button

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -171,4 +171,24 @@ describe("Modal", () => {
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
+	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
+		const consumerClick = vi.fn();
+		const { container } = render(
+			<Modal
+				open
+				onClose={() => {}}
+				data-testid="panel-x"
+				style={{ backgroundColor: "rgb(255, 0, 0)" }}
+				{...({ role: "menu", onClick: consumerClick } as Record<string, unknown>)}
+			>
+				Content
+			</Modal>,
+		);
+		const panel = container.querySelector(".modal_panel") as HTMLElement;
+		expect(panel).toHaveAttribute("data-testid", "panel-x");
+		expect(panel).toHaveAttribute("role", "document");
+		fireEvent.click(panel);
+		expect(consumerClick).not.toHaveBeenCalled();
+		expect(panel.style.backgroundColor).toBe("rgb(255, 0, 0)");
+	});
 });

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -141,6 +141,10 @@ export const Modal = ({
 		>
 			<animated.div
 				ref={panelRef}
+				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
+				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				{...props}
 				className={cn("modal_panel", className)}
 				style={{ ...panelStyle, width }}
 				role="document"
@@ -148,7 +152,6 @@ export const Modal = ({
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}
-				{...props}
 			>
 				{showCloseIcon && onClose && (
 					<button

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -9,7 +9,10 @@ import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
 
-export interface ModalProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+// onClick/onKeyDown/role 은 오버레이 동작(stopPropagation·Escape·role="document")을 위해
+// 컴포넌트가 전유하므로 타입에서 제외한다. style/className 은 병합되어 소비자 값도 반영된다.
+export interface ModalProps
+	extends Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "onClick" | "onKeyDown" | "role"> {
 	/** 모달 열림 여부 */
 	open: boolean;
 	/** 모달 닫기 콜백 */
@@ -146,7 +149,7 @@ export const Modal = ({
 				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
 				{...props}
 				className={cn("modal_panel", className)}
-				style={{ ...panelStyle, width }}
+				style={{ ...props.style, ...panelStyle, width }}
 				role="document"
 				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {


### PR DESCRIPTION
## 작업 개요
v3.4.0 리뷰에서 근거와 함께 보류했던 Low 백로그 반영 (다음 패치 대상). SR 힌트는 다른 Bigtablet 웹 레포(homepage-admin 등)의 clickable-row 컨벤션 참고.

## 작업한 내용
- [x] **Modal · Drawer `{...props}` 스프레드 순서 + style 병합** — `{...props}` 를 `ref` 뒤로 옮기고 `style={{ ...props.style, ...panelStyle, ... }}` 로 병합. 소비자 `style`/`className`/`data-*`/`aria-*`/`id` 는 반영되되 컴포넌트의 애니메이션 style·`onClick`/`onKeyDown`(stopPropagation·Escape)·`role="document"` 이 항상 승리. `onClick`/`onKeyDown`/`role` 은 컴포넌트 전유라 props 타입에서 `Omit`.
- [x] **Dropdown 옵션 리스트 max-height 토큰화** — `token.$overlay_list_max_height`(layout 도메인 신설).
- [x] **Table clickable-row 스크린리더 힌트** — `rowClickAriaLabel?: (item, index) => string` 로 서술형 접근성 이름 opt-in(예: `(row) => \`${row.name} 상세로 이동\``). 비-selectable clickable 행은 `role="button"` 유지(기본 affordance, aria-selected 없어 유효), selectable 행만 `role` 생략(aria-selected 충돌 → 체크박스가 1차 affordance).
- [x] 회귀 테스트 — Drawer/Modal props 보호·style 병합, Table role/aria-label affordance

## 검증
- `pnpm test` 49파일 · `pnpm build` · `pnpm lint:css` 전부 green

## 보류 유지 (별도 트랙)
- searchable dropdown NVDA/JAWS 실기기 검증 — 수동 테스트
- release.yml 정확-pin/`.nvmrc` 동기화 — floating 의도(재발 방지)라 현행 유지 권장
