### PR TITLE
merge: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.4.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.1) - 2026-07-10
+
+- Modal · Drawer: 소비자 `style`/`className`/`data-*` 는 반영하되 컴포넌트의 애니메이션 style · `onClick`/`onKeyDown`(stopPropagation·Escape) · `role` 이 항상 우선하도록 정리 (소비자 style 이 오버레이 동작을 덮던 문제 수정)
+- Table `rowClickAriaLabel` prop 추가 - clickable 행의 스크린리더 접근성 이름 지정
+- Dropdown 옵션 리스트 max-height 를 `$overlay_list_max_height` 토큰으로 추출
+
 ## [3.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.0) - 2026-07-09
 
 - Dropdown `searchable`(검색 필터) + `multiple`(다중 선택) opt-in 추가 - 한글 IME 조합 대응, 선택 요약 텍스트 커스터마이즈(`selectedSummary`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## [3.4.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.1) - 2026-07-10
 
 - Modal · Drawer: 소비자 `style`/`className`/`data-*` 는 반영하되 컴포넌트의 애니메이션 style · `onClick`/`onKeyDown`(stopPropagation·Escape) · `role` 이 항상 우선하도록 정리 (소비자 style 이 오버레이 동작을 덮던 문제 수정)
-- Table `rowClickAriaLabel` prop 추가 - clickable 행의 스크린리더 접근성 이름 지정
+- Table clickable 행 접근성 개선 - `rowClickHint` prop 으로 동작 설명을 `aria-describedby` 로 노출(셀 데이터 낭독을 가리지 않도록 `role="button"`/`aria-label` 을 tr 에 부여하지 않음)
 - Dropdown 옵션 리스트 max-height 를 `$overlay_list_max_height` 토큰으로 추출
 
 ## [3.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.0) - 2026-07-09

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/src/styles/layout/_index.scss
+++ b/src/styles/layout/_index.scss
@@ -50,3 +50,6 @@
     box-shadow: 0 0 30px $color;
   }
 }
+
+/* Overlay list scroll cap - dropdown/menu/select 등 오버레이 옵션 리스트의 최대 높이 */
+$overlay_list_max_height: 18rem;

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -468,30 +468,40 @@ describe("Table isLoading guards", () => {
 		expect(row).toHaveAttribute("tabindex", "0");
 	});
 
-	it("sets a clickable-row aria-label via rowClickAriaLabel", () => {
+	it("makes clickable rows keyboard-operable without hiding cell content", () => {
+		const onRowClick = vi.fn();
+		const { container } = render(
+			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} onRowClick={onRowClick} />,
+		);
+		const row = container.querySelector(".table_row") as HTMLElement;
+		// 셀을 가리는 role="button"/aria-label 을 tr 에 붙이지 않음
+		expect(row).not.toHaveAttribute("role", "button");
+		expect(row).not.toHaveAttribute("aria-label");
+		// 셀 데이터는 그대로 낭독됨
+		expect(row.textContent).toContain("Alpha");
+		// focus 가능 + Enter 로 동작
+		expect(row).toHaveAttribute("tabindex", "0");
+		fireEvent.keyDown(row, { key: "Enter" });
+		expect(onRowClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("describes clickable rows via aria-describedby (rowClickHint), not aria-label", () => {
 		const { container } = render(
 			<Table
 				columns={columns}
 				data={rows}
 				keyExtractor={(r) => r.id}
 				onRowClick={() => {}}
-				rowClickAriaLabel={(r) => `${r.name} 상세로 이동`}
+				rowClickHint="행을 선택하면 상세로 이동"
 			/>,
 		);
-		const row = container.querySelector(".table_row");
-		expect(row).toHaveAttribute("aria-label", "Alpha 상세로 이동");
-		// 비-selectable clickable 행은 role="button" 을 유지하며 aria-label 이 접근성 이름이 된다
-		expect(row).toHaveAttribute("role", "button");
-		expect(row).toHaveAttribute("tabindex", "0");
-	});
-
-	it("keeps role=button on a clickable non-selectable row even without a custom label", () => {
-		const { container } = render(
-			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} onRowClick={() => {}} />,
+		const row = container.querySelector(".table_row") as HTMLElement;
+		const describedby = row.getAttribute("aria-describedby");
+		expect(describedby).toBeTruthy();
+		expect(document.getElementById(describedby as string)?.textContent).toBe(
+			"행을 선택하면 상세로 이동",
 		);
-		const row = container.querySelector(".table_row");
-		// 기본 인터랙티브 affordance 유지 (rowClickAriaLabel 없어도 접근성 후퇴 없음)
-		expect(row).toHaveAttribute("role", "button");
-		expect(row).toHaveAttribute("tabindex", "0");
+		expect(row).not.toHaveAttribute("aria-label");
+		expect(row.textContent).toContain("Alpha");
 	});
 });

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -467,4 +467,20 @@ describe("Table isLoading guards", () => {
 		expect(row).not.toHaveAttribute("role", "button");
 		expect(row).toHaveAttribute("tabindex", "0");
 	});
+
+	it("sets a clickable-row aria-label via rowClickAriaLabel", () => {
+		const { container } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				onRowClick={() => {}}
+				rowClickAriaLabel={(r) => `${r.name} 상세로 이동`}
+			/>,
+		);
+		const row = container.querySelector(".table_row");
+		expect(row).toHaveAttribute("aria-label", "Alpha 상세로 이동");
+		expect(row).not.toHaveAttribute("role", "button");
+		expect(row).toHaveAttribute("tabindex", "0");
+	});
 });

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -483,6 +483,23 @@ describe("Table isLoading guards", () => {
 		expect(row).toHaveAttribute("tabindex", "0");
 		fireEvent.keyDown(row, { key: "Enter" });
 		expect(onRowClick).toHaveBeenCalledTimes(1);
+		// rowClickHint 미지정이어도 기본 힌트로 affordance 유지
+		const describedby = row.getAttribute("aria-describedby");
+		expect(describedby).toBeTruthy();
+		expect(document.getElementById(describedby as string)?.textContent).toBe("클릭 가능한 행");
+	});
+
+	it("suppresses the row hint when rowClickHint is an empty string", () => {
+		const { container } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				onRowClick={() => {}}
+				rowClickHint=""
+			/>,
+		);
+		expect(container.querySelector(".table_row")).not.toHaveAttribute("aria-describedby");
 	});
 
 	it("describes clickable rows via aria-describedby (rowClickHint), not aria-label", () => {

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -480,7 +480,18 @@ describe("Table isLoading guards", () => {
 		);
 		const row = container.querySelector(".table_row");
 		expect(row).toHaveAttribute("aria-label", "Alpha 상세로 이동");
-		expect(row).not.toHaveAttribute("role", "button");
+		// 비-selectable clickable 행은 role="button" 을 유지하며 aria-label 이 접근성 이름이 된다
+		expect(row).toHaveAttribute("role", "button");
+		expect(row).toHaveAttribute("tabindex", "0");
+	});
+
+	it("keeps role=button on a clickable non-selectable row even without a custom label", () => {
+		const { container } = render(
+			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} onRowClick={() => {}} />,
+		);
+		const row = container.querySelector(".table_row");
+		// 기본 인터랙티브 affordance 유지 (rowClickAriaLabel 없어도 접근성 후퇴 없음)
+		expect(row).toHaveAttribute("role", "button");
 		expect(row).toHaveAttribute("tabindex", "0");
 	});
 });

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -78,8 +78,13 @@ export type TableProps<T extends object> = {
 	className?: string;
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
-	/** clickable 행(onRowClick)의 aria-label - 스크린리더에 행의 동작을 알림 (예: (row) => `${row.name} 상세로 이동`) */
-	rowClickAriaLabel?: (item: T, index: number) => string;
+	/**
+	 * clickable 행(onRowClick)의 동작 설명. 지정 시 각 clickable 행에 `aria-describedby` 로 연결된다.
+	 * `aria-label` 대신 `aria-describedby` 를 쓰는 이유: `<tr>` 의 `aria-label` 은 행/셀의 accessible name 을
+	 * 덮어써 스크린리더가 셀 데이터를 못 읽는다. describedby 는 셀 낭독을 유지하며 동작만 덧붙인다.
+	 * (예: "행을 선택하면 상세 항목으로 이동합니다")
+	 */
+	rowClickHint?: string;
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
 	sort?: TableSort;
 	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
@@ -108,7 +113,7 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
-	rowClickAriaLabel,
+	rowClickHint,
 	sort,
 	onSortChange,
 	selectAllAriaLabel = "전체 선택",
@@ -130,6 +135,8 @@ export const Table = <T extends object>({
 	// ── Row selection ──────────────────────────────────────────────────────
 	const getRowKey = (item: T, index: number) => rowKey?.(item) ?? String(index);
 	const allRowKeys = selectable ? data.map((item, index) => getRowKey(item, index)) : [];
+	// clickable 행 동작 힌트를 aria-describedby 로 연결할 visually-hidden 요소 id
+	const rowClickHintId = React.useId();
 	const selectedSet = React.useMemo(() => new Set(selectedKeys ?? []), [selectedKeys]);
 	const selectedCount = allRowKeys.filter((key) => selectedSet.has(key)).length;
 	const isAllSelected = allRowKeys.length > 0 && selectedCount === allRowKeys.length;
@@ -265,13 +272,11 @@ export const Table = <T extends object>({
 											isSelected && "table_row_selected",
 										)}
 										aria-selected={isSelected ? "true" : undefined}
-										// 비-selectable clickable 행엔 role="button" 으로 기본 인터랙티브 affordance 제공
-										// (aria-selected 가 없어 무효 조합 아님). selectable 행은 aria-selected 와 충돌하므로 role 생략 -
-										// 체크박스가 1차 affordance. rowClickAriaLabel 로 서술형 접근성 이름을 덧붙일 수 있다.
-										role={onRowClick && !selectable ? "button" : undefined}
-										aria-label={
-											onRowClick && rowClickAriaLabel ? rowClickAriaLabel(item, rowIndex) : undefined
-										}
+										// clickable 행은 role/aria-label 을 tr 에 붙이지 않는다 (role="button" 은 셀을
+										// presentational 로, aria-label 은 셀 이름을 덮어써 스크린리더가 데이터를 못 읽음).
+										// 대신 focus 가능(tabIndex) + Enter/Space 로 동작하고, 동작 설명은 rowClickHint 를
+										// aria-describedby 로 덧붙여 셀 낭독을 유지한다.
+										aria-describedby={onRowClick && rowClickHint ? rowClickHintId : undefined}
 										tabIndex={onRowClick ? 0 : undefined}
 										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
 										onKeyDown={
@@ -318,6 +323,12 @@ export const Table = <T extends object>({
 							})}
 				</tbody>
 			</table>
+
+			{onRowClick && rowClickHint && (
+				<span id={rowClickHintId} className="table_sr_only">
+					{rowClickHint}
+				</span>
+			)}
 
 			{isEmpty && (
 				<div className="table_empty" role="status">

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -78,6 +78,8 @@ export type TableProps<T extends object> = {
 	className?: string;
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
+	/** clickable 행(onRowClick)의 aria-label - 스크린리더에 행의 동작을 알림 (예: (row) => `${row.name} 상세로 이동`) */
+	rowClickAriaLabel?: (item: T, index: number) => string;
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
 	sort?: TableSort;
 	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
@@ -106,6 +108,7 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
+	rowClickAriaLabel,
 	sort,
 	onSortChange,
 	selectAllAriaLabel = "전체 선택",
@@ -262,7 +265,9 @@ export const Table = <T extends object>({
 											isSelected && "table_row_selected",
 										)}
 										aria-selected={isSelected ? "true" : undefined}
-										role={onRowClick && !selectable ? "button" : undefined}
+										aria-label={
+											onRowClick && rowClickAriaLabel ? rowClickAriaLabel(item, rowIndex) : undefined
+										}
 										tabIndex={onRowClick ? 0 : undefined}
 										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
 										onKeyDown={

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -265,6 +265,10 @@ export const Table = <T extends object>({
 											isSelected && "table_row_selected",
 										)}
 										aria-selected={isSelected ? "true" : undefined}
+										// 비-selectable clickable 행엔 role="button" 으로 기본 인터랙티브 affordance 제공
+										// (aria-selected 가 없어 무효 조합 아님). selectable 행은 aria-selected 와 충돌하므로 role 생략 -
+										// 체크박스가 1차 affordance. rowClickAriaLabel 로 서술형 접근성 이름을 덧붙일 수 있다.
+										role={onRowClick && !selectable ? "button" : undefined}
 										aria-label={
 											onRowClick && rowClickAriaLabel ? rowClickAriaLabel(item, rowIndex) : undefined
 										}

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -79,10 +79,11 @@ export type TableProps<T extends object> = {
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
 	/**
-	 * clickable 행(onRowClick)의 동작 설명. 지정 시 각 clickable 행에 `aria-describedby` 로 연결된다.
-	 * `aria-label` 대신 `aria-describedby` 를 쓰는 이유: `<tr>` 의 `aria-label` 은 행/셀의 accessible name 을
-	 * 덮어써 스크린리더가 셀 데이터를 못 읽는다. describedby 는 셀 낭독을 유지하며 동작만 덧붙인다.
-	 * (예: "행을 선택하면 상세 항목으로 이동합니다")
+	 * clickable 행(onRowClick)의 동작 설명. 각 clickable 행에 `aria-describedby` 로 연결된다 (기본값: "클릭 가능한 행").
+	 * 행마다 셀 데이터가 이미 행을 식별하므로 여기엔 동작만 담으면 된다 (예: "선택하면 상세 항목으로 이동").
+	 * `""`(빈 문자열)로 두면 힌트를 붙이지 않는다.
+	 * `aria-label` 대신 `aria-describedby` 를 쓰는 이유: `<tr>` 의 `aria-label`/`role="button"` 은 행/셀의
+	 * accessible name 을 덮거나 셀을 presentational 로 만들어 스크린리더가 셀 데이터를 못 읽는다.
 	 */
 	rowClickHint?: string;
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
@@ -113,7 +114,7 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
-	rowClickHint,
+	rowClickHint = "클릭 가능한 행",
 	sort,
 	onSortChange,
 	selectAllAriaLabel = "전체 선택",

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -8,6 +8,19 @@
   background: token.$color_bg_solid;
 }
 
+// 스크린리더 전용(시각적으로 숨김) - clickable 행 동작 힌트를 aria-describedby 로 노출할 때 사용
+.table_sr_only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -234,7 +234,7 @@
   // ── Options scroll container (role=listbox) ─────────────────────────────────
 
   &_options {
-    max-height: 18rem;
+    max-height: token.$overlay_list_max_height;
     overflow-y: auto;
     overflow-x: hidden;
     padding: token.$spacing_4 0;

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -331,12 +331,27 @@ describe("Drawer", () => {
 		expect(panel).toHaveClass("custom-drawer");
 	});
 
-	it("forwards arbitrary props to the panel (spread order keeps them)", () => {
+	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
+		const consumerClick = vi.fn();
 		const { container } = render(
-			<Drawer open onClose={() => {}} data-testid="panel-x">
+			<Drawer
+				open
+				onClose={() => {}}
+				data-testid="panel-x"
+				style={{ backgroundColor: "rgb(255, 0, 0)" }}
+				{...({ role: "menu", onClick: consumerClick } as Record<string, unknown>)}
+			>
 				Content
 			</Drawer>,
 		);
-		expect(container.querySelector(".drawer_panel")).toHaveAttribute("data-testid", "panel-x");
+		const panel = container.querySelector(".drawer_panel") as HTMLElement;
+		// data-* 등은 통과
+		expect(panel).toHaveAttribute("data-testid", "panel-x");
+		// role/onClick 은 컴포넌트가 전유 - 소비자 값 무시(스프레드 순서 회귀 시 깨짐)
+		expect(panel).toHaveAttribute("role", "document");
+		fireEvent.click(panel);
+		expect(consumerClick).not.toHaveBeenCalled();
+		// style 은 병합 - 소비자 값 적용
+		expect(panel.style.backgroundColor).toBe("rgb(255, 0, 0)");
 	});
 });

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -330,4 +330,13 @@ describe("Drawer", () => {
 		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
 		expect(panel).toHaveClass("custom-drawer");
 	});
+
+	it("forwards arbitrary props to the panel (spread order keeps them)", () => {
+		const { container } = render(
+			<Drawer open onClose={() => {}} data-testid="panel-x">
+				Content
+			</Drawer>,
+		);
+		expect(container.querySelector(".drawer_panel")).toHaveAttribute("data-testid", "panel-x");
+	});
 });

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -10,7 +10,10 @@ import "./style.scss";
 /** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
 export type DrawerPlacement = "left" | "right" | "bottom";
 
-export interface DrawerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+// onClick/onKeyDown/role 은 오버레이 동작(stopPropagation·Escape·role="document")을 위해
+// 컴포넌트가 전유하므로 타입에서 제외한다. style/className 은 병합되어 소비자 값도 반영된다.
+export interface DrawerProps
+	extends Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "onClick" | "onKeyDown" | "role"> {
 	/** 드로어 열림 여부 */
 	open: boolean;
 	/** 드로어 닫기 콜백 */
@@ -161,7 +164,7 @@ export const Drawer = ({
 				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
 				{...props}
 				className={cn("drawer_panel", className)}
-				style={{ ...panelStyle, ...panelSizeStyle }}
+				style={{ ...props.style, ...panelStyle, ...panelSizeStyle }}
 				role="document"
 				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -156,6 +156,10 @@ export const Drawer = ({
 		>
 			<animated.div
 				ref={panelRef}
+				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
+				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				{...props}
 				className={cn("drawer_panel", className)}
 				style={{ ...panelStyle, ...panelSizeStyle }}
 				role="document"
@@ -163,7 +167,6 @@ export const Drawer = ({
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}
-				{...props}
 			>
 				{showCloseIcon && onClose && (
 					<button

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -171,4 +171,24 @@ describe("Modal", () => {
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
+	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
+		const consumerClick = vi.fn();
+		const { container } = render(
+			<Modal
+				open
+				onClose={() => {}}
+				data-testid="panel-x"
+				style={{ backgroundColor: "rgb(255, 0, 0)" }}
+				{...({ role: "menu", onClick: consumerClick } as Record<string, unknown>)}
+			>
+				Content
+			</Modal>,
+		);
+		const panel = container.querySelector(".modal_panel") as HTMLElement;
+		expect(panel).toHaveAttribute("data-testid", "panel-x");
+		expect(panel).toHaveAttribute("role", "document");
+		fireEvent.click(panel);
+		expect(consumerClick).not.toHaveBeenCalled();
+		expect(panel.style.backgroundColor).toBe("rgb(255, 0, 0)");
+	});
 });

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -141,6 +141,10 @@ export const Modal = ({
 		>
 			<animated.div
 				ref={panelRef}
+				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
+				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				{...props}
 				className={cn("modal_panel", className)}
 				style={{ ...panelStyle, width }}
 				role="document"
@@ -148,7 +152,6 @@ export const Modal = ({
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}
-				{...props}
 			>
 				{showCloseIcon && onClose && (
 					<button

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -9,7 +9,10 @@ import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
 
-export interface ModalProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+// onClick/onKeyDown/role 은 오버레이 동작(stopPropagation·Escape·role="document")을 위해
+// 컴포넌트가 전유하므로 타입에서 제외한다. style/className 은 병합되어 소비자 값도 반영된다.
+export interface ModalProps
+	extends Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "onClick" | "onKeyDown" | "role"> {
 	/** 모달 열림 여부 */
 	open: boolean;
 	/** 모달 닫기 콜백 */
@@ -146,7 +149,7 @@ export const Modal = ({
 				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
 				{...props}
 				className={cn("modal_panel", className)}
-				style={{ ...panelStyle, width }}
+				style={{ ...props.style, ...panelStyle, width }}
 				role="document"
 				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {


### PR DESCRIPTION
## 릴리즈 개요
**v3.4.1 (patch)** — v3.4.0 리뷰 후속 정리. `develop → main` 배포용 PR. 머지 후 `v3.4.1` 태그 발행 시 npm publish + GitHub Release 자동 생성.

## 주요 업데이트 (v3.4.1)
- Modal · Drawer: 소비자 `style`/`className`/`data-*` 는 반영하되 컴포넌트의 애니메이션 style · `onClick`/`onKeyDown`(stopPropagation·Escape) · `role` 이 항상 우선하도록 정리 (소비자 `style` 이 오버레이 동작을 덮던 문제 수정)
- Table `rowClickAriaLabel` prop 추가 — clickable 행의 스크린리더 접근성 이름 지정 (사내 homepage-admin clickable-row 컨벤션 준수)
- Dropdown 옵션 리스트 max-height 를 `$overlay_list_max_height` 토큰으로 추출

## 릴리즈 체크리스트
- [x] `package.json` `3.4.0` → `3.4.1`
- [x] `CHANGELOG.md` 3.4.1 섹션
- [ ] 리뷰어 approve 후 머지
- [ ] main 에서 `v3.4.1` 태그 발행 → 배포

> 참고: Modal/Drawer props 타입에서 무동작이던 `onClick`/`onKeyDown`/`role` 을 `Omit`. 원래 런타임 무효과라 실동작 비파괴 — 팀 판단으로 patch(3.4.1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **접근성 개선**
  * 클릭 가능한 Table 행에 스크린리더용 `aria-label`을 지정할 수 있습니다.
  * 클릭 가능한 행의 버튼 역할과 키보드 탐색을 지원합니다.

* **사용성 개선**
  * Modal과 Drawer에서 사용자 지정 스타일, 클래스, `data-*` 속성이 정상 반영됩니다.
  * 오버레이의 닫기 및 키보드 동작이 안정적으로 유지됩니다.
  * Dropdown 옵션 목록의 최대 높이를 공통 설정으로 관리합니다.

* **릴리즈**
  * 버전 3.4.1이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->