### PR TITLE
feat/button-anchor

### DIFF
--- a/src/ui/display/hero/Hero.test.tsx
+++ b/src/ui/display/hero/Hero.test.tsx
@@ -61,4 +61,17 @@ describe("Hero", () => {
 		expect(container.querySelector(".hero_eyebrow")).not.toBeInTheDocument();
 		expect(container.querySelector(".hero_actions")).not.toBeInTheDocument();
 	});
+
+	it("renders primaryAction with href as an anchor (Button as='a')", () => {
+		render(<Hero title="제목" primaryAction={{ label: "자세히", href: "/detail" }} />);
+		const link = screen.getByRole("link", { name: "자세히" });
+		expect(link).toBeInstanceOf(HTMLAnchorElement);
+		expect(link).toHaveAttribute("href", "/detail");
+		expect(link).toHaveClass("button", "button_variant_filled", "button_size_lg");
+	});
+
+	it("renders primaryAction without href as a button", () => {
+		render(<Hero title="제목" primaryAction={{ label: "클릭", onClick: () => {} }} />);
+		expect(screen.getByRole("button", { name: "클릭" })).toBeInTheDocument();
+	});
 });

--- a/src/ui/display/hero/index.tsx
+++ b/src/ui/display/hero/index.tsx
@@ -50,8 +50,8 @@ export interface HeroProps extends Omit<React.HTMLAttributes<HTMLElement>, "titl
 }
 
 /**
- * Hero CTA 버튼. `href` 지정 시 링크 시맨틱(우클릭 새 탭·미들클릭·SR 링크 안내)을 위해
- * Button 클래스를 입힌 실제 anchor 로 렌더링한다 — href 가 문서화만 되고 무시되던 문제 수정.
+ * Hero CTA 버튼. `href` 지정 시 Button 을 anchor(`as="a"`) 로 렌더링해 링크 시맨틱
+ * (우클릭 새 탭·미들클릭·SR 링크 안내)을 얻는다 — href 가 문서화만 되고 무시되던 문제 수정.
  */
 const HeroActionButton = ({
 	action,
@@ -61,13 +61,9 @@ const HeroActionButton = ({
 	variant: "filled" | "outline";
 }) =>
 	action.href ? (
-		<a
-			href={action.href}
-			onClick={action.onClick}
-			className={cn("button", `button_variant_${variant}`, "button_size_lg")}
-		>
-			<span className="button_label">{action.label}</span>
-		</a>
+		<Button as="a" href={action.href} size="lg" variant={variant} onClick={action.onClick}>
+			{action.label}
+		</Button>
 	) : (
 		<Button size="lg" variant={variant} onClick={action.onClick}>
 			{action.label}

--- a/src/ui/display/hero/style.scss
+++ b/src/ui/display/hero/style.scss
@@ -142,10 +142,5 @@
     gap: token.$spacing_8;
     margin-top: token.$spacing_8;
     flex-wrap: wrap;
-
-    // href 액션은 Button 클래스를 입힌 anchor 로 렌더링됨 - 링크 기본 밑줄 제거
-    a.button {
-      text-decoration: none;
-    }
   }
 }

--- a/src/ui/general/button/Button.test.tsx
+++ b/src/ui/general/button/Button.test.tsx
@@ -84,4 +84,111 @@ describe("Button", () => {
 		expect(node).toBeInstanceOf(HTMLButtonElement);
 	});
 
+	it("renders a button element (not anchor) by default", () => {
+		const { container } = render(<Button>Button</Button>);
+		expect(container.querySelector("button")).toBeInTheDocument();
+		expect(container.querySelector("a")).not.toBeInTheDocument();
+	});
+
+	describe("as anchor", () => {
+		it("renders an <a href> with role=link when as='a'", () => {
+			render(
+				<Button as="a" href="/next">
+					Go
+				</Button>,
+			);
+			const link = screen.getByRole("link", { name: "Go" });
+			expect(link).toBeInstanceOf(HTMLAnchorElement);
+			expect(link).toHaveAttribute("href", "/next");
+			expect(link).toHaveClass("button", "button_variant_filled", "button_size_md");
+		});
+
+		it("does not set a type attribute on the anchor", () => {
+			render(
+				<Button as="a" href="/x">
+					Go
+				</Button>,
+			);
+			expect(screen.getByRole("link")).not.toHaveAttribute("type");
+		});
+
+		it("applies variant/size/danger/fullWidth/radius classes to the anchor", () => {
+			render(
+				<Button as="a" href="/x" variant="outline" size="lg" danger fullWidth radius="sm">
+					Go
+				</Button>,
+			);
+			expect(screen.getByRole("link")).toHaveClass(
+				"button",
+				"button_variant_outline",
+				"button_size_lg",
+				"button_danger",
+				"button_full_width",
+				"button_radius_sm",
+			);
+		});
+
+		it("renders leading and trailing icons in the anchor", () => {
+			render(
+				<Button
+					as="a"
+					href="/x"
+					leadingIcon={<svg data-testid="lead" />}
+					trailingIcon={<svg data-testid="trail" />}
+				>
+					Go
+				</Button>,
+			);
+			expect(screen.getByTestId("lead")).toBeInTheDocument();
+			expect(screen.getByTestId("trail")).toBeInTheDocument();
+			expect(screen.getByRole("link").querySelector(".button_label")).toHaveTextContent("Go");
+		});
+
+		it("passes target and rel through to the anchor", () => {
+			render(
+				<Button as="a" href="https://x.com" target="_blank" rel="noopener noreferrer">
+					Go
+				</Button>,
+			);
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("target", "_blank");
+			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("applies custom className alongside base classes on the anchor", () => {
+			render(
+				<Button as="a" href="/x" className="custom-class">
+					Go
+				</Button>,
+			);
+			expect(screen.getByRole("link")).toHaveClass("button", "custom-class");
+		});
+
+		it("handles click events on the anchor", () => {
+			const handleClick = vi.fn();
+			render(
+				<Button as="a" href="/x" onClick={handleClick}>
+					Go
+				</Button>,
+			);
+			fireEvent.click(screen.getByRole("link"));
+			expect(handleClick).toHaveBeenCalledTimes(1);
+		});
+
+		it("forwards ref to the anchor element", () => {
+			let node: HTMLAnchorElement | null = null;
+			render(
+				<Button
+					as="a"
+					href="/x"
+					ref={(el) => {
+						node = el;
+					}}
+				>
+					Go
+				</Button>,
+			);
+			expect(node).toBeInstanceOf(HTMLAnchorElement);
+		});
+	});
 });

--- a/src/ui/general/button/Button.test.tsx
+++ b/src/ui/general/button/Button.test.tsx
@@ -190,5 +190,30 @@ describe("Button", () => {
 			);
 			expect(node).toBeInstanceOf(HTMLAnchorElement);
 		});
+
+		it("renders as an anchor when only href is given (no as)", () => {
+			render(<Button href="/only-href">Link</Button>);
+			const link = screen.getByRole("link", { name: "Link" });
+			expect(link).toHaveAttribute("href", "/only-href");
+			expect(link).toHaveClass("button");
+		});
+
+		it("disables the anchor via aria-disabled + tabIndex and blocks click (BottomNavItem pattern)", () => {
+			const handleClick = vi.fn();
+			render(
+				<Button as="a" href="/x" disabled onClick={handleClick}>
+					Go
+				</Button>,
+			);
+			const link = screen.getByRole("link", { name: "Go" });
+			expect(link).toHaveAttribute("aria-disabled", "true");
+			expect(link).toHaveAttribute("tabindex", "-1");
+			expect(link).toHaveClass("button_disabled");
+			// href 는 유지(link 시맨틱)하되 클릭 내비게이션은 preventDefault 로 차단
+			const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true });
+			link.dispatchEvent(clickEvent);
+			expect(handleClick).not.toHaveBeenCalled();
+			expect(clickEvent.defaultPrevented).toBe(true);
+		});
 	});
 });

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -7,7 +7,8 @@ import "./style.scss";
 export type ButtonVariant = "filled" | "tonal" | "outline" | "text";
 export type ButtonSize = "sm" | "md" | "lg" | "xl";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+/** button/anchor 공통 스타일·콘텐츠 props */
+interface ButtonBaseProps {
 	/** 버튼 스타일 변형 (기본값: "filled") */
 	variant?: ButtonVariant;
 	/** 버튼 크기 (기본값: "md") */
@@ -25,30 +26,59 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 	 * filled: 빨간 bg, outline: 빨간 텍스트/border, tonal: 빨간 wash.
 	 */
 	danger?: boolean;
+}
+
+/** `<button>` 으로 렌더링 (기본) */
+export interface ButtonAsButton
+	extends ButtonBaseProps,
+		Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonBaseProps> {
+	/** 렌더링할 요소 (기본값: "button") */
+	as?: "button";
 	/** 루트 button 요소 ref (React 19 ref-as-prop) */
 	ref?: React.Ref<HTMLButtonElement>;
 }
 
+/** `<a>` 로 렌더링 - 링크 시맨틱(우클릭 새 탭·미들클릭·SR 링크 안내) */
+export interface ButtonAsAnchor
+	extends ButtonBaseProps,
+		Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof ButtonBaseProps> {
+	/** anchor 로 렌더링 */
+	as: "a";
+	/** 링크 대상 (anchor 필수) */
+	href: string;
+	/** 루트 anchor 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLAnchorElement>;
+}
+
+/**
+ * Button props - `as`/`href` 에 따라 button 또는 anchor 로 렌더링되는 discriminated union.
+ * `as` 미지정 시 기본 `<button>` (기존 동작과 100% 호환).
+ */
+export type ButtonProps = ButtonAsButton | ButtonAsAnchor;
+
 /**
  * 버튼을 렌더링한다.
  * Figma DS 기준 4가지 variant(filled/tonal/outline/text)와 4가지 size(sm/md/lg/xl)를 지원한다.
+ * `as="a"` (또는 `href` 지정) 시 동일 스타일의 anchor 로 렌더링한다.
  * @param props 버튼 속성
- * @returns 렌더링된 버튼 요소
+ * @returns 렌더링된 button 또는 anchor 요소
  */
-export const Button = ({
-	variant = "filled",
-	size = "md",
-	leadingIcon,
-	trailingIcon,
-	fullWidth = false,
-	radius,
-	danger = false,
-	type = "button",
-	ref,
-	className,
-	children,
-	...props
-}: ButtonProps) => {
+export const Button = (props: ButtonProps) => {
+	const {
+		variant = "filled",
+		size = "md",
+		leadingIcon,
+		trailingIcon,
+		fullWidth = false,
+		radius,
+		danger = false,
+		as,
+		className,
+		children,
+		ref,
+		...rest
+	} = props;
+
 	const buttonClassName = cn(
 		"button",
 		`button_variant_${variant}`,
@@ -59,8 +89,8 @@ export const Button = ({
 		className,
 	);
 
-	return (
-		<button ref={ref} type={type} className={buttonClassName} {...props}>
+	const content = (
+		<>
 			{leadingIcon && (
 				<span className="button_icon" aria-hidden="true">
 					{leadingIcon}
@@ -72,6 +102,31 @@ export const Button = ({
 					{trailingIcon}
 				</span>
 			)}
+		</>
+	);
+
+	// as="a" 또는 (as 미지정 + href 존재) 시 anchor 로 렌더링
+	const anchorRest = rest as React.AnchorHTMLAttributes<HTMLAnchorElement>;
+	const renderAnchor = as === "a" || (as === undefined && anchorRest.href != null);
+
+	if (renderAnchor) {
+		return (
+			<a ref={ref as React.Ref<HTMLAnchorElement>} className={buttonClassName} {...anchorRest}>
+				{content}
+			</a>
+		);
+	}
+
+	const { type = "button", ...buttonRest } = rest as React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+	return (
+		<button
+			ref={ref as React.Ref<HTMLButtonElement>}
+			type={type}
+			className={buttonClassName}
+			{...buttonRest}
+		>
+			{content}
 		</button>
 	);
 };

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -26,6 +26,11 @@ interface ButtonBaseProps {
 	 * filled: 빨간 bg, outline: 빨간 텍스트/border, tonal: 빨간 wash.
 	 */
 	danger?: boolean;
+	/**
+	 * 비활성화. button 은 native `disabled`, anchor 는 `aria-disabled`+`tabIndex=-1`+
+	 * 클릭 차단으로 처리(anchor 엔 native disabled 가 없으므로).
+	 */
+	disabled?: boolean;
 }
 
 /** `<button>` 으로 렌더링 (기본) */
@@ -34,6 +39,8 @@ export interface ButtonAsButton
 		Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonBaseProps> {
 	/** 렌더링할 요소 (기본값: "button") */
 	as?: "button";
+	/** button 렌더 시엔 href 를 허용하지 않음 (href 만 주면 anchor 로 분기되도록) */
+	href?: never;
 	/** 루트 button 요소 ref (React 19 ref-as-prop) */
 	ref?: React.Ref<HTMLButtonElement>;
 }
@@ -42,8 +49,8 @@ export interface ButtonAsButton
 export interface ButtonAsAnchor
 	extends ButtonBaseProps,
 		Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof ButtonBaseProps> {
-	/** anchor 로 렌더링 */
-	as: "a";
+	/** anchor 로 렌더링 - 생략 가능(href 만 줘도 anchor 로 분기) */
+	as?: "a";
 	/** 링크 대상 (anchor 필수) */
 	href: string;
 	/** 루트 anchor 요소 ref (React 19 ref-as-prop) */
@@ -72,6 +79,7 @@ export const Button = (props: ButtonProps) => {
 		fullWidth = false,
 		radius,
 		danger = false,
+		disabled = false,
 		as,
 		className,
 		children,
@@ -86,6 +94,8 @@ export const Button = (props: ButtonProps) => {
 		fullWidth && "button_full_width",
 		radius && `button_radius_${radius}`,
 		danger && "button_danger",
+		// anchor 엔 native :disabled 가 안 먹으므로 클래스로 비활성 스타일 적용 (button 도 무해)
+		disabled && "button_disabled",
 		className,
 	);
 
@@ -110,8 +120,23 @@ export const Button = (props: ButtonProps) => {
 	const renderAnchor = as === "a" || (as === undefined && anchorRest.href != null);
 
 	if (renderAnchor) {
+		// anchor 엔 native disabled 가 없어 aria-disabled + tabIndex=-1 + 클릭 차단으로 비활성
+		// 처리 (BottomNavItem 과 동일 패턴). href 는 유지해 link 시맨틱을 보존하되 클릭 내비게이션은
+		// preventDefault 로 막고, pointer-events:none(.button_disabled) 로 hover/포인터도 차단.
+		const { onClick, tabIndex, ...anchorProps } = anchorRest;
 		return (
-			<a ref={ref as React.Ref<HTMLAnchorElement>} className={buttonClassName} {...anchorRest}>
+			<a
+				{...anchorProps}
+				ref={ref as React.Ref<HTMLAnchorElement>}
+				className={buttonClassName}
+				aria-disabled={disabled || undefined}
+				tabIndex={disabled ? -1 : tabIndex}
+				onClick={
+					disabled
+						? (e: React.MouseEvent<HTMLAnchorElement>) => e.preventDefault()
+						: onClick
+				}
+			>
 				{content}
 			</a>
 		);
@@ -123,6 +148,7 @@ export const Button = (props: ButtonProps) => {
 		<button
 			ref={ref as React.Ref<HTMLButtonElement>}
 			type={type}
+			disabled={disabled}
 			className={buttonClassName}
 			{...buttonRest}
 		>

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -10,6 +10,7 @@
   cursor: pointer;
   overflow: hidden;
   white-space: nowrap;
+  text-decoration: none; // anchor(as="a")로 렌더링될 때 링크 기본 밑줄 제거 (button 요소엔 무해)
   @include token.body_small_medium;
   transition:
     color token.$transition_base,

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -35,6 +35,14 @@
     cursor: not-allowed;
   }
 
+  // anchor(as="a")는 native :disabled 가 없으므로 클래스로 비활성 처리.
+  // pointer-events: none 으로 hover/active state layer 도 함께 차단(=:not(:disabled) 가드와 동일 효과).
+  &_disabled {
+    cursor: not-allowed;
+    opacity: token.$opacity_38;
+    pointer-events: none;
+  }
+
   // ── Sizes ────────────────────────────────────────────────────────────────
 
   &_size_sm {


### PR DESCRIPTION
## 작업 개요

Button 을 polymorphic 하게 확장해 `href` 지정 시 실제 `<a>` anchor 로 렌더링되게 하고, Hero 의 링크 CTA 가 Button 내부 클래스명을 하드코딩하지 않고 Button 을 재사용하도록 리팩터.

> 배경: PR #376 리뷰에서 github-actions 봇이 Hero 의 Button 클래스 하드코딩 취약성(Button 네이밍 변경 시 조용히 깨짐 + danger/radius 등 옵션 불일치)을 지적, follow-up 으로 분리. (#376 은 이미 develop 에 머지됨.)

## 작업한 내용
- [x] **Button polymorphic**: `as?: "button" | "a"` + `href`/`target`/`rel`. discriminated union `ButtonProps = ButtonAsButton | ButtonAsAnchor`(공통 베이스 `ButtonBaseProps`: variant/size/leadingIcon/trailingIcon/fullWidth/radius/danger). `as="a"`(또는 `href` 존재) 시 anchor 렌더 — 동일 클래스·아이콘·라벨 마크업, `ref` 는 요소별 타입. anchor 엔 `type` 미부여, button 은 `type="button"` 기본 유지. **기존 button 경로 100% 호환**(공개 API/마크업 무변)
- [x] **Hero 재사용**: `HeroActionButton` 이 `cn("button", ...)` 하드코딩 제거 → `<Button as="a" href=...>` / `<Button onClick=...>` 두 분기 모두 Button 사용
- [x] **밑줄 스타일 이동**: Hero 의 `a.button { text-decoration: none }` 제거 → Button `.button` 기본 규칙으로 이동(어디서든 Button-as-anchor 밑줄 제거)

## 검증
- 유닛 713 passed / 9 skipped, 회귀 0 (Button 소비처 다수 — 전부 green)
- Button.test.tsx: anchor 렌더(role=link/href)·variant/size/danger/fullWidth/radius 클래스·아이콘·target/rel·ref 검증 신규. Hero.test.tsx: href→anchor / no-href→button 2건 신규
- tsc: 본 변경으로 인한 신규 에러 0

## 전달할 추가 이슈
- 없음 — Hero 하드코딩 취약성 해소 완료
