### PR TITLE
fix/alert

### DIFF
--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AlertProvider, useAlert } from "./index";
 
@@ -185,5 +185,29 @@ describe("Alert", () => {
 
 		const actions = screen.getByRole("alertdialog").querySelector(".alert_actions");
 		expect(actions).toHaveClass("alert_actions_center");
+	});
+
+	it("activates the focus trap when opened via showAlert (mounted closed)", () => {
+		// AlertProvider 는 AlertModal 을 항상 isOpen=false 로 마운트해 두고 showAlert() 로 연다.
+		// 이 deferred-mount 경로에서도 트랩이 걸려 초기 포커스가 alertdialog 안으로 이동해야 함.
+		renderWithProvider(<TestComponent options={{ title: "Trap", showCancel: true }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+
+		const dialog = screen.getByRole("alertdialog");
+		expect(dialog.contains(document.activeElement)).toBe(true);
+	});
+
+	it("closes on Escape after opening via showAlert", async () => {
+		// 포커스가 alertdialog 안에 있어야 overlay onKeyDown 까지 버블되어 Escape 가 동작한다
+		// (트랩 미활성 시 포커스가 트리거에 남아 Escape 가 절대 발화하지 않던 회귀 방지).
+		renderWithProvider(<TestComponent options={{ title: "Esc" }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
+		// 퇴출 spring 애니메이션 완료 후 unmount 되므로 대기
+		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
 	});
 });

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -136,9 +136,12 @@ const AlertModal: React.FC<AlertModalProps> = ({
 
 	useFocusTrap(panelRef, isOpen);
 
-	React.useEffect(() => {
-		if (isOpen) setShouldRender(true);
-	}, [isOpen]);
+	// isOpen 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다 (Modal 과 동일한
+	// React "render 중 상태 조정" 패턴). effect 로 미루면 패널 마운트가 한 렌더 늦어져
+	// useFocusTrap effect 실행 시점에 panelRef.current 가 null 이라 트랩(초기 포커스 이동·
+	// Tab 격리·포커스 복원)이 전혀 걸리지 않는다 — AlertProvider 는 항상 isOpen=false 로
+	// 마운트해 두고 showAlert() 로 여는 구조라 모든 useAlert() 경로에서 재현되는 버그였다.
+	if (isOpen && !shouldRender) setShouldRender(true);
 
 	const overlayStyle = useSpring({
 		opacity: isOpen ? 1 : 0,
@@ -154,7 +157,9 @@ const AlertModal: React.FC<AlertModalProps> = ({
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 	});
 
-	if (!shouldRender) return null;
+	// isOpen 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
+	// panelRef.current 가 붙어 있다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
+	if (!isOpen && !shouldRender) return null;
 
 	// destructive: confirm을 빨간 filled(danger)로 강조 - 위험성을 시각적으로 표현
 	// (Material/shadcn/Radix 표준 - 빨간 버튼 = 위험한 액션)


### PR DESCRIPTION
## 작업 개요

전체 DS 감사에서 확정된 HIGH 접근성 버그 수정 — AlertModal 의 포커스 트랩이 `showAlert()` 로 여는 모든 경로에서 활성화되지 않던 문제.

`AlertProvider` 는 `AlertModal` 을 항상 `isOpen=false` 로 마운트해 두고 `showAlert()` 로 여는 구조인데, `shouldRender` 를 effect 에서 올리다 보니 `isOpen` 이 true 로 바뀌는 렌더에서 패널이 아직 DOM 에 없어 `useFocusTrap` effect 가 `panelRef.current === null` 로 조기 종료됨. 이후 패널이 마운트돼도 트랩 effect 는 재실행되지 않아:

- 초기 포커스가 alertdialog 안으로 이동하지 않음 (WAI-ARIA APG Alert Dialog 위반)
- Tab 이 배경 콘텐츠로 빠져나감 (`aria-modal=true` 인데 격리 안 됨)
- 닫을 때 포커스 복원 없음
- 포커스가 트리거에 남아 overlay `onKeyDown` 의 Escape 가 절대 발화하지 않음

v3.4.0 에서 Modal/Drawer 에 적용한 것과 동일한 버그로, Alert 만 수정이 누락돼 있었음.

## 작업한 내용
- [x] `AlertModal` 에 Modal/Drawer 와 동일한 render-phase 상태 조정 패턴 적용 (`if (isOpen && !shouldRender) setShouldRender(true)`)
- [x] 언마운트 가드를 `(!isOpen && !shouldRender)` 로 변경 — 퇴출 애니메이션 동안 마운트 유지
- [x] 회귀 테스트 2건 추가: deferred-mount 포커스 트랩 활성화 / Escape 닫힘 (퇴출 spring 대기 포함)
- [x] 유닛 702 passed · 빌드 통과

## 전달할 추가 이슈
- 같은 감사에서 나온 나머지 발견사항(Vanilla 번들 토큰 자기참조·Select 서버마크업 미파싱, Tooltip WCAG 1.4.13, Toast 타이밍 등)은 별도 이슈/PR 로 진행 예정
- notiiv 모노레포는 useAlert 19회 사용 중 — 이 수정 포함 버전으로 업그레이드 권장


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알림 모달이 동적으로 열릴 때도 포커스 트랩이 안정적으로 활성화되도록 개선했습니다.
  * 모달 내부에서 `Escape` 키를 누르면 알림 모달이 정상적으로 닫히도록 수정했습니다.
  * 닫힘 애니메이션이 완료될 때까지 모달이 유지되어 전환이 더 자연스러워졌습니다.

* **테스트**
  * 동적 열기, 포커스 트랩, `Escape` 키를 통한 비동기 닫힘 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->