### PR TITLE
fix/vanilla

### DIFF
--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -300,13 +300,24 @@ npm install @bigtablet/design-system
 
 **폼 제출 참여 (Thymeleaf/JSP):**
 
-`data-name` 을 지정하면 hidden input 이 생성되어 on/off(`"true"`/`"false"`)가
-폼 POST 에 포함됩니다. `role="switch"` + `aria-checked` 는 자동으로 관리됩니다.
+`data-name` 을 지정하면 hidden input 이 생성되어 on/off 가 폼 POST 에 포함됩니다.
+전송 값은 `"true"`/`"false"` 이며, `role="switch"` + `aria-checked` 는 자동으로 관리됩니다.
+`<button>` 은 내부에 폼 요소를 자식으로 둘 수 없어 hidden input 은 버튼의 **형제**로 삽입됩니다.
+
+서버 템플릿이 초기값 hidden input 을 미리 렌더링한 경우 그 값을 읽어 초기 상태를 맞추며,
+`"true"` 외에 `"1"`/`"on"`/`"y"`/`"yes"`(대소문자 무시)도 켜짐으로 인식합니다.
 
 ```html
+<!-- data-name 으로 자동 생성 -->
 <button type="button" class="bt-toggle" data-bt-toggle data-name="notifications">
   <span class="bt-toggle__thumb"></span>
 </button>
+
+<!-- 또는 서버 렌더링 초기값(형제 hidden input) -->
+<button type="button" class="bt-toggle" data-bt-toggle>
+  <span class="bt-toggle__thumb"></span>
+</button>
+<input type="hidden" name="notifications" th:value="${enabled}">
 ```
 
 ---

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -250,21 +250,21 @@ npm install @bigtablet/design-system
 
 ```html
 <!-- 기본 (Off) -->
-<button class="bt-toggle" data-bt-toggle>
+<button type="button" class="bt-toggle" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 
 <!-- On 상태 -->
-<button class="bt-toggle bt-toggle--on" data-bt-toggle>
+<button type="button" class="bt-toggle bt-toggle--on" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 
 <!-- Sizes -->
-<button class="bt-toggle" data-bt-toggle>...</button>  <!-- 기본 sm -->
-<button class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
+<button type="button" class="bt-toggle" data-bt-toggle>...</button>  <!-- 기본 sm -->
+<button type="button" class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
 
 <!-- 비활성화 -->
-<button class="bt-toggle bt-toggle--disabled" data-bt-toggle>
+<button type="button" class="bt-toggle bt-toggle--disabled" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 ```
@@ -272,7 +272,7 @@ npm install @bigtablet/design-system
 **JavaScript 연동:**
 
 ```html
-<button class="bt-toggle" data-bt-toggle id="my-toggle">
+<button type="button" class="bt-toggle" data-bt-toggle id="my-toggle">
   <span class="bt-toggle__thumb"></span>
 </button>
 
@@ -293,6 +293,20 @@ npm install @bigtablet/design-system
   myToggle.setChecked(true); // 상태 설정
   myToggle.toggle();        // 토글
 </script>
+```
+
+> `type="button"` 을 반드시 지정하세요 - 폼 안에서 기본 type(submit)이면 토글 클릭이
+> 폼을 제출합니다 (JS 초기화 시 자동 보정되지만 JS 로드 전 클릭은 막지 못합니다).
+
+**폼 제출 참여 (Thymeleaf/JSP):**
+
+`data-name` 을 지정하면 hidden input 이 생성되어 on/off(`"true"`/`"false"`)가
+폼 POST 에 포함됩니다. `role="switch"` + `aria-checked` 는 자동으로 관리됩니다.
+
+```html
+<button type="button" class="bt-toggle" data-bt-toggle data-name="notifications">
+  <span class="bt-toggle__thumb"></span>
+</button>
 ```
 
 ---
@@ -317,6 +331,22 @@ npm install @bigtablet/design-system
     <li class="bt-select__option is-disabled" data-value="mango">망고 (품절)</li>
     <li class="bt-select__option" data-value="orange">오렌지</li>
   </ul>
+</div>
+```
+
+옵션은 위처럼 서버가 렌더링한 `<li data-value>` 마크업에서 자동 파싱됩니다
+(`data-options` JSON 속성 또는 JS `options` 설정이 있으면 그쪽이 우선).
+
+**폼 제출 참여 (Thymeleaf/JSP):**
+
+`data-name` 을 지정하면 hidden input 이 생성되어 선택 값이 폼 POST 에 포함됩니다.
+서버 템플릿이 `.bt-select` 안에 hidden input 을 미리 렌더링해 두면 (예: `th:field`)
+그 input 의 name/초기값을 그대로 이어받아 표시·동기화합니다.
+
+```html
+<div class="bt-select" data-bt-select data-name="fruit">
+  <!-- 또는 서버 바인딩: <input type="hidden" th:field="*{fruit}"> -->
+  ...
 </div>
 ```
 

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -103,15 +103,27 @@
 		// Parse options: data-options JSON > JS config > 서버 렌더링된 <li data-value> 마크업.
 		// Thymeleaf/JSP 처럼 서버가 옵션 li 를 직접 렌더링하는 경우(문서화된 기본 마크업)를
 		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
-		const optionsData = wrapper.dataset.options
-			? JSON.parse(wrapper.dataset.options)
-			: (config.options && config.options.length
-				? config.options
-				: $$(".bt-select__option", list).map((el) => ({
-						value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
-						label: el.textContent.trim(),
-						disabled: el.classList.contains("is-disabled"),
-					})));
+		// data-options 는 잘못된 JSON(작은따옴표 등)이면 스크립트 전체가 크래시하므로 방어적 파싱.
+		const parseDomOptions = () =>
+			$$(".bt-select__option", list).map((el) => ({
+				value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
+				label: el.textContent.trim(),
+				disabled: el.classList.contains("is-disabled"),
+			}));
+
+		let optionsData;
+		if (wrapper.dataset.options) {
+			try {
+				const parsed = JSON.parse(wrapper.dataset.options);
+				optionsData = Array.isArray(parsed) ? parsed : (console.warn("Select: data-options is not a JSON array"), []);
+			} catch (e) {
+				console.warn("Select: invalid JSON in data-options", e);
+				optionsData = [];
+			}
+		}
+		if (!optionsData || optionsData.length === 0) {
+			optionsData = config.options && config.options.length ? config.options : parseDomOptions();
+		}
 
 		state.options = optionsData;
 
@@ -130,7 +142,9 @@
 		// State management
 		function setValue(newValue) {
 			state.value = newValue;
-			const option = state.options.find((o) => o.value === newValue);
+			// String 비교 - 서버 hidden input 초기값(항상 문자열)과 JS config 의 숫자 value 가
+			// 섞여도 매칭되도록 (엄격 === 이면 조용히 placeholder 로 남던 문제 방지).
+			const option = state.options.find((o) => String(o.value) === String(newValue));
 
 			// 폼 제출용 hidden input 동기화
 			if (hiddenInput) {
@@ -152,7 +166,7 @@
 
 			// Update selected state in list
 			$$(".bt-select__option", list).forEach((el, i) => {
-				el.classList.toggle("is-selected", state.options[i]?.value === newValue);
+				el.classList.toggle("is-selected", String(state.options[i]?.value) === String(newValue));
 			});
 
 			if (config.onChange) {
@@ -568,14 +582,24 @@
 		}
 
 		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 on/off 를 노출.
-		// 서버 템플릿이 미리 렌더링한 hidden input 이 있으면 재사용한다.
-		let hiddenInput = toggleEl.querySelector('input[type="hidden"]');
+		// toggleEl 이 <button> 이면 그 안에 대화형 콘텐츠/폼 요소를 자식으로 둘 수 없어(invalid
+		// HTML) hidden input 을 형제(sibling)로 삽입한다. 서버 템플릿이 미리 렌더링해둔 hidden
+		// input(자식이든 형제든)이 있으면 재사용한다.
 		const fieldName = config.name || toggleEl.dataset.name || null;
+		let hiddenInput =
+			toggleEl.querySelector('input[type="hidden"]') ||
+			(fieldName && toggleEl.parentNode
+				? toggleEl.parentNode.querySelector(`input[type="hidden"][name="${fieldName}"]`)
+				: null);
 		if (!hiddenInput && fieldName) {
 			hiddenInput = document.createElement("input");
 			hiddenInput.type = "hidden";
 			hiddenInput.name = fieldName;
-			toggleEl.appendChild(hiddenInput);
+			if (toggleEl.tagName === "BUTTON" && toggleEl.parentNode) {
+				toggleEl.parentNode.insertBefore(hiddenInput, toggleEl.nextSibling);
+			} else {
+				toggleEl.appendChild(hiddenInput);
+			}
 		}
 
 		function setChecked(checked) {
@@ -600,10 +624,14 @@
 
 		const cleanup = on(toggleEl, "click", toggle);
 
-		// Initialize - aria-checked/hidden input 을 초기 상태와 동기화
-		if (hiddenInput && hiddenInput.value === "true" && !state.checked) {
-			// 서버 바인딩 초기값(on)을 표시에 반영
-			state.checked = true;
+		// Initialize - aria-checked/hidden input 을 초기 상태와 동기화.
+		// 서버 템플릿이 boolean 을 "true" 외 표현("1"/"on"/"y"/"yes")으로 렌더링해도
+		// 켜짐으로 인식하도록 관대하게 파싱 (Thymeleaf/JSP 등 표현 차이 흡수).
+		if (hiddenInput && !state.checked) {
+			const raw = String(hiddenInput.value).trim().toLowerCase();
+			if (raw === "true" || raw === "1" || raw === "on" || raw === "y" || raw === "yes") {
+				state.checked = true;
+			}
 		}
 		toggleEl.classList.toggle("bt-toggle--on", state.checked);
 		toggleEl.setAttribute("aria-checked", state.checked ? "true" : "false");

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -88,13 +88,6 @@
 			options: [],
 		};
 
-		// Parse options from data attributes or config
-		const optionsData = wrapper.dataset.options
-			? JSON.parse(wrapper.dataset.options)
-			: config.options || [];
-
-		state.options = optionsData;
-
 		// Create DOM structure
 		const controlId = wrapper.id || generateId("select");
 		const _listId = `${controlId}_listbox`;
@@ -107,10 +100,42 @@
 			return null;
 		}
 
+		// Parse options: data-options JSON > JS config > 서버 렌더링된 <li data-value> 마크업.
+		// Thymeleaf/JSP 처럼 서버가 옵션 li 를 직접 렌더링하는 경우(문서화된 기본 마크업)를
+		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
+		const optionsData = wrapper.dataset.options
+			? JSON.parse(wrapper.dataset.options)
+			: (config.options && config.options.length
+				? config.options
+				: $$(".bt-select__option", list).map((el) => ({
+						value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
+						label: el.textContent.trim(),
+						disabled: el.classList.contains("is-disabled"),
+					})));
+
+		state.options = optionsData;
+
+		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 값을 노출한다.
+		// 서버 템플릿(th:field 등)이 미리 렌더링한 hidden input 이 있으면 그대로 재사용 -
+		// name/초기값을 서버 바인딩에서 이어받는다.
+		let hiddenInput = wrapper.querySelector('input[type="hidden"]');
+		const fieldName = config.name || wrapper.dataset.name || null;
+		if (!hiddenInput && fieldName) {
+			hiddenInput = document.createElement("input");
+			hiddenInput.type = "hidden";
+			hiddenInput.name = fieldName;
+			wrapper.appendChild(hiddenInput);
+		}
+
 		// State management
 		function setValue(newValue) {
 			state.value = newValue;
 			const option = state.options.find((o) => o.value === newValue);
+
+			// 폼 제출용 hidden input 동기화
+			if (hiddenInput) {
+				hiddenInput.value = newValue == null ? "" : newValue;
+			}
 
 			const valueEl = control.querySelector(".bt-select__value, .bt-select__placeholder");
 			if (valueEl) {
@@ -310,6 +335,9 @@
 		list.style.display = "none";
 		if (config.defaultValue) {
 			setValue(config.defaultValue);
+		} else if (hiddenInput && hiddenInput.value) {
+			// 서버 바인딩(th:field 등)이 넣어 둔 초기값을 표시에 반영
+			setValue(hiddenInput.value);
 		}
 
 		// Public API
@@ -532,9 +560,32 @@
 			checked: config.defaultChecked || toggleEl.classList.contains("bt-toggle--on"),
 		};
 
+		// Switch 시맨틱 (React Toggle 과 패리티): role + aria-checked 를 항상 유지
+		if (!toggleEl.hasAttribute("role")) toggleEl.setAttribute("role", "switch");
+		// 폼 안에서 클릭이 submit 으로 새지 않도록 (button 기본 type=submit)
+		if (toggleEl.tagName === "BUTTON" && !toggleEl.hasAttribute("type")) {
+			toggleEl.setAttribute("type", "button");
+		}
+
+		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 on/off 를 노출.
+		// 서버 템플릿이 미리 렌더링한 hidden input 이 있으면 재사용한다.
+		let hiddenInput = toggleEl.querySelector('input[type="hidden"]');
+		const fieldName = config.name || toggleEl.dataset.name || null;
+		if (!hiddenInput && fieldName) {
+			hiddenInput = document.createElement("input");
+			hiddenInput.type = "hidden";
+			hiddenInput.name = fieldName;
+			toggleEl.appendChild(hiddenInput);
+		}
+
 		function setChecked(checked) {
 			state.checked = checked;
 			toggleEl.classList.toggle("bt-toggle--on", checked);
+			toggleEl.setAttribute("aria-checked", checked ? "true" : "false");
+
+			if (hiddenInput) {
+				hiddenInput.value = checked ? "true" : "false";
+			}
 
 			if (config.onChange) {
 				config.onChange(checked);
@@ -549,10 +600,14 @@
 
 		const cleanup = on(toggleEl, "click", toggle);
 
-		// Initialize
-		if (config.defaultChecked) {
-			setChecked(true);
+		// Initialize - aria-checked/hidden input 을 초기 상태와 동기화
+		if (hiddenInput && hiddenInput.value === "true" && !state.checked) {
+			// 서버 바인딩 초기값(on)을 표시에 반영
+			state.checked = true;
 		}
+		toggleEl.classList.toggle("bt-toggle--on", state.checked);
+		toggleEl.setAttribute("aria-checked", state.checked ? "true" : "false");
+		if (hiddenInput) hiddenInput.value = state.checked ? "true" : "false";
 
 		return {
 			isChecked: () => state.checked,

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -5,6 +5,12 @@
 
 @use "../styles/token" as token;
 
+// theme.scss 를 반드시 포함한다. 색상 SCSS 토큰(token.$color_*)은 리터럴이 아니라
+// `var(--bt-color-*)` 간접 참조라, 그 var 정의(:root light + dark 테마)가 theme 에 있다.
+// 없으면 아래 :root 의 색 토큰이 전부 미정의 var 로 무효화된다 (자기참조 순환 포함).
+// 포함하면 [data-theme="dark"] / prefers-color-scheme 다크 테마도 함께 동작한다.
+@use "../styles/theme";
+
 /* ========================================
    CSS Custom Properties (Design Tokens)
    ======================================== */
@@ -15,24 +21,19 @@
 
   /* Colors - Accent (light=검정/dark=흰 자동 반전 - indicator/checked/focus 강조) */
   --bt-color-accent: #{token.$color_accent_default};
-  --bt-color-accent-on-surface: #{token.$color_accent_on_surface};
 
   /* Colors - Background */
   --bt-color-background: #{token.$color_bg_solid};
   --bt-color-background-dim: #{token.$color_bg_solid_dim};
   --bt-color-background-overlay: #{token.$color_bg_overlay};
 
-  /* Colors - Text */
-  --bt-color-text-heading: #{token.$color_text_heading};
-  --bt-color-text-body: #{token.$color_text_body};
-  --bt-color-text-caption: #{token.$color_text_caption};
-  --bt-color-text-inverse: #{token.$color_text_inverse};
-  --bt-color-text-disabled: #{token.$color_text_disabled};
+  /* Colors - Text/Border 원 토큰(--bt-color-text-heading, --bt-color-border-subtle 등)은
+     theme.scss 가 정의한다. 여기서 같은 이름으로 재선언하면
+     `--bt-color-text-heading: var(--bt-color-text-heading)` 자기참조 순환이 되어
+     theme 정의까지 덮어 무효화되므로 재선언 금지 (아래 Semantic alias 로만 노출). */
 
   /* Colors - Border */
   --bt-color-border: #{token.$color_border_default};
-  --bt-color-border-subtle: #{token.$color_border_subtle};
-  --bt-color-border-focus: #{token.$color_border_focus};
 
   /* Colors - Text Semantic */
   --bt-color-text-primary: var(--bt-color-text-heading);


### PR DESCRIPTION
## 작업 개요

전체 DS 감사에서 확정된 Vanilla 번들 HIGH 결함 3건 수정 — **단독 사용(Thymeleaf/JSP) 시 사실상 동작하지 않던 상태**를 복구.

## 작업한 내용
- [x] **CSS 토큰 전멸 수정**: 색상 SCSS 토큰은 `var(--bt-color-*)` 간접 참조인데 그 정의(theme.scss)가 vanilla 번들에 미포함 → 전 색상 무효화 + 8개는 자기참조 순환(`--bt-color-text-heading: var(--bt-color-text-heading)`). `bigtablet.scss` 에 theme.scss 포함 + 충돌 재선언 8줄 제거. **다크 테마(`[data-theme="dark"]` / `prefers-color-scheme`)도 함께 지원됨**
- [x] **Select 서버 마크업 파싱**: 문서화된 `<li data-value>` 마크업을 JS 가 전혀 읽지 않아 마우스/키보드 어느 쪽으로도 선택 불가였음 → `data-options` JSON > JS config > DOM `<li>` 파싱 순 폴백 추가
- [x] **폼 제출 참여**: Select/Toggle 이 name 있는 폼 요소를 노출하지 않아 폼 POST 시 값 유실·`th:field` 바인딩 불가 → `data-name`(또는 서버가 렌더링한 hidden input 재사용)으로 hidden input 생성·동기화, 서버 바인딩 초기값도 반영
- [x] Toggle `role="switch"` + `aria-checked` 자동 관리 (React 버전과 패리티), `type="button"` 방어적 설정
- [x] docs/VANILLA.md: 토글 예시 전부 `type="button"` 추가, Select/Toggle 폼 참여·서버 마크업 파싱 사용법 문서화

## 검증 (라이브 브라우저 실측)
- 버튼 배경 `rgb(18,18,18)` 렌더 (수정 전: transparent)
- 컴파일된 min.css 에 자기참조/미정의 `--bt-*` 변수 0개
- `<li data-value>` 마크업 Select: 열기→옵션 클릭→라벨/`is-selected` 갱신 확인
- `data-name` hidden input: name=`fruit`, value 동기화 확인
- `data-theme="dark"` 에서 `--bt-color-background: #0A0A0A` 등 정상 해석
- 유닛 700 passed · vanilla 빌드 통과 · `node --check` 통과

## 전달할 추가 이슈
- Vanilla Select 의 combobox ARIA(aria-expanded/listbox role 등)와 Modal 포커스 트랩은 별도 후속 작업 (이번 PR 은 "동작 자체가 안 되던" 결함에 한정)
- 감사의 나머지 medium 발견(FOUC용 select list CSS 숨김, init() 중복 바인딩 가드 등)도 후속 처리 예정
