### PR TITLE
fix/table-clickable-a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## [3.4.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.1) - 2026-07-10
 
 - Modal · Drawer: 소비자 `style`/`className`/`data-*` 는 반영하되 컴포넌트의 애니메이션 style · `onClick`/`onKeyDown`(stopPropagation·Escape) · `role` 이 항상 우선하도록 정리 (소비자 style 이 오버레이 동작을 덮던 문제 수정)
-- Table `rowClickAriaLabel` prop 추가 - clickable 행의 스크린리더 접근성 이름 지정
+- Table clickable 행 접근성 개선 - `rowClickHint` prop 으로 동작 설명을 `aria-describedby` 로 노출(셀 데이터 낭독을 가리지 않도록 `role="button"`/`aria-label` 을 tr 에 부여하지 않음)
 - Dropdown 옵션 리스트 max-height 를 `$overlay_list_max_height` 토큰으로 추출
 
 ## [3.4.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.0) - 2026-07-09

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -468,30 +468,40 @@ describe("Table isLoading guards", () => {
 		expect(row).toHaveAttribute("tabindex", "0");
 	});
 
-	it("sets a clickable-row aria-label via rowClickAriaLabel", () => {
+	it("makes clickable rows keyboard-operable without hiding cell content", () => {
+		const onRowClick = vi.fn();
+		const { container } = render(
+			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} onRowClick={onRowClick} />,
+		);
+		const row = container.querySelector(".table_row") as HTMLElement;
+		// 셀을 가리는 role="button"/aria-label 을 tr 에 붙이지 않음
+		expect(row).not.toHaveAttribute("role", "button");
+		expect(row).not.toHaveAttribute("aria-label");
+		// 셀 데이터는 그대로 낭독됨
+		expect(row.textContent).toContain("Alpha");
+		// focus 가능 + Enter 로 동작
+		expect(row).toHaveAttribute("tabindex", "0");
+		fireEvent.keyDown(row, { key: "Enter" });
+		expect(onRowClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("describes clickable rows via aria-describedby (rowClickHint), not aria-label", () => {
 		const { container } = render(
 			<Table
 				columns={columns}
 				data={rows}
 				keyExtractor={(r) => r.id}
 				onRowClick={() => {}}
-				rowClickAriaLabel={(r) => `${r.name} 상세로 이동`}
+				rowClickHint="행을 선택하면 상세로 이동"
 			/>,
 		);
-		const row = container.querySelector(".table_row");
-		expect(row).toHaveAttribute("aria-label", "Alpha 상세로 이동");
-		// 비-selectable clickable 행은 role="button" 을 유지하며 aria-label 이 접근성 이름이 된다
-		expect(row).toHaveAttribute("role", "button");
-		expect(row).toHaveAttribute("tabindex", "0");
-	});
-
-	it("keeps role=button on a clickable non-selectable row even without a custom label", () => {
-		const { container } = render(
-			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} onRowClick={() => {}} />,
+		const row = container.querySelector(".table_row") as HTMLElement;
+		const describedby = row.getAttribute("aria-describedby");
+		expect(describedby).toBeTruthy();
+		expect(document.getElementById(describedby as string)?.textContent).toBe(
+			"행을 선택하면 상세로 이동",
 		);
-		const row = container.querySelector(".table_row");
-		// 기본 인터랙티브 affordance 유지 (rowClickAriaLabel 없어도 접근성 후퇴 없음)
-		expect(row).toHaveAttribute("role", "button");
-		expect(row).toHaveAttribute("tabindex", "0");
+		expect(row).not.toHaveAttribute("aria-label");
+		expect(row.textContent).toContain("Alpha");
 	});
 });

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -483,6 +483,23 @@ describe("Table isLoading guards", () => {
 		expect(row).toHaveAttribute("tabindex", "0");
 		fireEvent.keyDown(row, { key: "Enter" });
 		expect(onRowClick).toHaveBeenCalledTimes(1);
+		// rowClickHint 미지정이어도 기본 힌트로 affordance 유지
+		const describedby = row.getAttribute("aria-describedby");
+		expect(describedby).toBeTruthy();
+		expect(document.getElementById(describedby as string)?.textContent).toBe("클릭 가능한 행");
+	});
+
+	it("suppresses the row hint when rowClickHint is an empty string", () => {
+		const { container } = render(
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				onRowClick={() => {}}
+				rowClickHint=""
+			/>,
+		);
+		expect(container.querySelector(".table_row")).not.toHaveAttribute("aria-describedby");
 	});
 
 	it("describes clickable rows via aria-describedby (rowClickHint), not aria-label", () => {

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -78,8 +78,13 @@ export type TableProps<T extends object> = {
 	className?: string;
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
-	/** clickable 행(onRowClick)의 aria-label - 스크린리더에 행의 동작을 알림 (예: (row) => `${row.name} 상세로 이동`) */
-	rowClickAriaLabel?: (item: T, index: number) => string;
+	/**
+	 * clickable 행(onRowClick)의 동작 설명. 지정 시 각 clickable 행에 `aria-describedby` 로 연결된다.
+	 * `aria-label` 대신 `aria-describedby` 를 쓰는 이유: `<tr>` 의 `aria-label` 은 행/셀의 accessible name 을
+	 * 덮어써 스크린리더가 셀 데이터를 못 읽는다. describedby 는 셀 낭독을 유지하며 동작만 덧붙인다.
+	 * (예: "행을 선택하면 상세 항목으로 이동합니다")
+	 */
+	rowClickHint?: string;
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
 	sort?: TableSort;
 	/** 정렬 가능한 헤더 클릭 시 발화 (none→asc→desc→none 순환). DS는 데이터를 직접 정렬하지 않음 - 정렬된 `data` 를 다시 전달해야 함 */
@@ -108,7 +113,7 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
-	rowClickAriaLabel,
+	rowClickHint,
 	sort,
 	onSortChange,
 	selectAllAriaLabel = "전체 선택",
@@ -130,6 +135,8 @@ export const Table = <T extends object>({
 	// ── Row selection ──────────────────────────────────────────────────────
 	const getRowKey = (item: T, index: number) => rowKey?.(item) ?? String(index);
 	const allRowKeys = selectable ? data.map((item, index) => getRowKey(item, index)) : [];
+	// clickable 행 동작 힌트를 aria-describedby 로 연결할 visually-hidden 요소 id
+	const rowClickHintId = React.useId();
 	const selectedSet = React.useMemo(() => new Set(selectedKeys ?? []), [selectedKeys]);
 	const selectedCount = allRowKeys.filter((key) => selectedSet.has(key)).length;
 	const isAllSelected = allRowKeys.length > 0 && selectedCount === allRowKeys.length;
@@ -265,13 +272,11 @@ export const Table = <T extends object>({
 											isSelected && "table_row_selected",
 										)}
 										aria-selected={isSelected ? "true" : undefined}
-										// 비-selectable clickable 행엔 role="button" 으로 기본 인터랙티브 affordance 제공
-										// (aria-selected 가 없어 무효 조합 아님). selectable 행은 aria-selected 와 충돌하므로 role 생략 -
-										// 체크박스가 1차 affordance. rowClickAriaLabel 로 서술형 접근성 이름을 덧붙일 수 있다.
-										role={onRowClick && !selectable ? "button" : undefined}
-										aria-label={
-											onRowClick && rowClickAriaLabel ? rowClickAriaLabel(item, rowIndex) : undefined
-										}
+										// clickable 행은 role/aria-label 을 tr 에 붙이지 않는다 (role="button" 은 셀을
+										// presentational 로, aria-label 은 셀 이름을 덮어써 스크린리더가 데이터를 못 읽음).
+										// 대신 focus 가능(tabIndex) + Enter/Space 로 동작하고, 동작 설명은 rowClickHint 를
+										// aria-describedby 로 덧붙여 셀 낭독을 유지한다.
+										aria-describedby={onRowClick && rowClickHint ? rowClickHintId : undefined}
 										tabIndex={onRowClick ? 0 : undefined}
 										onClick={onRowClick ? () => onRowClick(item, rowIndex) : undefined}
 										onKeyDown={
@@ -318,6 +323,12 @@ export const Table = <T extends object>({
 							})}
 				</tbody>
 			</table>
+
+			{onRowClick && rowClickHint && (
+				<span id={rowClickHintId} className="table_sr_only">
+					{rowClickHint}
+				</span>
+			)}
 
 			{isEmpty && (
 				<div className="table_empty" role="status">

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -79,10 +79,11 @@ export type TableProps<T extends object> = {
 	/** 행 클릭 콜백 */
 	onRowClick?: (item: T, index: number) => void;
 	/**
-	 * clickable 행(onRowClick)의 동작 설명. 지정 시 각 clickable 행에 `aria-describedby` 로 연결된다.
-	 * `aria-label` 대신 `aria-describedby` 를 쓰는 이유: `<tr>` 의 `aria-label` 은 행/셀의 accessible name 을
-	 * 덮어써 스크린리더가 셀 데이터를 못 읽는다. describedby 는 셀 낭독을 유지하며 동작만 덧붙인다.
-	 * (예: "행을 선택하면 상세 항목으로 이동합니다")
+	 * clickable 행(onRowClick)의 동작 설명. 각 clickable 행에 `aria-describedby` 로 연결된다 (기본값: "클릭 가능한 행").
+	 * 행마다 셀 데이터가 이미 행을 식별하므로 여기엔 동작만 담으면 된다 (예: "선택하면 상세 항목으로 이동").
+	 * `""`(빈 문자열)로 두면 힌트를 붙이지 않는다.
+	 * `aria-label` 대신 `aria-describedby` 를 쓰는 이유: `<tr>` 의 `aria-label`/`role="button"` 은 행/셀의
+	 * accessible name 을 덮거나 셀을 presentational 로 만들어 스크린리더가 셀 데이터를 못 읽는다.
 	 */
 	rowClickHint?: string;
 	/** 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 */
@@ -113,7 +114,7 @@ export const Table = <T extends object>({
 	ariaLabel,
 	className,
 	onRowClick,
-	rowClickHint,
+	rowClickHint = "클릭 가능한 행",
 	sort,
 	onSortChange,
 	selectAllAriaLabel = "전체 선택",

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -8,6 +8,19 @@
   background: token.$color_bg_solid;
 }
 
+// 스크린리더 전용(시각적으로 숨김) - clickable 행 동작 힌트를 aria-describedby 로 노출할 때 사용
+.table_sr_only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## 작업 개요
v3.4.1 릴리즈 PR(#362) 리뷰에서 gemini High 로 지적된 Table clickable-row 접근성 결함 재설계. (v3.4.1 에 포함)

## 문제 (gemini High)
`<tr>` 에 `role="button"` 을 주면 행이 버튼 위젯이 되어 하위 셀이 presentational 로 처리되고, `aria-label` 을 주면 행/셀의 accessible name 을 덮어써 — 두 경우 모두 **스크린리더가 셀 데이터를 읽지 못함**.

## 재설계
- `<tr>` 에 `role="button"`/`aria-label` **부여하지 않음** (셀 낭독 보존)
- clickable 행은 `tabIndex` + `onKeyDown`(Enter/Space) 으로 키보드 조작 유지
- 동작 설명은 `rowClickHint` prop 을 **`aria-describedby`** 로 연결(visually-hidden 요소) — accessible name 을 덮지 않고 설명만 덧붙임
- `rowClickAriaLabel`(footgun) 제거 → `rowClickHint?: string` 로 교체 (아직 미배포 prop 이라 호환 영향 없음)

## 검증
- `pnpm test` 49파일 699 pass · `pnpm build` · `pnpm lint:css` green
- 테스트: 셀 데이터 낭독 유지, role/aria-label 미부여, aria-describedby 연결, Enter 동작