### PR TITLE
fix/overlay

### DIFF
--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -210,4 +210,44 @@ describe("Alert", () => {
 		// 퇴출 spring 애니메이션 완료 후 unmount 되므로 대기
 		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
 	});
+
+	it("routes Escape and overlay-click dismissal through onCancel (APG alertdialog)", () => {
+		const onCancel = vi.fn();
+		renderWithProvider(<TestComponent options={{ title: "C", onCancel }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
+		expect(onCancel).toHaveBeenCalledTimes(1);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		const overlay = screen.getByRole("alertdialog").parentElement as HTMLElement;
+		fireEvent.click(overlay);
+		expect(onCancel).toHaveBeenCalledTimes(2);
+	});
+
+	it("closeOnOverlay=false ignores overlay clicks", () => {
+		const onCancel = vi.fn();
+		renderWithProvider(
+			<TestComponent options={{ title: "C", onCancel, closeOnOverlay: false }} />,
+		);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		const overlay = screen.getByRole("alertdialog").parentElement as HTMLElement;
+		fireEvent.click(overlay);
+
+		expect(onCancel).not.toHaveBeenCalled();
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+	});
+
+	it("locks body scroll while open (data-open-modals counter)", async () => {
+		renderWithProvider(<TestComponent options={{ title: "S" }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		expect(document.body.style.overflow).toBe("hidden");
+		expect(document.body.dataset.openModals).toBe("1");
+
+		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
+		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+		expect(document.body.style.overflow).toBe("");
+	});
 });

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -239,6 +239,29 @@ describe("Alert", () => {
 		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 	});
 
+	it("renders without motion when prefers-reduced-motion is set", () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+		renderWithProvider(<TestComponent options={{ title: "Reduced" }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+
+		// reduced-motion 에서 패널이 최종(휴지) 상태로 즉시 도달 (spring immediate)
+		const dialog = screen.getByRole("alertdialog");
+		expect(dialog).toHaveStyle({ transform: "scale(1) translateY(0px)" });
+		vi.unstubAllGlobals();
+	});
+
 	it("locks body scroll while open (data-open-modals counter)", async () => {
 		renderWithProvider(<TestComponent options={{ title: "S" }} />);
 

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -172,9 +172,11 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	});
 
 	// 바디 스크롤 잠금 - Modal/Drawer 와 동일한 data-open-modals 카운터 공유
-	// (Modal 위에서 confirm Alert 를 띄우는 패턴에서도 카운터가 맞게 유지된다)
+	// (Modal 위에서 confirm Alert 를 띄우는 패턴에서도 카운터가 맞게 유지된다).
+	// isOpen 대신 shouldRender 에 묶어 퇴출 애니메이션이 끝나 완전히 unmount 될 때까지
+	// 잠금을 유지한다 (isOpen 기준이면 닫힘 시작 즉시 풀려 페이드 중 배경이 스크롤됨).
 	React.useEffect(() => {
-		if (!isOpen) return;
+		if (!shouldRender) return;
 
 		const body = document.body;
 		const openModals = parseInt(body.dataset.openModals || "0", 10);
@@ -198,7 +200,7 @@ const AlertModal: React.FC<AlertModalProps> = ({
 				body.dataset.openModals = String(nextOpenModals);
 			}
 		};
-	}, [isOpen]);
+	}, [shouldRender]);
 
 	// isOpen 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
 	// panelRef.current 가 붙어 있다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -220,7 +220,13 @@ const AlertModal: React.FC<AlertModalProps> = ({
 			style={overlayStyle}
 			role="presentation"
 			onClick={() => closeOnOverlay && dismiss()}
-			onKeyDown={(e) => e.key === "Escape" && dismiss()}
+			onKeyDown={(e) => {
+				// Escape 전파 차단 - 상위 오버레이/전역 단축키가 함께 닫히지 않도록 (최상단만 닫힘)
+				if (e.key === "Escape") {
+					e.stopPropagation();
+					dismiss();
+				}
+			}}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap } from "../../../utils";
+import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
 import { Button, type ButtonVariant } from "../../general/button";
 import "./style.scss";
 
@@ -48,6 +48,11 @@ export interface AlertOptions {
 	onConfirm?: () => void;
 	/** 취소 버튼 클릭 시 호출되는 콜백 */
 	onCancel?: () => void;
+	/**
+	 * 오버레이 클릭으로 닫기 허용 여부 (기본값: true).
+	 * destructive 확인처럼 실수 닫힘을 막아야 하면 false 로.
+	 */
+	closeOnOverlay?: boolean;
 }
 
 interface AlertContextValue {
@@ -124,10 +129,14 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	destructive = false,
 	actionsAlign = "right",
 	showIcon = false,
+	closeOnOverlay = true,
 	onConfirm,
 	onCancel,
 	onClose,
 }) => {
+	// Escape/overlay 닫힘은 취소 동작과 동등해야 한다 (APG alertdialog) - onCancel 경로로
+	// 보내 소비자의 취소 정리 로직(롤백 등)이 우회되지 않게 한다.
+	const dismiss = onCancel ?? onClose;
 	const panelRef = React.useRef<HTMLDivElement>(null);
 	const titleId = React.useId();
 	const messageId = React.useId();
@@ -143,8 +152,12 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	// 마운트해 두고 showAlert() 로 여는 구조라 모든 useAlert() 경로에서 재현되는 버그였다.
 	if (isOpen && !shouldRender) setShouldRender(true);
 
+	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
+	const reduced = useReducedMotion();
+
 	const overlayStyle = useSpring({
 		opacity: isOpen ? 1 : 0,
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 		onRest: (result) => {
 			if (!isOpen && result.finished) setShouldRender(false);
@@ -154,8 +167,38 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	const panelStyle = useSpring({
 		opacity: isOpen ? 1 : 0,
 		transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 	});
+
+	// 바디 스크롤 잠금 - Modal/Drawer 와 동일한 data-open-modals 카운터 공유
+	// (Modal 위에서 confirm Alert 를 띄우는 패턴에서도 카운터가 맞게 유지된다)
+	React.useEffect(() => {
+		if (!isOpen) return;
+
+		const body = document.body;
+		const openModals = parseInt(body.dataset.openModals || "0", 10);
+
+		if (openModals === 0) {
+			body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
+			body.style.overflow = "hidden";
+		}
+
+		body.dataset.openModals = String(openModals + 1);
+
+		return () => {
+			const currentOpenModals = parseInt(body.dataset.openModals || "1", 10);
+			const nextOpenModals = currentOpenModals - 1;
+
+			if (nextOpenModals === 0) {
+				body.style.overflow = body.dataset.originalOverflow || "";
+				delete body.dataset.openModals;
+				delete body.dataset.originalOverflow;
+			} else {
+				body.dataset.openModals = String(nextOpenModals);
+			}
+		};
+	}, [isOpen]);
 
 	// isOpen 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
 	// panelRef.current 가 붙어 있다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
@@ -174,8 +217,8 @@ const AlertModal: React.FC<AlertModalProps> = ({
 			className="alert_overlay"
 			style={overlayStyle}
 			role="presentation"
-			onClick={onClose}
-			onKeyDown={(e) => e.key === "Escape" && onClose()}
+			onClick={() => closeOnOverlay && dismiss()}
+			onKeyDown={(e) => e.key === "Escape" && dismiss()}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -172,10 +172,11 @@ describe("Drawer", () => {
 			</Drawer>,
 		);
 
-		// getAllByRole("document") in DOM order: [outer panel, inner panel]
+		// 포털 렌더라 DOM 순서가 React 트리 순서와 다를 수 있음 - 내용으로 inner 패널을 찾는다
 		const panels = screen.getAllByRole("document");
 		expect(panels).toHaveLength(2);
-		fireEvent.keyDown(panels[1], { key: "Escape" });
+		const innerPanel = screen.getByText("Inner content").closest('[role="document"]') as HTMLElement;
+		fireEvent.keyDown(innerPanel, { key: "Escape" });
 
 		expect(innerClose).toHaveBeenCalledTimes(1);
 		expect(outerClose).not.toHaveBeenCalled();
@@ -333,7 +334,7 @@ describe("Drawer", () => {
 
 	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
 		const consumerClick = vi.fn();
-		const { container } = render(
+		render(
 			<Drawer
 				open
 				onClose={() => {}}
@@ -344,7 +345,8 @@ describe("Drawer", () => {
 				Content
 			</Drawer>,
 		);
-		const panel = container.querySelector(".drawer_panel") as HTMLElement;
+		// 포털 렌더라 render container 밖(document.body)에 붙는다
+		const panel = document.querySelector(".drawer_panel") as HTMLElement;
 		// data-* 등은 통과
 		expect(panel).toHaveAttribute("data-testid", "panel-x");
 		// role/onClick 은 컴포넌트가 전유 - 소비자 값 무시(스프레드 순서 회귀 시 깨짐)

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -3,6 +3,7 @@
 import { animated, useSpring } from "@react-spring/web";
 import { X } from "lucide-react";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
 import { cn, useFocusTrap, useReducedMotion, useSpringPresence } from "../../../utils";
 import "./style.scss";
@@ -134,11 +135,16 @@ export const Drawer = ({
 	// 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
+	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다.
+	if (typeof document === "undefined") return null;
+
 	const hasTitle = !!title;
 	const sizeValue = typeof size === "number" ? `${size}px` : size;
 	const panelSizeStyle = placement === "bottom" ? { height: sizeValue } : { width: sizeValue };
 
-	return (
+	// 포털로 body 끝에 렌더 - transform/filter 조상 아래서 position: fixed 가 깨지는 문제 방지
+	// (Modal/Alert/Toast 와 동일 패턴).
+	return createPortal(
 		<animated.div
 			className={cn("drawer", `drawer_placement_${placement}`)}
 			style={overlayStyle}
@@ -191,7 +197,8 @@ export const Drawer = ({
 				{children && <div className="drawer_body">{children}</div>}
 				{footer && <div className="drawer_footer">{footer}</div>}
 			</animated.div>
-		</animated.div>
+		</animated.div>,
+		document.body,
 	);
 };
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -173,7 +173,7 @@ describe("Modal", () => {
 
 	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
 		const consumerClick = vi.fn();
-		const { container } = render(
+		render(
 			<Modal
 				open
 				onClose={() => {}}
@@ -184,7 +184,8 @@ describe("Modal", () => {
 				Content
 			</Modal>,
 		);
-		const panel = container.querySelector(".modal_panel") as HTMLElement;
+		// 포털 렌더라 render container 밖(document.body)에 붙는다
+		const panel = document.querySelector(".modal_panel") as HTMLElement;
 		expect(panel).toHaveAttribute("data-testid", "panel-x");
 		expect(panel).toHaveAttribute("role", "document");
 		fireEvent.click(panel);

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -1,8 +1,38 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Modal } from "./index";
 
 describe("Modal", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("renders without motion when prefers-reduced-motion is set", () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+
+		render(
+			<Modal open onClose={() => {}} title="Reduced">
+				Content
+			</Modal>,
+		);
+
+		// reduced-motion 에서 패널이 최종(휴지) 상태로 즉시 도달 (spring immediate)
+		const panel = screen.getByRole("dialog").querySelector(".modal_panel");
+		expect(panel).toBeInTheDocument();
+		expect(panel).toHaveStyle({ transform: "scale(1) translateY(0px)" });
+	});
+
 	it("renders when open", () => {
 		render(
 			<Modal open onClose={() => {}}>

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -3,8 +3,9 @@
 import { animated, useSpring } from "@react-spring/web";
 import { X } from "lucide-react";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap } from "../../../utils";
+import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
 import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
@@ -72,9 +73,13 @@ export const Modal = ({
 	// 컴포넌트 자신만 대상으로 하고 조건이 곧 거짓이 되어 무한 루프가 없다.
 	if (open && !shouldRender) setShouldRender(true);
 
+	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
+	const reduced = useReducedMotion();
+
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({
 		opacity: open ? 1 : 0,
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 		onRest: (result) => {
 			if (!open && result.finished) setShouldRender(false);
@@ -85,6 +90,7 @@ export const Modal = ({
 	const panelStyle = useSpring({
 		opacity: open ? 1 : 0,
 		transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
@@ -121,9 +127,16 @@ export const Modal = ({
 	// 마운트가 한 렌더 늦어 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
+	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다. 클라이언트 하이드레이션 후
+	// 첫 렌더부터 포털이 붙으므로(commit 시점, effect 이전) 포커스 트랩 타이밍은 유지된다.
+	if (typeof document === "undefined") return null;
+
 	const hasTitle = !!title;
 
-	return (
+	// 포털로 body 끝에 렌더 - 트리거 위치 인라인 렌더는 transform/filter 조상 아래서
+	// position: fixed 의 containing block 이 뷰포트가 아니게 되어 오버레이가 깨진다
+	// (이 DS 자체가 useSpringHover 등 transform 을 광범위하게 사용). Alert/Toast 와 동일 패턴.
+	return createPortal(
 		<animated.div
 			className="modal"
 			style={overlayStyle}
@@ -177,6 +190,7 @@ export const Modal = ({
 					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>{footer}</div>
 				)}
 			</animated.div>
-		</animated.div>
+		</animated.div>,
+		document.body,
 	);
 };

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -257,4 +257,27 @@ describe("Popover", () => {
 		unmount();
 		expect(() => fireEvent.keyDown(document, { key: "Escape" })).not.toThrow();
 	});
+
+	it("Escape inside a Modal closes only the Popover, not the Modal (topmost overlay)", async () => {
+		const { Modal } = await import("../modal");
+		const modalClose = vi.fn();
+		render(
+			<Modal open onClose={modalClose} title="M">
+				<Popover
+					trigger={<button type="button">Open pop</button>}
+					content={<span>Pop content</span>}
+					aria-label="popover"
+				/>
+			</Modal>,
+		);
+		fireEvent.click(screen.getByText("Open pop"));
+		expect(screen.getByText("Pop content")).toBeInTheDocument();
+
+		// 회귀: bubble 리스너 시절엔 Modal 의 stopPropagation 때문에 Popover 리스너가
+		// 발화하지 못하고 Modal 만 닫혔다 (아래층이 닫히는 역전)
+		fireEvent.keyDown(screen.getByText("Pop content"), { key: "Escape" });
+
+		expect(modalClose).not.toHaveBeenCalled();
+		await waitFor(() => expect(screen.queryByText("Pop content")).not.toBeInTheDocument());
+	});
 });

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -59,7 +59,8 @@ describe("Popover", () => {
 		fireEvent.click(trigger);
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 
-		fireEvent.keyDown(document, { key: "Escape" });
+		// Escape 는 wrapper 의 React onKeyDown(버블)으로 처리되므로 팝오버 내부 요소에서 발사
+		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
 		await waitFor(() => {
 			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 		});

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -113,30 +113,28 @@ export const Popover = ({
 		(focusable ?? node).focus();
 	}, [open]);
 
-	// 외부 클릭 / Esc 로 닫기 (Esc 는 trigger 로 포커스 복귀)
+	// 외부 클릭으로 닫기. Escape 는 아래 wrapper 의 React onKeyDown 에서 처리한다.
 	React.useEffect(() => {
 		if (!open) return;
 		const handleClick = (e: MouseEvent) => {
 			if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
 		};
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				// capture 단계에서 전파를 끊어 아래층 오버레이(Modal 등)가 함께 닫히지 않게 한다.
-				// bubble 리스너였을 땐 Modal 의 React onKeyDown(stopPropagation)이 root 에서 먼저
-				// 실행돼 이 리스너가 아예 발화하지 못하고 Modal 만 닫히는 역전이 있었다 (APG:
-				// Escape 는 최상단 오버레이만 닫아야 함).
-				e.stopPropagation();
-				setOpen(false);
-				previousFocusRef.current?.focus();
-			}
-		};
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKeyDown, true);
-		return () => {
-			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKeyDown, true);
-		};
+		return () => document.removeEventListener("mousedown", handleClick);
 	}, [open, setOpen]);
+
+	// Escape 닫기 - document capture 리스너 대신 wrapper 의 React onKeyDown(버블) 로 처리한다.
+	// capture+stopPropagation 은 이벤트가 타겟(Popover 내부 input/select 등)에 닿기도 전에
+	// 최상단에서 끊어 자식 요소의 자체 Escape 처리를 마비시킨다(치명적). 버블 단계에서 잡으면
+	// 자식이 먼저 처리할 기회를 갖고, 여기서 stopPropagation 하면 상위 Modal 의 onKeyDown 으로도
+	// 전파되지 않아 "최상단만 닫힘"(APG)이 지켜진다.
+	const handleWrapperKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (open && e.key === "Escape") {
+			e.stopPropagation();
+			setOpen(false);
+			previousFocusRef.current?.focus();
+		}
+	};
 
 	const triggerWithProps = React.cloneElement(
 		trigger as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
@@ -153,7 +151,8 @@ export const Popover = ({
 	);
 
 	return (
-		<div className="popover_wrapper" ref={wrapperRef}>
+		// biome-ignore lint/a11y/noStaticElementInteractions: keyboard handler for Escape dismissal; interactive children carry their own roles
+		<div className="popover_wrapper" ref={wrapperRef} onKeyDown={handleWrapperKeyDown}>
 			{triggerWithProps}
 			{shouldRender && (
 				<div className={cn("popover_position", `popover_placement_${placement}`)}>

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -121,15 +121,20 @@ export const Popover = ({
 		};
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key === "Escape") {
+				// capture 단계에서 전파를 끊어 아래층 오버레이(Modal 등)가 함께 닫히지 않게 한다.
+				// bubble 리스너였을 땐 Modal 의 React onKeyDown(stopPropagation)이 root 에서 먼저
+				// 실행돼 이 리스너가 아예 발화하지 못하고 Modal 만 닫히는 역전이 있었다 (APG:
+				// Escape 는 최상단 오버레이만 닫아야 함).
+				e.stopPropagation();
 				setOpen(false);
 				previousFocusRef.current?.focus();
 			}
 		};
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKeyDown);
+		document.addEventListener("keydown", handleKeyDown, true);
 		return () => {
 			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKeyDown);
+			document.removeEventListener("keydown", handleKeyDown, true);
 		};
 	}, [open, setOpen]);
 

--- a/src/ui/overlay/tooltip/Tooltip.test.tsx
+++ b/src/ui/overlay/tooltip/Tooltip.test.tsx
@@ -34,7 +34,7 @@ describe("Tooltip", () => {
 		expect(screen.getByRole("tooltip")).toHaveTextContent("hint");
 	});
 
-	it("hides on mouseLeave", () => {
+	it("hides on mouseLeave (after the hoverable grace period)", () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
@@ -46,6 +46,53 @@ describe("Tooltip", () => {
 		});
 		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
 		fireEvent.mouseLeave(screen.getByRole("button"));
+		// WCAG 1.4.13 Hoverable - 포인터가 툴팁으로 건너갈 유예(120ms) 동안은 유지
+		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		act(() => {
+			vi.advanceTimersByTime(150);
+		});
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	it("stays open while the pointer is over the tooltip itself (WCAG 1.4.13 Hoverable)", () => {
+		render(
+			<Tooltip content="hint" delay={0}>
+				<button type="button">btn</button>
+			</Tooltip>,
+		);
+		fireEvent.mouseEnter(screen.getByRole("button"));
+		act(() => {
+			vi.advanceTimersByTime(10);
+		});
+		fireEvent.mouseLeave(screen.getByRole("button"));
+		// 유예 시간 안에 툴팁 위로 포인터 이동 → 열림 유지
+		const positionWrap = screen.getByRole("tooltip").parentElement as HTMLElement;
+		fireEvent.mouseEnter(positionWrap);
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		// 툴팁에서 떠나면 유예 후 닫힘
+		fireEvent.mouseLeave(positionWrap);
+		act(() => {
+			vi.advanceTimersByTime(150);
+		});
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	it("dismisses with Escape without moving the pointer (WCAG 1.4.13 Dismissable)", () => {
+		render(
+			<Tooltip content="hint" delay={0}>
+				<button type="button">btn</button>
+			</Tooltip>,
+		);
+		fireEvent.mouseEnter(screen.getByRole("button"));
+		act(() => {
+			vi.advanceTimersByTime(10);
+		});
+		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+
+		fireEvent.keyDown(document.body, { key: "Escape" });
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -40,14 +40,28 @@ export const Tooltip = ({
 	const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const tooltipId = React.useId();
 
+	// 포인터가 trigger→tooltip 사이 갭(6px)을 건널 시간 (WCAG 1.4.13 Hoverable)
+	const HIDE_DELAY = 120;
+
 	const show = React.useCallback(() => {
 		if (timerRef.current) clearTimeout(timerRef.current);
 		timerRef.current = setTimeout(() => setOpen(true), delay);
 	}, [delay]);
 
-	const hide = React.useCallback(() => {
+	// blur/Escape 는 즉시, mouseleave 는 지연 닫힘 - 포인터가 툴팁 위로 이동할 수 있도록
+	const hideNow = React.useCallback(() => {
 		if (timerRef.current) clearTimeout(timerRef.current);
 		setOpen(false);
+	}, []);
+
+	const hide = React.useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		timerRef.current = setTimeout(() => setOpen(false), HIDE_DELAY);
+	}, []);
+
+	// 툴팁 자체에 포인터가 올라오면 지연 닫힘 취소 (WCAG 1.4.13 Hoverable)
+	const cancelHide = React.useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
 	}, []);
 
 	React.useEffect(() => {
@@ -55,6 +69,20 @@ export const Tooltip = ({
 			if (timerRef.current) clearTimeout(timerRef.current);
 		};
 	}, []);
+
+	// WCAG 1.4.13 Dismissable - 포인터/포커스를 옮기지 않고 Escape 로 닫기.
+	// capture 단계 document 리스너라 아래층 오버레이(Modal 등)의 Escape 핸들러보다
+	// 먼저 실행되고, 닫을 때 전파를 끊어 최상단(툴팁)만 닫는다.
+	React.useEffect(() => {
+		if (!open) return;
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== "Escape") return;
+			e.stopPropagation();
+			hideNow();
+		};
+		document.addEventListener("keydown", onKeyDown, true);
+		return () => document.removeEventListener("keydown", onKeyDown, true);
+	}, [open, hideNow]);
 
 	const fromTransform = (() => {
 		switch (placement) {
@@ -89,7 +117,7 @@ export const Tooltip = ({
 		},
 		onBlur: (e: React.FocusEvent<HTMLElement>) => {
 			childProps.onBlur?.(e);
-			hide();
+			hideNow();
 		},
 		// 자식의 기존 aria-describedby 보존 + tooltip id 합성 (폼 설명/에러 연결 끊김 방지)
 		"aria-describedby": open
@@ -103,7 +131,12 @@ export const Tooltip = ({
 		<span className="tooltip_wrapper">
 			{trigger}
 			{open && (
-				<span className={cn("tooltip_position", `tooltip_placement_${placement}`)}>
+				<span
+					className={cn("tooltip_position", `tooltip_placement_${placement}`)}
+					// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
+					onMouseEnter={cancelHide}
+					onMouseLeave={hide}
+				>
 					<animated.span
 						id={tooltipId}
 						role="tooltip"

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -77,7 +77,9 @@ export const Tooltip = ({
 		if (!open) return;
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== "Escape") return;
-			e.stopPropagation();
+			// stopImmediatePropagation - 같은 document 노드에 등록된 다른 오버레이 리스너의
+			// 실행까지 막아(stopPropagation 은 못 막음) 툴팁만 닫히고 하위 오버레이는 유지.
+			e.stopImmediatePropagation();
 			hideNow();
 		};
 		document.addEventListener("keydown", onKeyDown, true);

--- a/src/ui/overlay/tooltip/style.scss
+++ b/src/ui/overlay/tooltip/style.scss
@@ -11,7 +11,8 @@
 .tooltip_position {
   position: absolute;
   z-index: token.$z_level5;
-  pointer-events: none;
+  // pointer-events 를 살려 둔다 - WCAG 1.4.13 Hoverable: 포인터를 툴팁 위로
+  // 옮겨 내용을 읽을 수 있어야 함 (none 이면 mouseenter 가 발화하지 않아 즉시 닫힘)
   display: block;
   width: max-content; // 내부 .tooltip 의 max-content 와 일치 - translateX(-50%) 정확
 


### PR DESCRIPTION
## 작업 개요

전체 DS 감사에서 나온 overlay/feedback(Alert) 발견사항 일괄 수정.

> ⚠️ **#373(fix/alert) 위에 스택된 PR** — Alert 파일 충돌 방지를 위해 base 를 `fix/alert` 로 설정. #373 머지 후 자동으로 develop 대상으로 리타겟됩니다. 머지 순서: #373 → 이 PR.

## 작업한 내용
- [x] **Tooltip — WCAG 2.1 SC 1.4.13 충족**: (Dismissable) capture 단계 document 리스너로 Escape 닫기 — 아래층 오버레이보다 먼저 발화 + 전파 차단으로 툴팁만 닫힘. (Hoverable) mouseleave 즉시 닫힘 → 120ms 유예 + 툴팁 위 포인터 시 유지, hover 를 원천 봉쇄하던 `pointer-events: none` 제거. blur/Escape 는 즉시 닫힘 유지. 회귀 테스트 3건
- [x] **Popover**: Modal 안에서 Escape 시 Popover 대신 Modal 이 닫히던 역전(bubble 리스너가 Modal 의 root stopPropagation 에 막힘) → capture 단계 + 전파 차단으로 최상단만 닫힘. Popover-in-Modal 회귀 테스트
- [x] **Modal/Drawer 포털화**: 인라인 렌더는 transform/filter 조상 아래서 `position: fixed` containing block 이 뷰포트가 아니게 되어 오버레이가 깨짐 (DS 자체가 useSpringHover 로 transform 다용) → `createPortal(document.body)` (Alert/Toast 와 동일 패턴). SSR 가드 포함, 포털은 commit 시점(effect 이전) 마운트라 포커스 트랩 타이밍 무변
- [x] **Modal/Alert reduced-motion**: raw `useSpring` 진입/퇴출에 `prefers-reduced-motion` 반영 (WCAG 2.3.3)
- [x] **Alert**: Escape/오버레이 닫힘이 `onCancel` 을 우회하던 문제 → APG alertdialog 대로 취소 경로로 라우팅. `closeOnOverlay` 옵션 신설 (destructive 실수 닫힘 방지). Modal/Drawer 와 `data-open-modals` 스크롤 잠금 카운터 공유

## 검증
- 유닛 708 passed (회귀 테스트 8건 신규: Tooltip 3, Popover-in-Modal 1, Alert 4)
- 포털 전환에 따른 기존 테스트 3건은 document 기준 조회로 갱신

## 전달할 추가 이슈
- Modal/Drawer 포털화는 동작 변경(마운트 위치가 body 끝으로 이동) — 소비자가 후손 선택자(`.wrap .modal`)로 스타일링했다면 영향. CHANGELOG 에 명시 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Alert가 오버레이 클릭 및 Escape 키를 통한 닫힘 여부를 설정할 수 있습니다.
  * Modal과 Drawer가 안정적인 포털 렌더링을 지원합니다.
  * 모션 감소 설정에 따라 전환 애니메이션이 즉시 적용됩니다.
  * Tooltip이 포인터 이동 중 유지되며, Escape 키로 닫을 수 있습니다.

* **버그 수정**
  * 중첩된 Popover에서 Escape 입력 시 상위 Modal까지 닫히는 문제를 수정했습니다.
  * Alert 사용 중 페이지 스크롤 잠금 및 복원이 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->