### PR TITLE
config/claude-review-otel-marker

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -72,6 +72,14 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    # OTel resource 마커 - Claude Code 텔레메트리에서 이 워커를 분류(그룹핑)한다.
+    # 러너가 실행마다 새 user.id 를 만들어 인트라넷 /admin/claude-usage 검역소에 휘발 설치로
+    # 쌓이는 것을 막고, bt.worker 로 CI 코드리뷰 워커를 우선 판별한다 (intranet PR #2307).
+    # 주의: self-asserted 분류 라벨이며 신뢰/인증 경계가 아니다 - 검역소는 이 마커를 그룹핑
+    #       용도로만 써야 한다 (워크플로 수정 가능자면 누구나 동일 마커 부착 가능).
+    # job-level 로 두어 두 claude-code-action 스텝(Review / Answer inline thread)에 함께 적용.
+    env:
+      OTEL_RESOURCE_ATTRIBUTES: bt.worker=coderev
     steps:
       # secret 미설정이면 리뷰 단계를 조용히 skip (첫 셋업 전 PR 에서 빨간 X 방지).
       # secret 은 job `if:` 에서 못 읽으므로 step 에서 존재 여부만 output 으로 넘긴다.


### PR DESCRIPTION
## 작업 개요
#364(moonjiho, base=main)의 OTel worker 마커 로직을 리뷰 반영 + 컨벤션(base=develop)에 맞춰 재작성.

## 배경
claude-review 워커가 러너 실행마다 새 `user.id` 를 만들어 인트라넷 `/admin/claude-usage` 검역소에 휘발 설치로 쌓임. `OTEL_RESOURCE_ATTRIBUTES=bt.worker=coderev` 마커로 CI 코드리뷰 워커를 분류.

## 작업한 내용
- [x] `OTEL_RESOURCE_ATTRIBUTES: bt.worker=coderev` 를 **job-level `env`** 로 추가 (#364 는 두 스텝에 동일 env 중복 → job-level 하나로 정리, DRY. 두 claude-code-action 스텝 모두 적용)
- [x] 마커가 **분류 라벨(신뢰/인증 경계 아님)** 임을 주석으로 명시 — 리뷰 봇 지적 반영(검역소가 이걸 신뢰 경계로 오용하면 워크플로 수정 가능자가 스푸핑 가능)
- [x] **base=develop** (컨벤션) — 정식 릴리즈 경로로 main 에 반영돼 develop/main claude-review.yml 드리프트 방지

## 참고 (인트라넷 팀 확인)
- 이 레포엔 OTel 활성화 설정(`OTEL_EXPORTER_OTLP_ENDPOINT` 등)이 없음 → 마커 소비는 org/인트라넷 수집기 전제 (intranet PR #2307)
- 기본 브랜치는 main 이라 comment 트리거(`@claude re-review`)는 main 반영 후 이 마커가 붙음

## 전달할 추가 이슈
- #364 는 이 PR 로 대체 가능 (base=main→develop 정렬 + env DRY). moonjiho 와 조율 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 코드 리뷰 자동화 작업에 관측성 메타데이터를 추가했습니다.
  * 관련 자동화 단계가 텔레메트리에서 일관된 작업 유형으로 분류되도록 개선했습니다.
  * 리뷰 및 인라인 답변 처리 흐름의 모니터링과 분석이 더욱 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->