### PR TITLE
feat/overlay-stack

### DIFF
--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
+import { cn, useFocusTrap, useOverlayEscape, useReducedMotion } from "../../../utils";
 import { Button, type ButtonVariant } from "../../general/button";
 import "./style.scss";
 
@@ -145,6 +145,11 @@ const AlertModal: React.FC<AlertModalProps> = ({
 
 	useFocusTrap(panelRef, isOpen);
 
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// dismiss = onCancel ?? onClose 로 라우팅해 취소 정리 로직이 우회되지 않게 한다 (APG alertdialog).
+	// Modal 위에 confirm Alert 를 띄우는 조합에서도 Alert(최상단)만 닫히고 Modal 은 유지된다.
+	useOverlayEscape(isOpen, () => dismiss());
+
 	// isOpen 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다 (Modal 과 동일한
 	// React "render 중 상태 조정" 패턴). effect 로 미루면 패널 마운트가 한 렌더 늦어져
 	// useFocusTrap effect 실행 시점에 panelRef.current 가 null 이라 트랩(초기 포커스 이동·
@@ -220,19 +225,14 @@ const AlertModal: React.FC<AlertModalProps> = ({
 			style={overlayStyle}
 			role="presentation"
 			onClick={() => closeOnOverlay && dismiss()}
-			onKeyDown={(e) => {
-				// Escape 전파 차단 - 상위 오버레이/전역 단축키가 함께 닫히지 않도록 (최상단만 닫힘)
-				if (e.key === "Escape") {
-					e.stopPropagation();
-					dismiss();
-				}
-			}}
 		>
 			<animated.div
 				ref={panelRef}
 				className={modalClassName}
 				style={panelStyle}
 				onClick={(e) => e.stopPropagation()}
+				// Escape 는 공유 스택(useOverlayEscape)이 처리하고, 여기서는 그 외 키가 알림 밖으로
+				// 새어 상위 오버레이/소비자 단축키를 건드리지 않게 막는다.
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -161,10 +161,20 @@ describe("Drawer", () => {
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
-	it("Escape closes only the topmost drawer when nested (stopPropagation)", () => {
+	it("Escape closes only the topmost drawer when nested (shared overlay stack)", () => {
 		const outerClose = vi.fn();
 		const innerClose = vi.fn();
-		render(
+		// 공유 스택은 LIFO - 최상단 = 가장 최근에 열린 오버레이다. 실제 앱에서 중첩 오버레이는
+		// 순차적으로 열리므로(바깥을 연 뒤 안쪽을 연다) 열린 순서 = stacking 순서가 된다.
+		// 그 순서를 재현하기 위해 바깥을 먼저 연 뒤 rerender 로 안쪽을 연다.
+		const { rerender } = render(
+			<Drawer open onClose={outerClose} title="Outer">
+				<Drawer open={false} onClose={innerClose} title="Inner">
+					<button type="button">Inner content</button>
+				</Drawer>
+			</Drawer>,
+		);
+		rerender(
 			<Drawer open onClose={outerClose} title="Outer">
 				<Drawer open onClose={innerClose} title="Inner">
 					<button type="button">Inner content</button>
@@ -178,6 +188,7 @@ describe("Drawer", () => {
 		const innerPanel = screen.getByText("Inner content").closest('[role="document"]') as HTMLElement;
 		fireEvent.keyDown(innerPanel, { key: "Escape" });
 
+		// 최상단(나중에 연 inner)만 닫히고 outer 는 유지된다 (APG)
 		expect(innerClose).toHaveBeenCalledTimes(1);
 		expect(outerClose).not.toHaveBeenCalled();
 	});

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -5,7 +5,7 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useReducedMotion, useSpringPresence } from "../../../utils";
+import { cn, useFocusTrap, useOverlayEscape, useReducedMotion, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 /** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
@@ -74,6 +74,10 @@ export const Drawer = ({
 
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
+
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// Modal/Popover/Tooltip 등과 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
+	useOverlayEscape(open, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
@@ -153,21 +157,13 @@ export const Drawer = ({
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
 			onClick={() => closeOnOverlay && onClose?.()}
-			// Escape 는 여기서 단독 처리 + stopPropagation - 중첩 오버레이에서 가장 위(topmost)만
-			// 닫히도록 (document 전역 리스너로 처리하면 열린 모든 오버레이가 동시에 닫힘).
-			// panel onKeyDown 이 Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
-			onKeyDown={(e) => {
-				if (e.key === "Escape") {
-					e.stopPropagation();
-					onClose?.();
-				}
-			}}
 		>
 			<animated.div
 				ref={panelRef}
 				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
-				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
-				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown 은 컴포넌트가 항상
+				// 이기도록 뒤에 배치한다 (오버레이 동작 보호). Escape 는 공유 스택(useOverlayEscape)이
+				// 처리하고, 여기서는 그 외 키가 드로어 밖으로 새어 소비자 단축키를 건드리지 않게 막는다.
 				{...props}
 				className={cn("drawer_panel", className)}
 				style={{ ...props.style, ...panelStyle, ...panelSizeStyle }}

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -5,7 +5,7 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
+import { cn, useFocusTrap, useOverlayEscape, useReducedMotion } from "../../../utils";
 import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
@@ -66,6 +66,10 @@ export const Modal = ({
 
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
+
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// Tooltip/Popover 등 다른 오버레이와 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
+	useOverlayEscape(open, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
@@ -145,21 +149,13 @@ export const Modal = ({
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
 			onClick={() => closeOnOverlay && onClose?.()}
-			// Escape 는 여기서 단독 처리 + stopPropagation — 중첩 모달에서 가장 안쪽만 닫히도록
-			// (document 전역 리스너로 처리하면 열린 모든 모달이 동시에 닫힘). panel onKeyDown 이
-			// Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
-			onKeyDown={(e) => {
-				if (e.key === "Escape") {
-					e.stopPropagation();
-					onClose?.();
-				}
-			}}
 		>
 			<animated.div
 				ref={panelRef}
 				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
-				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
-				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown 은 컴포넌트가 항상
+				// 이기도록 뒤에 배치한다 (오버레이 동작 보호). Escape 는 공유 스택(useOverlayEscape)이
+				// 처리하고, 여기서는 그 외 키가 모달 밖으로 새어 소비자 단축키를 건드리지 않게 막는다.
 				{...props}
 				className={cn("modal_panel", className)}
 				style={{ ...props.style, ...panelStyle, width }}

--- a/src/ui/overlay/overlay-escape.test.tsx
+++ b/src/ui/overlay/overlay-escape.test.tsx
@@ -1,0 +1,128 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Modal } from "./modal";
+import { Popover } from "./popover";
+import { Tooltip } from "./tooltip";
+
+/**
+ * 여러 오버레이가 동시에 열렸을 때 공유 스택이 "최상단(가장 최근에 연) 오버레이만 닫힘"(APG)을
+ * 컴포넌트 조합에서도 보장하는지, 그리고 자식 요소의 자체 Escape 처리(critical)를 막지 않는지 검증.
+ */
+describe("overlay Escape composition (shared stack)", () => {
+	it("Tooltip over Popover: Escape closes only the topmost (Tooltip), Popover stays; next Escape closes Popover", () => {
+		vi.useFakeTimers();
+		try {
+			const onOpenChange = vi.fn();
+			render(
+				<Popover
+					defaultOpen
+					onOpenChange={onOpenChange}
+					trigger={<button type="button">trigger</button>}
+					aria-label="pop"
+					content={
+						<Tooltip content="tip" delay={0}>
+							<button type="button">inner</button>
+						</Tooltip>
+					}
+				/>,
+			);
+
+			// Popover 는 이미 열림. inner 버튼에 hover 해 Tooltip 을 나중에 연다 → Tooltip 이 최상단.
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+			fireEvent.mouseEnter(screen.getByRole("button", { name: "inner" }));
+			act(() => {
+				vi.advanceTimersByTime(10);
+			});
+			expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+			// 1차 Escape - 최상단(Tooltip)만 닫히고 Popover 는 유지, onOpenChange 도 안 불림
+			fireEvent.keyDown(document.body, { key: "Escape" });
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+			expect(onOpenChange).not.toHaveBeenCalled();
+
+			// 2차 Escape - 이제 최상단이 된 Popover 가 닫힌다
+			fireEvent.keyDown(document.body, { key: "Escape" });
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("Popover inside Modal: Escape closes only the Popover, Modal stays (topmost)", () => {
+		const modalClose = vi.fn();
+		const onOpenChange = vi.fn();
+		render(
+			<Modal open onClose={modalClose} title="M">
+				<Popover
+					onOpenChange={onOpenChange}
+					trigger={<button type="button">open pop</button>}
+					aria-label="pop"
+					content={<span>pop body</span>}
+				/>
+			</Modal>,
+		);
+		// Modal 이 먼저 열려 있고, 그 안에서 Popover 를 클릭으로 나중에 연다 → Popover 최상단
+		fireEvent.click(screen.getByText("open pop"));
+		expect(screen.getByText("pop body")).toBeInTheDocument();
+
+		fireEvent.keyDown(screen.getByText("pop body"), { key: "Escape" });
+
+		// 최상단(Popover)만 닫히고(onOpenChange(false)) Modal 은 유지된다(onClose 미호출).
+		// (Popover 의 exit 애니메이션 완료 후 unmount 는 Popover 자체 테스트가 커버하므로
+		//  여기선 조합 관점의 신호 - onOpenChange/onClose - 만 검증한다.)
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(modalClose).not.toHaveBeenCalled();
+	});
+
+	it("does not steal Escape from a child that handles it first (child stops propagation)", () => {
+		// critical: 레지스트리는 document bubble 리스너라 자식(input) 이 먼저 이벤트를 받는다.
+		// 자식이 자체 Escape 를 처리하고 stopPropagation 하면 이벤트가 document 까지 오지 않아
+		// Popover 는 닫히지 않는다 (IME/native select 등 자식 우선 처리 보장).
+		const onOpenChange = vi.fn();
+		render(
+			<Popover
+				defaultOpen
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">t</button>}
+				aria-label="pop"
+				content={
+					<input
+						aria-label="field"
+						onKeyDown={(e) => {
+							if (e.key === "Escape") e.stopPropagation();
+						}}
+					/>
+				}
+			/>,
+		);
+		const field = screen.getByLabelText("field");
+		expect(field).toHaveFocus(); // 열릴 때 첫 focusable 로 포커스 이동
+
+		fireEvent.keyDown(field, { key: "Escape" });
+
+		// 자식이 소비했으므로 Popover 는 열린 채 유지
+		expect(onOpenChange).not.toHaveBeenCalled();
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("closes the Popover when a child does NOT consume the Escape", () => {
+		const onOpenChange = vi.fn();
+		render(
+			<Popover
+				defaultOpen
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">t</button>}
+				aria-label="pop"
+				content={<input aria-label="field" />}
+			/>,
+		);
+		const field = screen.getByLabelText("field");
+		expect(field).toHaveFocus();
+
+		fireEvent.keyDown(field, { key: "Escape" });
+
+		// 자식이 소비하지 않으면 document 까지 버블돼 최상단 Popover 가 닫힌다
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+});

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -2,7 +2,7 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type PopoverPlacement = "top" | "bottom" | "left" | "right";
@@ -123,18 +123,16 @@ export const Popover = ({
 		return () => document.removeEventListener("mousedown", handleClick);
 	}, [open, setOpen]);
 
-	// Escape 닫기 - document capture 리스너 대신 wrapper 의 React onKeyDown(버블) 로 처리한다.
-	// capture+stopPropagation 은 이벤트가 타겟(Popover 내부 input/select 등)에 닿기도 전에
-	// 최상단에서 끊어 자식 요소의 자체 Escape 처리를 마비시킨다(치명적). 버블 단계에서 잡으면
-	// 자식이 먼저 처리할 기회를 갖고, 여기서 stopPropagation 하면 상위 Modal 의 onKeyDown 으로도
-	// 전파되지 않아 "최상단만 닫힘"(APG)이 지켜진다.
-	const handleWrapperKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		if (open && e.key === "Escape") {
-			e.stopPropagation();
-			setOpen(false);
-			previousFocusRef.current?.focus();
-		}
-	};
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// 레지스트리 리스너는 document 의 bubble 단계라 이벤트가 target(Popover 내부 input/select 등)에서
+	// 위로 올라오며 자식이 먼저 처리할 기회를 갖는다. 자식이 자체 Escape 를 처리하고 stopPropagation
+	// 하면 이벤트가 document 까지 오지 않아 Popover 는 닫히지 않는다(자식 우선 - 이전 리뷰 critical).
+	// 아무도 소비하지 않고 document 까지 오면 최상단(=이 Popover)만 닫고, 상위 Modal 이나 소비자
+	// 앱으로의 전파를 끊어 "최상단만 닫힘"(APG)을 지킨다.
+	useOverlayEscape(open, () => {
+		setOpen(false);
+		previousFocusRef.current?.focus();
+	});
 
 	const triggerWithProps = React.cloneElement(
 		trigger as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
@@ -151,8 +149,7 @@ export const Popover = ({
 	);
 
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: keyboard handler for Escape dismissal; interactive children carry their own roles
-		<div className="popover_wrapper" ref={wrapperRef} onKeyDown={handleWrapperKeyDown}>
+		<div className="popover_wrapper" ref={wrapperRef}>
 			{triggerWithProps}
 			{shouldRender && (
 				<div className={cn("popover_position", `popover_placement_${placement}`)}>

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -2,7 +2,7 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type TooltipPlacement = "top" | "bottom" | "left" | "right";
@@ -71,20 +71,11 @@ export const Tooltip = ({
 	}, []);
 
 	// WCAG 1.4.13 Dismissable - 포인터/포커스를 옮기지 않고 Escape 로 닫기.
-	// capture 단계 document 리스너라 아래층 오버레이(Modal 등)의 Escape 핸들러보다
-	// 먼저 실행되고, 닫을 때 전파를 끊어 최상단(툴팁)만 닫는다.
-	React.useEffect(() => {
-		if (!open) return;
-		const onKeyDown = (e: KeyboardEvent) => {
-			if (e.key !== "Escape") return;
-			// stopImmediatePropagation - 같은 document 노드에 등록된 다른 오버레이 리스너의
-			// 실행까지 막아(stopPropagation 은 못 막음) 툴팁만 닫히고 하위 오버레이는 유지.
-			e.stopImmediatePropagation();
-			hideNow();
-		};
-		document.addEventListener("keydown", onKeyDown, true);
-		return () => document.removeEventListener("keydown", onKeyDown, true);
-	}, [open, hideNow]);
+	// 공유 오버레이 스택에 등록 - 열려 있는 동안 최상단일 때만 Escape 로 닫혀
+	// 다른 오버레이나 소비자 앱 핸들러를 삼키지 않는다 (overlay-stack.ts 참고).
+	// 툴팁은 hover 로 열려 포커스가 trigger 밖에 있을 수 있으므로 document 레벨 처리가 필요한데,
+	// 레지스트리가 그 역할을 대신한다.
+	useOverlayEscape(open, hideNow);
 
 	const fromTransform = (() => {
 		switch (placement) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { cn } from "./cn";
+export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export { useFocusTrap } from "./use-focus-trap";
 export { useReducedMotion } from "./use-reduced-motion";
 export { useSafeLayoutEffect } from "./use-safe-layout-effect";

--- a/src/utils/overlay-stack.test.ts
+++ b/src/utils/overlay-stack.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerOverlay } from "./overlay-stack";
+
+/**
+ * 공유 오버레이 Escape 스택의 단위 테스트.
+ *
+ * 스택은 모듈 스코프라 테스트 간 누수를 막아야 한다 - 등록/리스너를 tracker 로 모아
+ * afterEach 에서 강제 정리한다 (어떤 assert 가 던져도 스택이 반드시 비워지도록).
+ */
+
+const cleanups: Array<() => void> = [];
+
+/** registerOverlay + 자동 정리 등록 */
+const open = (fn: () => void) => {
+	const unreg = registerOverlay(fn);
+	cleanups.push(unreg);
+	return unreg;
+};
+
+/** window 레벨 소비자 리스너 + 자동 정리 등록 (document bubble → window 로 올라온다) */
+const consumerOnWindow = (fn: () => void) => {
+	window.addEventListener("keydown", fn);
+	cleanups.push(() => window.removeEventListener("keydown", fn));
+};
+
+/** document.body 에서 Escape 발생 → body(target) → document(bubble) → window(bubble) */
+const pressEscape = () =>
+	document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+afterEach(() => {
+	for (const c of cleanups.splice(0)) c();
+	vi.restoreAllMocks();
+});
+
+describe("overlay-stack", () => {
+	it("calls only the top (last-registered) overlay's onEscape", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		open(first);
+		open(second);
+
+		pressEscape();
+
+		expect(second).toHaveBeenCalledTimes(1);
+		expect(first).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the next overlay once the top unregisters (LIFO)", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		open(first);
+		const unregSecond = open(second);
+
+		unregSecond();
+		pressEscape();
+
+		// 최상단이 빠지면 그 아래가 새 최상단이 되어 Escape 를 받는다
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).not.toHaveBeenCalled();
+	});
+
+	it("attaches no listener while the stack is empty (does not swallow global Escape)", () => {
+		const consumer = vi.fn();
+		consumerOnWindow(consumer);
+
+		// 등록 전 - 레지스트리 리스너가 없어 소비자 핸들러가 그대로 받는다
+		pressEscape();
+		expect(consumer).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops the Escape from reaching window-level consumer handlers while open", () => {
+		const consumer = vi.fn();
+		consumerOnWindow(consumer);
+		const onEscape = vi.fn();
+		open(onEscape);
+
+		pressEscape();
+
+		// stopImmediatePropagation 으로 window 로의 전파까지 차단 (최상단 오버레이만 반응)
+		expect(onEscape).toHaveBeenCalledTimes(1);
+		expect(consumer).not.toHaveBeenCalled();
+	});
+
+	it("releases the global listener again once the stack empties", () => {
+		const onEscape = vi.fn();
+		open(onEscape)();
+
+		const consumer = vi.fn();
+		consumerOnWindow(consumer);
+		pressEscape();
+
+		// 스택이 비면 레지스트리 리스너가 제거되어 소비자가 다시 Escape 를 받는다
+		expect(onEscape).not.toHaveBeenCalled();
+		expect(consumer).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores non-Escape keys", () => {
+		const onEscape = vi.fn();
+		open(onEscape);
+
+		document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+		expect(onEscape).not.toHaveBeenCalled();
+	});
+
+	it("unregister is idempotent and only removes its own entry", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		open(first);
+		const unregSecond = open(second);
+
+		unregSecond();
+		unregSecond(); // 두 번째 호출은 no-op - first 를 지우지 않아야 함
+
+		pressEscape();
+		expect(first).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/overlay-stack.ts
+++ b/src/utils/overlay-stack.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * 공유 오버레이 Escape 스택 (WAI-ARIA APG "최상단 오버레이만 닫힘").
+ *
+ * Tooltip / Popover / Modal / Drawer / Alert 가 각자 다른 방식(document capture 리스너,
+ * wrapper onKeyDown, overlay div React onKeyDown)으로 Escape 를 처리하면 동시에 열렸을 때
+ * "가장 위 오버레이만 닫힘"이 일관되게 보장되지 않는다. 이 모듈은 모든 오버레이가 공유하는
+ * 단일 keydown 리스너로 그 규칙을 일원화한다.
+ *
+ * ## 설계 결정: bubble 단계 + 단일 document 리스너
+ *
+ * 리스너는 **bubble** 단계(`capture: false`)로 등록한다. 이유:
+ *
+ * 1. **자식 우선 처리(critical)** — 이벤트는 target(오버레이 내부 input/select 등)에서 위로
+ *    올라오며(target → bubble), 자식이 먼저 처리할 기회를 갖는다. 자식이 자체 Escape(예: IME
+ *    조합 취소, native `<select>` 드롭다운 닫기)를 처리하고 `stopPropagation` 하면 이벤트는
+ *    document 까지 오지 않아 이 리스너가 아예 실행되지 않는다 → 오버레이가 닫히지 않는다.
+ *    capture 단계로 등록하면 자식보다 먼저 가로채 자식의 Escape 를 마비시키는 회귀(이전 리뷰
+ *    critical 지적)가 재발하므로 반드시 bubble 이어야 한다.
+ * 2. **최상단만 닫힘** — document 까지 도달했다는 건 아무 자식도 이벤트를 소비하지 않았다는
+ *    뜻이다. 이때 스택 최상단(가장 최근에 등록/열린 오버레이)의 onEscape 만 호출하고
+ *    `stopImmediatePropagation` 으로 같은 document 노드의 다른(소비자 앱) Escape 리스너 및
+ *    window 로의 전파를 끊어, 최상단 하나만 반응하도록 한다.
+ * 3. **오버레이가 없으면 리스너도 없음** — 스택이 비면 리스너를 완전히 제거해, 오버레이가 하나도
+ *    열려있지 않을 때 소비자 앱의 전역 Escape 핸들러를 삼키지 않는다.
+ *
+ * 스택은 등록 순서 LIFO 다. 실제 앱에서 오버레이는 순차적으로 열리므로(예: Modal 을 연 뒤 그
+ * 안의 Popover 를 클릭으로 열기) 등록 순서 = 열린 순서 = 시각적 stacking 순서가 되어 최상단이
+ * 정확히 결정된다.
+ */
+
+type EscapeHandler = () => void;
+
+/** 모듈 스코프 스택. 마지막 원소 = 최상단(가장 최근에 등록된) 오버레이. */
+const stack: EscapeHandler[] = [];
+
+const handleKeyDown = (e: KeyboardEvent) => {
+	if (e.key !== "Escape") return;
+	const top = stack[stack.length - 1];
+	if (!top) return;
+	// 여기까지 왔다는 건 자식(input/select/IME 등)이 이벤트를 소비하지 않았다는 뜻.
+	// 최상단만 닫고, 소비자 앱의 document/window Escape 리스너까지 전파를 끊는다.
+	e.stopImmediatePropagation();
+	top();
+};
+
+/**
+ * 오버레이를 Escape 스택 최상단에 등록한다.
+ *
+ * @param onEscape 이 오버레이가 최상단일 때 Escape 로 호출될 콜백 (보통 close)
+ * @returns 등록 해제 함수. 스택에서 제거하고, 마지막 항목이면 document 리스너까지 정리한다.
+ */
+export function registerOverlay(onEscape: EscapeHandler): () => void {
+	// SSR 가드 - 서버에는 document 가 없다. no-op unregister 반환.
+	if (typeof document === "undefined") {
+		return () => {};
+	}
+
+	// 스택이 비어 있다가 첫 항목이 들어올 때만 리스너를 붙인다 (단 하나의 리스너 유지).
+	if (stack.length === 0) {
+		document.addEventListener("keydown", handleKeyDown);
+	}
+	stack.push(onEscape);
+
+	let done = false;
+	return () => {
+		if (done) return;
+		done = true;
+		const index = stack.lastIndexOf(onEscape);
+		if (index !== -1) stack.splice(index, 1);
+		// 마지막 항목이 빠지면 리스너를 제거해 스택이 빈 동안 전역 Escape 를 삼키지 않게 한다.
+		if (stack.length === 0) {
+			document.removeEventListener("keydown", handleKeyDown);
+		}
+	};
+}
+
+/**
+ * 오버레이 컴포넌트가 Escape 스택에 참여하도록 하는 훅.
+ *
+ * `active` 가 true 인 동안 스택에 등록되고, false 가 되거나 unmount 되면 등록 해제된다.
+ * 최상단일 때만 Escape 에 반응하므로 각 오버레이는 `useOverlayEscape(open, close)` 만 쓰면 된다.
+ *
+ * @param active 오버레이 열림 여부
+ * @param onEscape Escape 시 호출할 콜백 (매 렌더 새 참조여도 재등록되지 않도록 ref 로 잡는다)
+ */
+export function useOverlayEscape(active: boolean, onEscape: EscapeHandler): void {
+	// 최신 onEscape 를 ref 로 유지 - register/unregister 를 active 변화에만 묶어
+	// (콜백이 매 렌더 바뀌어도) 불필요한 재등록/스택 순서 교란을 막는다.
+	const handlerRef = React.useRef(onEscape);
+	handlerRef.current = onEscape;
+
+	React.useEffect(() => {
+		if (!active) return;
+		return registerOverlay(() => handlerRef.current());
+	}, [active]);
+}

--- a/src/utils/overlay-stack.ts
+++ b/src/utils/overlay-stack.ts
@@ -20,16 +20,29 @@ import * as React from "react";
  *    document 까지 오지 않아 이 리스너가 아예 실행되지 않는다 → 오버레이가 닫히지 않는다.
  *    capture 단계로 등록하면 자식보다 먼저 가로채 자식의 Escape 를 마비시키는 회귀(이전 리뷰
  *    critical 지적)가 재발하므로 반드시 bubble 이어야 한다.
- * 2. **최상단만 닫힘** — document 까지 도달했다는 건 아무 자식도 이벤트를 소비하지 않았다는
- *    뜻이다. 이때 스택 최상단(가장 최근에 등록/열린 오버레이)의 onEscape 만 호출하고
- *    `stopImmediatePropagation` 으로 같은 document 노드의 다른(소비자 앱) Escape 리스너 및
- *    window 로의 전파를 끊어, 최상단 하나만 반응하도록 한다.
+ * 2. **오버레이 간 최상단만 닫힘** — 모든 오버레이가 이 단일 리스너 하나를 공유하므로, document
+ *    까지 도달한 Escape 는 스택 최상단(가장 최근에 등록/열린 오버레이)의 onEscape 만 호출한다.
+ *    즉 "우리 오버레이들 사이"에서는 최상단 하나만 반응하는 것이 순서와 무관하게 보장된다.
  * 3. **오버레이가 없으면 리스너도 없음** — 스택이 비면 리스너를 완전히 제거해, 오버레이가 하나도
  *    열려있지 않을 때 소비자 앱의 전역 Escape 핸들러를 삼키지 않는다.
  *
- * 스택은 등록 순서 LIFO 다. 실제 앱에서 오버레이는 순차적으로 열리므로(예: Modal 을 연 뒤 그
- * 안의 Popover 를 클릭으로 열기) 등록 순서 = 열린 순서 = 시각적 stacking 순서가 되어 최상단이
- * 정확히 결정된다.
+ * ### `stopImmediatePropagation` 의 실제 보장 범위 (주의)
+ *
+ * Escape 처리 후 `stopImmediatePropagation()` 을 호출하지만, 이는 같은 document 노드에 **나중에**
+ * 등록된 리스너와 window 로의 전파만 막는다. 오버레이가 열리기 **전에** 소비자 앱이 이미 document
+ * 에 Escape 리스너를 걸어 두었다면(우리 리스너보다 앞 순서) 그 리스너는 여전히 실행된다. 따라서
+ * 이 모듈은 "우리 오버레이들 사이의 최상단만 닫힘"을 보장할 뿐, 소비자 앱의 선등록 Escape 핸들러
+ * 까지 완전히 차단한다고 보장하지는 않는다.
+ *
+ * ### LIFO 한계 (동시-open 마운트)
+ *
+ * 스택은 등록 순서 LIFO 다. 실제 앱에서 오버레이는 순차적으로 열리므로(예: Modal 을 연 뒤 그 안의
+ * Popover 를 클릭으로 열기) 등록 순서 = 열린 순서 = 시각적 stacking 순서가 되어 최상단이 정확히
+ * 결정된다. 단, React 는 effect 를 **자식 → 부모** 순서로 커밋하므로, 부모/자식 오버레이가 **동시에
+ * 마운트되며 둘 다 이미 open**(예: `<Modal><Popover defaultOpen /></Modal>`, 중첩 Drawer 동시 open)
+ * 인 경우 자식이 먼저·부모가 나중에 등록되어 부모가 최상단이 된다 → 첫 Escape 가 자식(위에 있어야
+ * 할 오버레이) 대신 부모를 닫는다. 흔치 않은 degenerate 케이스이며, z-order 기반 topmost 판정으로
+ * 개선 가능하나(별도) 순차 open 조합에는 영향 없다.
  */
 
 type EscapeHandler = () => void;
@@ -42,7 +55,8 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	const top = stack[stack.length - 1];
 	if (!top) return;
 	// 여기까지 왔다는 건 자식(input/select/IME 등)이 이벤트를 소비하지 않았다는 뜻.
-	// 최상단만 닫고, 소비자 앱의 document/window Escape 리스너까지 전파를 끊는다.
+	// 최상단만 닫고, document 에 나중 등록된 리스너 + window 로의 전파를 끊는다.
+	// (선등록된 소비자 리스너는 못 막음 - 파일 상단 주석 참고.)
 	e.stopImmediatePropagation();
 	top();
 };
@@ -90,8 +104,13 @@ export function registerOverlay(onEscape: EscapeHandler): () => void {
 export function useOverlayEscape(active: boolean, onEscape: EscapeHandler): void {
 	// 최신 onEscape 를 ref 로 유지 - register/unregister 를 active 변화에만 묶어
 	// (콜백이 매 렌더 바뀌어도) 불필요한 재등록/스택 순서 교란을 막는다.
+	// ref 갱신은 effect 안에서 - 렌더 단계에서 ref.current 를 수정하면 concurrent 렌더링에서
+	// 문제가 될 수 있다. Escape 콜백은 항상 커밋(=이 effect) 이후 이벤트 시점에 호출되므로
+	// effect 로 갱신해도 최신 값이 보장된다.
 	const handlerRef = React.useRef(onEscape);
-	handlerRef.current = onEscape;
+	React.useEffect(() => {
+		handlerRef.current = onEscape;
+	});
 
 	React.useEffect(() => {
 		if (!active) return;


### PR DESCRIPTION
## 작업 개요

오버레이(Tooltip/Popover/Modal/Drawer/Alert)의 Escape 처리를 **공유 스택 레지스트리**로 통일해, 컴포넌트 조합에서도 "최상단 오버레이만 닫힘"(WAI-ARIA APG)을 보장한다.

> 배경: PR #377 리뷰에서 github-actions 봇이, 각 오버레이가 서로 다른 방식(document capture 리스너 / wrapper onKeyDown / overlay div onKeyDown)으로 Escape 를 처리해 `stopPropagation` 으로는 동시 열림 시 최상단만 닫힘이 보장되지 않는다고 지적, follow-up 으로 분리. (#377 은 이미 develop 에 머지됨.)

## 작업한 내용
- [x] **`src/utils/overlay-stack.ts` 신규**: `registerOverlay(onEscape)` + `useOverlayEscape(active, onEscape)` 훅. 스택이 처음 채워질 때만 **document bubble 단계** keydown 리스너 하나를 붙이고, 비면 제거. Escape 시 스택 최상단(LIFO=가장 최근에 열린)만 `onEscape` + `stopImmediatePropagation`
- [x] **5개 오버레이 마이그레이션**: Tooltip(document capture 리스너 제거)·Popover(wrapper onKeyDown 제거)·Modal·Drawer·Alert(overlay div onKeyDown 의 Escape 분기 제거) 전부 `useOverlayEscape(open, close)` 로 통일. 패널의 비-Escape `stopPropagation`(Tab 트랩 등)은 그대로 유지
- [x] 회귀 테스트: `overlay-stack.test.ts`(단위) + `overlay-escape.test.tsx`(Tooltip+Popover 동시 열림→Escape→최상단만 닫힘 / 자식 우선 처리)

## 핵심 설계 — capture 아닌 **bubble**
단일 document 리스너를 bubble 단계로 등록. 이유: 이벤트가 target(오버레이 내부 input/select/IME)에서 위로 올라오므로 **자식이 먼저 처리할 기회**를 갖는다 — 자식이 자체 Escape 를 처리하고 `stopPropagation` 하면 document 까지 오지 않아 오버레이가 안 닫힘(이전 #377 리뷰의 critical: capture 는 자식 Escape 마비 재발). document 까지 왔다 = 아무도 소비 안 함 → 최상단만 닫고 `stopImmediatePropagation` 으로 소비자 앱/window 리스너 전파 차단. 스택이 비면 리스너 제거 → 오버레이 없을 때 전역 Escape 안 삼킴.

## 검증
- `vitest run --project unit src/ui/overlay src/ui/feedback/alert src/utils` → 121 passed
- 전체 유닛 721 passed / 9 skip
- tsc: 기존 stories 7건 외 신규 에러 0
- 기존 Popover-in-Modal 등 순차 조합 테스트 무변 통과

## 전달할 추가 이슈
- **known-limitation (LIFO 동시-open)**: 부모-자식 오버레이가 **동시에 마운트되며 둘 다 이미 open** 인 경우(`<Modal><Popover defaultOpen/></Modal>`, 중첩 Drawer 동시 open 등) React effect 가 자식→부모 순으로 커밋돼 부모가 스택 최상단이 됨 → 첫 Escape 가 자식 대신 부모를 닫음. Drawer 뿐 아니라 모든 부모-자식 조합에 적용되는 한계. 순차 open 에는 영향 없음. z-order 기반 topmost 판정으로 개선 가능(별도)
- `stopImmediatePropagation` 은 document 에 **나중** 등록된 리스너 + window 전파만 차단 — 오버레이보다 먼저 등록된 소비자 앱 Escape 리스너는 실행됨(모듈은 "우리 오버레이들 사이 최상단만 반응"만 보장)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 모달, 드로어, 팝오버, 툴팁의 `Escape` 닫기 동작을 일관되게 개선했습니다.
  - 여러 오버레이가 겹쳐 있을 때 가장 최근에 열린 최상단 오버레이만 닫힙니다.
  - 내부 요소가 `Escape`를 처리하면 상위 오버레이가 닫히지 않습니다.
  - 오버레이가 닫히면 다음 오버레이가 순서대로 닫기 동작을 이어받습니다.

- **테스트**
  - 중첩 오버레이, 이벤트 전파, 닫기 순서 등 관련 동작 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
