### PR TITLE
docs/stories-types

### DIFF
--- a/src/stories/cookbook/data.stories.tsx
+++ b/src/stories/cookbook/data.stories.tsx
@@ -474,7 +474,7 @@ export const OrderTimeline: Story = {
 									)}
 								</Stack>
 
-								<Stack gap={6} style={{ flex: 1, paddingBottom: isLast ? 0 : 8 }}>
+								<Stack gap={4} style={{ flex: 1, paddingBottom: isLast ? 0 : 8 }}>
 									<Stack direction="horizontal" justify="between" align="center">
 										<span
 											style={{

--- a/src/stories/examples/page-composition.stories.tsx
+++ b/src/stories/examples/page-composition.stories.tsx
@@ -393,7 +393,7 @@ export const AdminDashboard: Story = {
 								<path d="M16 10a4 4 0 0 1-8 0" />
 							</svg>
 						}
-						badge={<Badge shape="count" variant="danger">5</Badge>}
+						trailing={<Badge shape="count" variant="error">5</Badge>}
 					>
 						주문
 					</SidebarItem>

--- a/src/stories/foundation/form-comparison.stories.tsx
+++ b/src/stories/foundation/form-comparison.stories.tsx
@@ -30,7 +30,7 @@ export const SideBySide: Story = {
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 					<TextField label="이메일" placeholder="placeholder@example.com" />
 					<TextField label="비밀번호" placeholder="••••••••" type="password" />
-					<TextField label="값 있음" value="user@example.com" onChange={() => {}} />
+					<TextField label="값 있음" value="user@example.com" onValueChange={() => {}} />
 				</div>
 			</div>
 			<div>

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { MapPin } from "lucide-react";
 import * as React from "react";
-import { Dropdown, type DropdownOption } from ".";
+import {
+	Dropdown,
+	type DropdownMultipleProps,
+	type DropdownOption,
+	type DropdownSingleProps,
+} from ".";
 
 const basicOptions: DropdownOption[] = [
 	{ value: "apple", label: "Apple" },
@@ -107,7 +112,8 @@ export const Controlled: Story = {
 		const [value, setValue] = React.useState<string | null>("banana");
 		return (
 			<div style={{ width: 320 }}>
-				<Dropdown {...args} value={value} onChange={setValue} />
+				{/* args 는 single/multiple 유니온이라 단일 모드 제어 prop 과 스프레드로 섞을 수 없음 - 단일로 단언 */}
+				<Dropdown {...(args as DropdownSingleProps)} value={value} onValueChange={setValue} />
 				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 					선택: <strong>{String(value)}</strong>
 				</div>
@@ -151,7 +157,7 @@ export const Multiple: Story = {
 		return (
 			<div style={{ width: 320 }}>
 				<Dropdown
-					{...args}
+					{...(args as DropdownMultipleProps)}
 					multiple
 					options={fruitOptions}
 					label="Fruit"
@@ -183,7 +189,7 @@ export const SearchableMultiple: Story = {
 		return (
 			<div style={{ width: 320 }}>
 				<Dropdown
-					{...args}
+					{...(args as DropdownMultipleProps)}
 					multiple
 					searchable
 					options={fruitOptions}

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -112,8 +112,15 @@ export const Controlled: Story = {
 		const [value, setValue] = React.useState<string | null>("banana");
 		return (
 			<div style={{ width: 320 }}>
-				{/* args 는 single/multiple 유니온이라 단일 모드 제어 prop 과 스프레드로 섞을 수 없음 - 단일로 단언 */}
-				<Dropdown {...(args as DropdownSingleProps)} value={value} onValueChange={setValue} />
+				{/* args 는 single/multiple 유니온이라 단일 모드 제어 prop 과 스프레드로 섞을 수 없음 - 단일로 단언.
+				    multiple={false} 을 명시 고정해 Storybook Controls 에서 multiple 을 켜도
+				    단일 문자열 value 에 .filter 를 호출해 크래시하지 않도록 방지. */}
+				<Dropdown
+					{...(args as DropdownSingleProps)}
+					multiple={false}
+					value={value}
+					onValueChange={setValue}
+				/>
 				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 					선택: <strong>{String(value)}</strong>
 				</div>


### PR DESCRIPTION
## 작업 개요

`pnpm exec tsc --noEmit` 에 방치돼 있던 stories 파일 타입 에러 7건을 실제 컴포넌트 API 에 맞게 정리 (CI 게이트에 없어 누적된 것들).

## 작업한 내용
- [x] `data.stories.tsx`: `Stack gap={6}` — StackGap 스케일(0|2|4|8|...)에 없는 값 → `4`
- [x] `page-composition.stories.tsx`: `SidebarItem` 에 존재하지 않는 `badge` prop → 실제 API 인 `trailing`, `BadgeVariant` 에 없는 `"danger"` → `"error"`
- [x] `form-comparison.stories.tsx`: TextField 는 native `onChange` 를 Omit → `onValueChange` 로
- [x] `dropdown.stories.tsx` 3건: single/multiple 유니온인 args 스프레드 + 모드 특정 prop 오버라이드가 타입 불성립 → 스토리 의도에 맞는 유니온 멤버로 단언 (`DropdownSingleProps` / `DropdownMultipleProps`), deprecated `onChange` → `onValueChange` 마이그레이션

## 검증
- `pnpm exec tsc --noEmit` → **0 에러**
- 유닛 700 passed

## 전달할 추가 이슈
- tsc --noEmit 을 CI 에 게이트로 추가할지 검토 권장 (이번 같은 방치 방지)
