### PR TITLE
fix/toast

### DIFF
--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -597,29 +597,40 @@ describe("Toast stack & ids", () => {
 		expect(document.querySelectorAll(".toast_item")).toHaveLength(3);
 	});
 
-	it("auto-closes via setTimeout under prefers-reduced-motion (progress animation disabled)", async () => {
-		// reduced-motion 에서는 progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지
-		// 않으므로 setTimeout 분기가 자동 닫힘을 대신해야 한다 (없으면 토스트가 영구히 남음)
-		const originalMatchMedia = window.matchMedia;
-		window.matchMedia = vi.fn().mockReturnValue({
-			matches: true,
-			addEventListener: vi.fn(),
-			removeEventListener: vi.fn(),
-		}) as unknown as typeof window.matchMedia;
-
-		try {
-			render(
-				<ToastProvider>
-					<ToastTrigger fn={(t) => t.info("잠깐 표시", 30)} label="quick" />
-				</ToastProvider>,
+	it("hands focus to an adjacent toast when a focused toast is closed (WCAG 2.4.3)", async () => {
+		function MultiTrigger() {
+			const t = useToast();
+			return (
+				<button
+					type="button"
+					onClick={() => {
+						t.success("첫 번째");
+						t.success("두 번째");
+					}}
+				>
+					two
+				</button>
 			);
-			fireEvent.click(screen.getByRole("button", { name: "quick" }));
-			expect(screen.getByText("잠깐 표시")).toBeInTheDocument();
-
-			// setTimeout(30ms) → visible=false → spring 퇴출(immediate) 후 unmount
-			await waitFor(() => expect(screen.queryByText("잠깐 표시")).not.toBeInTheDocument());
-		} finally {
-			window.matchMedia = originalMatchMedia;
 		}
+
+		render(
+			<ToastProvider>
+				<MultiTrigger />
+			</ToastProvider>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "two" }));
+
+		const closeButtons = screen.getAllByRole("button", { name: "Close" });
+		expect(closeButtons).toHaveLength(2);
+
+		// 첫 번째(맨 위) 토스트의 닫기 버튼에 포커스를 두고 닫으면,
+		// 포커스가 body 로 유실되지 않고 인접 토스트의 닫기 버튼으로 이관되어야 한다.
+		closeButtons[0].focus();
+		fireEvent.click(closeButtons[0]);
+
+		await waitFor(() => {
+			expect(document.activeElement).toBe(closeButtons[1]);
+		});
 	});
 });

--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -596,4 +596,30 @@ describe("Toast stack & ids", () => {
 		expect(screen.getAllByText("같은 메시지")).toHaveLength(3);
 		expect(document.querySelectorAll(".toast_item")).toHaveLength(3);
 	});
+
+	it("auto-closes via setTimeout under prefers-reduced-motion (progress animation disabled)", async () => {
+		// reduced-motion 에서는 progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지
+		// 않으므로 setTimeout 분기가 자동 닫힘을 대신해야 한다 (없으면 토스트가 영구히 남음)
+		const originalMatchMedia = window.matchMedia;
+		window.matchMedia = vi.fn().mockReturnValue({
+			matches: true,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+		}) as unknown as typeof window.matchMedia;
+
+		try {
+			render(
+				<ToastProvider>
+					<ToastTrigger fn={(t) => t.info("잠깐 표시", 30)} label="quick" />
+				</ToastProvider>,
+			);
+			fireEvent.click(screen.getByRole("button", { name: "quick" }));
+			expect(screen.getByText("잠깐 표시")).toBeInTheDocument();
+
+			// setTimeout(30ms) → visible=false → spring 퇴출(immediate) 후 unmount
+			await waitFor(() => expect(screen.queryByText("잠깐 표시")).not.toBeInTheDocument());
+		} finally {
+			window.matchMedia = originalMatchMedia;
+		}
+	});
 });

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-reac
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useReducedMotion, useSpringPresence } from "../../../utils";
+import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info" | "default";
@@ -58,23 +58,27 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 	const [visible, setVisible] = React.useState(true);
 	const closingRef = React.useRef(false);
 	const rootRef = React.useRef<HTMLDivElement>(null);
-	const reduced = useReducedMotion();
 
 	const style = useSpringPresence({
 		visible,
 		from: "translateX(20px)", // 우측에서 슬라이드 인
 		onExitComplete: () => {
 			// 포커스가 이 토스트 안에 있었으면(닫기 버튼 Enter 등) unmount 로 포커스가
-			// body 로 유실되지 않게 다음 토스트의 닫기 버튼으로 넘긴다 (WCAG 2.4.3).
+			// body 로 유실되지 않게 인접 토스트의 닫기 버튼으로 넘긴다 (WCAG 2.4.3).
+			// onRemove(=state 갱신) 전에 포커스를 옮겨 배치 flush 타이밍에 의존하지 않는다.
 			const hadFocus = rootRef.current?.contains(document.activeElement) ?? false;
-			onRemove(item.id);
 			if (hadFocus) {
-				// onRemove 의 상태 갱신이 아직 flush 전이라 자기 자신도 DOM 에 남아 있음 - 제외하고 탐색
-				const next = Array.from(
+				const closeButtons = Array.from(
 					document.querySelectorAll<HTMLElement>(".toast_item .toast_close"),
-				).find((el) => !rootRef.current?.contains(el));
-				next?.focus();
+				);
+				const currentIndex = closeButtons.findIndex((el) => rootRef.current?.contains(el));
+				if (currentIndex !== -1) {
+					// 다음(아래) 우선, 없으면 이전(위) 토스트로 - 논리적 인접 이동
+					const next = closeButtons[currentIndex + 1] || closeButtons[currentIndex - 1];
+					next?.focus();
+				}
 			}
+			onRemove(item.id);
 		},
 	});
 
@@ -87,14 +91,6 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 		closingRef.current = true;
 		setVisible(false);
 	}, []);
-
-	// reduced-motion: progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지 않으므로
-	// setTimeout 으로 자동 닫힘을 대신한다 (없으면 토스트가 영구히 남음).
-	React.useEffect(() => {
-		if (!reduced) return;
-		const timer = setTimeout(close, item.duration);
-		return () => clearTimeout(timer);
-	}, [reduced, item.duration, close]);
 
 	return (
 		<animated.div

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-reac
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useReducedMotion, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info" | "default";
@@ -57,11 +57,25 @@ interface ToastItemComponentProps {
 const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemComponentProps) => {
 	const [visible, setVisible] = React.useState(true);
 	const closingRef = React.useRef(false);
+	const rootRef = React.useRef<HTMLDivElement>(null);
+	const reduced = useReducedMotion();
 
 	const style = useSpringPresence({
 		visible,
 		from: "translateX(20px)", // 우측에서 슬라이드 인
-		onExitComplete: () => onRemove(item.id),
+		onExitComplete: () => {
+			// 포커스가 이 토스트 안에 있었으면(닫기 버튼 Enter 등) unmount 로 포커스가
+			// body 로 유실되지 않게 다음 토스트의 닫기 버튼으로 넘긴다 (WCAG 2.4.3).
+			const hadFocus = rootRef.current?.contains(document.activeElement) ?? false;
+			onRemove(item.id);
+			if (hadFocus) {
+				// onRemove 의 상태 갱신이 아직 flush 전이라 자기 자신도 DOM 에 남아 있음 - 제외하고 탐색
+				const next = Array.from(
+					document.querySelectorAll<HTMLElement>(".toast_item .toast_close"),
+				).find((el) => !rootRef.current?.contains(el));
+				next?.focus();
+			}
+		},
 	});
 
 	/**
@@ -74,8 +88,17 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 		setVisible(false);
 	}, []);
 
+	// reduced-motion: progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지 않으므로
+	// setTimeout 으로 자동 닫힘을 대신한다 (없으면 토스트가 영구히 남음).
+	React.useEffect(() => {
+		if (!reduced) return;
+		const timer = setTimeout(close, item.duration);
+		return () => clearTimeout(timer);
+	}, [reduced, item.duration, close]);
+
 	return (
 		<animated.div
+			ref={rootRef}
 			className="toast_item"
 			style={style}
 			role={item.variant === "error" ? "alert" : "status"}

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -10,6 +10,14 @@
   to   { width: 0%; }
 }
 
+// reduced-motion 용 정적 keyframe - 폭 변화(시각 모션) 없이 동일 duration 동안 진행.
+// onAnimationEnd(자동 닫힘 트리거)와 animation-play-state:paused(hover/focus 일시정지)를
+// 그대로 살리기 위해 animation 을 끄지 않고 정적 keyframe 로 교체한다.
+@keyframes toast_progress_reduced {
+  from { width: 0; }
+  to   { width: 0; }
+}
+
 // ── Container ────────────────────────────────────────────────────────────────
 
 .toast_container {
@@ -157,10 +165,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  // progress 시각 모션 제거. 자동 닫힘은 컴포넌트의 reduced-motion 분기(setTimeout)가
-  // 대신 처리한다 - animation 만 없애면 onAnimationEnd 가 발화하지 않아 영구히 남기 때문.
+  // 시각 모션만 제거 - animation-name 만 정적 keyframe 로 바꿔 duration/타이밍/play-state 는
+  // 유지한다. 이렇게 하면 onAnimationEnd 로 자동 닫힘이 그대로 발화하고, hover/focus 시
+  // animation-play-state:paused 로 타이머가 함께 멈춰 WCAG 2.2.1 이 reduced-motion 에서도 지켜진다.
+  // (animation:none 이면 onAnimationEnd 가 안 나 토스트가 영구히 남고 pause 도 무력화됨.)
   .toast_progress {
-    animation: none;
+    animation-name: toast_progress_reduced;
     width: 0;
   }
 }

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -147,3 +147,20 @@
   &_info    { background: token.$color_status_info; }
   &_default { background: token.$color_text_body; }
 }
+
+// WCAG 2.2.1 Timing Adjustable - 포인터를 올리거나 닫기 버튼에 포커스가 있는 동안
+// 자동 닫힘 타이머(progress 애니메이션)를 일시정지해 읽기/조작 시간을 연장한다.
+// onAnimationEnd 가 닫힘 트리거라 play-state 정지만으로 타이머까지 함께 멈춘다.
+.toast_item:hover .toast_progress,
+.toast_item:focus-within .toast_progress {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  // progress 시각 모션 제거. 자동 닫힘은 컴포넌트의 reduced-motion 분기(setTimeout)가
+  // 대신 처리한다 - animation 만 없애면 onAnimationEnd 가 발화하지 않아 영구히 남기 때문.
+  .toast_progress {
+    animation: none;
+    width: 0;
+  }
+}


### PR DESCRIPTION
## 작업 개요

전체 DS 감사에서 나온 Toast 타이밍/포커스 발견사항 수정 (WCAG 2.1 SC 2.2.1 Timing Adjustable).

## 작업한 내용
- [x] **자동 닫힘 일시정지**: 토스트에 포인터를 올리거나(:hover) 닫기 버튼에 포커스(:focus-within)가 있는 동안 progress 애니메이션 정지 — `onAnimationEnd` 가 닫힘 트리거라 play-state 정지만으로 타이머까지 함께 멈춤. 기본 3초 안에 도달 못하는 사용자(스크린리더·스위치·저시력)가 읽기/조작 시간 연장 가능
- [x] **포커스 유실 방지**: 포커스된 토스트가 제거될 때(닫기 버튼 Enter) 포커스를 body 로 떨어뜨리지 않고 다음 토스트의 닫기 버튼으로 이관 (WCAG 2.4.3)
- [x] **reduced-motion 자동 닫힘**: `prefers-reduced-motion` 에서 progress 애니메이션을 끄면 `onAnimationEnd` 가 영영 발화하지 않아 토스트가 영구히 남는 결합 구조 → `setTimeout` 분기로 자동 닫힘 보장 + SCSS reduced-motion 블록 추가 (matchMedia 목 회귀 테스트 포함)

## 검증
- 유닛 701 passed (reduced-motion 자동 닫힘 회귀 테스트 신규)
- hover/focus 일시정지는 CSS `animation-play-state` — jsdom 검증 불가, 코드 리뷰로 확인 요망

## 전달할 추가 이슈
- 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 토스트에 마우스를 올리거나 내부 요소에 포커스가 있을 때 진행 애니메이션이 일시 중지됩니다.
  * 시스템에서 애니메이션 감소 설정을 사용해도 토스트가 지정된 시간 후 정상적으로 자동 닫힙니다.
  * 토스트가 닫힐 때 포커스가 다음 토스트의 닫기 버튼으로 자연스럽게 이동합니다.
* **버그 수정**
  * 애니메이션 감소 환경에서 토스트가 화면에 계속 남는 문제를 수정했습니다.
* **테스트**
  * 애니메이션 감소 환경에서 토스트가 자동으로 제거되는 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->