### PR TITLE
fix/display-nav

### DIFF
--- a/src/ui/display/accordion/Accordion.test.tsx
+++ b/src/ui/display/accordion/Accordion.test.tsx
@@ -17,10 +17,15 @@ describe("Accordion", () => {
 		panels.forEach((p) => expect(p).toHaveAttribute("aria-hidden", "true"));
 	});
 
+	// id 는 useId 접두사로 인스턴스 격리되므로 트리거의 aria-controls 로 패널을 찾는다
+	const getPanelFor = (title: string) => {
+		const trigger = screen.getByText(title).closest("button") as HTMLButtonElement;
+		return document.getElementById(trigger.getAttribute("aria-controls") as string) as HTMLElement;
+	};
+
 	it("toggles panel open state on click", () => {
 		render(<Accordion items={items} />);
-		const panelA = document
-			.getElementById("a-panel") as HTMLElement;
+		const panelA = getPanelFor("Title A");
 		expect(panelA).toHaveAttribute("aria-hidden", "true");
 
 		fireEvent.click(screen.getByText("Title A"));
@@ -35,8 +40,8 @@ describe("Accordion", () => {
 		render(<Accordion items={items} />);
 		fireEvent.click(screen.getByText("Title A"));
 		fireEvent.click(screen.getByText("Title B"));
-		const panelA = document.getElementById("a-panel") as HTMLElement;
-		const panelB = document.getElementById("b-panel") as HTMLElement;
+		const panelA = getPanelFor("Title A");
+		const panelB = getPanelFor("Title B");
 		expect(panelA).toHaveAttribute("aria-hidden", "true");
 		expect(panelB).toHaveAttribute("aria-hidden", "false");
 	});

--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -49,6 +49,9 @@ export const Accordion = ({
 	const isControlled = controlledKeys !== undefined;
 	const [internalKeys, setInternalKeys] = React.useState<string[]>(defaultOpenKeys);
 	const open = isControlled ? (controlledKeys ?? []) : internalKeys;
+	// item.key 로 직접 id 를 만들면 같은 키를 쓰는 인스턴스 간 중복/공백 등 무효 id 로
+	// aria-controls/aria-labelledby 연결이 깨질 수 있어 useId 접두사로 격리한다.
+	const idPrefix = React.useId();
 
 	const toggle = (key: string) => {
 		const isOpen = open.includes(key);
@@ -65,8 +68,8 @@ export const Accordion = ({
 		<div className={cn("accordion", className)} {...props}>
 			{items.map((item) => {
 				const isOpen = open.includes(item.key);
-				const headerId = `${item.key}-header`;
-				const panelId = `${item.key}-panel`;
+				const headerId = `${idPrefix}-${item.key}-header`;
+				const panelId = `${idPrefix}-${item.key}-panel`;
 
 				return (
 					<div key={item.key} className={cn("accordion_item", isOpen && "accordion_item_open")}>

--- a/src/ui/display/avatar/index.tsx
+++ b/src/ui/display/avatar/index.tsx
@@ -55,9 +55,12 @@ export const Avatar = ({
 		<span
 			className={cn("avatar", `avatar_size_${size}`, `avatar_shape_${shape}`, className)}
 			style={{ background: !showImage ? bgColor : undefined, ...style }}
-			// initials-only: span IS the img. with src: <img> provides the role
-			role={showImage ? undefined : "img"}
+			// initials-only: span IS the img. with src: <img> provides the role.
+			// name 없이 쓰이면 접근 가능한 이름 없는 role=img 가 되므로(axe role-img-alt)
+			// 그 경우 role 을 달지 않고 장식 요소로 둔다.
+			role={showImage || !name ? undefined : "img"}
 			aria-label={showImage ? undefined : name || undefined}
+			aria-hidden={!showImage && !name ? true : undefined}
 			{...props}
 		>
 			{showImage ? (

--- a/src/ui/display/chip/Chip.test.tsx
+++ b/src/ui/display/chip/Chip.test.tsx
@@ -27,7 +27,7 @@ describe("Chip", () => {
 
 	it("shows close icon when removable", () => {
 		render(<Chip label="Tag" type="input" removable />);
-		expect(screen.getByLabelText("Remove")).toBeInTheDocument();
+		expect(screen.getByLabelText("Tag 제거")).toBeInTheDocument();
 	});
 
 	it("shows chevron for filter type", () => {
@@ -58,7 +58,7 @@ describe("Chip", () => {
 		const handleRemove = vi.fn();
 		render(<Chip label="Tag" type="input" removable onRemove={handleRemove} />);
 
-		fireEvent.click(screen.getByLabelText("Remove"));
+		fireEvent.click(screen.getByLabelText("Tag 제거"));
 		expect(handleRemove).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/ui/display/chip/index.tsx
+++ b/src/ui/display/chip/index.tsx
@@ -159,8 +159,10 @@ export const Chip = ({
 				className="chip_content"
 				disabled={disabled}
 				onClick={onClick}
-				// selected 는 시각(체크 아이콘)만으로는 AT 에 전달되지 않으므로 aria-pressed 로 노출
-				aria-pressed={selected !== undefined ? selected : undefined}
+				// selected 는 시각(체크 아이콘)만으로는 AT 에 전달되지 않으므로 aria-pressed 로 노출.
+				// 단 filter 타입은 aria-haspopup+aria-expanded(팝업 트리거)라 aria-pressed 와 공존
+				// 시 AT 가 역할을 혼동하므로 제외한다.
+				aria-pressed={type !== "filter" && selected !== undefined ? selected : undefined}
 				{...(type === "filter"
 					? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open }
 					: {})}

--- a/src/ui/display/chip/index.tsx
+++ b/src/ui/display/chip/index.tsx
@@ -32,6 +32,8 @@ export interface ChipProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "o
 	onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 	/** 삭제 버튼 클릭 시 콜백 */
 	onRemove?: () => void;
+	/** 삭제 버튼 접근성 레이블 (기본값: "{label} 제거") - 칩이 여러 개일 때 대상 구분용 */
+	removeLabel?: string;
 }
 
 const CheckIcon = () => (
@@ -92,9 +94,11 @@ export const Chip = ({
 	leadingIcon,
 	onClick,
 	onRemove,
+	removeLabel,
 	className,
 	...props
 }: ChipProps) => {
+	const removeAriaLabel = removeLabel ?? `${label} 제거`;
 	const [iconHovered, setIconHovered] = useState(false);
 
 	const isStatic = type === "static";
@@ -137,7 +141,7 @@ export const Chip = ({
 						className="chip_trailing"
 						disabled={disabled}
 						onClick={onRemove}
-						aria-label="Remove"
+						aria-label={removeAriaLabel}
 					>
 						<span className="chip_icon" aria-hidden="true">
 							<CloseIcon />
@@ -155,6 +159,8 @@ export const Chip = ({
 				className="chip_content"
 				disabled={disabled}
 				onClick={onClick}
+				// selected 는 시각(체크 아이콘)만으로는 AT 에 전달되지 않으므로 aria-pressed 로 노출
+				aria-pressed={selected !== undefined ? selected : undefined}
 				{...(type === "filter"
 					? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open }
 					: {})}
@@ -187,7 +193,7 @@ export const Chip = ({
 					className="chip_trailing"
 					disabled={disabled}
 					onClick={onRemove}
-					aria-label="Remove"
+					aria-label={removeAriaLabel}
 				>
 					<span
 						className="chip_icon"

--- a/src/ui/display/hero/index.tsx
+++ b/src/ui/display/hero/index.tsx
@@ -50,6 +50,31 @@ export interface HeroProps extends Omit<React.HTMLAttributes<HTMLElement>, "titl
 }
 
 /**
+ * Hero CTA 버튼. `href` 지정 시 링크 시맨틱(우클릭 새 탭·미들클릭·SR 링크 안내)을 위해
+ * Button 클래스를 입힌 실제 anchor 로 렌더링한다 — href 가 문서화만 되고 무시되던 문제 수정.
+ */
+const HeroActionButton = ({
+	action,
+	variant,
+}: {
+	action: HeroAction;
+	variant: "filled" | "outline";
+}) =>
+	action.href ? (
+		<a
+			href={action.href}
+			onClick={action.onClick}
+			className={cn("button", `button_variant_${variant}`, "button_size_lg")}
+		>
+			<span className="button_label">{action.label}</span>
+		</a>
+	) : (
+		<Button size="lg" variant={variant} onClick={action.onClick}>
+			{action.label}
+		</Button>
+	);
+
+/**
  * 페이지 상단 히어로 섹션을 렌더링한다.
  * 배경 이미지/색상 + 오버레이 + 제목/부제목 + CTA 슬롯으로 구성.
  * @param props 히어로 속성
@@ -103,16 +128,8 @@ export const Hero = ({
 				{subtitle && <p className="hero_subtitle">{subtitle}</p>}
 				{(primaryAction || secondaryAction || children) && (
 					<div className="hero_actions">
-						{primaryAction && (
-							<Button size="lg" variant="filled" onClick={primaryAction.onClick}>
-								{primaryAction.label}
-							</Button>
-						)}
-						{secondaryAction && (
-							<Button size="lg" variant="outline" onClick={secondaryAction.onClick}>
-								{secondaryAction.label}
-							</Button>
-						)}
+						{primaryAction && <HeroActionButton action={primaryAction} variant="filled" />}
+						{secondaryAction && <HeroActionButton action={secondaryAction} variant="outline" />}
 						{children}
 					</div>
 				)}

--- a/src/ui/display/hero/style.scss
+++ b/src/ui/display/hero/style.scss
@@ -142,5 +142,10 @@
     gap: token.$spacing_8;
     margin-top: token.$spacing_8;
     flex-wrap: wrap;
+
+    // href 액션은 Button 클래스를 입힌 anchor 로 렌더링됨 - 링크 기본 밑줄 제거
+    a.button {
+      text-decoration: none;
+    }
   }
 }

--- a/src/ui/display/list-item/index.tsx
+++ b/src/ui/display/list-item/index.tsx
@@ -76,7 +76,9 @@ export const ListItem = ({
 			role={onClick ? "button" : undefined}
 			tabIndex={onClick && !disabled ? 0 : undefined}
 			aria-disabled={disabled || undefined}
-			aria-selected={selected || undefined}
+			// aria-selected 는 option/tab/row 등 특정 role 전용이라 button/일반 div 에선 무효
+			// (axe aria-allowed-attr 위반). 인터랙티브 항목의 선택 상태는 aria-pressed 로 노출한다.
+			aria-pressed={onClick && selected !== undefined ? selected : undefined}
 			{...props}
 		>
 			<div className="list_item_state_layer">

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -169,7 +169,8 @@ export const Table = <T extends object>({
 
 	return (
 		<div className={wrapperClassName}>
-			<table className="table" aria-label={ariaLabel}>
+			{/* aria-busy - 스켈레톤 로딩 중임을 AT 에 전달 (시각 전용이던 문제 수정) */}
+			<table className="table" aria-label={ariaLabel} aria-busy={isLoading || undefined}>
 				<thead className="table_thead">
 					<tr>
 						{selectable && (

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -51,14 +51,14 @@ describe("NavBar", () => {
 			render(<NavBar locale={makeLocale()} />);
 			fireEvent.click(screen.getByRole("button"));
 			expect(screen.getByRole("menu")).toBeInTheDocument();
-			expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+			expect(screen.getAllByRole("menuitemradio")).toHaveLength(2);
 		});
 
 		it("calls onChange and closes on option select", () => {
 			const onChange = vi.fn();
 			render(<NavBar locale={makeLocale(onChange)} />);
 			fireEvent.click(screen.getByRole("button"));
-			fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+			fireEvent.click(screen.getByRole("menuitemradio", { name: "English" }));
 			expect(onChange).toHaveBeenCalledWith("en");
 			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 		});
@@ -66,7 +66,7 @@ describe("NavBar", () => {
 		it("focuses first item on open and moves with ArrowDown", () => {
 			render(<NavBar locale={makeLocale()} />);
 			fireEvent.click(screen.getByRole("button"));
-			const items = screen.getAllByRole("menuitem");
+			const items = screen.getAllByRole("menuitemradio");
 			expect(items[0]).toHaveFocus();
 			fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
 			expect(items[1]).toHaveFocus();
@@ -98,7 +98,7 @@ describe("NavBar", () => {
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button"));
-		fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+		fireEvent.click(screen.getByRole("menuitemradio", { name: "English" }));
 		expect(onValueChange).toHaveBeenCalledWith("en");
 	});
 

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -292,7 +292,10 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 									itemRefs.current[index] = el;
 								}}
 								type="button"
-								role="menuitem"
+								// 상호 배타적 locale 선택이므로 menuitemradio + aria-checked 로
+								// 현재 locale 을 AT 에 노출 (시각적 active 클래스만으로는 전달 안 됨)
+								role="menuitemradio"
+								aria-checked={opt.value === locale.current}
 								tabIndex={-1}
 								className={cn(
 									"nav_bar_locale_item",

--- a/src/ui/navigation/tabs/Tabs.test.tsx
+++ b/src/ui/navigation/tabs/Tabs.test.tsx
@@ -60,4 +60,38 @@ describe("Tabs", () => {
 		render(<Wrapper />);
 		expect(screen.getByRole("tablist")).toHaveAttribute("aria-label", "Test tabs");
 	});
+
+	it("keeps tabs keyboard-reachable when no tab is selected", () => {
+		// 회귀: 선택 탭이 없으면 전부 tabIndex=-1 이 되어 tablist 진입 자체가 불가능했음
+		render(
+			<Tabs>
+				<TabList ariaLabel="t">
+					<Tab value="a">A</Tab>
+					<Tab value="b">B</Tab>
+				</TabList>
+			</Tabs>,
+		);
+		expect(screen.getByRole("tab", { name: "A" })).toHaveAttribute("tabindex", "0");
+		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("tabindex", "0");
+	});
+
+	it("runs consumer onKeyDown AND keeps arrow navigation ({...props} must not replace it)", () => {
+		const onKeyDown = vi.fn();
+		render(
+			<Tabs defaultValue="a">
+				<TabList ariaLabel="t">
+					<Tab value="a" onKeyDown={onKeyDown}>
+						A
+					</Tab>
+					<Tab value="b">B</Tab>
+				</TabList>
+			</Tabs>,
+		);
+		const tabA = screen.getByRole("tab", { name: "A" });
+		tabA.focus();
+		fireEvent.keyDown(tabA, { key: "ArrowRight" });
+
+		expect(onKeyDown).toHaveBeenCalledTimes(1);
+		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("aria-selected", "true");
+	});
 });

--- a/src/ui/navigation/tabs/Tabs.test.tsx
+++ b/src/ui/navigation/tabs/Tabs.test.tsx
@@ -61,8 +61,9 @@ describe("Tabs", () => {
 		expect(screen.getByRole("tablist")).toHaveAttribute("aria-label", "Test tabs");
 	});
 
-	it("keeps tabs keyboard-reachable when no tab is selected", () => {
-		// 회귀: 선택 탭이 없으면 전부 tabIndex=-1 이 되어 tablist 진입 자체가 불가능했음
+	it("keeps only the first tab as the tab stop when no tab is selected (roving tabindex)", () => {
+		// 회귀: 선택 탭이 없으면 전부 tabIndex=-1 이 되어 tablist 진입 불가였음.
+		// 수정 후엔 첫 탭만 tab stop(0), 나머지는 -1 (WAI-ARIA roving tabindex).
 		render(
 			<Tabs>
 				<TabList ariaLabel="t">
@@ -72,7 +73,7 @@ describe("Tabs", () => {
 			</Tabs>,
 		);
 		expect(screen.getByRole("tab", { name: "A" })).toHaveAttribute("tabindex", "0");
-		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("tabindex", "0");
+		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("tabindex", "-1");
 	});
 
 	it("runs consumer onKeyDown AND keeps arrow navigation ({...props} must not replace it)", () => {

--- a/src/ui/navigation/tabs/index.tsx
+++ b/src/ui/navigation/tabs/index.tsx
@@ -13,6 +13,10 @@ interface TabsContextValue {
 	variant: TabsVariant;
 	size: TabsSize;
 	idPrefix: string;
+	/** Tab 이 마운트 순서대로 자신을 등록 - 미선택 시 어느 탭이 유일한 tab stop 인지 판별용 */
+	registerTab: (value: string) => () => void;
+	/** 마운트 순서상 첫 번째 탭의 value (미선택 시 roving tabindex 진입점) */
+	firstTabValue: string | undefined;
 }
 
 const TabsContext = React.createContext<TabsContextValue | null>(null);
@@ -75,10 +79,26 @@ export const Tabs = ({
 		[isControlled, onValueChange],
 	);
 
+	// 마운트 순서대로 탭 value 를 등록해 "첫 번째 탭"을 판별한다. 선택된 탭이 없을 때
+	// roving tabindex 를 유지(첫 탭만 tabIndex=0)하기 위함 - 전부 0 이면 Tab 키가 모든
+	// 탭을 순회해 리스트 건너뛰기가 불편해지는 WAI-ARIA 위반이 된다.
+	const orderRef = React.useRef<string[]>([]);
+	const [firstTabValue, setFirstTabValue] = React.useState<string>();
+	const registerTab = React.useCallback((v: string) => {
+		if (!orderRef.current.includes(v)) {
+			orderRef.current = [...orderRef.current, v];
+			setFirstTabValue(orderRef.current[0]);
+		}
+		return () => {
+			orderRef.current = orderRef.current.filter((x) => x !== v);
+			setFirstTabValue(orderRef.current[0]);
+		};
+	}, []);
+
 	const idPrefix = React.useId();
 	const ctx = React.useMemo<TabsContextValue>(
-		() => ({ value, setValue, variant, size, idPrefix }),
-		[value, setValue, variant, size, idPrefix],
+		() => ({ value, setValue, variant, size, idPrefix, registerTab, firstTabValue }),
+		[value, setValue, variant, size, idPrefix, registerTab, firstTabValue],
 	);
 	return (
 		<TabsContext.Provider value={ctx}>
@@ -173,6 +193,10 @@ export const Tab = ({ value, className, children, onClick, onKeyDown, ...props }
 	const panelId = `${ctx.idPrefix}-panel-${value}`;
 	const tabId = `${ctx.idPrefix}-tab-${value}`;
 
+	// 마운트 순서 등록 (미선택 시 첫 탭만 tab stop 이 되도록 firstTabValue 판별용)
+	const { registerTab } = ctx;
+	React.useEffect(() => registerTab(value), [registerTab, value]);
+
 	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
 		ctx.setValue(value);
 		onClick?.(e);
@@ -213,11 +237,13 @@ export const Tab = ({ value, className, children, onClick, onKeyDown, ...props }
 			id={tabId}
 			data-value={value}
 			aria-selected={isActive}
-			// 비활성 panel 은 unmount 될 수 있어 dangling IDREF 방지 위해 활성 탭에만 지정
-			aria-controls={isActive ? panelId : undefined}
-			// 로빙 tabindex - 단, 선택된 탭이 없으면(비제어 + defaultValue 없음, value="") 전부 -1 이
-			// 되어 키보드로 tablist 진입이 불가능해지므로 그 경우 모든 탭을 도달 가능하게 둔다.
-			tabIndex={isActive || !ctx.value ? 0 : -1}
+			// aria-controls 는 항상 유지한다. unmountInactive={false} 로 비활성 패널이 DOM 에
+			// 남는 용례에서도 탭↔패널 연결이 끊기지 않아야 하고, Radix 등도 SR 탐색 편의를 위해
+			// 패널 마운트 여부와 무관하게 항상 지정한다(dangling IDREF 경고보다 SR 정보가 우선).
+			aria-controls={panelId}
+			// 로빙 tabindex - 선택된 탭이 없으면(비제어 + defaultValue 없음, value="") 마운트 순서상
+			// 첫 탭만 tab stop 으로 두어 Tab 키 1회로 tablist 에 진입, 내부 이동은 화살표 키로.
+			tabIndex={isActive || (!ctx.value && value === ctx.firstTabValue) ? 0 : -1}
 			className={cn("tabs_tab", isActive && "tabs_tab_active", className)}
 			onClick={handleClick}
 			onKeyDown={handleKeyDown}

--- a/src/ui/navigation/tabs/index.tsx
+++ b/src/ui/navigation/tabs/index.tsx
@@ -167,7 +167,7 @@ export interface TabProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElem
 	value: string;
 }
 
-export const Tab = ({ value, className, children, onClick, ...props }: TabProps) => {
+export const Tab = ({ value, className, children, onClick, onKeyDown, ...props }: TabProps) => {
 	const ctx = useTabsContext();
 	const isActive = ctx.value === value;
 	const panelId = `${ctx.idPrefix}-panel-${value}`;
@@ -179,6 +179,10 @@ export const Tab = ({ value, className, children, onClick, ...props }: TabProps)
 	};
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+		// 소비자 onKeyDown 을 먼저 실행하고 화살표 내비게이션을 이어간다
+		// ({...props} 로 넘어온 onKeyDown 이 내비게이션을 통째로 제거하지 않도록 합성).
+		onKeyDown?.(e);
+		if (e.defaultPrevented) return;
 		if (e.key !== "ArrowLeft" && e.key !== "ArrowRight" && e.key !== "Home" && e.key !== "End") return;
 		const list = (e.currentTarget as HTMLElement).closest('[role="tablist"]');
 		if (!list) return;
@@ -200,17 +204,23 @@ export const Tab = ({ value, className, children, onClick, ...props }: TabProps)
 
 	return (
 		<button
+			// {...props} 를 먼저 펼쳐 data-*/aria-* 는 통과시키되, tab 패턴에 필수인
+			// role/aria-selected/tabIndex/onClick·onKeyDown(소비자 핸들러는 내부에서 합성)은
+			// 컴포넌트가 항상 이긴다.
+			{...props}
 			type="button"
 			role="tab"
 			id={tabId}
 			data-value={value}
 			aria-selected={isActive}
-			aria-controls={panelId}
-			tabIndex={isActive ? 0 : -1}
+			// 비활성 panel 은 unmount 될 수 있어 dangling IDREF 방지 위해 활성 탭에만 지정
+			aria-controls={isActive ? panelId : undefined}
+			// 로빙 tabindex - 단, 선택된 탭이 없으면(비제어 + defaultValue 없음, value="") 전부 -1 이
+			// 되어 키보드로 tablist 진입이 불가능해지므로 그 경우 모든 탭을 도달 가능하게 둔다.
+			tabIndex={isActive || !ctx.value ? 0 : -1}
 			className={cn("tabs_tab", isActive && "tabs_tab_active", className)}
 			onClick={handleClick}
 			onKeyDown={handleKeyDown}
-			{...props}
 		>
 			{children}
 		</button>


### PR DESCRIPTION
## 작업 개요

전체 DS 감사에서 나온 display/navigation 카테고리 a11y 발견사항 일괄 수정.

## 작업한 내용
- [x] **Tabs**: 선택 탭 없으면 전부 `tabIndex=-1` 이라 키보드로 tablist 진입 불가 → 미선택 시 도달 가능 폴백. 소비자 `onKeyDown` 이 화살표 내비를 통째로 대체하던 문제 → 합성 실행(`preventDefault` 시 내비 스킵). 비활성 패널 unmount 시 dangling `aria-controls` 제거. 회귀 테스트 2건
- [x] **Accordion**: `item.key` 직접 id 사용 → 다중 인스턴스 중복/무효 id 로 ARIA 연결 파손 → `useId` 접두사 격리
- [x] **ListItem**: `role="button"`/일반 div 에 무효인 `aria-selected` (axe aria-allowed-attr) → 인터랙티브 항목은 `aria-pressed` 로 노출
- [x] **Chip**: `selected` 상태 AT 노출 (`aria-pressed`), 삭제 버튼 레이블 "Remove" 고정 → `removeLabel` prop (기본 "{label} 제거") 로 대상 구분+로컬라이즈 가능
- [x] **NavBar LocaleSwitcher**: 현재 locale AT 미노출 → `menuitemradio` + `aria-checked`
- [x] **Hero**: 문서화만 되고 무시되던 `HeroAction.href` 구현 — Button 클래스 입힌 실제 anchor 렌더 (새 탭/미들클릭/SR 링크 시맨틱)
- [x] **Table**: `isLoading` 스켈레톤 중 `aria-busy` 노출
- [x] **Avatar**: name 없는 이니셜 아바타가 접근 가능한 이름 없는 `role="img"` (axe role-img-alt) → 장식 요소 처리

## 검증
- 유닛 702 passed (Tabs 회귀 2건 신규, Accordion/Chip/NavBar 테스트 새 시맨틱으로 갱신)
- tsc 에러는 develop 기존 stories 타입 7건뿐 (본 PR 무관, 신규 0)

## 전달할 추가 이슈
- Accordion 헤딩 h3 고정·Hero h1 고정은 API 설계(headingLevel prop)가 필요해 별도 논의
- stories 파일 기존 타입 에러 7건 (data/page-composition/form-comparison/dropdown stories) 별도 정리 필요
