### PR TITLE
fix/vanilla-a11y

### DIFF
--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -61,6 +61,36 @@
 		return Array.from(context.querySelectorAll(selector));
 	}
 
+	/** 포커스 가능한 요소 셀렉터 (React useFocusTrap 과 동일 기준) */
+	const FOCUSABLE_SELECTORS = [
+		"a[href]",
+		"button:not([disabled])",
+		"input:not([disabled])",
+		"select:not([disabled])",
+		"textarea:not([disabled])",
+		'[tabindex]:not([tabindex="-1"])',
+	].join(", ");
+
+	/**
+	 * 바디 스크롤 잠금 카운터 - Modal 위 Alert 처럼 오버레이가 겹칠 때
+	 * 하나만 닫혀도 배경 스크롤이 풀리던 문제 방지 (React 쪽 data-open-modals 와 동일 패턴)
+	 */
+	function lockScroll() {
+		const n = parseInt(document.body.dataset.btOpenModals || "0", 10);
+		if (n === 0) document.body.style.overflow = "hidden";
+		document.body.dataset.btOpenModals = String(n + 1);
+	}
+
+	function unlockScroll() {
+		const n = parseInt(document.body.dataset.btOpenModals || "1", 10) - 1;
+		if (n <= 0) {
+			document.body.style.overflow = "";
+			delete document.body.dataset.btOpenModals;
+		} else {
+			document.body.dataset.btOpenModals = String(n);
+		}
+	}
+
 	/* ========================================
      Select Component
      ======================================== */
@@ -115,6 +145,20 @@
 
 		state.options = optionsData;
 
+		// Combobox ARIA (WAI-ARIA APG select-only combobox) - React Dropdown 과 패리티
+		list.id = list.id || _listId;
+		list.setAttribute("role", "listbox");
+		control.setAttribute("role", "combobox");
+		control.setAttribute("aria-haspopup", "listbox");
+		control.setAttribute("aria-expanded", "false");
+		control.setAttribute("aria-controls", list.id);
+		$$(".bt-select__option", list).forEach((el, i) => {
+			el.id = el.id || `${controlId}_option_${i}`;
+			el.setAttribute("role", "option");
+			el.setAttribute("aria-selected", "false");
+			if (state.options[i]?.disabled) el.setAttribute("aria-disabled", "true");
+		});
+
 		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 값을 노출한다.
 		// 서버 템플릿(th:field 등)이 미리 렌더링한 hidden input 이 있으면 그대로 재사용 -
 		// name/초기값을 서버 바인딩에서 이어받는다.
@@ -152,7 +196,9 @@
 
 			// Update selected state in list
 			$$(".bt-select__option", list).forEach((el, i) => {
-				el.classList.toggle("is-selected", state.options[i]?.value === newValue);
+				const selected = state.options[i]?.value === newValue;
+				el.classList.toggle("is-selected", selected);
+				el.setAttribute("aria-selected", selected ? "true" : "false");
 			});
 
 			if (config.onChange) {
@@ -165,6 +211,7 @@
 
 			state.isOpen = true;
 			control.classList.add("is-open");
+			control.setAttribute("aria-expanded", "true");
 			list.style.display = "block";
 
 			// Calculate position (auto-flip)
@@ -192,6 +239,8 @@
 		function close() {
 			state.isOpen = false;
 			control.classList.remove("is-open");
+			control.setAttribute("aria-expanded", "false");
+			control.removeAttribute("aria-activedescendant");
 			list.style.display = "none";
 
 			const icon = control.querySelector(".bt-select__icon");
@@ -208,7 +257,10 @@
 
 		function updateActiveOption() {
 			$$(".bt-select__option", list).forEach((el, i) => {
-				el.classList.toggle("is-active", i === state.activeIndex);
+				const active = i === state.activeIndex;
+				el.classList.toggle("is-active", active);
+				// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음)
+				if (active) control.setAttribute("aria-activedescendant", el.id);
 			});
 		}
 
@@ -384,12 +436,31 @@
 			isOpen: false,
 		};
 
-		const _panel = modal.querySelector(".bt-modal__panel");
+		const panel = modal.querySelector(".bt-modal__panel");
+		let previousFocus = null;
+
+		// Dialog ARIA - React Modal 과 패리티
+		if (panel) {
+			panel.setAttribute("role", "dialog");
+			panel.setAttribute("aria-modal", "true");
+		}
 
 		function open() {
 			state.isOpen = true;
 			modal.classList.add("is-open");
-			document.body.style.overflow = "hidden";
+			lockScroll();
+
+			// 포커스 이동 - 이전 포커스 저장 후 패널 첫 focusable(없으면 패널 자체)로 (WCAG 2.4.3)
+			previousFocus = document.activeElement;
+			if (panel) {
+				const first = panel.querySelector(FOCUSABLE_SELECTORS);
+				if (first) {
+					first.focus();
+				} else {
+					panel.setAttribute("tabindex", "-1");
+					panel.focus();
+				}
+			}
 
 			if (config.onOpen) {
 				config.onOpen();
@@ -399,7 +470,13 @@
 		function close() {
 			state.isOpen = false;
 			modal.classList.remove("is-open");
-			document.body.style.overflow = "";
+			unlockScroll();
+
+			// 포커스 복원
+			if (previousFocus && typeof previousFocus.focus === "function") {
+				previousFocus.focus();
+			}
+			previousFocus = null;
 
 			if (config.onClose) {
 				config.onClose();
@@ -413,8 +490,27 @@
 		}
 
 		function onKeyDown(e) {
-			if (config.closeOnEscape && e.key === "Escape" && state.isOpen) {
+			if (!state.isOpen) return;
+			if (config.closeOnEscape && e.key === "Escape") {
 				close();
+				return;
+			}
+			// Tab 트랩 - 포커스가 패널 밖으로 빠지지 않게 순환 (WAI-ARIA APG Dialog)
+			if (e.key === "Tab" && panel) {
+				const focusables = $$(FOCUSABLE_SELECTORS, panel);
+				if (focusables.length === 0) {
+					e.preventDefault();
+					return;
+				}
+				const first = focusables[0];
+				const last = focusables[focusables.length - 1];
+				if (e.shiftKey && document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				} else if (!e.shiftKey && document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
 			}
 		}
 
@@ -436,7 +532,8 @@
 				cleanups.forEach((cleanup) => {
 					cleanup();
 				});
-				document.body.style.overflow = "";
+				// 열린 채 destroy 되면 카운터 정합 유지를 위해 잠금 해제
+				if (state.isOpen) unlockScroll();
 			},
 		};
 	}
@@ -488,14 +585,39 @@
       </div>
     `;
 
+		// Alertdialog ARIA + 포커스 관리 (React Alert 와 패리티)
+		const alertPanel = overlay.querySelector(".bt-alert__modal");
+		if (alertPanel) {
+			alertPanel.setAttribute("role", "alertdialog");
+			alertPanel.setAttribute("aria-modal", "true");
+			const titleEl = overlay.querySelector(".bt-alert__title");
+			const messageEl = overlay.querySelector(".bt-alert__message");
+			if (titleEl) {
+				titleEl.id = generateId("alert_title");
+				alertPanel.setAttribute("aria-labelledby", titleEl.id);
+			}
+			if (messageEl) {
+				messageEl.id = generateId("alert_message");
+				alertPanel.setAttribute("aria-describedby", messageEl.id);
+			}
+		}
+
+		const previousFocus = document.activeElement;
+
 		document.body.appendChild(overlay);
-		document.body.style.overflow = "hidden";
+		lockScroll();
 
 		function close() {
+			// Escape 리스너를 닫힘 경로 공통에서 해제 - 버튼/오버레이로 닫을 때
+			// 리스너가 남아 누수되던 문제 방지
+			document.removeEventListener("keydown", onKeyDown);
 			overlay.classList.remove("is-open");
+			if (previousFocus && typeof previousFocus.focus === "function") {
+				previousFocus.focus();
+			}
 			setTimeout(() => {
 				overlay.remove();
-				document.body.style.overflow = "";
+				unlockScroll();
 			}, 200);
 		}
 
@@ -524,14 +646,16 @@
 			}
 		});
 
-		// Close on Escape
-		const onKeyDown = (e) => {
+		// Close on Escape (해제는 close() 공통 경로에서)
+		function onKeyDown(e) {
 			if (e.key === "Escape") {
 				close();
-				document.removeEventListener("keydown", onKeyDown);
 			}
-		};
+		}
 		document.addEventListener("keydown", onKeyDown);
+
+		// 초기 포커스 - 확인 버튼 (APG alertdialog: 열릴 때 포커스를 내부로 이동)
+		if (confirmBtn) confirmBtn.focus();
 
 		return { close };
 	}
@@ -785,11 +909,13 @@
 			}
 		});
 
-		// Modal triggers
+		// Modal triggers - init() 재호출 시 리스너 중복 바인딩 방지 가드
 		$$("[data-bt-modal-open]").forEach((btn) => {
+			if (btn.dataset.btBound) return;
 			const targetId = btn.dataset.btModalOpen;
 			const modal = $(`#${targetId}`);
 			if (modal?._btModal) {
+				btn.dataset.btBound = "true";
 				btn.addEventListener("click", () => modal._btModal.open());
 			}
 		});

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -76,18 +76,26 @@
 	 * 하나만 닫혀도 배경 스크롤이 풀리던 문제 방지 (React 쪽 data-open-modals 와 동일 패턴)
 	 */
 	function lockScroll() {
-		const n = parseInt(document.body.dataset.btOpenModals || "0", 10);
-		if (n === 0) document.body.style.overflow = "hidden";
-		document.body.dataset.btOpenModals = String(n + 1);
+		const body = document.body;
+		const n = parseInt(body.dataset.btOpenModals || "0", 10);
+		if (n === 0) {
+			// 소비자가 인라인으로 지정해둔 overflow 를 저장했다가 마지막 unlock 때 복원
+			// (React Modal 의 dataset.originalOverflow 와 동일 동작).
+			body.dataset.btOriginalOverflow = body.style.overflow;
+			body.style.overflow = "hidden";
+		}
+		body.dataset.btOpenModals = String(n + 1);
 	}
 
 	function unlockScroll() {
-		const n = parseInt(document.body.dataset.btOpenModals || "1", 10) - 1;
+		const body = document.body;
+		const n = parseInt(body.dataset.btOpenModals || "1", 10) - 1;
 		if (n <= 0) {
-			document.body.style.overflow = "";
-			delete document.body.dataset.btOpenModals;
+			body.style.overflow = body.dataset.btOriginalOverflow || "";
+			delete body.dataset.btOpenModals;
+			delete body.dataset.btOriginalOverflow;
 		} else {
-			document.body.dataset.btOpenModals = String(n);
+			body.dataset.btOpenModals = String(n);
 		}
 	}
 
@@ -256,12 +264,19 @@
 		}
 
 		function updateActiveOption() {
+			let activeId = null;
 			$$(".bt-select__option", list).forEach((el, i) => {
 				const active = i === state.activeIndex;
 				el.classList.toggle("is-active", active);
-				// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음)
-				if (active) control.setAttribute("aria-activedescendant", el.id);
+				if (active) activeId = el.id;
 			});
+			// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음).
+			// 활성 옵션이 없으면(activeIndex=-1 등) 잘못된 참조가 남지 않게 속성을 제거.
+			if (activeId) {
+				control.setAttribute("aria-activedescendant", activeId);
+			} else {
+				control.removeAttribute("aria-activedescendant");
+			}
 		}
 
 		function moveActive(dir) {
@@ -438,14 +453,26 @@
 
 		const panel = modal.querySelector(".bt-modal__panel");
 		let previousFocus = null;
+		let panelTabindexAdded = false;
 
-		// Dialog ARIA - React Modal 과 패리티
+		// Dialog ARIA - React Modal 과 패리티. 접근 가능한 이름(aria-labelledby/label)도 연결한다
+		// (없으면 axe aria-dialog-name 실패). 헤더가 있으면 그 id 로, 없으면 aria-label fallback.
 		if (panel) {
 			panel.setAttribute("role", "dialog");
 			panel.setAttribute("aria-modal", "true");
+			if (!panel.hasAttribute("aria-label") && !panel.hasAttribute("aria-labelledby")) {
+				const header = panel.querySelector(".bt-modal__header");
+				if (header) {
+					header.id = header.id || generateId("modal_title");
+					panel.setAttribute("aria-labelledby", header.id);
+				} else {
+					panel.setAttribute("aria-label", "Dialog");
+				}
+			}
 		}
 
 		function open() {
+			if (state.isOpen) return; // 이미 열림 - 중복 lockScroll 방지
 			state.isOpen = true;
 			modal.classList.add("is-open");
 			lockScroll();
@@ -458,6 +485,7 @@
 					first.focus();
 				} else {
 					panel.setAttribute("tabindex", "-1");
+					panelTabindexAdded = true;
 					panel.focus();
 				}
 			}
@@ -468,9 +496,16 @@
 		}
 
 		function close() {
+			if (!state.isOpen) return; // 이미 닫힘 - 중복 unlockScroll 방지
 			state.isOpen = false;
 			modal.classList.remove("is-open");
 			unlockScroll();
+
+			// 우리가 추가한 tabindex 정리 (React useFocusTrap 의 wasTabIndexAdded 와 동일)
+			if (panelTabindexAdded && panel) {
+				panel.removeAttribute("tabindex");
+				panelTabindexAdded = false;
+			}
 
 			// 포커스 복원
 			if (previousFocus && typeof previousFocus.focus === "function") {
@@ -607,7 +642,13 @@
 		document.body.appendChild(overlay);
 		lockScroll();
 
+		let isOpen = true;
+
 		function close() {
+			// 중복 호출 방지 - 버튼/오버레이/Escape 연타 시 unlockScroll 이 여러 번 불려
+			// 스크롤 잠금 카운터가 오동작하지 않도록 최초 1회만 실행.
+			if (!isOpen) return;
+			isOpen = false;
 			// Escape 리스너를 닫힘 경로 공통에서 해제 - 버튼/오버레이로 닫을 때
 			// 리스너가 남아 누수되던 문제 방지
 			document.removeEventListener("keydown", onKeyDown);
@@ -646,10 +687,27 @@
 			}
 		});
 
-		// Close on Escape (해제는 close() 공통 경로에서)
+		// Close on Escape + Tab 포커스 트랩 (WAI-ARIA APG Dialog) - Modal 과 동일 패턴
 		function onKeyDown(e) {
 			if (e.key === "Escape") {
 				close();
+				return;
+			}
+			if (e.key === "Tab" && alertPanel) {
+				const focusables = $$(FOCUSABLE_SELECTORS, alertPanel);
+				if (focusables.length === 0) {
+					e.preventDefault();
+					return;
+				}
+				const first = focusables[0];
+				const last = focusables[focusables.length - 1];
+				if (e.shiftKey && document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				} else if (!e.shiftKey && document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
 			}
 		}
 		document.addEventListener("keydown", onKeyDown);

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -726,6 +726,9 @@
   }
 
   &__list {
+    // 기본 숨김 - JS 초기화 전/JS 비활성 시 드롭다운이 펼쳐진 채 렌더링(FOUC)되지 않게.
+    // 열림/닫힘은 JS 가 inline display 로 토글한다.
+    display: none;
     position: absolute;
     z-index: var(--bt-z-modal);
     top: 100%;

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -288,7 +288,7 @@
           <div class="bt-card__title">Card Title</div>
           <p>This is a card component with bordered style and medium padding.</p>
         </div>
-        <div class="bt-card bt-card--shadow-md bt-card--p-md" style="width: 300px;">
+        <div class="bt-card bt-card--elevation-2 bt-card--p-md" style="width: 300px;">
           <div class="bt-card__title">Shadow Card</div>
           <p>This card uses shadow instead of border.</p>
         </div>


### PR DESCRIPTION
## 작업 개요

전체 DS 감사에서 나온 Vanilla 번들 medium 발견사항 일괄 수정 — React 컴포넌트와의 접근성 패리티.

> ⚠️ **#374(fix/vanilla) 위에 스택된 PR** — 같은 파일(bigtablet.js/scss) 충돌 방지를 위해 base 를 `fix/vanilla` 로 설정. #374 머지 후 자동 리타겟. 머지 순서: #374 → 이 PR.

## 작업한 내용
- [x] **Select combobox ARIA 전체 배선**: `role=combobox/listbox/option`, `aria-haspopup`, `aria-expanded` 동기화, `aria-controls`, `aria-selected`, `aria-disabled`, 키보드 탐색 따라가는 `aria-activedescendant` — 화살표 탐색이 스크린리더에 무음이던 문제
- [x] **Modal 포커스 관리**: 패널 `role=dialog`+`aria-modal`, 트리거 포커스 저장/복원, 초기 포커스 진입, Tab 순환 트랩 (APG Dialog) — 기존엔 포커스 관리 전무
- [x] **Alert**: `role=alertdialog` + labelledby/describedby, 확인 버튼 초기 포커스, 닫힘 시 포커스 복원. **Escape 리스너 누수 수정** — 버튼/오버레이로 닫으면 document 리스너가 해제되지 않던 문제
- [x] **스크롤 잠금 카운터** (`data-bt-open-modals`): Modal 위 Alert 패턴에서 하나만 닫혀도 배경 스크롤이 풀리던 문제 — React 쪽과 동일 카운터 패턴, `destroy()` 정합 포함
- [x] **FOUC 수정**: `.bt-select__list` CSS 기본 숨김 — JS 초기화 전/JS 비활성 시 옵션 리스트가 펼쳐진 채 렌더되던 문제
- [x] **init() 중복 바인딩 가드**: `data-bt-modal-open` 트리거 재초기화 시 리스너 중복 방지
- [x] **예제 수정**: 존재하지 않는 `bt-card--shadow-md` → `bt-card--elevation-2`

## 검증 (라이브 브라우저 실측)
- combobox 속성 + `aria-activedescendant` 가 화살표 키 따라 갱신 확인
- Modal: 포커스 진입 `true` → 닫기 후 트리거 복원 `true`, 카운터 1→0, overflow hidden→""
- select list 초기화 전 `display: none` 확인
- `node --check` + vanilla 빌드 + 유닛 700 passed

## 전달할 추가 이슈
- 없음 — 감사에서 나온 Vanilla 발견사항은 #374 + 이 PR 로 전부 처리됨
