### PR TITLE
fix/forms

### DIFF
--- a/src/ui/forms/checkbox/index.tsx
+++ b/src/ui/forms/checkbox/index.tsx
@@ -50,13 +50,15 @@ export const Checkbox = ({
 
 	return (
 		<label className={rootClassName}>
-			{/* error 는 시각 표시만으로는 AT 에 전달되지 않으므로 aria-invalid 로 노출 (WCAG 4.1.2) */}
+			{/* {...props} 를 먼저 펼쳐 소비자 값은 통과시키되 type/className/aria-invalid 는
+			    컴포넌트가 항상 이기도록 뒤에 배치 (Toggle 과 동일한 스프레드 순서).
+			    error 는 시각 표시만으로는 AT 에 전달되지 않으므로 aria-invalid 로 노출 (WCAG 4.1.2) */}
 			<input
+				{...props}
 				ref={inputRef}
 				type="checkbox"
 				className="checkbox_input"
 				aria-invalid={error || undefined}
-				{...props}
 			/>
 			<span className="checkbox_state_layer" aria-hidden="true">
 				<span className="checkbox_icon" />

--- a/src/ui/forms/checkbox/index.tsx
+++ b/src/ui/forms/checkbox/index.tsx
@@ -50,7 +50,14 @@ export const Checkbox = ({
 
 	return (
 		<label className={rootClassName}>
-			<input ref={inputRef} type="checkbox" className="checkbox_input" {...props} />
+			{/* error 는 시각 표시만으로는 AT 에 전달되지 않으므로 aria-invalid 로 노출 (WCAG 4.1.2) */}
+			<input
+				ref={inputRef}
+				type="checkbox"
+				className="checkbox_input"
+				aria-invalid={error || undefined}
+				{...props}
+			/>
 			<span className="checkbox_state_layer" aria-hidden="true">
 				<span className="checkbox_icon" />
 			</span>

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -422,10 +422,12 @@ describe("Dropdown", () => {
 		const button = screen.getByRole("button");
 		expect(button).toHaveAttribute("aria-haspopup", "listbox");
 		expect(button).toHaveAttribute("aria-expanded", "false");
-		expect(button).toHaveAttribute("aria-controls", "dd-1_listbox");
+		// 닫힌 상태에서는 listbox 가 unmount 라 aria-controls 를 달지 않는다 (dangling IDREF 방지)
+		expect(button).not.toHaveAttribute("aria-controls");
 
 		fireEvent.click(button);
 		expect(button).toHaveAttribute("aria-expanded", "true");
+		expect(button).toHaveAttribute("aria-controls", "dd-1_listbox");
 
 		const listbox = screen.getByRole("listbox");
 		expect(listbox).toHaveAttribute("id", "dd-1_listbox");
@@ -700,5 +702,45 @@ describe("Dropdown", () => {
 		const activeId = input.getAttribute("aria-activedescendant");
 		expect(activeId).toBeTruthy();
 		expect(document.getElementById(activeId as string)).toHaveAttribute("role", "option");
+	});
+
+	it("closes the listbox on Tab from the control (APG combobox)", () => {
+		render(<Dropdown options={options} />);
+		const control = screen.getByRole("button");
+		fireEvent.click(control);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		fireEvent.keyDown(control, { key: "Tab" });
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	it("omits aria-controls while closed (no dangling IDREF)", () => {
+		render(<Dropdown options={options} />);
+		const control = screen.getByRole("button");
+		expect(control).not.toHaveAttribute("aria-controls");
+
+		fireEvent.click(control);
+		expect(control).toHaveAttribute("aria-controls");
+	});
+
+	it("renders hidden input(s) for native form submission when name is given", () => {
+		const { container, rerender } = render(
+			<Dropdown options={options} name="fruit" value="1" onValueChange={() => {}} />,
+		);
+		const hidden = container.querySelector('input[type="hidden"][name="fruit"]');
+		expect(hidden).toHaveValue("1");
+
+		// multiple: 같은 name 의 hidden input 반복
+		rerender(
+			<Dropdown
+				options={options}
+				name="fruit"
+				multiple
+				value={["1", "2"]}
+				onValueChange={() => {}}
+			/>,
+		);
+		const hiddens = container.querySelectorAll('input[type="hidden"][name="fruit"]');
+		expect(Array.from(hiddens).map((el) => (el as HTMLInputElement).value)).toEqual(["1", "2"]);
 	});
 });

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -63,6 +63,11 @@ interface DropdownCommonProps {
 	emptyText?: string;
 	/** 멀티 선택 요약 텍스트 (기본값: "N개 선택") */
 	selectedSummary?: (count: number) => string;
+	/**
+	 * 네이티브 폼 제출 참여용 name. 지정 시 선택 값이 hidden input 으로 렌더되어
+	 * `<form>` POST 에 포함됩니다 (multiple 은 같은 name 의 hidden input 반복).
+	 */
+	name?: string;
 }
 
 /** 단일 선택 (기본) */
@@ -118,6 +123,7 @@ export const Dropdown = (props: DropdownProps) => {
 		searchPlaceholder = "검색…",
 		emptyText = "결과 없음",
 		selectedSummary = (count: number) => `${count}개 선택`,
+		name,
 	} = props;
 
 	const multiple = props.multiple === true;
@@ -295,6 +301,10 @@ export const Dropdown = (props: DropdownProps) => {
 				e.preventDefault();
 				setIsOpen(false);
 				break;
+			case "Tab":
+				// APG Combobox: Tab 은 리스트를 닫고 자연스러운 포커스 이동을 허용 (preventDefault 안 함)
+				setIsOpen(false);
+				break;
 		}
 	};
 
@@ -317,6 +327,11 @@ export const Dropdown = (props: DropdownProps) => {
 				break;
 			case "Escape":
 				e.preventDefault();
+				closePanel();
+				break;
+			case "Tab":
+				// APG Combobox: Tab 은 리스트를 닫는다. closePanel 이 트리거로 포커스를
+				// 되돌린 뒤 브라우저 기본 Tab 이동이 이어진다 (preventDefault 안 함).
 				closePanel();
 				break;
 		}
@@ -405,7 +420,8 @@ export const Dropdown = (props: DropdownProps) => {
 					className={cn("dropdown_control", { is_disabled: disabled })}
 					aria-haspopup="listbox"
 					aria-expanded={isOpen}
-					aria-controls={`${dropdownId}_listbox`}
+					// 닫힌 상태에서는 listbox 가 unmount 라 dangling IDREF 방지 위해 열렸을 때만 지정
+					aria-controls={isOpen ? `${dropdownId}_listbox` : undefined}
 					onClick={() => !disabled && setIsOpen((o) => !o)}
 					onKeyDown={onControlKeyDown}
 					disabled={disabled}
@@ -418,6 +434,14 @@ export const Dropdown = (props: DropdownProps) => {
 					</span>
 				</button>
 			</div>
+
+			{/* 네이티브 폼 제출 참여 - name 지정 시 선택 값을 hidden input 으로 노출 */}
+			{name &&
+				(multiple ? (
+					selectedValues.map((v) => <input key={v} type="hidden" name={name} value={v} />)
+				) : (
+					<input type="hidden" name={name} value={selectedValues[0] ?? ""} />
+				))}
 
 			{isOpen && (
 				<animated.div className={listClassName} style={listStyle}>

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -435,12 +435,15 @@ export const Dropdown = (props: DropdownProps) => {
 				</button>
 			</div>
 
-			{/* 네이티브 폼 제출 참여 - name 지정 시 선택 값을 hidden input 으로 노출 */}
+			{/* 네이티브 폼 제출 참여 - name 지정 시 선택 값을 hidden input 으로 노출.
+			    disabled 시 값 전송 제외 (native <select disabled> 처럼 FormData 에서 빠지도록). */}
 			{name &&
 				(multiple ? (
-					selectedValues.map((v) => <input key={v} type="hidden" name={name} value={v} />)
+					selectedValues.map((v) => (
+						<input key={v} type="hidden" name={name} value={v} disabled={disabled} />
+					))
 				) : (
-					<input type="hidden" name={name} value={selectedValues[0] ?? ""} />
+					<input type="hidden" name={name} value={selectedValues[0] ?? ""} disabled={disabled} />
 				))}
 
 			{isOpen && (

--- a/src/ui/forms/otp-input/OtpInput.test.tsx
+++ b/src/ui/forms/otp-input/OtpInput.test.tsx
@@ -54,6 +54,15 @@ describe("OtpInput", () => {
 		expect(onChange).toHaveBeenCalledWith("123456");
 	});
 
+	it("distributes a multi-char value from SMS autofill (onChange with full code)", () => {
+		// autocomplete="one-time-code" 자동입력은 첫 박스 onChange 로 전체 코드가 한 번에 들어옴
+		const onChange = vi.fn();
+		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		fireEvent.change(inputs[0], { target: { value: "123456" } });
+		expect(onChange).toHaveBeenCalledWith("123456");
+	});
+
 	it("handles paste with non-numeric characters", () => {
 		const onChange = vi.fn();
 		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
@@ -375,12 +384,14 @@ describe("OtpInput", () => {
 	});
 
 	describe("Non-digit handling on change", () => {
-		it("rejects multi-character input", () => {
+		it("distributes multi-character input across boxes (SMS autofill)", () => {
+			// 이전엔 멀티문자를 거부했으나, SMS 자동입력이 첫 박스에 전체 코드를 넣으므로
+			// handlePaste 처럼 각 자리에 분배하도록 변경됨.
 			const onChange = vi.fn();
 			render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
 			const inputs = screen.getAllByRole("textbox");
 			fireEvent.change(inputs[0], { target: { value: "12" } });
-			expect(onChange).not.toHaveBeenCalled();
+			expect(onChange).toHaveBeenCalledWith("12");
 		});
 
 		it("allows clearing a digit (empty string)", () => {

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -69,6 +69,19 @@ export const OtpInput = ({
 
 	const handleChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {
 		const nextDigit = e.target.value;
+
+		// SMS/키체인 자동입력(autocomplete="one-time-code")은 첫 박스의 onChange 로 전체 코드가
+		// 한 번에 들어온다. 단일 숫자 정규식에 걸려 무시되지 않도록 handlePaste 처럼 각 자리에 분배.
+		if (nextDigit.length > 1) {
+			const filled = nextDigit.replace(/\D/g, "").slice(0, length);
+			if (!filled) return;
+			const newDigits = [...digits];
+			for (let i = 0; i < filled.length; i++) newDigits[i] = filled[i];
+			updateValue(newDigits);
+			focusInput(Math.min(filled.length, length - 1));
+			return;
+		}
+
 		if (nextDigit && !/^\d$/.test(nextDigit)) return;
 
 		const newDigits = [...digits];

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -136,6 +136,7 @@ export const OtpInput = ({
 	};
 
 	const rootClassName = cn("otp_input", className);
+	const supportingId = React.useId();
 
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: <fieldset> would force border/legend styles; role=group is the WAI-ARIA equivalent for OTP grouping
@@ -152,6 +153,8 @@ export const OtpInput = ({
 						inputMode="numeric"
 						pattern="\d*"
 						maxLength={1}
+						// SMS/키체인의 OTP 자동입력 - 첫 입력에만 지정 (paste 핸들러가 전 자리 분배)
+						autoComplete={i === 0 ? "one-time-code" : "off"}
 						value={digit}
 						onChange={(e) => handleChange(i, e)}
 						onFocus={() => handleFocus(i)}
@@ -159,6 +162,9 @@ export const OtpInput = ({
 						onPaste={handlePaste}
 						disabled={disabled}
 						aria-label={`${i + 1}번째 자리`}
+						// error/supportingText 를 AT 에 전달 (시각 전용이던 문제 수정)
+						aria-invalid={error || undefined}
+						aria-describedby={supportingText ? supportingId : undefined}
 						className={cn(
 							"otp_input_box",
 							error && "otp_input_box_error",
@@ -168,7 +174,10 @@ export const OtpInput = ({
 				))}
 			</div>
 			{supportingText && (
-				<span className={cn("otp_input_supporting", error && "otp_input_supporting_error")}>
+				<span
+					id={supportingId}
+					className={cn("otp_input_supporting", error && "otp_input_supporting_error")}
+				>
 					{supportingText}
 				</span>
 			)}

--- a/src/ui/forms/radio-group/RadioGroup.test.tsx
+++ b/src/ui/forms/radio-group/RadioGroup.test.tsx
@@ -146,4 +146,17 @@ describe("Radio standalone (no RadioGroup) — 기존 동작 보존", () => {
 		fireEvent.click(screen.getByRole("radio"));
 		expect(onChange).toHaveBeenCalled();
 	});
+
+	it("does not mark value-less radios checked while the group is unselected", () => {
+		// 회귀: group.value(undefined) === value(undefined) 가 true 로 평가되어
+		// value 없는 라디오가 전부 checked 렌더되던 버그
+		render(
+			<RadioGroup label="g">
+				<Radio label="A" />
+				<Radio label="B" />
+			</RadioGroup>,
+		);
+		expect(screen.getByRole("radio", { name: "A" })).not.toBeChecked();
+		expect(screen.getByRole("radio", { name: "B" })).not.toBeChecked();
+	});
 });

--- a/src/ui/forms/radio/index.tsx
+++ b/src/ui/forms/radio/index.tsx
@@ -39,7 +39,9 @@ export const Radio = ({
 	const size = sizeProp ?? group?.size ?? "md";
 	const name = nameProp ?? group?.name;
 	const disabled = disabledProp ?? group?.disabled;
-	const resolvedChecked = group ? group.value === value : checked;
+	// value 없는 Radio 가 그룹 미선택 상태(group.value === undefined)에서
+	// undefined === undefined 로 전부 checked 렌더되지 않도록 value 존재를 먼저 확인.
+	const resolvedChecked = group ? value !== undefined && group.value === value : checked;
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		if (group && value !== undefined) group.onChange(String(value));

--- a/src/ui/forms/toggle/Toggle.test.tsx
+++ b/src/ui/forms/toggle/Toggle.test.tsx
@@ -89,4 +89,31 @@ describe("Toggle", () => {
 		expect(onCheckedChange).toHaveBeenCalledWith(true);
 	});
 
+	it("runs consumer onClick AND still toggles ({...props} spread must not replace toggle handler)", () => {
+		const onClick = vi.fn();
+		const onCheckedChange = vi.fn();
+		render(<Toggle ariaLabel="Toggle" onClick={onClick} onCheckedChange={onCheckedChange} />);
+
+		fireEvent.click(screen.getByRole("switch"));
+
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(onCheckedChange).toHaveBeenCalledWith(true);
+		expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+	});
+
+	it("skips toggling when consumer onClick calls preventDefault", () => {
+		const onCheckedChange = vi.fn();
+		render(
+			<Toggle
+				ariaLabel="Toggle"
+				onClick={(e) => e.preventDefault()}
+				onCheckedChange={onCheckedChange}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("switch"));
+
+		expect(onCheckedChange).not.toHaveBeenCalled();
+		expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+	});
 });

--- a/src/ui/forms/toggle/index.tsx
+++ b/src/ui/forms/toggle/index.tsx
@@ -48,10 +48,12 @@ export const Toggle = ({
 
 	/**
 	 * 현재 상태를 토글하고 변경 콜백을 호출한다.
+	 * 소비자 onClick 을 먼저 실행하고 preventDefault 시 토글을 건너뛴다.
 	 * @returns void
 	 */
-	const handleToggle = () => {
-		if (disabled) return;
+	const handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+		props.onClick?.(e);
+		if (disabled || e.defaultPrevented) return;
 		const next = !isOn;
 		if (!isControlled) setInnerChecked(next);
 		(onCheckedChange ?? onChange)?.(next);
@@ -66,6 +68,10 @@ export const Toggle = ({
 
 	return (
 		<button
+			// {...props} 를 먼저 펼쳐 data-*/aria-* 는 통과시키되, switch 동작에 필수인
+			// role/aria-checked/onClick(소비자 onClick 은 handleToggle 안에서 합성 실행)은
+			// 컴포넌트가 항상 이기도록 뒤에 둔다.
+			{...props}
 			ref={ref}
 			type="button"
 			role="switch"
@@ -74,7 +80,6 @@ export const Toggle = ({
 			disabled={disabled}
 			onClick={handleToggle}
 			className={rootClassName}
-			{...props}
 		>
 			<span className="toggle_thumb" />
 		</button>


### PR DESCRIPTION
## 작업 개요

전체 DS 감사에서 나온 forms 카테고리 medium/low 발견사항 일괄 수정.

## 작업한 내용
- [x] **Toggle**: `{...props}` 의 소비자 `onClick` 이 내부 토글 핸들러를 통째로 대체해 스위치가 동작하지 않던 문제 — props 먼저 spread + `handleToggle` 안에서 소비자 onClick 합성 실행(`preventDefault` 시 토글 스킵). 회귀 테스트 2건
- [x] **Checkbox**: `error` 가 시각 전용 → input 에 `aria-invalid` 노출
- [x] **OtpInput**: `error`/`supportingText` AT 미전달 → `aria-invalid` + `aria-describedby` 연결, 첫 칸에 `autocomplete="one-time-code"` (SMS OTP 자동입력)
- [x] **Radio**: 그룹 미선택 상태에서 value 없는 Radio 전부 checked 렌더되던 버그 (`undefined === undefined`) → value 존재 확인 후 비교. 회귀 테스트
- [x] **Dropdown**: `name` prop 신설 — hidden input 렌더로 네이티브 폼 POST 참여(multiple 은 같은 name 반복), Tab 으로 리스트 닫힘(APG Combobox), 닫힌 상태 `aria-controls` dangling IDREF 제거

## 검증
- 유닛 706 passed (신규 회귀 테스트 6건 포함)
- 기존 `aria-controls` 상시 노출 단언 테스트는 새 동작(열림 시에만)으로 갱신

## 전달할 추가 이슈
- Dropdown 검색 필터 축소 시 `aria-activedescendant` 1프레임 stale 가능성은 low 로 보류 (다음 방향키 입력에 자가 복구)
