### PR TITLE
merge: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.5.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.5.0) - 2026-07-16
+
+- 접근성(a11y) 대규모 개선 - 전체 컴포넌트 감사 후 WAI-ARIA/WCAG 위반 수정: Alert 포커스 트랩, Tooltip dismissable·hoverable(WCAG 1.4.13), Toast 자동 닫힘 hover/focus 일시정지(WCAG 2.2.1), Tabs 로빙 tabindex, Checkbox·OTP `aria-invalid`, Chip·ListItem 선택 상태 노출, NavBar locale `menuitemradio`, Table `aria-busy`
+- Button `as`/`href` 지원 - `<Button as="a" href="...">` 로 동일 스타일의 anchor 렌더링(링크 시맨틱), `disabled` anchor 대응. Hero CTA 가 이를 재사용
+- 폼 참여 prop 추가 - Dropdown `name`(hidden input 으로 네이티브 폼 제출), Alert `closeOnOverlay`, Chip `removeLabel`(삭제 버튼 레이블 커스터마이즈)
+- 오버레이 Escape 통일 - `useOverlayEscape`/`registerOverlay` 공유 스택으로 "최상단 오버레이만 닫힘"(APG) 보장, 자식 요소 Escape 우선 처리
+- Modal · Drawer 포털 렌더링 - `createPortal(document.body)` 로 transform/filter 조상 아래에서도 `position: fixed` 정상 동작 (기존 인라인 렌더 → body 포털; 후손 선택자 스타일링 시 영향 가능)
+- Vanilla 번들 대폭 수정 - 색상 토큰 자기참조/미정의 해소(+다크 테마), Select `<li data-value>` 서버 마크업 파싱, Select/Toggle 폼 제출 참여(`data-name`)·combobox ARIA·Modal 포커스 트랩·스크롤 잠금 카운터·FOUC 방지
+- reduced-motion(WCAG 2.3.3) - Modal/Alert 진입·퇴출, Toast progress 를 `prefers-reduced-motion` 대응
+- (주의) `ButtonProps` 가 discriminated union(`ButtonAsButton | ButtonAsAnchor`)으로 변경 - 런타임/공개 prop 은 100% 호환이나, 타입 레벨에서 `interface X extends ButtonProps` 확장은 불가(union 확장 불가). 확장이 필요하면 `ButtonBaseProps` 또는 `ComponentProps<typeof Button>` 사용
+
 ## [3.4.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.1) - 2026-07-10
 
 - Modal · Drawer: 소비자 `style`/`className`/`data-*` 는 반영하되 컴포넌트의 애니메이션 style · `onClick`/`onKeyDown`(stopPropagation·Escape) · `role` 이 항상 우선하도록 정리 (소비자 style 이 오버레이 동작을 덮던 문제 수정)

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -300,13 +300,24 @@ npm install @bigtablet/design-system
 
 **폼 제출 참여 (Thymeleaf/JSP):**
 
-`data-name` 을 지정하면 hidden input 이 생성되어 on/off(`"true"`/`"false"`)가
-폼 POST 에 포함됩니다. `role="switch"` + `aria-checked` 는 자동으로 관리됩니다.
+`data-name` 을 지정하면 hidden input 이 생성되어 on/off 가 폼 POST 에 포함됩니다.
+전송 값은 `"true"`/`"false"` 이며, `role="switch"` + `aria-checked` 는 자동으로 관리됩니다.
+`<button>` 은 내부에 폼 요소를 자식으로 둘 수 없어 hidden input 은 버튼의 **형제**로 삽입됩니다.
+
+서버 템플릿이 초기값 hidden input 을 미리 렌더링한 경우 그 값을 읽어 초기 상태를 맞추며,
+`"true"` 외에 `"1"`/`"on"`/`"y"`/`"yes"`(대소문자 무시)도 켜짐으로 인식합니다.
 
 ```html
+<!-- data-name 으로 자동 생성 -->
 <button type="button" class="bt-toggle" data-bt-toggle data-name="notifications">
   <span class="bt-toggle__thumb"></span>
 </button>
+
+<!-- 또는 서버 렌더링 초기값(형제 hidden input) -->
+<button type="button" class="bt-toggle" data-bt-toggle>
+  <span class="bt-toggle__thumb"></span>
+</button>
+<input type="hidden" name="notifications" th:value="${enabled}">
 ```
 
 ---

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -250,21 +250,21 @@ npm install @bigtablet/design-system
 
 ```html
 <!-- 기본 (Off) -->
-<button class="bt-toggle" data-bt-toggle>
+<button type="button" class="bt-toggle" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 
 <!-- On 상태 -->
-<button class="bt-toggle bt-toggle--on" data-bt-toggle>
+<button type="button" class="bt-toggle bt-toggle--on" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 
 <!-- Sizes -->
-<button class="bt-toggle" data-bt-toggle>...</button>  <!-- 기본 sm -->
-<button class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
+<button type="button" class="bt-toggle" data-bt-toggle>...</button>  <!-- 기본 sm -->
+<button type="button" class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
 
 <!-- 비활성화 -->
-<button class="bt-toggle bt-toggle--disabled" data-bt-toggle>
+<button type="button" class="bt-toggle bt-toggle--disabled" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 ```
@@ -272,7 +272,7 @@ npm install @bigtablet/design-system
 **JavaScript 연동:**
 
 ```html
-<button class="bt-toggle" data-bt-toggle id="my-toggle">
+<button type="button" class="bt-toggle" data-bt-toggle id="my-toggle">
   <span class="bt-toggle__thumb"></span>
 </button>
 
@@ -293,6 +293,20 @@ npm install @bigtablet/design-system
   myToggle.setChecked(true); // 상태 설정
   myToggle.toggle();        // 토글
 </script>
+```
+
+> `type="button"` 을 반드시 지정하세요 - 폼 안에서 기본 type(submit)이면 토글 클릭이
+> 폼을 제출합니다 (JS 초기화 시 자동 보정되지만 JS 로드 전 클릭은 막지 못합니다).
+
+**폼 제출 참여 (Thymeleaf/JSP):**
+
+`data-name` 을 지정하면 hidden input 이 생성되어 on/off(`"true"`/`"false"`)가
+폼 POST 에 포함됩니다. `role="switch"` + `aria-checked` 는 자동으로 관리됩니다.
+
+```html
+<button type="button" class="bt-toggle" data-bt-toggle data-name="notifications">
+  <span class="bt-toggle__thumb"></span>
+</button>
 ```
 
 ---
@@ -317,6 +331,22 @@ npm install @bigtablet/design-system
     <li class="bt-select__option is-disabled" data-value="mango">망고 (품절)</li>
     <li class="bt-select__option" data-value="orange">오렌지</li>
   </ul>
+</div>
+```
+
+옵션은 위처럼 서버가 렌더링한 `<li data-value>` 마크업에서 자동 파싱됩니다
+(`data-options` JSON 속성 또는 JS `options` 설정이 있으면 그쪽이 우선).
+
+**폼 제출 참여 (Thymeleaf/JSP):**
+
+`data-name` 을 지정하면 hidden input 이 생성되어 선택 값이 폼 POST 에 포함됩니다.
+서버 템플릿이 `.bt-select` 안에 hidden input 을 미리 렌더링해 두면 (예: `th:field`)
+그 input 의 name/초기값을 그대로 이어받아 표시·동기화합니다.
+
+```html
+<div class="bt-select" data-bt-select data-name="fruit">
+  <!-- 또는 서버 바인딩: <input type="hidden" th:field="*{fruit}"> -->
+  ...
 </div>
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.4.1",
+	"version": "3.5.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/src/stories/cookbook/data.stories.tsx
+++ b/src/stories/cookbook/data.stories.tsx
@@ -474,7 +474,7 @@ export const OrderTimeline: Story = {
 									)}
 								</Stack>
 
-								<Stack gap={6} style={{ flex: 1, paddingBottom: isLast ? 0 : 8 }}>
+								<Stack gap={4} style={{ flex: 1, paddingBottom: isLast ? 0 : 8 }}>
 									<Stack direction="horizontal" justify="between" align="center">
 										<span
 											style={{

--- a/src/stories/examples/page-composition.stories.tsx
+++ b/src/stories/examples/page-composition.stories.tsx
@@ -393,7 +393,7 @@ export const AdminDashboard: Story = {
 								<path d="M16 10a4 4 0 0 1-8 0" />
 							</svg>
 						}
-						badge={<Badge shape="count" variant="danger">5</Badge>}
+						trailing={<Badge shape="count" variant="error">5</Badge>}
 					>
 						주문
 					</SidebarItem>

--- a/src/stories/foundation/form-comparison.stories.tsx
+++ b/src/stories/foundation/form-comparison.stories.tsx
@@ -30,7 +30,7 @@ export const SideBySide: Story = {
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
 					<TextField label="이메일" placeholder="placeholder@example.com" />
 					<TextField label="비밀번호" placeholder="••••••••" type="password" />
-					<TextField label="값 있음" value="user@example.com" onChange={() => {}} />
+					<TextField label="값 있음" value="user@example.com" onValueChange={() => {}} />
 				</div>
 			</div>
 			<div>

--- a/src/ui/display/accordion/Accordion.test.tsx
+++ b/src/ui/display/accordion/Accordion.test.tsx
@@ -17,10 +17,15 @@ describe("Accordion", () => {
 		panels.forEach((p) => expect(p).toHaveAttribute("aria-hidden", "true"));
 	});
 
+	// id 는 useId 접두사로 인스턴스 격리되므로 트리거의 aria-controls 로 패널을 찾는다
+	const getPanelFor = (title: string) => {
+		const trigger = screen.getByText(title).closest("button") as HTMLButtonElement;
+		return document.getElementById(trigger.getAttribute("aria-controls") as string) as HTMLElement;
+	};
+
 	it("toggles panel open state on click", () => {
 		render(<Accordion items={items} />);
-		const panelA = document
-			.getElementById("a-panel") as HTMLElement;
+		const panelA = getPanelFor("Title A");
 		expect(panelA).toHaveAttribute("aria-hidden", "true");
 
 		fireEvent.click(screen.getByText("Title A"));
@@ -35,8 +40,8 @@ describe("Accordion", () => {
 		render(<Accordion items={items} />);
 		fireEvent.click(screen.getByText("Title A"));
 		fireEvent.click(screen.getByText("Title B"));
-		const panelA = document.getElementById("a-panel") as HTMLElement;
-		const panelB = document.getElementById("b-panel") as HTMLElement;
+		const panelA = getPanelFor("Title A");
+		const panelB = getPanelFor("Title B");
 		expect(panelA).toHaveAttribute("aria-hidden", "true");
 		expect(panelB).toHaveAttribute("aria-hidden", "false");
 	});

--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -49,6 +49,9 @@ export const Accordion = ({
 	const isControlled = controlledKeys !== undefined;
 	const [internalKeys, setInternalKeys] = React.useState<string[]>(defaultOpenKeys);
 	const open = isControlled ? (controlledKeys ?? []) : internalKeys;
+	// item.key 로 직접 id 를 만들면 같은 키를 쓰는 인스턴스 간 중복/공백 등 무효 id 로
+	// aria-controls/aria-labelledby 연결이 깨질 수 있어 useId 접두사로 격리한다.
+	const idPrefix = React.useId();
 
 	const toggle = (key: string) => {
 		const isOpen = open.includes(key);
@@ -65,8 +68,8 @@ export const Accordion = ({
 		<div className={cn("accordion", className)} {...props}>
 			{items.map((item) => {
 				const isOpen = open.includes(item.key);
-				const headerId = `${item.key}-header`;
-				const panelId = `${item.key}-panel`;
+				const headerId = `${idPrefix}-${item.key}-header`;
+				const panelId = `${idPrefix}-${item.key}-panel`;
 
 				return (
 					<div key={item.key} className={cn("accordion_item", isOpen && "accordion_item_open")}>

--- a/src/ui/display/avatar/index.tsx
+++ b/src/ui/display/avatar/index.tsx
@@ -55,9 +55,12 @@ export const Avatar = ({
 		<span
 			className={cn("avatar", `avatar_size_${size}`, `avatar_shape_${shape}`, className)}
 			style={{ background: !showImage ? bgColor : undefined, ...style }}
-			// initials-only: span IS the img. with src: <img> provides the role
-			role={showImage ? undefined : "img"}
+			// initials-only: span IS the img. with src: <img> provides the role.
+			// name 없이 쓰이면 접근 가능한 이름 없는 role=img 가 되므로(axe role-img-alt)
+			// 그 경우 role 을 달지 않고 장식 요소로 둔다.
+			role={showImage || !name ? undefined : "img"}
 			aria-label={showImage ? undefined : name || undefined}
+			aria-hidden={!showImage && !name ? true : undefined}
 			{...props}
 		>
 			{showImage ? (

--- a/src/ui/display/chip/Chip.test.tsx
+++ b/src/ui/display/chip/Chip.test.tsx
@@ -27,7 +27,7 @@ describe("Chip", () => {
 
 	it("shows close icon when removable", () => {
 		render(<Chip label="Tag" type="input" removable />);
-		expect(screen.getByLabelText("Remove")).toBeInTheDocument();
+		expect(screen.getByLabelText("Tag 제거")).toBeInTheDocument();
 	});
 
 	it("shows chevron for filter type", () => {
@@ -58,7 +58,7 @@ describe("Chip", () => {
 		const handleRemove = vi.fn();
 		render(<Chip label="Tag" type="input" removable onRemove={handleRemove} />);
 
-		fireEvent.click(screen.getByLabelText("Remove"));
+		fireEvent.click(screen.getByLabelText("Tag 제거"));
 		expect(handleRemove).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/ui/display/chip/index.tsx
+++ b/src/ui/display/chip/index.tsx
@@ -159,8 +159,10 @@ export const Chip = ({
 				className="chip_content"
 				disabled={disabled}
 				onClick={onClick}
-				// selected 는 시각(체크 아이콘)만으로는 AT 에 전달되지 않으므로 aria-pressed 로 노출
-				aria-pressed={selected !== undefined ? selected : undefined}
+				// selected 는 시각(체크 아이콘)만으로는 AT 에 전달되지 않으므로 aria-pressed 로 노출.
+				// 단 filter 타입은 aria-haspopup+aria-expanded(팝업 트리거)라 aria-pressed 와 공존
+				// 시 AT 가 역할을 혼동하므로 제외한다.
+				aria-pressed={type !== "filter" && selected !== undefined ? selected : undefined}
 				{...(type === "filter"
 					? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open }
 					: {})}

--- a/src/ui/display/chip/index.tsx
+++ b/src/ui/display/chip/index.tsx
@@ -32,6 +32,8 @@ export interface ChipProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "o
 	onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 	/** 삭제 버튼 클릭 시 콜백 */
 	onRemove?: () => void;
+	/** 삭제 버튼 접근성 레이블 (기본값: "{label} 제거") - 칩이 여러 개일 때 대상 구분용 */
+	removeLabel?: string;
 }
 
 const CheckIcon = () => (
@@ -92,9 +94,11 @@ export const Chip = ({
 	leadingIcon,
 	onClick,
 	onRemove,
+	removeLabel,
 	className,
 	...props
 }: ChipProps) => {
+	const removeAriaLabel = removeLabel ?? `${label} 제거`;
 	const [iconHovered, setIconHovered] = useState(false);
 
 	const isStatic = type === "static";
@@ -137,7 +141,7 @@ export const Chip = ({
 						className="chip_trailing"
 						disabled={disabled}
 						onClick={onRemove}
-						aria-label="Remove"
+						aria-label={removeAriaLabel}
 					>
 						<span className="chip_icon" aria-hidden="true">
 							<CloseIcon />
@@ -155,6 +159,8 @@ export const Chip = ({
 				className="chip_content"
 				disabled={disabled}
 				onClick={onClick}
+				// selected 는 시각(체크 아이콘)만으로는 AT 에 전달되지 않으므로 aria-pressed 로 노출
+				aria-pressed={selected !== undefined ? selected : undefined}
 				{...(type === "filter"
 					? { "aria-haspopup": "listbox" as const, "aria-expanded": !!open }
 					: {})}
@@ -187,7 +193,7 @@ export const Chip = ({
 					className="chip_trailing"
 					disabled={disabled}
 					onClick={onRemove}
-					aria-label="Remove"
+					aria-label={removeAriaLabel}
 				>
 					<span
 						className="chip_icon"

--- a/src/ui/display/hero/Hero.test.tsx
+++ b/src/ui/display/hero/Hero.test.tsx
@@ -61,4 +61,17 @@ describe("Hero", () => {
 		expect(container.querySelector(".hero_eyebrow")).not.toBeInTheDocument();
 		expect(container.querySelector(".hero_actions")).not.toBeInTheDocument();
 	});
+
+	it("renders primaryAction with href as an anchor (Button as='a')", () => {
+		render(<Hero title="제목" primaryAction={{ label: "자세히", href: "/detail" }} />);
+		const link = screen.getByRole("link", { name: "자세히" });
+		expect(link).toBeInstanceOf(HTMLAnchorElement);
+		expect(link).toHaveAttribute("href", "/detail");
+		expect(link).toHaveClass("button", "button_variant_filled", "button_size_lg");
+	});
+
+	it("renders primaryAction without href as a button", () => {
+		render(<Hero title="제목" primaryAction={{ label: "클릭", onClick: () => {} }} />);
+		expect(screen.getByRole("button", { name: "클릭" })).toBeInTheDocument();
+	});
 });

--- a/src/ui/display/hero/index.tsx
+++ b/src/ui/display/hero/index.tsx
@@ -50,8 +50,8 @@ export interface HeroProps extends Omit<React.HTMLAttributes<HTMLElement>, "titl
 }
 
 /**
- * Hero CTA 버튼. `href` 지정 시 링크 시맨틱(우클릭 새 탭·미들클릭·SR 링크 안내)을 위해
- * Button 클래스를 입힌 실제 anchor 로 렌더링한다 — href 가 문서화만 되고 무시되던 문제 수정.
+ * Hero CTA 버튼. `href` 지정 시 Button 을 anchor(`as="a"`) 로 렌더링해 링크 시맨틱
+ * (우클릭 새 탭·미들클릭·SR 링크 안내)을 얻는다 — href 가 문서화만 되고 무시되던 문제 수정.
  */
 const HeroActionButton = ({
 	action,
@@ -61,13 +61,9 @@ const HeroActionButton = ({
 	variant: "filled" | "outline";
 }) =>
 	action.href ? (
-		<a
-			href={action.href}
-			onClick={action.onClick}
-			className={cn("button", `button_variant_${variant}`, "button_size_lg")}
-		>
-			<span className="button_label">{action.label}</span>
-		</a>
+		<Button as="a" href={action.href} size="lg" variant={variant} onClick={action.onClick}>
+			{action.label}
+		</Button>
 	) : (
 		<Button size="lg" variant={variant} onClick={action.onClick}>
 			{action.label}

--- a/src/ui/display/hero/index.tsx
+++ b/src/ui/display/hero/index.tsx
@@ -50,6 +50,31 @@ export interface HeroProps extends Omit<React.HTMLAttributes<HTMLElement>, "titl
 }
 
 /**
+ * Hero CTA 버튼. `href` 지정 시 링크 시맨틱(우클릭 새 탭·미들클릭·SR 링크 안내)을 위해
+ * Button 클래스를 입힌 실제 anchor 로 렌더링한다 — href 가 문서화만 되고 무시되던 문제 수정.
+ */
+const HeroActionButton = ({
+	action,
+	variant,
+}: {
+	action: HeroAction;
+	variant: "filled" | "outline";
+}) =>
+	action.href ? (
+		<a
+			href={action.href}
+			onClick={action.onClick}
+			className={cn("button", `button_variant_${variant}`, "button_size_lg")}
+		>
+			<span className="button_label">{action.label}</span>
+		</a>
+	) : (
+		<Button size="lg" variant={variant} onClick={action.onClick}>
+			{action.label}
+		</Button>
+	);
+
+/**
  * 페이지 상단 히어로 섹션을 렌더링한다.
  * 배경 이미지/색상 + 오버레이 + 제목/부제목 + CTA 슬롯으로 구성.
  * @param props 히어로 속성
@@ -103,16 +128,8 @@ export const Hero = ({
 				{subtitle && <p className="hero_subtitle">{subtitle}</p>}
 				{(primaryAction || secondaryAction || children) && (
 					<div className="hero_actions">
-						{primaryAction && (
-							<Button size="lg" variant="filled" onClick={primaryAction.onClick}>
-								{primaryAction.label}
-							</Button>
-						)}
-						{secondaryAction && (
-							<Button size="lg" variant="outline" onClick={secondaryAction.onClick}>
-								{secondaryAction.label}
-							</Button>
-						)}
+						{primaryAction && <HeroActionButton action={primaryAction} variant="filled" />}
+						{secondaryAction && <HeroActionButton action={secondaryAction} variant="outline" />}
 						{children}
 					</div>
 				)}

--- a/src/ui/display/hero/style.scss
+++ b/src/ui/display/hero/style.scss
@@ -142,5 +142,10 @@
     gap: token.$spacing_8;
     margin-top: token.$spacing_8;
     flex-wrap: wrap;
+
+    // href 액션은 Button 클래스를 입힌 anchor 로 렌더링됨 - 링크 기본 밑줄 제거
+    a.button {
+      text-decoration: none;
+    }
   }
 }

--- a/src/ui/display/hero/style.scss
+++ b/src/ui/display/hero/style.scss
@@ -142,10 +142,5 @@
     gap: token.$spacing_8;
     margin-top: token.$spacing_8;
     flex-wrap: wrap;
-
-    // href 액션은 Button 클래스를 입힌 anchor 로 렌더링됨 - 링크 기본 밑줄 제거
-    a.button {
-      text-decoration: none;
-    }
   }
 }

--- a/src/ui/display/list-item/index.tsx
+++ b/src/ui/display/list-item/index.tsx
@@ -76,7 +76,9 @@ export const ListItem = ({
 			role={onClick ? "button" : undefined}
 			tabIndex={onClick && !disabled ? 0 : undefined}
 			aria-disabled={disabled || undefined}
-			aria-selected={selected || undefined}
+			// aria-selected 는 option/tab/row 등 특정 role 전용이라 button/일반 div 에선 무효
+			// (axe aria-allowed-attr 위반). 인터랙티브 항목의 선택 상태는 aria-pressed 로 노출한다.
+			aria-pressed={onClick && selected !== undefined ? selected : undefined}
 			{...props}
 		>
 			<div className="list_item_state_layer">

--- a/src/ui/display/table/index.tsx
+++ b/src/ui/display/table/index.tsx
@@ -169,7 +169,8 @@ export const Table = <T extends object>({
 
 	return (
 		<div className={wrapperClassName}>
-			<table className="table" aria-label={ariaLabel}>
+			{/* aria-busy - 스켈레톤 로딩 중임을 AT 에 전달 (시각 전용이던 문제 수정) */}
+			<table className="table" aria-label={ariaLabel} aria-busy={isLoading || undefined}>
 				<thead className="table_thead">
 					<tr>
 						{selectable && (

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AlertProvider, useAlert } from "./index";
 
@@ -185,5 +185,29 @@ describe("Alert", () => {
 
 		const actions = screen.getByRole("alertdialog").querySelector(".alert_actions");
 		expect(actions).toHaveClass("alert_actions_center");
+	});
+
+	it("activates the focus trap when opened via showAlert (mounted closed)", () => {
+		// AlertProvider 는 AlertModal 을 항상 isOpen=false 로 마운트해 두고 showAlert() 로 연다.
+		// 이 deferred-mount 경로에서도 트랩이 걸려 초기 포커스가 alertdialog 안으로 이동해야 함.
+		renderWithProvider(<TestComponent options={{ title: "Trap", showCancel: true }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+
+		const dialog = screen.getByRole("alertdialog");
+		expect(dialog.contains(document.activeElement)).toBe(true);
+	});
+
+	it("closes on Escape after opening via showAlert", async () => {
+		// 포커스가 alertdialog 안에 있어야 overlay onKeyDown 까지 버블되어 Escape 가 동작한다
+		// (트랩 미활성 시 포커스가 트리거에 남아 Escape 가 절대 발화하지 않던 회귀 방지).
+		renderWithProvider(<TestComponent options={{ title: "Esc" }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
+		// 퇴출 spring 애니메이션 완료 후 unmount 되므로 대기
+		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
 	});
 });

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -210,4 +210,44 @@ describe("Alert", () => {
 		// 퇴출 spring 애니메이션 완료 후 unmount 되므로 대기
 		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
 	});
+
+	it("routes Escape and overlay-click dismissal through onCancel (APG alertdialog)", () => {
+		const onCancel = vi.fn();
+		renderWithProvider(<TestComponent options={{ title: "C", onCancel }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
+		expect(onCancel).toHaveBeenCalledTimes(1);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		const overlay = screen.getByRole("alertdialog").parentElement as HTMLElement;
+		fireEvent.click(overlay);
+		expect(onCancel).toHaveBeenCalledTimes(2);
+	});
+
+	it("closeOnOverlay=false ignores overlay clicks", () => {
+		const onCancel = vi.fn();
+		renderWithProvider(
+			<TestComponent options={{ title: "C", onCancel, closeOnOverlay: false }} />,
+		);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		const overlay = screen.getByRole("alertdialog").parentElement as HTMLElement;
+		fireEvent.click(overlay);
+
+		expect(onCancel).not.toHaveBeenCalled();
+		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+	});
+
+	it("locks body scroll while open (data-open-modals counter)", async () => {
+		renderWithProvider(<TestComponent options={{ title: "S" }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+		expect(document.body.style.overflow).toBe("hidden");
+		expect(document.body.dataset.openModals).toBe("1");
+
+		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
+		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+		expect(document.body.style.overflow).toBe("");
+	});
 });

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -239,6 +239,29 @@ describe("Alert", () => {
 		expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 	});
 
+	it("renders without motion when prefers-reduced-motion is set", () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+		renderWithProvider(<TestComponent options={{ title: "Reduced" }} />);
+
+		fireEvent.click(screen.getByText("Show Alert"));
+
+		// reduced-motion 에서 패널이 최종(휴지) 상태로 즉시 도달 (spring immediate)
+		const dialog = screen.getByRole("alertdialog");
+		expect(dialog).toHaveStyle({ transform: "scale(1) translateY(0px)" });
+		vi.unstubAllGlobals();
+	});
+
 	it("locks body scroll while open (data-open-modals counter)", async () => {
 		renderWithProvider(<TestComponent options={{ title: "S" }} />);
 

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
+import { cn, useFocusTrap, useOverlayEscape, useReducedMotion } from "../../../utils";
 import { Button, type ButtonVariant } from "../../general/button";
 import "./style.scss";
 
@@ -145,6 +145,11 @@ const AlertModal: React.FC<AlertModalProps> = ({
 
 	useFocusTrap(panelRef, isOpen);
 
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// dismiss = onCancel ?? onClose 로 라우팅해 취소 정리 로직이 우회되지 않게 한다 (APG alertdialog).
+	// Modal 위에 confirm Alert 를 띄우는 조합에서도 Alert(최상단)만 닫히고 Modal 은 유지된다.
+	useOverlayEscape(isOpen, () => dismiss());
+
 	// isOpen 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다 (Modal 과 동일한
 	// React "render 중 상태 조정" 패턴). effect 로 미루면 패널 마운트가 한 렌더 늦어져
 	// useFocusTrap effect 실행 시점에 panelRef.current 가 null 이라 트랩(초기 포커스 이동·
@@ -220,19 +225,14 @@ const AlertModal: React.FC<AlertModalProps> = ({
 			style={overlayStyle}
 			role="presentation"
 			onClick={() => closeOnOverlay && dismiss()}
-			onKeyDown={(e) => {
-				// Escape 전파 차단 - 상위 오버레이/전역 단축키가 함께 닫히지 않도록 (최상단만 닫힘)
-				if (e.key === "Escape") {
-					e.stopPropagation();
-					dismiss();
-				}
-			}}
 		>
 			<animated.div
 				ref={panelRef}
 				className={modalClassName}
 				style={panelStyle}
 				onClick={(e) => e.stopPropagation()}
+				// Escape 는 공유 스택(useOverlayEscape)이 처리하고, 여기서는 그 외 키가 알림 밖으로
+				// 새어 상위 오버레이/소비자 단축키를 건드리지 않게 막는다.
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -172,9 +172,11 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	});
 
 	// 바디 스크롤 잠금 - Modal/Drawer 와 동일한 data-open-modals 카운터 공유
-	// (Modal 위에서 confirm Alert 를 띄우는 패턴에서도 카운터가 맞게 유지된다)
+	// (Modal 위에서 confirm Alert 를 띄우는 패턴에서도 카운터가 맞게 유지된다).
+	// isOpen 대신 shouldRender 에 묶어 퇴출 애니메이션이 끝나 완전히 unmount 될 때까지
+	// 잠금을 유지한다 (isOpen 기준이면 닫힘 시작 즉시 풀려 페이드 중 배경이 스크롤됨).
 	React.useEffect(() => {
-		if (!isOpen) return;
+		if (!shouldRender) return;
 
 		const body = document.body;
 		const openModals = parseInt(body.dataset.openModals || "0", 10);
@@ -198,7 +200,7 @@ const AlertModal: React.FC<AlertModalProps> = ({
 				body.dataset.openModals = String(nextOpenModals);
 			}
 		};
-	}, [isOpen]);
+	}, [shouldRender]);
 
 	// isOpen 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
 	// panelRef.current 가 붙어 있다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -220,7 +220,13 @@ const AlertModal: React.FC<AlertModalProps> = ({
 			style={overlayStyle}
 			role="presentation"
 			onClick={() => closeOnOverlay && dismiss()}
-			onKeyDown={(e) => e.key === "Escape" && dismiss()}
+			onKeyDown={(e) => {
+				// Escape 전파 차단 - 상위 오버레이/전역 단축키가 함께 닫히지 않도록 (최상단만 닫힘)
+				if (e.key === "Escape") {
+					e.stopPropagation();
+					dismiss();
+				}
+			}}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -136,9 +136,12 @@ const AlertModal: React.FC<AlertModalProps> = ({
 
 	useFocusTrap(panelRef, isOpen);
 
-	React.useEffect(() => {
-		if (isOpen) setShouldRender(true);
-	}, [isOpen]);
+	// isOpen 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다 (Modal 과 동일한
+	// React "render 중 상태 조정" 패턴). effect 로 미루면 패널 마운트가 한 렌더 늦어져
+	// useFocusTrap effect 실행 시점에 panelRef.current 가 null 이라 트랩(초기 포커스 이동·
+	// Tab 격리·포커스 복원)이 전혀 걸리지 않는다 — AlertProvider 는 항상 isOpen=false 로
+	// 마운트해 두고 showAlert() 로 여는 구조라 모든 useAlert() 경로에서 재현되는 버그였다.
+	if (isOpen && !shouldRender) setShouldRender(true);
 
 	const overlayStyle = useSpring({
 		opacity: isOpen ? 1 : 0,
@@ -154,7 +157,9 @@ const AlertModal: React.FC<AlertModalProps> = ({
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 	});
 
-	if (!shouldRender) return null;
+	// isOpen 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
+	// panelRef.current 가 붙어 있다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
+	if (!isOpen && !shouldRender) return null;
 
 	// destructive: confirm을 빨간 filled(danger)로 강조 - 위험성을 시각적으로 표현
 	// (Material/shadcn/Radix 표준 - 빨간 버튼 = 위험한 액션)

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { createContext, useCallback, useContext, useState } from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap } from "../../../utils";
+import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
 import { Button, type ButtonVariant } from "../../general/button";
 import "./style.scss";
 
@@ -48,6 +48,11 @@ export interface AlertOptions {
 	onConfirm?: () => void;
 	/** 취소 버튼 클릭 시 호출되는 콜백 */
 	onCancel?: () => void;
+	/**
+	 * 오버레이 클릭으로 닫기 허용 여부 (기본값: true).
+	 * destructive 확인처럼 실수 닫힘을 막아야 하면 false 로.
+	 */
+	closeOnOverlay?: boolean;
 }
 
 interface AlertContextValue {
@@ -124,10 +129,14 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	destructive = false,
 	actionsAlign = "right",
 	showIcon = false,
+	closeOnOverlay = true,
 	onConfirm,
 	onCancel,
 	onClose,
 }) => {
+	// Escape/overlay 닫힘은 취소 동작과 동등해야 한다 (APG alertdialog) - onCancel 경로로
+	// 보내 소비자의 취소 정리 로직(롤백 등)이 우회되지 않게 한다.
+	const dismiss = onCancel ?? onClose;
 	const panelRef = React.useRef<HTMLDivElement>(null);
 	const titleId = React.useId();
 	const messageId = React.useId();
@@ -143,8 +152,12 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	// 마운트해 두고 showAlert() 로 여는 구조라 모든 useAlert() 경로에서 재현되는 버그였다.
 	if (isOpen && !shouldRender) setShouldRender(true);
 
+	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
+	const reduced = useReducedMotion();
+
 	const overlayStyle = useSpring({
 		opacity: isOpen ? 1 : 0,
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 		onRest: (result) => {
 			if (!isOpen && result.finished) setShouldRender(false);
@@ -154,8 +167,38 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	const panelStyle = useSpring({
 		opacity: isOpen ? 1 : 0,
 		transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 	});
+
+	// 바디 스크롤 잠금 - Modal/Drawer 와 동일한 data-open-modals 카운터 공유
+	// (Modal 위에서 confirm Alert 를 띄우는 패턴에서도 카운터가 맞게 유지된다)
+	React.useEffect(() => {
+		if (!isOpen) return;
+
+		const body = document.body;
+		const openModals = parseInt(body.dataset.openModals || "0", 10);
+
+		if (openModals === 0) {
+			body.dataset.originalOverflow = window.getComputedStyle(body).overflow;
+			body.style.overflow = "hidden";
+		}
+
+		body.dataset.openModals = String(openModals + 1);
+
+		return () => {
+			const currentOpenModals = parseInt(body.dataset.openModals || "1", 10);
+			const nextOpenModals = currentOpenModals - 1;
+
+			if (nextOpenModals === 0) {
+				body.style.overflow = body.dataset.originalOverflow || "";
+				delete body.dataset.openModals;
+				delete body.dataset.originalOverflow;
+			} else {
+				body.dataset.openModals = String(nextOpenModals);
+			}
+		};
+	}, [isOpen]);
 
 	// isOpen 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
 	// panelRef.current 가 붙어 있다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
@@ -174,8 +217,8 @@ const AlertModal: React.FC<AlertModalProps> = ({
 			className="alert_overlay"
 			style={overlayStyle}
 			role="presentation"
-			onClick={onClose}
-			onKeyDown={(e) => e.key === "Escape" && onClose()}
+			onClick={() => closeOnOverlay && dismiss()}
+			onKeyDown={(e) => e.key === "Escape" && dismiss()}
 		>
 			<animated.div
 				ref={panelRef}

--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -597,29 +597,40 @@ describe("Toast stack & ids", () => {
 		expect(document.querySelectorAll(".toast_item")).toHaveLength(3);
 	});
 
-	it("auto-closes via setTimeout under prefers-reduced-motion (progress animation disabled)", async () => {
-		// reduced-motion 에서는 progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지
-		// 않으므로 setTimeout 분기가 자동 닫힘을 대신해야 한다 (없으면 토스트가 영구히 남음)
-		const originalMatchMedia = window.matchMedia;
-		window.matchMedia = vi.fn().mockReturnValue({
-			matches: true,
-			addEventListener: vi.fn(),
-			removeEventListener: vi.fn(),
-		}) as unknown as typeof window.matchMedia;
-
-		try {
-			render(
-				<ToastProvider>
-					<ToastTrigger fn={(t) => t.info("잠깐 표시", 30)} label="quick" />
-				</ToastProvider>,
+	it("hands focus to an adjacent toast when a focused toast is closed (WCAG 2.4.3)", async () => {
+		function MultiTrigger() {
+			const t = useToast();
+			return (
+				<button
+					type="button"
+					onClick={() => {
+						t.success("첫 번째");
+						t.success("두 번째");
+					}}
+				>
+					two
+				</button>
 			);
-			fireEvent.click(screen.getByRole("button", { name: "quick" }));
-			expect(screen.getByText("잠깐 표시")).toBeInTheDocument();
-
-			// setTimeout(30ms) → visible=false → spring 퇴출(immediate) 후 unmount
-			await waitFor(() => expect(screen.queryByText("잠깐 표시")).not.toBeInTheDocument());
-		} finally {
-			window.matchMedia = originalMatchMedia;
 		}
+
+		render(
+			<ToastProvider>
+				<MultiTrigger />
+			</ToastProvider>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "two" }));
+
+		const closeButtons = screen.getAllByRole("button", { name: "Close" });
+		expect(closeButtons).toHaveLength(2);
+
+		// 첫 번째(맨 위) 토스트의 닫기 버튼에 포커스를 두고 닫으면,
+		// 포커스가 body 로 유실되지 않고 인접 토스트의 닫기 버튼으로 이관되어야 한다.
+		closeButtons[0].focus();
+		fireEvent.click(closeButtons[0]);
+
+		await waitFor(() => {
+			expect(document.activeElement).toBe(closeButtons[1]);
+		});
 	});
 });

--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -596,4 +596,30 @@ describe("Toast stack & ids", () => {
 		expect(screen.getAllByText("같은 메시지")).toHaveLength(3);
 		expect(document.querySelectorAll(".toast_item")).toHaveLength(3);
 	});
+
+	it("auto-closes via setTimeout under prefers-reduced-motion (progress animation disabled)", async () => {
+		// reduced-motion 에서는 progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지
+		// 않으므로 setTimeout 분기가 자동 닫힘을 대신해야 한다 (없으면 토스트가 영구히 남음)
+		const originalMatchMedia = window.matchMedia;
+		window.matchMedia = vi.fn().mockReturnValue({
+			matches: true,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+		}) as unknown as typeof window.matchMedia;
+
+		try {
+			render(
+				<ToastProvider>
+					<ToastTrigger fn={(t) => t.info("잠깐 표시", 30)} label="quick" />
+				</ToastProvider>,
+			);
+			fireEvent.click(screen.getByRole("button", { name: "quick" }));
+			expect(screen.getByText("잠깐 표시")).toBeInTheDocument();
+
+			// setTimeout(30ms) → visible=false → spring 퇴출(immediate) 후 unmount
+			await waitFor(() => expect(screen.queryByText("잠깐 표시")).not.toBeInTheDocument());
+		} finally {
+			window.matchMedia = originalMatchMedia;
+		}
+	});
 });

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-reac
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useReducedMotion, useSpringPresence } from "../../../utils";
+import { cn, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info" | "default";
@@ -58,23 +58,27 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 	const [visible, setVisible] = React.useState(true);
 	const closingRef = React.useRef(false);
 	const rootRef = React.useRef<HTMLDivElement>(null);
-	const reduced = useReducedMotion();
 
 	const style = useSpringPresence({
 		visible,
 		from: "translateX(20px)", // 우측에서 슬라이드 인
 		onExitComplete: () => {
 			// 포커스가 이 토스트 안에 있었으면(닫기 버튼 Enter 등) unmount 로 포커스가
-			// body 로 유실되지 않게 다음 토스트의 닫기 버튼으로 넘긴다 (WCAG 2.4.3).
+			// body 로 유실되지 않게 인접 토스트의 닫기 버튼으로 넘긴다 (WCAG 2.4.3).
+			// onRemove(=state 갱신) 전에 포커스를 옮겨 배치 flush 타이밍에 의존하지 않는다.
 			const hadFocus = rootRef.current?.contains(document.activeElement) ?? false;
-			onRemove(item.id);
 			if (hadFocus) {
-				// onRemove 의 상태 갱신이 아직 flush 전이라 자기 자신도 DOM 에 남아 있음 - 제외하고 탐색
-				const next = Array.from(
+				const closeButtons = Array.from(
 					document.querySelectorAll<HTMLElement>(".toast_item .toast_close"),
-				).find((el) => !rootRef.current?.contains(el));
-				next?.focus();
+				);
+				const currentIndex = closeButtons.findIndex((el) => rootRef.current?.contains(el));
+				if (currentIndex !== -1) {
+					// 다음(아래) 우선, 없으면 이전(위) 토스트로 - 논리적 인접 이동
+					const next = closeButtons[currentIndex + 1] || closeButtons[currentIndex - 1];
+					next?.focus();
+				}
 			}
+			onRemove(item.id);
 		},
 	});
 
@@ -87,14 +91,6 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 		closingRef.current = true;
 		setVisible(false);
 	}, []);
-
-	// reduced-motion: progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지 않으므로
-	// setTimeout 으로 자동 닫힘을 대신한다 (없으면 토스트가 영구히 남음).
-	React.useEffect(() => {
-		if (!reduced) return;
-		const timer = setTimeout(close, item.duration);
-		return () => clearTimeout(timer);
-	}, [reduced, item.duration, close]);
 
 	return (
 		<animated.div

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-reac
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useReducedMotion, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info" | "default";
@@ -57,11 +57,25 @@ interface ToastItemComponentProps {
 const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemComponentProps) => {
 	const [visible, setVisible] = React.useState(true);
 	const closingRef = React.useRef(false);
+	const rootRef = React.useRef<HTMLDivElement>(null);
+	const reduced = useReducedMotion();
 
 	const style = useSpringPresence({
 		visible,
 		from: "translateX(20px)", // 우측에서 슬라이드 인
-		onExitComplete: () => onRemove(item.id),
+		onExitComplete: () => {
+			// 포커스가 이 토스트 안에 있었으면(닫기 버튼 Enter 등) unmount 로 포커스가
+			// body 로 유실되지 않게 다음 토스트의 닫기 버튼으로 넘긴다 (WCAG 2.4.3).
+			const hadFocus = rootRef.current?.contains(document.activeElement) ?? false;
+			onRemove(item.id);
+			if (hadFocus) {
+				// onRemove 의 상태 갱신이 아직 flush 전이라 자기 자신도 DOM 에 남아 있음 - 제외하고 탐색
+				const next = Array.from(
+					document.querySelectorAll<HTMLElement>(".toast_item .toast_close"),
+				).find((el) => !rootRef.current?.contains(el));
+				next?.focus();
+			}
+		},
 	});
 
 	/**
@@ -74,8 +88,17 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 		setVisible(false);
 	}, []);
 
+	// reduced-motion: progress CSS 애니메이션이 꺼져 onAnimationEnd 가 발화하지 않으므로
+	// setTimeout 으로 자동 닫힘을 대신한다 (없으면 토스트가 영구히 남음).
+	React.useEffect(() => {
+		if (!reduced) return;
+		const timer = setTimeout(close, item.duration);
+		return () => clearTimeout(timer);
+	}, [reduced, item.duration, close]);
+
 	return (
 		<animated.div
+			ref={rootRef}
 			className="toast_item"
 			style={style}
 			role={item.variant === "error" ? "alert" : "status"}

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-reac
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useIsMounted, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info" | "default";
@@ -133,11 +133,8 @@ export const ToastProvider = ({
 	closeAriaLabel = "Close",
 }: ToastProviderProps) => {
 	const [toasts, setToasts] = React.useState<ToastItem[]>([]);
-	const [isMounted, setIsMounted] = React.useState(false);
-
-	React.useEffect(() => {
-		setIsMounted(true);
-	}, []);
+	// 포털은 클라이언트 마운트 후에만 렌더 (SSR/hydration 안전) - 공유 훅
+	const isMounted = useIsMounted();
 
 	/**
 	 * 토스트를 큐에 추가한다. maxCount를 초과하면 가장 오래된 항목을 제거한다.

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -10,6 +10,14 @@
   to   { width: 0%; }
 }
 
+// reduced-motion 용 정적 keyframe - 폭 변화(시각 모션) 없이 동일 duration 동안 진행.
+// onAnimationEnd(자동 닫힘 트리거)와 animation-play-state:paused(hover/focus 일시정지)를
+// 그대로 살리기 위해 animation 을 끄지 않고 정적 keyframe 로 교체한다.
+@keyframes toast_progress_reduced {
+  from { width: 0; }
+  to   { width: 0; }
+}
+
 // ── Container ────────────────────────────────────────────────────────────────
 
 .toast_container {
@@ -157,10 +165,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  // progress 시각 모션 제거. 자동 닫힘은 컴포넌트의 reduced-motion 분기(setTimeout)가
-  // 대신 처리한다 - animation 만 없애면 onAnimationEnd 가 발화하지 않아 영구히 남기 때문.
+  // 시각 모션만 제거 - animation-name 만 정적 keyframe 로 바꿔 duration/타이밍/play-state 는
+  // 유지한다. 이렇게 하면 onAnimationEnd 로 자동 닫힘이 그대로 발화하고, hover/focus 시
+  // animation-play-state:paused 로 타이머가 함께 멈춰 WCAG 2.2.1 이 reduced-motion 에서도 지켜진다.
+  // (animation:none 이면 onAnimationEnd 가 안 나 토스트가 영구히 남고 pause 도 무력화됨.)
   .toast_progress {
-    animation: none;
+    animation-name: toast_progress_reduced;
     width: 0;
   }
 }

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -147,3 +147,20 @@
   &_info    { background: token.$color_status_info; }
   &_default { background: token.$color_text_body; }
 }
+
+// WCAG 2.2.1 Timing Adjustable - 포인터를 올리거나 닫기 버튼에 포커스가 있는 동안
+// 자동 닫힘 타이머(progress 애니메이션)를 일시정지해 읽기/조작 시간을 연장한다.
+// onAnimationEnd 가 닫힘 트리거라 play-state 정지만으로 타이머까지 함께 멈춘다.
+.toast_item:hover .toast_progress,
+.toast_item:focus-within .toast_progress {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  // progress 시각 모션 제거. 자동 닫힘은 컴포넌트의 reduced-motion 분기(setTimeout)가
+  // 대신 처리한다 - animation 만 없애면 onAnimationEnd 가 발화하지 않아 영구히 남기 때문.
+  .toast_progress {
+    animation: none;
+    width: 0;
+  }
+}

--- a/src/ui/forms/checkbox/index.tsx
+++ b/src/ui/forms/checkbox/index.tsx
@@ -50,13 +50,15 @@ export const Checkbox = ({
 
 	return (
 		<label className={rootClassName}>
-			{/* error 는 시각 표시만으로는 AT 에 전달되지 않으므로 aria-invalid 로 노출 (WCAG 4.1.2) */}
+			{/* {...props} 를 먼저 펼쳐 소비자 값은 통과시키되 type/className/aria-invalid 는
+			    컴포넌트가 항상 이기도록 뒤에 배치 (Toggle 과 동일한 스프레드 순서).
+			    error 는 시각 표시만으로는 AT 에 전달되지 않으므로 aria-invalid 로 노출 (WCAG 4.1.2) */}
 			<input
+				{...props}
 				ref={inputRef}
 				type="checkbox"
 				className="checkbox_input"
 				aria-invalid={error || undefined}
-				{...props}
 			/>
 			<span className="checkbox_state_layer" aria-hidden="true">
 				<span className="checkbox_icon" />

--- a/src/ui/forms/checkbox/index.tsx
+++ b/src/ui/forms/checkbox/index.tsx
@@ -50,7 +50,14 @@ export const Checkbox = ({
 
 	return (
 		<label className={rootClassName}>
-			<input ref={inputRef} type="checkbox" className="checkbox_input" {...props} />
+			{/* error 는 시각 표시만으로는 AT 에 전달되지 않으므로 aria-invalid 로 노출 (WCAG 4.1.2) */}
+			<input
+				ref={inputRef}
+				type="checkbox"
+				className="checkbox_input"
+				aria-invalid={error || undefined}
+				{...props}
+			/>
 			<span className="checkbox_state_layer" aria-hidden="true">
 				<span className="checkbox_icon" />
 			</span>

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -422,10 +422,12 @@ describe("Dropdown", () => {
 		const button = screen.getByRole("button");
 		expect(button).toHaveAttribute("aria-haspopup", "listbox");
 		expect(button).toHaveAttribute("aria-expanded", "false");
-		expect(button).toHaveAttribute("aria-controls", "dd-1_listbox");
+		// 닫힌 상태에서는 listbox 가 unmount 라 aria-controls 를 달지 않는다 (dangling IDREF 방지)
+		expect(button).not.toHaveAttribute("aria-controls");
 
 		fireEvent.click(button);
 		expect(button).toHaveAttribute("aria-expanded", "true");
+		expect(button).toHaveAttribute("aria-controls", "dd-1_listbox");
 
 		const listbox = screen.getByRole("listbox");
 		expect(listbox).toHaveAttribute("id", "dd-1_listbox");
@@ -700,5 +702,45 @@ describe("Dropdown", () => {
 		const activeId = input.getAttribute("aria-activedescendant");
 		expect(activeId).toBeTruthy();
 		expect(document.getElementById(activeId as string)).toHaveAttribute("role", "option");
+	});
+
+	it("closes the listbox on Tab from the control (APG combobox)", () => {
+		render(<Dropdown options={options} />);
+		const control = screen.getByRole("button");
+		fireEvent.click(control);
+		expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+		fireEvent.keyDown(control, { key: "Tab" });
+		expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+	});
+
+	it("omits aria-controls while closed (no dangling IDREF)", () => {
+		render(<Dropdown options={options} />);
+		const control = screen.getByRole("button");
+		expect(control).not.toHaveAttribute("aria-controls");
+
+		fireEvent.click(control);
+		expect(control).toHaveAttribute("aria-controls");
+	});
+
+	it("renders hidden input(s) for native form submission when name is given", () => {
+		const { container, rerender } = render(
+			<Dropdown options={options} name="fruit" value="1" onValueChange={() => {}} />,
+		);
+		const hidden = container.querySelector('input[type="hidden"][name="fruit"]');
+		expect(hidden).toHaveValue("1");
+
+		// multiple: 같은 name 의 hidden input 반복
+		rerender(
+			<Dropdown
+				options={options}
+				name="fruit"
+				multiple
+				value={["1", "2"]}
+				onValueChange={() => {}}
+			/>,
+		);
+		const hiddens = container.querySelectorAll('input[type="hidden"][name="fruit"]');
+		expect(Array.from(hiddens).map((el) => (el as HTMLInputElement).value)).toEqual(["1", "2"]);
 	});
 });

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { MapPin } from "lucide-react";
 import * as React from "react";
-import { Dropdown, type DropdownOption } from ".";
+import {
+	Dropdown,
+	type DropdownMultipleProps,
+	type DropdownOption,
+	type DropdownSingleProps,
+} from ".";
 
 const basicOptions: DropdownOption[] = [
 	{ value: "apple", label: "Apple" },
@@ -107,7 +112,8 @@ export const Controlled: Story = {
 		const [value, setValue] = React.useState<string | null>("banana");
 		return (
 			<div style={{ width: 320 }}>
-				<Dropdown {...args} value={value} onChange={setValue} />
+				{/* args 는 single/multiple 유니온이라 단일 모드 제어 prop 과 스프레드로 섞을 수 없음 - 단일로 단언 */}
+				<Dropdown {...(args as DropdownSingleProps)} value={value} onValueChange={setValue} />
 				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 					선택: <strong>{String(value)}</strong>
 				</div>
@@ -151,7 +157,7 @@ export const Multiple: Story = {
 		return (
 			<div style={{ width: 320 }}>
 				<Dropdown
-					{...args}
+					{...(args as DropdownMultipleProps)}
 					multiple
 					options={fruitOptions}
 					label="Fruit"
@@ -183,7 +189,7 @@ export const SearchableMultiple: Story = {
 		return (
 			<div style={{ width: 320 }}>
 				<Dropdown
-					{...args}
+					{...(args as DropdownMultipleProps)}
 					multiple
 					searchable
 					options={fruitOptions}

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -112,8 +112,15 @@ export const Controlled: Story = {
 		const [value, setValue] = React.useState<string | null>("banana");
 		return (
 			<div style={{ width: 320 }}>
-				{/* args 는 single/multiple 유니온이라 단일 모드 제어 prop 과 스프레드로 섞을 수 없음 - 단일로 단언 */}
-				<Dropdown {...(args as DropdownSingleProps)} value={value} onValueChange={setValue} />
+				{/* args 는 single/multiple 유니온이라 단일 모드 제어 prop 과 스프레드로 섞을 수 없음 - 단일로 단언.
+				    multiple={false} 을 명시 고정해 Storybook Controls 에서 multiple 을 켜도
+				    단일 문자열 value 에 .filter 를 호출해 크래시하지 않도록 방지. */}
+				<Dropdown
+					{...(args as DropdownSingleProps)}
+					multiple={false}
+					value={value}
+					onValueChange={setValue}
+				/>
 				<div style={{ marginTop: 8, fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 					선택: <strong>{String(value)}</strong>
 				</div>

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -63,6 +63,11 @@ interface DropdownCommonProps {
 	emptyText?: string;
 	/** 멀티 선택 요약 텍스트 (기본값: "N개 선택") */
 	selectedSummary?: (count: number) => string;
+	/**
+	 * 네이티브 폼 제출 참여용 name. 지정 시 선택 값이 hidden input 으로 렌더되어
+	 * `<form>` POST 에 포함됩니다 (multiple 은 같은 name 의 hidden input 반복).
+	 */
+	name?: string;
 }
 
 /** 단일 선택 (기본) */
@@ -118,6 +123,7 @@ export const Dropdown = (props: DropdownProps) => {
 		searchPlaceholder = "검색…",
 		emptyText = "결과 없음",
 		selectedSummary = (count: number) => `${count}개 선택`,
+		name,
 	} = props;
 
 	const multiple = props.multiple === true;
@@ -295,6 +301,10 @@ export const Dropdown = (props: DropdownProps) => {
 				e.preventDefault();
 				setIsOpen(false);
 				break;
+			case "Tab":
+				// APG Combobox: Tab 은 리스트를 닫고 자연스러운 포커스 이동을 허용 (preventDefault 안 함)
+				setIsOpen(false);
+				break;
 		}
 	};
 
@@ -317,6 +327,11 @@ export const Dropdown = (props: DropdownProps) => {
 				break;
 			case "Escape":
 				e.preventDefault();
+				closePanel();
+				break;
+			case "Tab":
+				// APG Combobox: Tab 은 리스트를 닫는다. closePanel 이 트리거로 포커스를
+				// 되돌린 뒤 브라우저 기본 Tab 이동이 이어진다 (preventDefault 안 함).
 				closePanel();
 				break;
 		}
@@ -405,7 +420,8 @@ export const Dropdown = (props: DropdownProps) => {
 					className={cn("dropdown_control", { is_disabled: disabled })}
 					aria-haspopup="listbox"
 					aria-expanded={isOpen}
-					aria-controls={`${dropdownId}_listbox`}
+					// 닫힌 상태에서는 listbox 가 unmount 라 dangling IDREF 방지 위해 열렸을 때만 지정
+					aria-controls={isOpen ? `${dropdownId}_listbox` : undefined}
 					onClick={() => !disabled && setIsOpen((o) => !o)}
 					onKeyDown={onControlKeyDown}
 					disabled={disabled}
@@ -418,6 +434,14 @@ export const Dropdown = (props: DropdownProps) => {
 					</span>
 				</button>
 			</div>
+
+			{/* 네이티브 폼 제출 참여 - name 지정 시 선택 값을 hidden input 으로 노출 */}
+			{name &&
+				(multiple ? (
+					selectedValues.map((v) => <input key={v} type="hidden" name={name} value={v} />)
+				) : (
+					<input type="hidden" name={name} value={selectedValues[0] ?? ""} />
+				))}
 
 			{isOpen && (
 				<animated.div className={listClassName} style={listStyle}>

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -435,12 +435,15 @@ export const Dropdown = (props: DropdownProps) => {
 				</button>
 			</div>
 
-			{/* 네이티브 폼 제출 참여 - name 지정 시 선택 값을 hidden input 으로 노출 */}
+			{/* 네이티브 폼 제출 참여 - name 지정 시 선택 값을 hidden input 으로 노출.
+			    disabled 시 값 전송 제외 (native <select disabled> 처럼 FormData 에서 빠지도록). */}
 			{name &&
 				(multiple ? (
-					selectedValues.map((v) => <input key={v} type="hidden" name={name} value={v} />)
+					selectedValues.map((v) => (
+						<input key={v} type="hidden" name={name} value={v} disabled={disabled} />
+					))
 				) : (
-					<input type="hidden" name={name} value={selectedValues[0] ?? ""} />
+					<input type="hidden" name={name} value={selectedValues[0] ?? ""} disabled={disabled} />
 				))}
 
 			{isOpen && (

--- a/src/ui/forms/otp-input/OtpInput.test.tsx
+++ b/src/ui/forms/otp-input/OtpInput.test.tsx
@@ -54,6 +54,15 @@ describe("OtpInput", () => {
 		expect(onChange).toHaveBeenCalledWith("123456");
 	});
 
+	it("distributes a multi-char value from SMS autofill (onChange with full code)", () => {
+		// autocomplete="one-time-code" 자동입력은 첫 박스 onChange 로 전체 코드가 한 번에 들어옴
+		const onChange = vi.fn();
+		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
+		const inputs = screen.getAllByRole("textbox");
+		fireEvent.change(inputs[0], { target: { value: "123456" } });
+		expect(onChange).toHaveBeenCalledWith("123456");
+	});
+
 	it("handles paste with non-numeric characters", () => {
 		const onChange = vi.fn();
 		render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
@@ -375,12 +384,14 @@ describe("OtpInput", () => {
 	});
 
 	describe("Non-digit handling on change", () => {
-		it("rejects multi-character input", () => {
+		it("distributes multi-character input across boxes (SMS autofill)", () => {
+			// 이전엔 멀티문자를 거부했으나, SMS 자동입력이 첫 박스에 전체 코드를 넣으므로
+			// handlePaste 처럼 각 자리에 분배하도록 변경됨.
 			const onChange = vi.fn();
 			render(<OtpInput length={6} value="" onChange={onChange} ariaLabel="OTP" />);
 			const inputs = screen.getAllByRole("textbox");
 			fireEvent.change(inputs[0], { target: { value: "12" } });
-			expect(onChange).not.toHaveBeenCalled();
+			expect(onChange).toHaveBeenCalledWith("12");
 		});
 
 		it("allows clearing a digit (empty string)", () => {

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -69,6 +69,19 @@ export const OtpInput = ({
 
 	const handleChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {
 		const nextDigit = e.target.value;
+
+		// SMS/키체인 자동입력(autocomplete="one-time-code")은 첫 박스의 onChange 로 전체 코드가
+		// 한 번에 들어온다. 단일 숫자 정규식에 걸려 무시되지 않도록 handlePaste 처럼 각 자리에 분배.
+		if (nextDigit.length > 1) {
+			const filled = nextDigit.replace(/\D/g, "").slice(0, length);
+			if (!filled) return;
+			const newDigits = [...digits];
+			for (let i = 0; i < filled.length; i++) newDigits[i] = filled[i];
+			updateValue(newDigits);
+			focusInput(Math.min(filled.length, length - 1));
+			return;
+		}
+
 		if (nextDigit && !/^\d$/.test(nextDigit)) return;
 
 		const newDigits = [...digits];

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -72,7 +72,9 @@ export const OtpInput = ({
 
 		// SMS/키체인 자동입력(autocomplete="one-time-code")은 첫 박스의 onChange 로 전체 코드가
 		// 한 번에 들어온다. 단일 숫자 정규식에 걸려 무시되지 않도록 handlePaste 처럼 각 자리에 분배.
-		if (nextDigit.length > 1) {
+		// index 0 에서만 처리 - 분배가 항상 0번부터 채우므로, 다른 박스에서 멀티문자 change 가
+		// 발생해도(브라우저별 자동완성 차이 등) 기존 자릿수를 밀지 않도록 트리거 위치를 명시 가드.
+		if (index === 0 && nextDigit.length > 1) {
 			const filled = nextDigit.replace(/\D/g, "").slice(0, length);
 			if (!filled) return;
 			const newDigits = [...digits];

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -136,6 +136,7 @@ export const OtpInput = ({
 	};
 
 	const rootClassName = cn("otp_input", className);
+	const supportingId = React.useId();
 
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: <fieldset> would force border/legend styles; role=group is the WAI-ARIA equivalent for OTP grouping
@@ -152,6 +153,8 @@ export const OtpInput = ({
 						inputMode="numeric"
 						pattern="\d*"
 						maxLength={1}
+						// SMS/키체인의 OTP 자동입력 - 첫 입력에만 지정 (paste 핸들러가 전 자리 분배)
+						autoComplete={i === 0 ? "one-time-code" : "off"}
 						value={digit}
 						onChange={(e) => handleChange(i, e)}
 						onFocus={() => handleFocus(i)}
@@ -159,6 +162,9 @@ export const OtpInput = ({
 						onPaste={handlePaste}
 						disabled={disabled}
 						aria-label={`${i + 1}번째 자리`}
+						// error/supportingText 를 AT 에 전달 (시각 전용이던 문제 수정)
+						aria-invalid={error || undefined}
+						aria-describedby={supportingText ? supportingId : undefined}
 						className={cn(
 							"otp_input_box",
 							error && "otp_input_box_error",
@@ -168,7 +174,10 @@ export const OtpInput = ({
 				))}
 			</div>
 			{supportingText && (
-				<span className={cn("otp_input_supporting", error && "otp_input_supporting_error")}>
+				<span
+					id={supportingId}
+					className={cn("otp_input_supporting", error && "otp_input_supporting_error")}
+				>
 					{supportingText}
 				</span>
 			)}

--- a/src/ui/forms/radio-group/RadioGroup.test.tsx
+++ b/src/ui/forms/radio-group/RadioGroup.test.tsx
@@ -173,4 +173,17 @@ describe("Radio standalone (no RadioGroup) — 기존 동작 보존", () => {
 		expect(screen.getByRole("radio", { name: "One" })).toBeChecked();
 		expect(screen.getByRole("radio", { name: "Two" })).not.toBeChecked();
 	});
+
+	it("does not check a value=\"null\" radio when the group value is null", () => {
+		// 회귀: group.value 가 null 이면 String(null)==="null" 이라 value=\"null\" Radio 가 선택되던
+		// 문제 - group.value != null 로 null/undefined 모두 방어
+		render(
+			<RadioGroup label="g" value={null as unknown as string}>
+				<Radio value="null" label="Null" />
+				<Radio value="a" label="A" />
+			</RadioGroup>,
+		);
+		expect(screen.getByRole("radio", { name: "Null" })).not.toBeChecked();
+		expect(screen.getByRole("radio", { name: "A" })).not.toBeChecked();
+	});
 });

--- a/src/ui/forms/radio-group/RadioGroup.test.tsx
+++ b/src/ui/forms/radio-group/RadioGroup.test.tsx
@@ -146,4 +146,17 @@ describe("Radio standalone (no RadioGroup) — 기존 동작 보존", () => {
 		fireEvent.click(screen.getByRole("radio"));
 		expect(onChange).toHaveBeenCalled();
 	});
+
+	it("does not mark value-less radios checked while the group is unselected", () => {
+		// 회귀: group.value(undefined) === value(undefined) 가 true 로 평가되어
+		// value 없는 라디오가 전부 checked 렌더되던 버그
+		render(
+			<RadioGroup label="g">
+				<Radio label="A" />
+				<Radio label="B" />
+			</RadioGroup>,
+		);
+		expect(screen.getByRole("radio", { name: "A" })).not.toBeChecked();
+		expect(screen.getByRole("radio", { name: "B" })).not.toBeChecked();
+	});
 });

--- a/src/ui/forms/radio-group/RadioGroup.test.tsx
+++ b/src/ui/forms/radio-group/RadioGroup.test.tsx
@@ -159,4 +159,18 @@ describe("Radio standalone (no RadioGroup) — 기존 동작 보존", () => {
 		expect(screen.getByRole("radio", { name: "A" })).not.toBeChecked();
 		expect(screen.getByRole("radio", { name: "B" })).not.toBeChecked();
 	});
+
+	it("keeps a numeric-value radio checked after selecting it", () => {
+		// 회귀: handleChange 가 group.onChange(String(value)) 로 문자열을 넘기는데 비교가
+		// group.value === value 이면 "1" === 1 → false 라 클릭 직후 선택 해제되던 버그
+		render(
+			<RadioGroup label="g">
+				<Radio value={1} label="One" />
+				<Radio value={2} label="Two" />
+			</RadioGroup>,
+		);
+		fireEvent.click(screen.getByRole("radio", { name: "One" }));
+		expect(screen.getByRole("radio", { name: "One" })).toBeChecked();
+		expect(screen.getByRole("radio", { name: "Two" })).not.toBeChecked();
+	});
 });

--- a/src/ui/forms/radio/index.tsx
+++ b/src/ui/forms/radio/index.tsx
@@ -39,7 +39,9 @@ export const Radio = ({
 	const size = sizeProp ?? group?.size ?? "md";
 	const name = nameProp ?? group?.name;
 	const disabled = disabledProp ?? group?.disabled;
-	const resolvedChecked = group ? group.value === value : checked;
+	// value 없는 Radio 가 그룹 미선택 상태(group.value === undefined)에서
+	// undefined === undefined 로 전부 checked 렌더되지 않도록 value 존재를 먼저 확인.
+	const resolvedChecked = group ? value !== undefined && group.value === value : checked;
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		if (group && value !== undefined) group.onChange(String(value));

--- a/src/ui/forms/radio/index.tsx
+++ b/src/ui/forms/radio/index.tsx
@@ -44,7 +44,7 @@ export const Radio = ({
 	// 넘기므로, 숫자 value 를 그대로 비교하면(예: "1" === 1) 클릭 직후 선택 해제되는 버그가 있어
 	// 양쪽 String() 으로 강제 비교한다.
 	const resolvedChecked = group
-		? value !== undefined && group.value !== undefined && String(group.value) === String(value)
+		? value !== undefined && group.value != null && String(group.value) === String(value)
 		: checked;
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/forms/radio/index.tsx
+++ b/src/ui/forms/radio/index.tsx
@@ -39,9 +39,13 @@ export const Radio = ({
 	const size = sizeProp ?? group?.size ?? "md";
 	const name = nameProp ?? group?.name;
 	const disabled = disabledProp ?? group?.disabled;
-	// value 없는 Radio 가 그룹 미선택 상태(group.value === undefined)에서
-	// undefined === undefined 로 전부 checked 렌더되지 않도록 value 존재를 먼저 확인.
-	const resolvedChecked = group ? value !== undefined && group.value === value : checked;
+	// value 없는 Radio 가 그룹 미선택 상태(group.value === undefined)에서 전부 checked 되지 않도록
+	// value 존재를 먼저 확인. 또 handleChange 가 group.onChange(String(value)) 로 항상 문자열을
+	// 넘기므로, 숫자 value 를 그대로 비교하면(예: "1" === 1) 클릭 직후 선택 해제되는 버그가 있어
+	// 양쪽 String() 으로 강제 비교한다.
+	const resolvedChecked = group
+		? value !== undefined && group.value !== undefined && String(group.value) === String(value)
+		: checked;
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		if (group && value !== undefined) group.onChange(String(value));

--- a/src/ui/forms/toggle/Toggle.test.tsx
+++ b/src/ui/forms/toggle/Toggle.test.tsx
@@ -89,4 +89,31 @@ describe("Toggle", () => {
 		expect(onCheckedChange).toHaveBeenCalledWith(true);
 	});
 
+	it("runs consumer onClick AND still toggles ({...props} spread must not replace toggle handler)", () => {
+		const onClick = vi.fn();
+		const onCheckedChange = vi.fn();
+		render(<Toggle ariaLabel="Toggle" onClick={onClick} onCheckedChange={onCheckedChange} />);
+
+		fireEvent.click(screen.getByRole("switch"));
+
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(onCheckedChange).toHaveBeenCalledWith(true);
+		expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+	});
+
+	it("skips toggling when consumer onClick calls preventDefault", () => {
+		const onCheckedChange = vi.fn();
+		render(
+			<Toggle
+				ariaLabel="Toggle"
+				onClick={(e) => e.preventDefault()}
+				onCheckedChange={onCheckedChange}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("switch"));
+
+		expect(onCheckedChange).not.toHaveBeenCalled();
+		expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+	});
 });

--- a/src/ui/forms/toggle/index.tsx
+++ b/src/ui/forms/toggle/index.tsx
@@ -48,10 +48,12 @@ export const Toggle = ({
 
 	/**
 	 * 현재 상태를 토글하고 변경 콜백을 호출한다.
+	 * 소비자 onClick 을 먼저 실행하고 preventDefault 시 토글을 건너뛴다.
 	 * @returns void
 	 */
-	const handleToggle = () => {
-		if (disabled) return;
+	const handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+		props.onClick?.(e);
+		if (disabled || e.defaultPrevented) return;
 		const next = !isOn;
 		if (!isControlled) setInnerChecked(next);
 		(onCheckedChange ?? onChange)?.(next);
@@ -66,6 +68,10 @@ export const Toggle = ({
 
 	return (
 		<button
+			// {...props} 를 먼저 펼쳐 data-*/aria-* 는 통과시키되, switch 동작에 필수인
+			// role/aria-checked/onClick(소비자 onClick 은 handleToggle 안에서 합성 실행)은
+			// 컴포넌트가 항상 이기도록 뒤에 둔다.
+			{...props}
 			ref={ref}
 			type="button"
 			role="switch"
@@ -74,7 +80,6 @@ export const Toggle = ({
 			disabled={disabled}
 			onClick={handleToggle}
 			className={rootClassName}
-			{...props}
 		>
 			<span className="toggle_thumb" />
 		</button>

--- a/src/ui/general/button/Button.test.tsx
+++ b/src/ui/general/button/Button.test.tsx
@@ -84,4 +84,111 @@ describe("Button", () => {
 		expect(node).toBeInstanceOf(HTMLButtonElement);
 	});
 
+	it("renders a button element (not anchor) by default", () => {
+		const { container } = render(<Button>Button</Button>);
+		expect(container.querySelector("button")).toBeInTheDocument();
+		expect(container.querySelector("a")).not.toBeInTheDocument();
+	});
+
+	describe("as anchor", () => {
+		it("renders an <a href> with role=link when as='a'", () => {
+			render(
+				<Button as="a" href="/next">
+					Go
+				</Button>,
+			);
+			const link = screen.getByRole("link", { name: "Go" });
+			expect(link).toBeInstanceOf(HTMLAnchorElement);
+			expect(link).toHaveAttribute("href", "/next");
+			expect(link).toHaveClass("button", "button_variant_filled", "button_size_md");
+		});
+
+		it("does not set a type attribute on the anchor", () => {
+			render(
+				<Button as="a" href="/x">
+					Go
+				</Button>,
+			);
+			expect(screen.getByRole("link")).not.toHaveAttribute("type");
+		});
+
+		it("applies variant/size/danger/fullWidth/radius classes to the anchor", () => {
+			render(
+				<Button as="a" href="/x" variant="outline" size="lg" danger fullWidth radius="sm">
+					Go
+				</Button>,
+			);
+			expect(screen.getByRole("link")).toHaveClass(
+				"button",
+				"button_variant_outline",
+				"button_size_lg",
+				"button_danger",
+				"button_full_width",
+				"button_radius_sm",
+			);
+		});
+
+		it("renders leading and trailing icons in the anchor", () => {
+			render(
+				<Button
+					as="a"
+					href="/x"
+					leadingIcon={<svg data-testid="lead" />}
+					trailingIcon={<svg data-testid="trail" />}
+				>
+					Go
+				</Button>,
+			);
+			expect(screen.getByTestId("lead")).toBeInTheDocument();
+			expect(screen.getByTestId("trail")).toBeInTheDocument();
+			expect(screen.getByRole("link").querySelector(".button_label")).toHaveTextContent("Go");
+		});
+
+		it("passes target and rel through to the anchor", () => {
+			render(
+				<Button as="a" href="https://x.com" target="_blank" rel="noopener noreferrer">
+					Go
+				</Button>,
+			);
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("target", "_blank");
+			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("applies custom className alongside base classes on the anchor", () => {
+			render(
+				<Button as="a" href="/x" className="custom-class">
+					Go
+				</Button>,
+			);
+			expect(screen.getByRole("link")).toHaveClass("button", "custom-class");
+		});
+
+		it("handles click events on the anchor", () => {
+			const handleClick = vi.fn();
+			render(
+				<Button as="a" href="/x" onClick={handleClick}>
+					Go
+				</Button>,
+			);
+			fireEvent.click(screen.getByRole("link"));
+			expect(handleClick).toHaveBeenCalledTimes(1);
+		});
+
+		it("forwards ref to the anchor element", () => {
+			let node: HTMLAnchorElement | null = null;
+			render(
+				<Button
+					as="a"
+					href="/x"
+					ref={(el) => {
+						node = el;
+					}}
+				>
+					Go
+				</Button>,
+			);
+			expect(node).toBeInstanceOf(HTMLAnchorElement);
+		});
+	});
 });

--- a/src/ui/general/button/Button.test.tsx
+++ b/src/ui/general/button/Button.test.tsx
@@ -190,5 +190,30 @@ describe("Button", () => {
 			);
 			expect(node).toBeInstanceOf(HTMLAnchorElement);
 		});
+
+		it("renders as an anchor when only href is given (no as)", () => {
+			render(<Button href="/only-href">Link</Button>);
+			const link = screen.getByRole("link", { name: "Link" });
+			expect(link).toHaveAttribute("href", "/only-href");
+			expect(link).toHaveClass("button");
+		});
+
+		it("disables the anchor via aria-disabled + tabIndex and blocks click (BottomNavItem pattern)", () => {
+			const handleClick = vi.fn();
+			render(
+				<Button as="a" href="/x" disabled onClick={handleClick}>
+					Go
+				</Button>,
+			);
+			const link = screen.getByRole("link", { name: "Go" });
+			expect(link).toHaveAttribute("aria-disabled", "true");
+			expect(link).toHaveAttribute("tabindex", "-1");
+			expect(link).toHaveClass("button_disabled");
+			// href 는 유지(link 시맨틱)하되 클릭 내비게이션은 preventDefault 로 차단
+			const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true });
+			link.dispatchEvent(clickEvent);
+			expect(handleClick).not.toHaveBeenCalled();
+			expect(clickEvent.defaultPrevented).toBe(true);
+		});
 	});
 });

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -7,7 +7,8 @@ import "./style.scss";
 export type ButtonVariant = "filled" | "tonal" | "outline" | "text";
 export type ButtonSize = "sm" | "md" | "lg" | "xl";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+/** button/anchor 공통 스타일·콘텐츠 props */
+interface ButtonBaseProps {
 	/** 버튼 스타일 변형 (기본값: "filled") */
 	variant?: ButtonVariant;
 	/** 버튼 크기 (기본값: "md") */
@@ -25,30 +26,59 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 	 * filled: 빨간 bg, outline: 빨간 텍스트/border, tonal: 빨간 wash.
 	 */
 	danger?: boolean;
+}
+
+/** `<button>` 으로 렌더링 (기본) */
+export interface ButtonAsButton
+	extends ButtonBaseProps,
+		Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonBaseProps> {
+	/** 렌더링할 요소 (기본값: "button") */
+	as?: "button";
 	/** 루트 button 요소 ref (React 19 ref-as-prop) */
 	ref?: React.Ref<HTMLButtonElement>;
 }
 
+/** `<a>` 로 렌더링 - 링크 시맨틱(우클릭 새 탭·미들클릭·SR 링크 안내) */
+export interface ButtonAsAnchor
+	extends ButtonBaseProps,
+		Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof ButtonBaseProps> {
+	/** anchor 로 렌더링 */
+	as: "a";
+	/** 링크 대상 (anchor 필수) */
+	href: string;
+	/** 루트 anchor 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLAnchorElement>;
+}
+
+/**
+ * Button props - `as`/`href` 에 따라 button 또는 anchor 로 렌더링되는 discriminated union.
+ * `as` 미지정 시 기본 `<button>` (기존 동작과 100% 호환).
+ */
+export type ButtonProps = ButtonAsButton | ButtonAsAnchor;
+
 /**
  * 버튼을 렌더링한다.
  * Figma DS 기준 4가지 variant(filled/tonal/outline/text)와 4가지 size(sm/md/lg/xl)를 지원한다.
+ * `as="a"` (또는 `href` 지정) 시 동일 스타일의 anchor 로 렌더링한다.
  * @param props 버튼 속성
- * @returns 렌더링된 버튼 요소
+ * @returns 렌더링된 button 또는 anchor 요소
  */
-export const Button = ({
-	variant = "filled",
-	size = "md",
-	leadingIcon,
-	trailingIcon,
-	fullWidth = false,
-	radius,
-	danger = false,
-	type = "button",
-	ref,
-	className,
-	children,
-	...props
-}: ButtonProps) => {
+export const Button = (props: ButtonProps) => {
+	const {
+		variant = "filled",
+		size = "md",
+		leadingIcon,
+		trailingIcon,
+		fullWidth = false,
+		radius,
+		danger = false,
+		as,
+		className,
+		children,
+		ref,
+		...rest
+	} = props;
+
 	const buttonClassName = cn(
 		"button",
 		`button_variant_${variant}`,
@@ -59,8 +89,8 @@ export const Button = ({
 		className,
 	);
 
-	return (
-		<button ref={ref} type={type} className={buttonClassName} {...props}>
+	const content = (
+		<>
 			{leadingIcon && (
 				<span className="button_icon" aria-hidden="true">
 					{leadingIcon}
@@ -72,6 +102,31 @@ export const Button = ({
 					{trailingIcon}
 				</span>
 			)}
+		</>
+	);
+
+	// as="a" 또는 (as 미지정 + href 존재) 시 anchor 로 렌더링
+	const anchorRest = rest as React.AnchorHTMLAttributes<HTMLAnchorElement>;
+	const renderAnchor = as === "a" || (as === undefined && anchorRest.href != null);
+
+	if (renderAnchor) {
+		return (
+			<a ref={ref as React.Ref<HTMLAnchorElement>} className={buttonClassName} {...anchorRest}>
+				{content}
+			</a>
+		);
+	}
+
+	const { type = "button", ...buttonRest } = rest as React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+	return (
+		<button
+			ref={ref as React.Ref<HTMLButtonElement>}
+			type={type}
+			className={buttonClassName}
+			{...buttonRest}
+		>
+			{content}
 		</button>
 	);
 };

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -26,6 +26,11 @@ interface ButtonBaseProps {
 	 * filled: 빨간 bg, outline: 빨간 텍스트/border, tonal: 빨간 wash.
 	 */
 	danger?: boolean;
+	/**
+	 * 비활성화. button 은 native `disabled`, anchor 는 `aria-disabled`+`tabIndex=-1`+
+	 * 클릭 차단으로 처리(anchor 엔 native disabled 가 없으므로).
+	 */
+	disabled?: boolean;
 }
 
 /** `<button>` 으로 렌더링 (기본) */
@@ -34,6 +39,8 @@ export interface ButtonAsButton
 		Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonBaseProps> {
 	/** 렌더링할 요소 (기본값: "button") */
 	as?: "button";
+	/** button 렌더 시엔 href 를 허용하지 않음 (href 만 주면 anchor 로 분기되도록) */
+	href?: never;
 	/** 루트 button 요소 ref (React 19 ref-as-prop) */
 	ref?: React.Ref<HTMLButtonElement>;
 }
@@ -42,8 +49,8 @@ export interface ButtonAsButton
 export interface ButtonAsAnchor
 	extends ButtonBaseProps,
 		Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof ButtonBaseProps> {
-	/** anchor 로 렌더링 */
-	as: "a";
+	/** anchor 로 렌더링 - 생략 가능(href 만 줘도 anchor 로 분기) */
+	as?: "a";
 	/** 링크 대상 (anchor 필수) */
 	href: string;
 	/** 루트 anchor 요소 ref (React 19 ref-as-prop) */
@@ -72,6 +79,7 @@ export const Button = (props: ButtonProps) => {
 		fullWidth = false,
 		radius,
 		danger = false,
+		disabled = false,
 		as,
 		className,
 		children,
@@ -86,6 +94,8 @@ export const Button = (props: ButtonProps) => {
 		fullWidth && "button_full_width",
 		radius && `button_radius_${radius}`,
 		danger && "button_danger",
+		// anchor 엔 native :disabled 가 안 먹으므로 클래스로 비활성 스타일 적용 (button 도 무해)
+		disabled && "button_disabled",
 		className,
 	);
 
@@ -110,8 +120,23 @@ export const Button = (props: ButtonProps) => {
 	const renderAnchor = as === "a" || (as === undefined && anchorRest.href != null);
 
 	if (renderAnchor) {
+		// anchor 엔 native disabled 가 없어 aria-disabled + tabIndex=-1 + 클릭 차단으로 비활성
+		// 처리 (BottomNavItem 과 동일 패턴). href 는 유지해 link 시맨틱을 보존하되 클릭 내비게이션은
+		// preventDefault 로 막고, pointer-events:none(.button_disabled) 로 hover/포인터도 차단.
+		const { onClick, tabIndex, ...anchorProps } = anchorRest;
 		return (
-			<a ref={ref as React.Ref<HTMLAnchorElement>} className={buttonClassName} {...anchorRest}>
+			<a
+				{...anchorProps}
+				ref={ref as React.Ref<HTMLAnchorElement>}
+				className={buttonClassName}
+				aria-disabled={disabled || undefined}
+				tabIndex={disabled ? -1 : tabIndex}
+				onClick={
+					disabled
+						? (e: React.MouseEvent<HTMLAnchorElement>) => e.preventDefault()
+						: onClick
+				}
+			>
 				{content}
 			</a>
 		);
@@ -123,6 +148,7 @@ export const Button = (props: ButtonProps) => {
 		<button
 			ref={ref as React.Ref<HTMLButtonElement>}
 			type={type}
+			disabled={disabled}
 			className={buttonClassName}
 			{...buttonRest}
 		>

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -10,6 +10,7 @@
   cursor: pointer;
   overflow: hidden;
   white-space: nowrap;
+  text-decoration: none; // anchor(as="a")로 렌더링될 때 링크 기본 밑줄 제거 (button 요소엔 무해)
   @include token.body_small_medium;
   transition:
     color token.$transition_base,

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -35,6 +35,14 @@
     cursor: not-allowed;
   }
 
+  // anchor(as="a")는 native :disabled 가 없으므로 클래스로 비활성 처리.
+  // pointer-events: none 으로 hover/active state layer 도 함께 차단(=:not(:disabled) 가드와 동일 효과).
+  &_disabled {
+    cursor: not-allowed;
+    opacity: token.$opacity_38;
+    pointer-events: none;
+  }
+
   // ── Sizes ────────────────────────────────────────────────────────────────
 
   &_size_sm {

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -51,14 +51,14 @@ describe("NavBar", () => {
 			render(<NavBar locale={makeLocale()} />);
 			fireEvent.click(screen.getByRole("button"));
 			expect(screen.getByRole("menu")).toBeInTheDocument();
-			expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+			expect(screen.getAllByRole("menuitemradio")).toHaveLength(2);
 		});
 
 		it("calls onChange and closes on option select", () => {
 			const onChange = vi.fn();
 			render(<NavBar locale={makeLocale(onChange)} />);
 			fireEvent.click(screen.getByRole("button"));
-			fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+			fireEvent.click(screen.getByRole("menuitemradio", { name: "English" }));
 			expect(onChange).toHaveBeenCalledWith("en");
 			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 		});
@@ -66,7 +66,7 @@ describe("NavBar", () => {
 		it("focuses first item on open and moves with ArrowDown", () => {
 			render(<NavBar locale={makeLocale()} />);
 			fireEvent.click(screen.getByRole("button"));
-			const items = screen.getAllByRole("menuitem");
+			const items = screen.getAllByRole("menuitemradio");
 			expect(items[0]).toHaveFocus();
 			fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
 			expect(items[1]).toHaveFocus();
@@ -98,7 +98,7 @@ describe("NavBar", () => {
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button"));
-		fireEvent.click(screen.getByRole("menuitem", { name: "English" }));
+		fireEvent.click(screen.getByRole("menuitemradio", { name: "English" }));
 		expect(onValueChange).toHaveBeenCalledWith("en");
 	});
 

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -292,7 +292,10 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 									itemRefs.current[index] = el;
 								}}
 								type="button"
-								role="menuitem"
+								// 상호 배타적 locale 선택이므로 menuitemradio + aria-checked 로
+								// 현재 locale 을 AT 에 노출 (시각적 active 클래스만으로는 전달 안 됨)
+								role="menuitemradio"
+								aria-checked={opt.value === locale.current}
 								tabIndex={-1}
 								className={cn(
 									"nav_bar_locale_item",

--- a/src/ui/navigation/tabs/Tabs.test.tsx
+++ b/src/ui/navigation/tabs/Tabs.test.tsx
@@ -60,4 +60,38 @@ describe("Tabs", () => {
 		render(<Wrapper />);
 		expect(screen.getByRole("tablist")).toHaveAttribute("aria-label", "Test tabs");
 	});
+
+	it("keeps tabs keyboard-reachable when no tab is selected", () => {
+		// 회귀: 선택 탭이 없으면 전부 tabIndex=-1 이 되어 tablist 진입 자체가 불가능했음
+		render(
+			<Tabs>
+				<TabList ariaLabel="t">
+					<Tab value="a">A</Tab>
+					<Tab value="b">B</Tab>
+				</TabList>
+			</Tabs>,
+		);
+		expect(screen.getByRole("tab", { name: "A" })).toHaveAttribute("tabindex", "0");
+		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("tabindex", "0");
+	});
+
+	it("runs consumer onKeyDown AND keeps arrow navigation ({...props} must not replace it)", () => {
+		const onKeyDown = vi.fn();
+		render(
+			<Tabs defaultValue="a">
+				<TabList ariaLabel="t">
+					<Tab value="a" onKeyDown={onKeyDown}>
+						A
+					</Tab>
+					<Tab value="b">B</Tab>
+				</TabList>
+			</Tabs>,
+		);
+		const tabA = screen.getByRole("tab", { name: "A" });
+		tabA.focus();
+		fireEvent.keyDown(tabA, { key: "ArrowRight" });
+
+		expect(onKeyDown).toHaveBeenCalledTimes(1);
+		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("aria-selected", "true");
+	});
 });

--- a/src/ui/navigation/tabs/Tabs.test.tsx
+++ b/src/ui/navigation/tabs/Tabs.test.tsx
@@ -61,8 +61,9 @@ describe("Tabs", () => {
 		expect(screen.getByRole("tablist")).toHaveAttribute("aria-label", "Test tabs");
 	});
 
-	it("keeps tabs keyboard-reachable when no tab is selected", () => {
-		// 회귀: 선택 탭이 없으면 전부 tabIndex=-1 이 되어 tablist 진입 자체가 불가능했음
+	it("keeps only the first tab as the tab stop when no tab is selected (roving tabindex)", () => {
+		// 회귀: 선택 탭이 없으면 전부 tabIndex=-1 이 되어 tablist 진입 불가였음.
+		// 수정 후엔 첫 탭만 tab stop(0), 나머지는 -1 (WAI-ARIA roving tabindex).
 		render(
 			<Tabs>
 				<TabList ariaLabel="t">
@@ -72,7 +73,7 @@ describe("Tabs", () => {
 			</Tabs>,
 		);
 		expect(screen.getByRole("tab", { name: "A" })).toHaveAttribute("tabindex", "0");
-		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("tabindex", "0");
+		expect(screen.getByRole("tab", { name: "B" })).toHaveAttribute("tabindex", "-1");
 	});
 
 	it("runs consumer onKeyDown AND keeps arrow navigation ({...props} must not replace it)", () => {

--- a/src/ui/navigation/tabs/index.tsx
+++ b/src/ui/navigation/tabs/index.tsx
@@ -13,6 +13,10 @@ interface TabsContextValue {
 	variant: TabsVariant;
 	size: TabsSize;
 	idPrefix: string;
+	/** Tab 이 마운트 순서대로 자신을 등록 - 미선택 시 어느 탭이 유일한 tab stop 인지 판별용 */
+	registerTab: (value: string) => () => void;
+	/** 마운트 순서상 첫 번째 탭의 value (미선택 시 roving tabindex 진입점) */
+	firstTabValue: string | undefined;
 }
 
 const TabsContext = React.createContext<TabsContextValue | null>(null);
@@ -75,10 +79,26 @@ export const Tabs = ({
 		[isControlled, onValueChange],
 	);
 
+	// 마운트 순서대로 탭 value 를 등록해 "첫 번째 탭"을 판별한다. 선택된 탭이 없을 때
+	// roving tabindex 를 유지(첫 탭만 tabIndex=0)하기 위함 - 전부 0 이면 Tab 키가 모든
+	// 탭을 순회해 리스트 건너뛰기가 불편해지는 WAI-ARIA 위반이 된다.
+	const orderRef = React.useRef<string[]>([]);
+	const [firstTabValue, setFirstTabValue] = React.useState<string>();
+	const registerTab = React.useCallback((v: string) => {
+		if (!orderRef.current.includes(v)) {
+			orderRef.current = [...orderRef.current, v];
+			setFirstTabValue(orderRef.current[0]);
+		}
+		return () => {
+			orderRef.current = orderRef.current.filter((x) => x !== v);
+			setFirstTabValue(orderRef.current[0]);
+		};
+	}, []);
+
 	const idPrefix = React.useId();
 	const ctx = React.useMemo<TabsContextValue>(
-		() => ({ value, setValue, variant, size, idPrefix }),
-		[value, setValue, variant, size, idPrefix],
+		() => ({ value, setValue, variant, size, idPrefix, registerTab, firstTabValue }),
+		[value, setValue, variant, size, idPrefix, registerTab, firstTabValue],
 	);
 	return (
 		<TabsContext.Provider value={ctx}>
@@ -173,6 +193,10 @@ export const Tab = ({ value, className, children, onClick, onKeyDown, ...props }
 	const panelId = `${ctx.idPrefix}-panel-${value}`;
 	const tabId = `${ctx.idPrefix}-tab-${value}`;
 
+	// 마운트 순서 등록 (미선택 시 첫 탭만 tab stop 이 되도록 firstTabValue 판별용)
+	const { registerTab } = ctx;
+	React.useEffect(() => registerTab(value), [registerTab, value]);
+
 	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
 		ctx.setValue(value);
 		onClick?.(e);
@@ -213,11 +237,13 @@ export const Tab = ({ value, className, children, onClick, onKeyDown, ...props }
 			id={tabId}
 			data-value={value}
 			aria-selected={isActive}
-			// 비활성 panel 은 unmount 될 수 있어 dangling IDREF 방지 위해 활성 탭에만 지정
-			aria-controls={isActive ? panelId : undefined}
-			// 로빙 tabindex - 단, 선택된 탭이 없으면(비제어 + defaultValue 없음, value="") 전부 -1 이
-			// 되어 키보드로 tablist 진입이 불가능해지므로 그 경우 모든 탭을 도달 가능하게 둔다.
-			tabIndex={isActive || !ctx.value ? 0 : -1}
+			// aria-controls 는 항상 유지한다. unmountInactive={false} 로 비활성 패널이 DOM 에
+			// 남는 용례에서도 탭↔패널 연결이 끊기지 않아야 하고, Radix 등도 SR 탐색 편의를 위해
+			// 패널 마운트 여부와 무관하게 항상 지정한다(dangling IDREF 경고보다 SR 정보가 우선).
+			aria-controls={panelId}
+			// 로빙 tabindex - 선택된 탭이 없으면(비제어 + defaultValue 없음, value="") 마운트 순서상
+			// 첫 탭만 tab stop 으로 두어 Tab 키 1회로 tablist 에 진입, 내부 이동은 화살표 키로.
+			tabIndex={isActive || (!ctx.value && value === ctx.firstTabValue) ? 0 : -1}
 			className={cn("tabs_tab", isActive && "tabs_tab_active", className)}
 			onClick={handleClick}
 			onKeyDown={handleKeyDown}

--- a/src/ui/navigation/tabs/index.tsx
+++ b/src/ui/navigation/tabs/index.tsx
@@ -167,7 +167,7 @@ export interface TabProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElem
 	value: string;
 }
 
-export const Tab = ({ value, className, children, onClick, ...props }: TabProps) => {
+export const Tab = ({ value, className, children, onClick, onKeyDown, ...props }: TabProps) => {
 	const ctx = useTabsContext();
 	const isActive = ctx.value === value;
 	const panelId = `${ctx.idPrefix}-panel-${value}`;
@@ -179,6 +179,10 @@ export const Tab = ({ value, className, children, onClick, ...props }: TabProps)
 	};
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+		// 소비자 onKeyDown 을 먼저 실행하고 화살표 내비게이션을 이어간다
+		// ({...props} 로 넘어온 onKeyDown 이 내비게이션을 통째로 제거하지 않도록 합성).
+		onKeyDown?.(e);
+		if (e.defaultPrevented) return;
 		if (e.key !== "ArrowLeft" && e.key !== "ArrowRight" && e.key !== "Home" && e.key !== "End") return;
 		const list = (e.currentTarget as HTMLElement).closest('[role="tablist"]');
 		if (!list) return;
@@ -200,17 +204,23 @@ export const Tab = ({ value, className, children, onClick, ...props }: TabProps)
 
 	return (
 		<button
+			// {...props} 를 먼저 펼쳐 data-*/aria-* 는 통과시키되, tab 패턴에 필수인
+			// role/aria-selected/tabIndex/onClick·onKeyDown(소비자 핸들러는 내부에서 합성)은
+			// 컴포넌트가 항상 이긴다.
+			{...props}
 			type="button"
 			role="tab"
 			id={tabId}
 			data-value={value}
 			aria-selected={isActive}
-			aria-controls={panelId}
-			tabIndex={isActive ? 0 : -1}
+			// 비활성 panel 은 unmount 될 수 있어 dangling IDREF 방지 위해 활성 탭에만 지정
+			aria-controls={isActive ? panelId : undefined}
+			// 로빙 tabindex - 단, 선택된 탭이 없으면(비제어 + defaultValue 없음, value="") 전부 -1 이
+			// 되어 키보드로 tablist 진입이 불가능해지므로 그 경우 모든 탭을 도달 가능하게 둔다.
+			tabIndex={isActive || !ctx.value ? 0 : -1}
 			className={cn("tabs_tab", isActive && "tabs_tab_active", className)}
 			onClick={handleClick}
 			onKeyDown={handleKeyDown}
-			{...props}
 		>
 			{children}
 		</button>

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -161,10 +161,20 @@ describe("Drawer", () => {
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
-	it("Escape closes only the topmost drawer when nested (stopPropagation)", () => {
+	it("Escape closes only the topmost drawer when nested (shared overlay stack)", () => {
 		const outerClose = vi.fn();
 		const innerClose = vi.fn();
-		render(
+		// 공유 스택은 LIFO - 최상단 = 가장 최근에 열린 오버레이다. 실제 앱에서 중첩 오버레이는
+		// 순차적으로 열리므로(바깥을 연 뒤 안쪽을 연다) 열린 순서 = stacking 순서가 된다.
+		// 그 순서를 재현하기 위해 바깥을 먼저 연 뒤 rerender 로 안쪽을 연다.
+		const { rerender } = render(
+			<Drawer open onClose={outerClose} title="Outer">
+				<Drawer open={false} onClose={innerClose} title="Inner">
+					<button type="button">Inner content</button>
+				</Drawer>
+			</Drawer>,
+		);
+		rerender(
 			<Drawer open onClose={outerClose} title="Outer">
 				<Drawer open onClose={innerClose} title="Inner">
 					<button type="button">Inner content</button>
@@ -178,6 +188,7 @@ describe("Drawer", () => {
 		const innerPanel = screen.getByText("Inner content").closest('[role="document"]') as HTMLElement;
 		fireEvent.keyDown(innerPanel, { key: "Escape" });
 
+		// 최상단(나중에 연 inner)만 닫히고 outer 는 유지된다 (APG)
 		expect(innerClose).toHaveBeenCalledTimes(1);
 		expect(outerClose).not.toHaveBeenCalled();
 	});

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -172,10 +172,11 @@ describe("Drawer", () => {
 			</Drawer>,
 		);
 
-		// getAllByRole("document") in DOM order: [outer panel, inner panel]
+		// 포털 렌더라 DOM 순서가 React 트리 순서와 다를 수 있음 - 내용으로 inner 패널을 찾는다
 		const panels = screen.getAllByRole("document");
 		expect(panels).toHaveLength(2);
-		fireEvent.keyDown(panels[1], { key: "Escape" });
+		const innerPanel = screen.getByText("Inner content").closest('[role="document"]') as HTMLElement;
+		fireEvent.keyDown(innerPanel, { key: "Escape" });
 
 		expect(innerClose).toHaveBeenCalledTimes(1);
 		expect(outerClose).not.toHaveBeenCalled();
@@ -333,7 +334,7 @@ describe("Drawer", () => {
 
 	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
 		const consumerClick = vi.fn();
-		const { container } = render(
+		render(
 			<Drawer
 				open
 				onClose={() => {}}
@@ -344,7 +345,8 @@ describe("Drawer", () => {
 				Content
 			</Drawer>,
 		);
-		const panel = container.querySelector(".drawer_panel") as HTMLElement;
+		// 포털 렌더라 render container 밖(document.body)에 붙는다
+		const panel = document.querySelector(".drawer_panel") as HTMLElement;
 		// data-* 등은 통과
 		expect(panel).toHaveAttribute("data-testid", "panel-x");
 		// role/onClick 은 컴포넌트가 전유 - 소비자 값 무시(스프레드 순서 회귀 시 깨짐)

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -222,6 +222,18 @@ describe("Drawer", () => {
 		expect(panel?.contains(document.activeElement)).toBe(true);
 	});
 
+	it("renders the portal and traps focus when mounted already open (isMounted gate)", () => {
+		// 마운트 시점부터 open=true - isMounted 게이트가 걸려도 mount effect 이후 포털+트랩 활성화
+		render(
+			<Drawer open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).not.toBeNull();
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	// ── Accessibility ────────────────────────────────────────────────────────
 
 	it("has dialog role and modal accessibility attributes", () => {

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -5,7 +5,14 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useOverlayEscape, useReducedMotion, useSpringPresence } from "../../../utils";
+import {
+	cn,
+	useFocusTrap,
+	useIsMounted,
+	useOverlayEscape,
+	useReducedMotion,
+	useSpringPresence,
+} from "../../../utils";
 import "./style.scss";
 
 /** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
@@ -72,18 +79,16 @@ export const Drawer = ({
 	const [shouldRender, setShouldRender] = React.useState(open);
 	const reduced = useReducedMotion();
 	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
-	// mismatch(서버 null vs 클라 포털)를 피한다 (Modal/Toast/Alert 와 동일 패턴).
-	const [isMounted, setIsMounted] = React.useState(false);
-	React.useEffect(() => {
-		setIsMounted(true);
-	}, []);
+	// mismatch(서버 null vs 클라 포털)를 피한다 (Modal/Toast/Alert 와 동일 패턴을 훅으로 공유).
+	const isMounted = useIsMounted();
 
 	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
 	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Modal/Popover/Tooltip 등과 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
-	useOverlayEscape(open, () => onClose?.());
+	// 마운트 전(하이드레이션)엔 등록하지 않아 화면에 없는 드로어가 Escape 스택 순서를 교란하지 않게 한다.
+	useOverlayEscape(open && isMounted, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -5,7 +5,7 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useReducedMotion, useSpringPresence } from "../../../utils";
+import { cn, useFocusTrap, useOverlayEscape, useReducedMotion, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 /** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
@@ -74,6 +74,10 @@ export const Drawer = ({
 
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
+
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// Modal/Popover/Tooltip 등과 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
+	useOverlayEscape(open, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
@@ -153,21 +157,13 @@ export const Drawer = ({
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
 			onClick={() => closeOnOverlay && onClose?.()}
-			// Escape 는 여기서 단독 처리 + stopPropagation - 중첩 오버레이에서 가장 위(topmost)만
-			// 닫히도록 (document 전역 리스너로 처리하면 열린 모든 오버레이가 동시에 닫힘).
-			// panel onKeyDown 이 Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
-			onKeyDown={(e) => {
-				if (e.key === "Escape") {
-					e.stopPropagation();
-					onClose?.();
-				}
-			}}
 		>
 			<animated.div
 				ref={panelRef}
 				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
-				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
-				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown 은 컴포넌트가 항상
+				// 이기도록 뒤에 배치한다 (오버레이 동작 보호). Escape 는 공유 스택(useOverlayEscape)이
+				// 처리하고, 여기서는 그 외 키가 드로어 밖으로 새어 소비자 단축키를 건드리지 않게 막는다.
 				{...props}
 				className={cn("drawer_panel", className)}
 				style={{ ...props.style, ...panelStyle, ...panelSizeStyle }}

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -3,6 +3,7 @@
 import { animated, useSpring } from "@react-spring/web";
 import { X } from "lucide-react";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
 import { cn, useFocusTrap, useReducedMotion, useSpringPresence } from "../../../utils";
 import "./style.scss";
@@ -134,11 +135,16 @@ export const Drawer = ({
 	// 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
+	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다.
+	if (typeof document === "undefined") return null;
+
 	const hasTitle = !!title;
 	const sizeValue = typeof size === "number" ? `${size}px` : size;
 	const panelSizeStyle = placement === "bottom" ? { height: sizeValue } : { width: sizeValue };
 
-	return (
+	// 포털로 body 끝에 렌더 - transform/filter 조상 아래서 position: fixed 가 깨지는 문제 방지
+	// (Modal/Alert/Toast 와 동일 패턴).
+	return createPortal(
 		<animated.div
 			className={cn("drawer", `drawer_placement_${placement}`)}
 			style={overlayStyle}
@@ -191,7 +197,8 @@ export const Drawer = ({
 				{children && <div className="drawer_body">{children}</div>}
 				{footer && <div className="drawer_footer">{footer}</div>}
 			</animated.div>
-		</animated.div>
+		</animated.div>,
+		document.body,
 	);
 };
 

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -71,9 +71,15 @@ export const Drawer = ({
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
 	const reduced = useReducedMotion();
+	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
+	// mismatch(서버 null vs 클라 포털)를 피한다 (Modal/Toast/Alert 와 동일 패턴).
+	const [isMounted, setIsMounted] = React.useState(false);
+	React.useEffect(() => {
+		setIsMounted(true);
+	}, []);
 
-	// 포커스 트랩
-	useFocusTrap(panelRef, open);
+	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
+	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Modal/Popover/Tooltip 등과 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
@@ -139,8 +145,9 @@ export const Drawer = ({
 	// 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
-	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다.
-	if (typeof document === "undefined") return null;
+	// SSR/하이드레이션 가드 - 서버(document 없음) 및 클라이언트 첫 렌더(isMounted=false)에서는
+	// null 을 반환해 서버/클라 출력을 일치시킨다(hydration mismatch 방지).
+	if (typeof document === "undefined" || !isMounted) return null;
 
 	const hasTitle = !!title;
 	const sizeValue = typeof size === "number" ? `${size}px` : size;

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -190,6 +190,20 @@ describe("Modal", () => {
 		expect(panel?.contains(document.activeElement)).toBe(true);
 	});
 
+	it("renders the portal and traps focus when mounted already open (isMounted gate)", () => {
+		// 마운트 시점부터 open=true - isMounted 게이트가 걸려 서버/첫 렌더엔 null 이지만,
+		// mount effect 이후 포털이 붙고 focus trap 이 활성화되어야 한다. (가드가 영구 null 로
+		// 깨지면 dialog 가 안 뜨고 이 테스트가 실패한다.)
+		render(
+			<Modal open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Modal>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".modal_panel");
+		expect(panel).not.toBeNull();
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	it("calls onClose once on Escape from inside the modal (no duplicate handler)", () => {
 		const handleClose = vi.fn();
 		render(

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -173,7 +173,7 @@ describe("Modal", () => {
 
 	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
 		const consumerClick = vi.fn();
-		const { container } = render(
+		render(
 			<Modal
 				open
 				onClose={() => {}}
@@ -184,7 +184,8 @@ describe("Modal", () => {
 				Content
 			</Modal>,
 		);
-		const panel = container.querySelector(".modal_panel") as HTMLElement;
+		// 포털 렌더라 render container 밖(document.body)에 붙는다
+		const panel = document.querySelector(".modal_panel") as HTMLElement;
 		expect(panel).toHaveAttribute("data-testid", "panel-x");
 		expect(panel).toHaveAttribute("role", "document");
 		fireEvent.click(panel);

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -1,8 +1,38 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Modal } from "./index";
 
 describe("Modal", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("renders without motion when prefers-reduced-motion is set", () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+
+		render(
+			<Modal open onClose={() => {}} title="Reduced">
+				Content
+			</Modal>,
+		);
+
+		// reduced-motion 에서 패널이 최종(휴지) 상태로 즉시 도달 (spring immediate)
+		const panel = screen.getByRole("dialog").querySelector(".modal_panel");
+		expect(panel).toBeInTheDocument();
+		expect(panel).toHaveStyle({ transform: "scale(1) translateY(0px)" });
+	});
+
 	it("renders when open", () => {
 		render(
 			<Modal open onClose={() => {}}>

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -5,7 +5,7 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
+import { cn, useFocusTrap, useOverlayEscape, useReducedMotion } from "../../../utils";
 import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
@@ -66,6 +66,10 @@ export const Modal = ({
 
 	// 포커스 트랩
 	useFocusTrap(panelRef, open);
+
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// Tooltip/Popover 등 다른 오버레이와 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
+	useOverlayEscape(open, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처
@@ -145,21 +149,13 @@ export const Modal = ({
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
 			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
 			onClick={() => closeOnOverlay && onClose?.()}
-			// Escape 는 여기서 단독 처리 + stopPropagation — 중첩 모달에서 가장 안쪽만 닫히도록
-			// (document 전역 리스너로 처리하면 열린 모든 모달이 동시에 닫힘). panel onKeyDown 이
-			// Escape 는 막지 않으므로 focus 가 panel 안에 있어도 여기까지 버블됨.
-			onKeyDown={(e) => {
-				if (e.key === "Escape") {
-					e.stopPropagation();
-					onClose?.();
-				}
-			}}
 		>
 			<animated.div
 				ref={panelRef}
 				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
-				// 아래 className/style(애니메이션)/role/onClick·onKeyDown(stopPropagation·Escape) 은
-				// 컴포넌트가 항상 이기도록 뒤에 배치한다 (오버레이 동작 보호).
+				// 아래 className/style(애니메이션)/role/onClick·onKeyDown 은 컴포넌트가 항상
+				// 이기도록 뒤에 배치한다 (오버레이 동작 보호). Escape 는 공유 스택(useOverlayEscape)이
+				// 처리하고, 여기서는 그 외 키가 모달 밖으로 새어 소비자 단축키를 건드리지 않게 막는다.
 				{...props}
 				className={cn("modal_panel", className)}
 				style={{ ...props.style, ...panelStyle, width }}

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -3,8 +3,9 @@
 import { animated, useSpring } from "@react-spring/web";
 import { X } from "lucide-react";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap } from "../../../utils";
+import { cn, useFocusTrap, useReducedMotion } from "../../../utils";
 import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
@@ -72,9 +73,13 @@ export const Modal = ({
 	// 컴포넌트 자신만 대상으로 하고 조건이 곧 거짓이 되어 무한 루프가 없다.
 	if (open && !shouldRender) setShouldRender(true);
 
+	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
+	const reduced = useReducedMotion();
+
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({
 		opacity: open ? 1 : 0,
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 		onRest: (result) => {
 			if (!open && result.finished) setShouldRender(false);
@@ -85,6 +90,7 @@ export const Modal = ({
 	const panelStyle = useSpring({
 		opacity: open ? 1 : 0,
 		transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 	});
 
@@ -121,9 +127,16 @@ export const Modal = ({
 	// 마운트가 한 렌더 늦어 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
+	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다. 클라이언트 하이드레이션 후
+	// 첫 렌더부터 포털이 붙으므로(commit 시점, effect 이전) 포커스 트랩 타이밍은 유지된다.
+	if (typeof document === "undefined") return null;
+
 	const hasTitle = !!title;
 
-	return (
+	// 포털로 body 끝에 렌더 - 트리거 위치 인라인 렌더는 transform/filter 조상 아래서
+	// position: fixed 의 containing block 이 뷰포트가 아니게 되어 오버레이가 깨진다
+	// (이 DS 자체가 useSpringHover 등 transform 을 광범위하게 사용). Alert/Toast 와 동일 패턴.
+	return createPortal(
 		<animated.div
 			className="modal"
 			style={overlayStyle}
@@ -177,6 +190,7 @@ export const Modal = ({
 					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>{footer}</div>
 				)}
 			</animated.div>
-		</animated.div>
+		</animated.div>,
+		document.body,
 	);
 };

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -5,7 +5,7 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useOverlayEscape, useReducedMotion } from "../../../utils";
+import { cn, useFocusTrap, useIsMounted, useOverlayEscape, useReducedMotion } from "../../../utils";
 import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
@@ -64,18 +64,16 @@ export const Modal = ({
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
 	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
-	// mismatch(서버 null vs 클라 포털)를 피한다. Toast/Alert 와 동일한 isMounted 패턴.
-	const [isMounted, setIsMounted] = React.useState(false);
-	React.useEffect(() => {
-		setIsMounted(true);
-	}, []);
+	// mismatch(서버 null vs 클라 포털)를 피한다. Toast/Alert 와 동일한 패턴을 훅으로 공유.
+	const isMounted = useIsMounted();
 
 	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
 	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Tooltip/Popover 등 다른 오버레이와 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
-	useOverlayEscape(open, () => onClose?.());
+	// 마운트 전(하이드레이션)엔 등록하지 않아 화면에 없는 모달이 Escape 스택 순서를 교란하지 않게 한다.
+	useOverlayEscape(open && isMounted, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -63,9 +63,15 @@ export const Modal = ({
 	const panelRef = React.useRef<HTMLDivElement>(null);
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
+	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
+	// mismatch(서버 null vs 클라 포털)를 피한다. Toast/Alert 와 동일한 isMounted 패턴.
+	const [isMounted, setIsMounted] = React.useState(false);
+	React.useEffect(() => {
+		setIsMounted(true);
+	}, []);
 
-	// 포커스 트랩
-	useFocusTrap(panelRef, open);
+	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
+	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Tooltip/Popover 등 다른 오버레이와 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
@@ -131,9 +137,10 @@ export const Modal = ({
 	// 마운트가 한 렌더 늦어 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
-	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다. 클라이언트 하이드레이션 후
-	// 첫 렌더부터 포털이 붙으므로(commit 시점, effect 이전) 포커스 트랩 타이밍은 유지된다.
-	if (typeof document === "undefined") return null;
+	// SSR/하이드레이션 가드 - 서버(document 없음) 및 클라이언트 첫 렌더(isMounted=false)에서는
+	// null 을 반환해 서버/클라 출력을 일치시킨다(hydration mismatch 방지). 마운트 후 open&&isMounted
+	// 가 되는 렌더에서 패널이 붙고 useFocusTrap 이 그 시점에 활성화된다.
+	if (typeof document === "undefined" || !isMounted) return null;
 
 	const hasTitle = !!title;
 

--- a/src/ui/overlay/overlay-escape.test.tsx
+++ b/src/ui/overlay/overlay-escape.test.tsx
@@ -1,0 +1,128 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Modal } from "./modal";
+import { Popover } from "./popover";
+import { Tooltip } from "./tooltip";
+
+/**
+ * 여러 오버레이가 동시에 열렸을 때 공유 스택이 "최상단(가장 최근에 연) 오버레이만 닫힘"(APG)을
+ * 컴포넌트 조합에서도 보장하는지, 그리고 자식 요소의 자체 Escape 처리(critical)를 막지 않는지 검증.
+ */
+describe("overlay Escape composition (shared stack)", () => {
+	it("Tooltip over Popover: Escape closes only the topmost (Tooltip), Popover stays; next Escape closes Popover", () => {
+		vi.useFakeTimers();
+		try {
+			const onOpenChange = vi.fn();
+			render(
+				<Popover
+					defaultOpen
+					onOpenChange={onOpenChange}
+					trigger={<button type="button">trigger</button>}
+					aria-label="pop"
+					content={
+						<Tooltip content="tip" delay={0}>
+							<button type="button">inner</button>
+						</Tooltip>
+					}
+				/>,
+			);
+
+			// Popover 는 이미 열림. inner 버튼에 hover 해 Tooltip 을 나중에 연다 → Tooltip 이 최상단.
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+			fireEvent.mouseEnter(screen.getByRole("button", { name: "inner" }));
+			act(() => {
+				vi.advanceTimersByTime(10);
+			});
+			expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+			// 1차 Escape - 최상단(Tooltip)만 닫히고 Popover 는 유지, onOpenChange 도 안 불림
+			fireEvent.keyDown(document.body, { key: "Escape" });
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+			expect(screen.getByRole("dialog")).toBeInTheDocument();
+			expect(onOpenChange).not.toHaveBeenCalled();
+
+			// 2차 Escape - 이제 최상단이 된 Popover 가 닫힌다
+			fireEvent.keyDown(document.body, { key: "Escape" });
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("Popover inside Modal: Escape closes only the Popover, Modal stays (topmost)", () => {
+		const modalClose = vi.fn();
+		const onOpenChange = vi.fn();
+		render(
+			<Modal open onClose={modalClose} title="M">
+				<Popover
+					onOpenChange={onOpenChange}
+					trigger={<button type="button">open pop</button>}
+					aria-label="pop"
+					content={<span>pop body</span>}
+				/>
+			</Modal>,
+		);
+		// Modal 이 먼저 열려 있고, 그 안에서 Popover 를 클릭으로 나중에 연다 → Popover 최상단
+		fireEvent.click(screen.getByText("open pop"));
+		expect(screen.getByText("pop body")).toBeInTheDocument();
+
+		fireEvent.keyDown(screen.getByText("pop body"), { key: "Escape" });
+
+		// 최상단(Popover)만 닫히고(onOpenChange(false)) Modal 은 유지된다(onClose 미호출).
+		// (Popover 의 exit 애니메이션 완료 후 unmount 는 Popover 자체 테스트가 커버하므로
+		//  여기선 조합 관점의 신호 - onOpenChange/onClose - 만 검증한다.)
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(modalClose).not.toHaveBeenCalled();
+	});
+
+	it("does not steal Escape from a child that handles it first (child stops propagation)", () => {
+		// critical: 레지스트리는 document bubble 리스너라 자식(input) 이 먼저 이벤트를 받는다.
+		// 자식이 자체 Escape 를 처리하고 stopPropagation 하면 이벤트가 document 까지 오지 않아
+		// Popover 는 닫히지 않는다 (IME/native select 등 자식 우선 처리 보장).
+		const onOpenChange = vi.fn();
+		render(
+			<Popover
+				defaultOpen
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">t</button>}
+				aria-label="pop"
+				content={
+					<input
+						aria-label="field"
+						onKeyDown={(e) => {
+							if (e.key === "Escape") e.stopPropagation();
+						}}
+					/>
+				}
+			/>,
+		);
+		const field = screen.getByLabelText("field");
+		expect(field).toHaveFocus(); // 열릴 때 첫 focusable 로 포커스 이동
+
+		fireEvent.keyDown(field, { key: "Escape" });
+
+		// 자식이 소비했으므로 Popover 는 열린 채 유지
+		expect(onOpenChange).not.toHaveBeenCalled();
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("closes the Popover when a child does NOT consume the Escape", () => {
+		const onOpenChange = vi.fn();
+		render(
+			<Popover
+				defaultOpen
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">t</button>}
+				aria-label="pop"
+				content={<input aria-label="field" />}
+			/>,
+		);
+		const field = screen.getByLabelText("field");
+		expect(field).toHaveFocus();
+
+		fireEvent.keyDown(field, { key: "Escape" });
+
+		// 자식이 소비하지 않으면 document 까지 버블돼 최상단 Popover 가 닫힌다
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+});

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -257,4 +257,27 @@ describe("Popover", () => {
 		unmount();
 		expect(() => fireEvent.keyDown(document, { key: "Escape" })).not.toThrow();
 	});
+
+	it("Escape inside a Modal closes only the Popover, not the Modal (topmost overlay)", async () => {
+		const { Modal } = await import("../modal");
+		const modalClose = vi.fn();
+		render(
+			<Modal open onClose={modalClose} title="M">
+				<Popover
+					trigger={<button type="button">Open pop</button>}
+					content={<span>Pop content</span>}
+					aria-label="popover"
+				/>
+			</Modal>,
+		);
+		fireEvent.click(screen.getByText("Open pop"));
+		expect(screen.getByText("Pop content")).toBeInTheDocument();
+
+		// 회귀: bubble 리스너 시절엔 Modal 의 stopPropagation 때문에 Popover 리스너가
+		// 발화하지 못하고 Modal 만 닫혔다 (아래층이 닫히는 역전)
+		fireEvent.keyDown(screen.getByText("Pop content"), { key: "Escape" });
+
+		expect(modalClose).not.toHaveBeenCalled();
+		await waitFor(() => expect(screen.queryByText("Pop content")).not.toBeInTheDocument());
+	});
 });

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -59,7 +59,8 @@ describe("Popover", () => {
 		fireEvent.click(trigger);
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 
-		fireEvent.keyDown(document, { key: "Escape" });
+		// Escape 는 wrapper 의 React onKeyDown(버블)으로 처리되므로 팝오버 내부 요소에서 발사
+		fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
 		await waitFor(() => {
 			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 		});

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -113,30 +113,28 @@ export const Popover = ({
 		(focusable ?? node).focus();
 	}, [open]);
 
-	// 외부 클릭 / Esc 로 닫기 (Esc 는 trigger 로 포커스 복귀)
+	// 외부 클릭으로 닫기. Escape 는 아래 wrapper 의 React onKeyDown 에서 처리한다.
 	React.useEffect(() => {
 		if (!open) return;
 		const handleClick = (e: MouseEvent) => {
 			if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
 		};
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				// capture 단계에서 전파를 끊어 아래층 오버레이(Modal 등)가 함께 닫히지 않게 한다.
-				// bubble 리스너였을 땐 Modal 의 React onKeyDown(stopPropagation)이 root 에서 먼저
-				// 실행돼 이 리스너가 아예 발화하지 못하고 Modal 만 닫히는 역전이 있었다 (APG:
-				// Escape 는 최상단 오버레이만 닫아야 함).
-				e.stopPropagation();
-				setOpen(false);
-				previousFocusRef.current?.focus();
-			}
-		};
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKeyDown, true);
-		return () => {
-			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKeyDown, true);
-		};
+		return () => document.removeEventListener("mousedown", handleClick);
 	}, [open, setOpen]);
+
+	// Escape 닫기 - document capture 리스너 대신 wrapper 의 React onKeyDown(버블) 로 처리한다.
+	// capture+stopPropagation 은 이벤트가 타겟(Popover 내부 input/select 등)에 닿기도 전에
+	// 최상단에서 끊어 자식 요소의 자체 Escape 처리를 마비시킨다(치명적). 버블 단계에서 잡으면
+	// 자식이 먼저 처리할 기회를 갖고, 여기서 stopPropagation 하면 상위 Modal 의 onKeyDown 으로도
+	// 전파되지 않아 "최상단만 닫힘"(APG)이 지켜진다.
+	const handleWrapperKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (open && e.key === "Escape") {
+			e.stopPropagation();
+			setOpen(false);
+			previousFocusRef.current?.focus();
+		}
+	};
 
 	const triggerWithProps = React.cloneElement(
 		trigger as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
@@ -153,7 +151,8 @@ export const Popover = ({
 	);
 
 	return (
-		<div className="popover_wrapper" ref={wrapperRef}>
+		// biome-ignore lint/a11y/noStaticElementInteractions: keyboard handler for Escape dismissal; interactive children carry their own roles
+		<div className="popover_wrapper" ref={wrapperRef} onKeyDown={handleWrapperKeyDown}>
 			{triggerWithProps}
 			{shouldRender && (
 				<div className={cn("popover_position", `popover_placement_${placement}`)}>

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -2,7 +2,7 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type PopoverPlacement = "top" | "bottom" | "left" | "right";
@@ -123,18 +123,16 @@ export const Popover = ({
 		return () => document.removeEventListener("mousedown", handleClick);
 	}, [open, setOpen]);
 
-	// Escape 닫기 - document capture 리스너 대신 wrapper 의 React onKeyDown(버블) 로 처리한다.
-	// capture+stopPropagation 은 이벤트가 타겟(Popover 내부 input/select 등)에 닿기도 전에
-	// 최상단에서 끊어 자식 요소의 자체 Escape 처리를 마비시킨다(치명적). 버블 단계에서 잡으면
-	// 자식이 먼저 처리할 기회를 갖고, 여기서 stopPropagation 하면 상위 Modal 의 onKeyDown 으로도
-	// 전파되지 않아 "최상단만 닫힘"(APG)이 지켜진다.
-	const handleWrapperKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		if (open && e.key === "Escape") {
-			e.stopPropagation();
-			setOpen(false);
-			previousFocusRef.current?.focus();
-		}
-	};
+	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
+	// 레지스트리 리스너는 document 의 bubble 단계라 이벤트가 target(Popover 내부 input/select 등)에서
+	// 위로 올라오며 자식이 먼저 처리할 기회를 갖는다. 자식이 자체 Escape 를 처리하고 stopPropagation
+	// 하면 이벤트가 document 까지 오지 않아 Popover 는 닫히지 않는다(자식 우선 - 이전 리뷰 critical).
+	// 아무도 소비하지 않고 document 까지 오면 최상단(=이 Popover)만 닫고, 상위 Modal 이나 소비자
+	// 앱으로의 전파를 끊어 "최상단만 닫힘"(APG)을 지킨다.
+	useOverlayEscape(open, () => {
+		setOpen(false);
+		previousFocusRef.current?.focus();
+	});
 
 	const triggerWithProps = React.cloneElement(
 		trigger as React.ReactElement<React.HTMLAttributes<HTMLElement>>,
@@ -151,8 +149,7 @@ export const Popover = ({
 	);
 
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: keyboard handler for Escape dismissal; interactive children carry their own roles
-		<div className="popover_wrapper" ref={wrapperRef} onKeyDown={handleWrapperKeyDown}>
+		<div className="popover_wrapper" ref={wrapperRef}>
 			{triggerWithProps}
 			{shouldRender && (
 				<div className={cn("popover_position", `popover_placement_${placement}`)}>

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -121,15 +121,20 @@ export const Popover = ({
 		};
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key === "Escape") {
+				// capture 단계에서 전파를 끊어 아래층 오버레이(Modal 등)가 함께 닫히지 않게 한다.
+				// bubble 리스너였을 땐 Modal 의 React onKeyDown(stopPropagation)이 root 에서 먼저
+				// 실행돼 이 리스너가 아예 발화하지 못하고 Modal 만 닫히는 역전이 있었다 (APG:
+				// Escape 는 최상단 오버레이만 닫아야 함).
+				e.stopPropagation();
 				setOpen(false);
 				previousFocusRef.current?.focus();
 			}
 		};
 		document.addEventListener("mousedown", handleClick);
-		document.addEventListener("keydown", handleKeyDown);
+		document.addEventListener("keydown", handleKeyDown, true);
 		return () => {
 			document.removeEventListener("mousedown", handleClick);
-			document.removeEventListener("keydown", handleKeyDown);
+			document.removeEventListener("keydown", handleKeyDown, true);
 		};
 	}, [open, setOpen]);
 

--- a/src/ui/overlay/tooltip/Tooltip.test.tsx
+++ b/src/ui/overlay/tooltip/Tooltip.test.tsx
@@ -34,7 +34,7 @@ describe("Tooltip", () => {
 		expect(screen.getByRole("tooltip")).toHaveTextContent("hint");
 	});
 
-	it("hides on mouseLeave", () => {
+	it("hides on mouseLeave (after the hoverable grace period)", () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
@@ -46,6 +46,53 @@ describe("Tooltip", () => {
 		});
 		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
 		fireEvent.mouseLeave(screen.getByRole("button"));
+		// WCAG 1.4.13 Hoverable - 포인터가 툴팁으로 건너갈 유예(120ms) 동안은 유지
+		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		act(() => {
+			vi.advanceTimersByTime(150);
+		});
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	it("stays open while the pointer is over the tooltip itself (WCAG 1.4.13 Hoverable)", () => {
+		render(
+			<Tooltip content="hint" delay={0}>
+				<button type="button">btn</button>
+			</Tooltip>,
+		);
+		fireEvent.mouseEnter(screen.getByRole("button"));
+		act(() => {
+			vi.advanceTimersByTime(10);
+		});
+		fireEvent.mouseLeave(screen.getByRole("button"));
+		// 유예 시간 안에 툴팁 위로 포인터 이동 → 열림 유지
+		const positionWrap = screen.getByRole("tooltip").parentElement as HTMLElement;
+		fireEvent.mouseEnter(positionWrap);
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		// 툴팁에서 떠나면 유예 후 닫힘
+		fireEvent.mouseLeave(positionWrap);
+		act(() => {
+			vi.advanceTimersByTime(150);
+		});
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	it("dismisses with Escape without moving the pointer (WCAG 1.4.13 Dismissable)", () => {
+		render(
+			<Tooltip content="hint" delay={0}>
+				<button type="button">btn</button>
+			</Tooltip>,
+		);
+		fireEvent.mouseEnter(screen.getByRole("button"));
+		act(() => {
+			vi.advanceTimersByTime(10);
+		});
+		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+
+		fireEvent.keyDown(document.body, { key: "Escape" });
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -40,14 +40,28 @@ export const Tooltip = ({
 	const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const tooltipId = React.useId();
 
+	// 포인터가 trigger→tooltip 사이 갭(6px)을 건널 시간 (WCAG 1.4.13 Hoverable)
+	const HIDE_DELAY = 120;
+
 	const show = React.useCallback(() => {
 		if (timerRef.current) clearTimeout(timerRef.current);
 		timerRef.current = setTimeout(() => setOpen(true), delay);
 	}, [delay]);
 
-	const hide = React.useCallback(() => {
+	// blur/Escape 는 즉시, mouseleave 는 지연 닫힘 - 포인터가 툴팁 위로 이동할 수 있도록
+	const hideNow = React.useCallback(() => {
 		if (timerRef.current) clearTimeout(timerRef.current);
 		setOpen(false);
+	}, []);
+
+	const hide = React.useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		timerRef.current = setTimeout(() => setOpen(false), HIDE_DELAY);
+	}, []);
+
+	// 툴팁 자체에 포인터가 올라오면 지연 닫힘 취소 (WCAG 1.4.13 Hoverable)
+	const cancelHide = React.useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
 	}, []);
 
 	React.useEffect(() => {
@@ -55,6 +69,20 @@ export const Tooltip = ({
 			if (timerRef.current) clearTimeout(timerRef.current);
 		};
 	}, []);
+
+	// WCAG 1.4.13 Dismissable - 포인터/포커스를 옮기지 않고 Escape 로 닫기.
+	// capture 단계 document 리스너라 아래층 오버레이(Modal 등)의 Escape 핸들러보다
+	// 먼저 실행되고, 닫을 때 전파를 끊어 최상단(툴팁)만 닫는다.
+	React.useEffect(() => {
+		if (!open) return;
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== "Escape") return;
+			e.stopPropagation();
+			hideNow();
+		};
+		document.addEventListener("keydown", onKeyDown, true);
+		return () => document.removeEventListener("keydown", onKeyDown, true);
+	}, [open, hideNow]);
 
 	const fromTransform = (() => {
 		switch (placement) {
@@ -89,7 +117,7 @@ export const Tooltip = ({
 		},
 		onBlur: (e: React.FocusEvent<HTMLElement>) => {
 			childProps.onBlur?.(e);
-			hide();
+			hideNow();
 		},
 		// 자식의 기존 aria-describedby 보존 + tooltip id 합성 (폼 설명/에러 연결 끊김 방지)
 		"aria-describedby": open
@@ -103,7 +131,12 @@ export const Tooltip = ({
 		<span className="tooltip_wrapper">
 			{trigger}
 			{open && (
-				<span className={cn("tooltip_position", `tooltip_placement_${placement}`)}>
+				<span
+					className={cn("tooltip_position", `tooltip_placement_${placement}`)}
+					// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
+					onMouseEnter={cancelHide}
+					onMouseLeave={hide}
+				>
 					<animated.span
 						id={tooltipId}
 						role="tooltip"

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -2,7 +2,7 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type TooltipPlacement = "top" | "bottom" | "left" | "right";
@@ -71,20 +71,11 @@ export const Tooltip = ({
 	}, []);
 
 	// WCAG 1.4.13 Dismissable - 포인터/포커스를 옮기지 않고 Escape 로 닫기.
-	// capture 단계 document 리스너라 아래층 오버레이(Modal 등)의 Escape 핸들러보다
-	// 먼저 실행되고, 닫을 때 전파를 끊어 최상단(툴팁)만 닫는다.
-	React.useEffect(() => {
-		if (!open) return;
-		const onKeyDown = (e: KeyboardEvent) => {
-			if (e.key !== "Escape") return;
-			// stopImmediatePropagation - 같은 document 노드에 등록된 다른 오버레이 리스너의
-			// 실행까지 막아(stopPropagation 은 못 막음) 툴팁만 닫히고 하위 오버레이는 유지.
-			e.stopImmediatePropagation();
-			hideNow();
-		};
-		document.addEventListener("keydown", onKeyDown, true);
-		return () => document.removeEventListener("keydown", onKeyDown, true);
-	}, [open, hideNow]);
+	// 공유 오버레이 스택에 등록 - 열려 있는 동안 최상단일 때만 Escape 로 닫혀
+	// 다른 오버레이나 소비자 앱 핸들러를 삼키지 않는다 (overlay-stack.ts 참고).
+	// 툴팁은 hover 로 열려 포커스가 trigger 밖에 있을 수 있으므로 document 레벨 처리가 필요한데,
+	// 레지스트리가 그 역할을 대신한다.
+	useOverlayEscape(open, hideNow);
 
 	const fromTransform = (() => {
 		switch (placement) {

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -77,7 +77,9 @@ export const Tooltip = ({
 		if (!open) return;
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== "Escape") return;
-			e.stopPropagation();
+			// stopImmediatePropagation - 같은 document 노드에 등록된 다른 오버레이 리스너의
+			// 실행까지 막아(stopPropagation 은 못 막음) 툴팁만 닫히고 하위 오버레이는 유지.
+			e.stopImmediatePropagation();
 			hideNow();
 		};
 		document.addEventListener("keydown", onKeyDown, true);

--- a/src/ui/overlay/tooltip/style.scss
+++ b/src/ui/overlay/tooltip/style.scss
@@ -11,7 +11,8 @@
 .tooltip_position {
   position: absolute;
   z-index: token.$z_level5;
-  pointer-events: none;
+  // pointer-events 를 살려 둔다 - WCAG 1.4.13 Hoverable: 포인터를 툴팁 위로
+  // 옮겨 내용을 읽을 수 있어야 함 (none 이면 mouseenter 가 발화하지 않아 즉시 닫힘)
   display: block;
   width: max-content; // 내부 .tooltip 의 max-content 와 일치 - translateX(-50%) 정확
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export { useFocusTrap } from "./use-focus-trap";
+export { useIsMounted } from "./use-is-mounted";
 export { useReducedMotion } from "./use-reduced-motion";
 export { useSafeLayoutEffect } from "./use-safe-layout-effect";
 export { useSpringHover } from "./use-spring-hover";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { cn } from "./cn";
+export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export { useFocusTrap } from "./use-focus-trap";
 export { useReducedMotion } from "./use-reduced-motion";
 export { useSafeLayoutEffect } from "./use-safe-layout-effect";

--- a/src/utils/overlay-stack.test.ts
+++ b/src/utils/overlay-stack.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerOverlay } from "./overlay-stack";
+
+/**
+ * 공유 오버레이 Escape 스택의 단위 테스트.
+ *
+ * 스택은 모듈 스코프라 테스트 간 누수를 막아야 한다 - 등록/리스너를 tracker 로 모아
+ * afterEach 에서 강제 정리한다 (어떤 assert 가 던져도 스택이 반드시 비워지도록).
+ */
+
+const cleanups: Array<() => void> = [];
+
+/** registerOverlay + 자동 정리 등록 */
+const open = (fn: () => void) => {
+	const unreg = registerOverlay(fn);
+	cleanups.push(unreg);
+	return unreg;
+};
+
+/** window 레벨 소비자 리스너 + 자동 정리 등록 (document bubble → window 로 올라온다) */
+const consumerOnWindow = (fn: () => void) => {
+	window.addEventListener("keydown", fn);
+	cleanups.push(() => window.removeEventListener("keydown", fn));
+};
+
+/** document.body 에서 Escape 발생 → body(target) → document(bubble) → window(bubble) */
+const pressEscape = () =>
+	document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+afterEach(() => {
+	for (const c of cleanups.splice(0)) c();
+	vi.restoreAllMocks();
+});
+
+describe("overlay-stack", () => {
+	it("calls only the top (last-registered) overlay's onEscape", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		open(first);
+		open(second);
+
+		pressEscape();
+
+		expect(second).toHaveBeenCalledTimes(1);
+		expect(first).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the next overlay once the top unregisters (LIFO)", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		open(first);
+		const unregSecond = open(second);
+
+		unregSecond();
+		pressEscape();
+
+		// 최상단이 빠지면 그 아래가 새 최상단이 되어 Escape 를 받는다
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).not.toHaveBeenCalled();
+	});
+
+	it("attaches no listener while the stack is empty (does not swallow global Escape)", () => {
+		const consumer = vi.fn();
+		consumerOnWindow(consumer);
+
+		// 등록 전 - 레지스트리 리스너가 없어 소비자 핸들러가 그대로 받는다
+		pressEscape();
+		expect(consumer).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops the Escape from reaching window-level consumer handlers while open", () => {
+		const consumer = vi.fn();
+		consumerOnWindow(consumer);
+		const onEscape = vi.fn();
+		open(onEscape);
+
+		pressEscape();
+
+		// stopImmediatePropagation 으로 window 로의 전파까지 차단 (최상단 오버레이만 반응)
+		expect(onEscape).toHaveBeenCalledTimes(1);
+		expect(consumer).not.toHaveBeenCalled();
+	});
+
+	it("releases the global listener again once the stack empties", () => {
+		const onEscape = vi.fn();
+		open(onEscape)();
+
+		const consumer = vi.fn();
+		consumerOnWindow(consumer);
+		pressEscape();
+
+		// 스택이 비면 레지스트리 리스너가 제거되어 소비자가 다시 Escape 를 받는다
+		expect(onEscape).not.toHaveBeenCalled();
+		expect(consumer).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores non-Escape keys", () => {
+		const onEscape = vi.fn();
+		open(onEscape);
+
+		document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+		expect(onEscape).not.toHaveBeenCalled();
+	});
+
+	it("unregister is idempotent and only removes its own entry", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		open(first);
+		const unregSecond = open(second);
+
+		unregSecond();
+		unregSecond(); // 두 번째 호출은 no-op - first 를 지우지 않아야 함
+
+		pressEscape();
+		expect(first).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/overlay-stack.ts
+++ b/src/utils/overlay-stack.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * 공유 오버레이 Escape 스택 (WAI-ARIA APG "최상단 오버레이만 닫힘").
+ *
+ * Tooltip / Popover / Modal / Drawer / Alert 가 각자 다른 방식(document capture 리스너,
+ * wrapper onKeyDown, overlay div React onKeyDown)으로 Escape 를 처리하면 동시에 열렸을 때
+ * "가장 위 오버레이만 닫힘"이 일관되게 보장되지 않는다. 이 모듈은 모든 오버레이가 공유하는
+ * 단일 keydown 리스너로 그 규칙을 일원화한다.
+ *
+ * ## 설계 결정: bubble 단계 + 단일 document 리스너
+ *
+ * 리스너는 **bubble** 단계(`capture: false`)로 등록한다. 이유:
+ *
+ * 1. **자식 우선 처리(critical)** — 이벤트는 target(오버레이 내부 input/select 등)에서 위로
+ *    올라오며(target → bubble), 자식이 먼저 처리할 기회를 갖는다. 자식이 자체 Escape(예: IME
+ *    조합 취소, native `<select>` 드롭다운 닫기)를 처리하고 `stopPropagation` 하면 이벤트는
+ *    document 까지 오지 않아 이 리스너가 아예 실행되지 않는다 → 오버레이가 닫히지 않는다.
+ *    capture 단계로 등록하면 자식보다 먼저 가로채 자식의 Escape 를 마비시키는 회귀(이전 리뷰
+ *    critical 지적)가 재발하므로 반드시 bubble 이어야 한다.
+ * 2. **최상단만 닫힘** — document 까지 도달했다는 건 아무 자식도 이벤트를 소비하지 않았다는
+ *    뜻이다. 이때 스택 최상단(가장 최근에 등록/열린 오버레이)의 onEscape 만 호출하고
+ *    `stopImmediatePropagation` 으로 같은 document 노드의 다른(소비자 앱) Escape 리스너 및
+ *    window 로의 전파를 끊어, 최상단 하나만 반응하도록 한다.
+ * 3. **오버레이가 없으면 리스너도 없음** — 스택이 비면 리스너를 완전히 제거해, 오버레이가 하나도
+ *    열려있지 않을 때 소비자 앱의 전역 Escape 핸들러를 삼키지 않는다.
+ *
+ * 스택은 등록 순서 LIFO 다. 실제 앱에서 오버레이는 순차적으로 열리므로(예: Modal 을 연 뒤 그
+ * 안의 Popover 를 클릭으로 열기) 등록 순서 = 열린 순서 = 시각적 stacking 순서가 되어 최상단이
+ * 정확히 결정된다.
+ */
+
+type EscapeHandler = () => void;
+
+/** 모듈 스코프 스택. 마지막 원소 = 최상단(가장 최근에 등록된) 오버레이. */
+const stack: EscapeHandler[] = [];
+
+const handleKeyDown = (e: KeyboardEvent) => {
+	if (e.key !== "Escape") return;
+	const top = stack[stack.length - 1];
+	if (!top) return;
+	// 여기까지 왔다는 건 자식(input/select/IME 등)이 이벤트를 소비하지 않았다는 뜻.
+	// 최상단만 닫고, 소비자 앱의 document/window Escape 리스너까지 전파를 끊는다.
+	e.stopImmediatePropagation();
+	top();
+};
+
+/**
+ * 오버레이를 Escape 스택 최상단에 등록한다.
+ *
+ * @param onEscape 이 오버레이가 최상단일 때 Escape 로 호출될 콜백 (보통 close)
+ * @returns 등록 해제 함수. 스택에서 제거하고, 마지막 항목이면 document 리스너까지 정리한다.
+ */
+export function registerOverlay(onEscape: EscapeHandler): () => void {
+	// SSR 가드 - 서버에는 document 가 없다. no-op unregister 반환.
+	if (typeof document === "undefined") {
+		return () => {};
+	}
+
+	// 스택이 비어 있다가 첫 항목이 들어올 때만 리스너를 붙인다 (단 하나의 리스너 유지).
+	if (stack.length === 0) {
+		document.addEventListener("keydown", handleKeyDown);
+	}
+	stack.push(onEscape);
+
+	let done = false;
+	return () => {
+		if (done) return;
+		done = true;
+		const index = stack.lastIndexOf(onEscape);
+		if (index !== -1) stack.splice(index, 1);
+		// 마지막 항목이 빠지면 리스너를 제거해 스택이 빈 동안 전역 Escape 를 삼키지 않게 한다.
+		if (stack.length === 0) {
+			document.removeEventListener("keydown", handleKeyDown);
+		}
+	};
+}
+
+/**
+ * 오버레이 컴포넌트가 Escape 스택에 참여하도록 하는 훅.
+ *
+ * `active` 가 true 인 동안 스택에 등록되고, false 가 되거나 unmount 되면 등록 해제된다.
+ * 최상단일 때만 Escape 에 반응하므로 각 오버레이는 `useOverlayEscape(open, close)` 만 쓰면 된다.
+ *
+ * @param active 오버레이 열림 여부
+ * @param onEscape Escape 시 호출할 콜백 (매 렌더 새 참조여도 재등록되지 않도록 ref 로 잡는다)
+ */
+export function useOverlayEscape(active: boolean, onEscape: EscapeHandler): void {
+	// 최신 onEscape 를 ref 로 유지 - register/unregister 를 active 변화에만 묶어
+	// (콜백이 매 렌더 바뀌어도) 불필요한 재등록/스택 순서 교란을 막는다.
+	const handlerRef = React.useRef(onEscape);
+	handlerRef.current = onEscape;
+
+	React.useEffect(() => {
+		if (!active) return;
+		return registerOverlay(() => handlerRef.current());
+	}, [active]);
+}

--- a/src/utils/overlay-stack.ts
+++ b/src/utils/overlay-stack.ts
@@ -20,16 +20,29 @@ import * as React from "react";
  *    document 까지 오지 않아 이 리스너가 아예 실행되지 않는다 → 오버레이가 닫히지 않는다.
  *    capture 단계로 등록하면 자식보다 먼저 가로채 자식의 Escape 를 마비시키는 회귀(이전 리뷰
  *    critical 지적)가 재발하므로 반드시 bubble 이어야 한다.
- * 2. **최상단만 닫힘** — document 까지 도달했다는 건 아무 자식도 이벤트를 소비하지 않았다는
- *    뜻이다. 이때 스택 최상단(가장 최근에 등록/열린 오버레이)의 onEscape 만 호출하고
- *    `stopImmediatePropagation` 으로 같은 document 노드의 다른(소비자 앱) Escape 리스너 및
- *    window 로의 전파를 끊어, 최상단 하나만 반응하도록 한다.
+ * 2. **오버레이 간 최상단만 닫힘** — 모든 오버레이가 이 단일 리스너 하나를 공유하므로, document
+ *    까지 도달한 Escape 는 스택 최상단(가장 최근에 등록/열린 오버레이)의 onEscape 만 호출한다.
+ *    즉 "우리 오버레이들 사이"에서는 최상단 하나만 반응하는 것이 순서와 무관하게 보장된다.
  * 3. **오버레이가 없으면 리스너도 없음** — 스택이 비면 리스너를 완전히 제거해, 오버레이가 하나도
  *    열려있지 않을 때 소비자 앱의 전역 Escape 핸들러를 삼키지 않는다.
  *
- * 스택은 등록 순서 LIFO 다. 실제 앱에서 오버레이는 순차적으로 열리므로(예: Modal 을 연 뒤 그
- * 안의 Popover 를 클릭으로 열기) 등록 순서 = 열린 순서 = 시각적 stacking 순서가 되어 최상단이
- * 정확히 결정된다.
+ * ### `stopImmediatePropagation` 의 실제 보장 범위 (주의)
+ *
+ * Escape 처리 후 `stopImmediatePropagation()` 을 호출하지만, 이는 같은 document 노드에 **나중에**
+ * 등록된 리스너와 window 로의 전파만 막는다. 오버레이가 열리기 **전에** 소비자 앱이 이미 document
+ * 에 Escape 리스너를 걸어 두었다면(우리 리스너보다 앞 순서) 그 리스너는 여전히 실행된다. 따라서
+ * 이 모듈은 "우리 오버레이들 사이의 최상단만 닫힘"을 보장할 뿐, 소비자 앱의 선등록 Escape 핸들러
+ * 까지 완전히 차단한다고 보장하지는 않는다.
+ *
+ * ### LIFO 한계 (동시-open 마운트)
+ *
+ * 스택은 등록 순서 LIFO 다. 실제 앱에서 오버레이는 순차적으로 열리므로(예: Modal 을 연 뒤 그 안의
+ * Popover 를 클릭으로 열기) 등록 순서 = 열린 순서 = 시각적 stacking 순서가 되어 최상단이 정확히
+ * 결정된다. 단, React 는 effect 를 **자식 → 부모** 순서로 커밋하므로, 부모/자식 오버레이가 **동시에
+ * 마운트되며 둘 다 이미 open**(예: `<Modal><Popover defaultOpen /></Modal>`, 중첩 Drawer 동시 open)
+ * 인 경우 자식이 먼저·부모가 나중에 등록되어 부모가 최상단이 된다 → 첫 Escape 가 자식(위에 있어야
+ * 할 오버레이) 대신 부모를 닫는다. 흔치 않은 degenerate 케이스이며, z-order 기반 topmost 판정으로
+ * 개선 가능하나(별도) 순차 open 조합에는 영향 없다.
  */
 
 type EscapeHandler = () => void;
@@ -42,7 +55,8 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	const top = stack[stack.length - 1];
 	if (!top) return;
 	// 여기까지 왔다는 건 자식(input/select/IME 등)이 이벤트를 소비하지 않았다는 뜻.
-	// 최상단만 닫고, 소비자 앱의 document/window Escape 리스너까지 전파를 끊는다.
+	// 최상단만 닫고, document 에 나중 등록된 리스너 + window 로의 전파를 끊는다.
+	// (선등록된 소비자 리스너는 못 막음 - 파일 상단 주석 참고.)
 	e.stopImmediatePropagation();
 	top();
 };
@@ -90,8 +104,13 @@ export function registerOverlay(onEscape: EscapeHandler): () => void {
 export function useOverlayEscape(active: boolean, onEscape: EscapeHandler): void {
 	// 최신 onEscape 를 ref 로 유지 - register/unregister 를 active 변화에만 묶어
 	// (콜백이 매 렌더 바뀌어도) 불필요한 재등록/스택 순서 교란을 막는다.
+	// ref 갱신은 effect 안에서 - 렌더 단계에서 ref.current 를 수정하면 concurrent 렌더링에서
+	// 문제가 될 수 있다. Escape 콜백은 항상 커밋(=이 effect) 이후 이벤트 시점에 호출되므로
+	// effect 로 갱신해도 최신 값이 보장된다.
 	const handlerRef = React.useRef(onEscape);
-	handlerRef.current = onEscape;
+	React.useEffect(() => {
+		handlerRef.current = onEscape;
+	});
 
 	React.useEffect(() => {
 		if (!active) return;

--- a/src/utils/use-is-mounted.test.ts
+++ b/src/utils/use-is-mounted.test.ts
@@ -1,0 +1,17 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useIsMounted } from "./use-is-mounted";
+
+describe("useIsMounted", () => {
+	it("returns true after mount effect runs", () => {
+		const { result } = renderHook(() => useIsMounted());
+		// renderHook 은 act 로 effect 를 flush 하므로 마운트 후 true
+		expect(result.current).toBe(true);
+	});
+
+	it("stays true across re-renders", () => {
+		const { result, rerender } = renderHook(() => useIsMounted());
+		rerender();
+		expect(result.current).toBe(true);
+	});
+});

--- a/src/utils/use-is-mounted.ts
+++ b/src/utils/use-is-mounted.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * 클라이언트 마운트 여부를 반환한다.
+ *
+ * 서버 렌더 및 클라이언트 하이드레이션 첫 렌더에서는 `false`, 마운트 effect 실행 후 `true`.
+ * SSR 에서 `document`(포털 대상)가 없거나, open 상태로 마운트되는 오버레이가 서버 `null` /
+ * 클라 포털로 갈려 hydration mismatch 가 나는 것을 막을 때 쓴다.
+ *
+ * @example
+ * ```tsx
+ * const isMounted = useIsMounted();
+ * if (typeof document === "undefined" || !isMounted) return null;
+ * return createPortal(..., document.body);
+ * ```
+ */
+export function useIsMounted(): boolean {
+	const [mounted, setMounted] = React.useState(false);
+	React.useEffect(() => {
+		setMounted(true);
+	}, []);
+	return mounted;
+}

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -103,15 +103,27 @@
 		// Parse options: data-options JSON > JS config > 서버 렌더링된 <li data-value> 마크업.
 		// Thymeleaf/JSP 처럼 서버가 옵션 li 를 직접 렌더링하는 경우(문서화된 기본 마크업)를
 		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
-		const optionsData = wrapper.dataset.options
-			? JSON.parse(wrapper.dataset.options)
-			: (config.options && config.options.length
-				? config.options
-				: $$(".bt-select__option", list).map((el) => ({
-						value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
-						label: el.textContent.trim(),
-						disabled: el.classList.contains("is-disabled"),
-					})));
+		// data-options 는 잘못된 JSON(작은따옴표 등)이면 스크립트 전체가 크래시하므로 방어적 파싱.
+		const parseDomOptions = () =>
+			$$(".bt-select__option", list).map((el) => ({
+				value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
+				label: el.textContent.trim(),
+				disabled: el.classList.contains("is-disabled"),
+			}));
+
+		let optionsData;
+		if (wrapper.dataset.options) {
+			try {
+				const parsed = JSON.parse(wrapper.dataset.options);
+				optionsData = Array.isArray(parsed) ? parsed : (console.warn("Select: data-options is not a JSON array"), []);
+			} catch (e) {
+				console.warn("Select: invalid JSON in data-options", e);
+				optionsData = [];
+			}
+		}
+		if (!optionsData || optionsData.length === 0) {
+			optionsData = config.options && config.options.length ? config.options : parseDomOptions();
+		}
 
 		state.options = optionsData;
 
@@ -130,7 +142,9 @@
 		// State management
 		function setValue(newValue) {
 			state.value = newValue;
-			const option = state.options.find((o) => o.value === newValue);
+			// String 비교 - 서버 hidden input 초기값(항상 문자열)과 JS config 의 숫자 value 가
+			// 섞여도 매칭되도록 (엄격 === 이면 조용히 placeholder 로 남던 문제 방지).
+			const option = state.options.find((o) => String(o.value) === String(newValue));
 
 			// 폼 제출용 hidden input 동기화
 			if (hiddenInput) {
@@ -152,7 +166,7 @@
 
 			// Update selected state in list
 			$$(".bt-select__option", list).forEach((el, i) => {
-				el.classList.toggle("is-selected", state.options[i]?.value === newValue);
+				el.classList.toggle("is-selected", String(state.options[i]?.value) === String(newValue));
 			});
 
 			if (config.onChange) {
@@ -568,14 +582,24 @@
 		}
 
 		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 on/off 를 노출.
-		// 서버 템플릿이 미리 렌더링한 hidden input 이 있으면 재사용한다.
-		let hiddenInput = toggleEl.querySelector('input[type="hidden"]');
+		// toggleEl 이 <button> 이면 그 안에 대화형 콘텐츠/폼 요소를 자식으로 둘 수 없어(invalid
+		// HTML) hidden input 을 형제(sibling)로 삽입한다. 서버 템플릿이 미리 렌더링해둔 hidden
+		// input(자식이든 형제든)이 있으면 재사용한다.
 		const fieldName = config.name || toggleEl.dataset.name || null;
+		let hiddenInput =
+			toggleEl.querySelector('input[type="hidden"]') ||
+			(fieldName && toggleEl.parentNode
+				? toggleEl.parentNode.querySelector(`input[type="hidden"][name="${fieldName}"]`)
+				: null);
 		if (!hiddenInput && fieldName) {
 			hiddenInput = document.createElement("input");
 			hiddenInput.type = "hidden";
 			hiddenInput.name = fieldName;
-			toggleEl.appendChild(hiddenInput);
+			if (toggleEl.tagName === "BUTTON" && toggleEl.parentNode) {
+				toggleEl.parentNode.insertBefore(hiddenInput, toggleEl.nextSibling);
+			} else {
+				toggleEl.appendChild(hiddenInput);
+			}
 		}
 
 		function setChecked(checked) {
@@ -600,10 +624,14 @@
 
 		const cleanup = on(toggleEl, "click", toggle);
 
-		// Initialize - aria-checked/hidden input 을 초기 상태와 동기화
-		if (hiddenInput && hiddenInput.value === "true" && !state.checked) {
-			// 서버 바인딩 초기값(on)을 표시에 반영
-			state.checked = true;
+		// Initialize - aria-checked/hidden input 을 초기 상태와 동기화.
+		// 서버 템플릿이 boolean 을 "true" 외 표현("1"/"on"/"y"/"yes")으로 렌더링해도
+		// 켜짐으로 인식하도록 관대하게 파싱 (Thymeleaf/JSP 등 표현 차이 흡수).
+		if (hiddenInput && !state.checked) {
+			const raw = String(hiddenInput.value).trim().toLowerCase();
+			if (raw === "true" || raw === "1" || raw === "on" || raw === "y" || raw === "yes") {
+				state.checked = true;
+			}
 		}
 		toggleEl.classList.toggle("bt-toggle--on", state.checked);
 		toggleEl.setAttribute("aria-checked", state.checked ? "true" : "false");

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -149,17 +149,19 @@
 				disabled: el.classList.contains("is-disabled"),
 			}));
 
+		// data-options 가 유효한 배열이면(빈 배열 포함) 그대로 존중 - 명시적 빈 배열은 "옵션 없음"
+		// 의도이므로 DOM 파싱으로 덮지 않는다. undefined(속성 없음/파싱 실패)일 때만 폴백.
 		let optionsData;
 		if (wrapper.dataset.options) {
 			try {
 				const parsed = JSON.parse(wrapper.dataset.options);
-				optionsData = Array.isArray(parsed) ? parsed : (console.warn("Select: data-options is not a JSON array"), []);
+				if (Array.isArray(parsed)) optionsData = parsed;
+				else console.warn("Select: data-options is not a JSON array");
 			} catch (e) {
 				console.warn("Select: invalid JSON in data-options", e);
-				optionsData = [];
 			}
 		}
-		if (!optionsData || optionsData.length === 0) {
+		if (optionsData === undefined) {
 			optionsData = config.options && config.options.length ? config.options : parseDomOptions();
 		}
 

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -88,13 +88,6 @@
 			options: [],
 		};
 
-		// Parse options from data attributes or config
-		const optionsData = wrapper.dataset.options
-			? JSON.parse(wrapper.dataset.options)
-			: config.options || [];
-
-		state.options = optionsData;
-
 		// Create DOM structure
 		const controlId = wrapper.id || generateId("select");
 		const _listId = `${controlId}_listbox`;
@@ -107,10 +100,42 @@
 			return null;
 		}
 
+		// Parse options: data-options JSON > JS config > 서버 렌더링된 <li data-value> 마크업.
+		// Thymeleaf/JSP 처럼 서버가 옵션 li 를 직접 렌더링하는 경우(문서화된 기본 마크업)를
+		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
+		const optionsData = wrapper.dataset.options
+			? JSON.parse(wrapper.dataset.options)
+			: (config.options && config.options.length
+				? config.options
+				: $$(".bt-select__option", list).map((el) => ({
+						value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
+						label: el.textContent.trim(),
+						disabled: el.classList.contains("is-disabled"),
+					})));
+
+		state.options = optionsData;
+
+		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 값을 노출한다.
+		// 서버 템플릿(th:field 등)이 미리 렌더링한 hidden input 이 있으면 그대로 재사용 -
+		// name/초기값을 서버 바인딩에서 이어받는다.
+		let hiddenInput = wrapper.querySelector('input[type="hidden"]');
+		const fieldName = config.name || wrapper.dataset.name || null;
+		if (!hiddenInput && fieldName) {
+			hiddenInput = document.createElement("input");
+			hiddenInput.type = "hidden";
+			hiddenInput.name = fieldName;
+			wrapper.appendChild(hiddenInput);
+		}
+
 		// State management
 		function setValue(newValue) {
 			state.value = newValue;
 			const option = state.options.find((o) => o.value === newValue);
+
+			// 폼 제출용 hidden input 동기화
+			if (hiddenInput) {
+				hiddenInput.value = newValue == null ? "" : newValue;
+			}
 
 			const valueEl = control.querySelector(".bt-select__value, .bt-select__placeholder");
 			if (valueEl) {
@@ -310,6 +335,9 @@
 		list.style.display = "none";
 		if (config.defaultValue) {
 			setValue(config.defaultValue);
+		} else if (hiddenInput && hiddenInput.value) {
+			// 서버 바인딩(th:field 등)이 넣어 둔 초기값을 표시에 반영
+			setValue(hiddenInput.value);
 		}
 
 		// Public API
@@ -532,9 +560,32 @@
 			checked: config.defaultChecked || toggleEl.classList.contains("bt-toggle--on"),
 		};
 
+		// Switch 시맨틱 (React Toggle 과 패리티): role + aria-checked 를 항상 유지
+		if (!toggleEl.hasAttribute("role")) toggleEl.setAttribute("role", "switch");
+		// 폼 안에서 클릭이 submit 으로 새지 않도록 (button 기본 type=submit)
+		if (toggleEl.tagName === "BUTTON" && !toggleEl.hasAttribute("type")) {
+			toggleEl.setAttribute("type", "button");
+		}
+
+		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 on/off 를 노출.
+		// 서버 템플릿이 미리 렌더링한 hidden input 이 있으면 재사용한다.
+		let hiddenInput = toggleEl.querySelector('input[type="hidden"]');
+		const fieldName = config.name || toggleEl.dataset.name || null;
+		if (!hiddenInput && fieldName) {
+			hiddenInput = document.createElement("input");
+			hiddenInput.type = "hidden";
+			hiddenInput.name = fieldName;
+			toggleEl.appendChild(hiddenInput);
+		}
+
 		function setChecked(checked) {
 			state.checked = checked;
 			toggleEl.classList.toggle("bt-toggle--on", checked);
+			toggleEl.setAttribute("aria-checked", checked ? "true" : "false");
+
+			if (hiddenInput) {
+				hiddenInput.value = checked ? "true" : "false";
+			}
 
 			if (config.onChange) {
 				config.onChange(checked);
@@ -549,10 +600,14 @@
 
 		const cleanup = on(toggleEl, "click", toggle);
 
-		// Initialize
-		if (config.defaultChecked) {
-			setChecked(true);
+		// Initialize - aria-checked/hidden input 을 초기 상태와 동기화
+		if (hiddenInput && hiddenInput.value === "true" && !state.checked) {
+			// 서버 바인딩 초기값(on)을 표시에 반영
+			state.checked = true;
 		}
+		toggleEl.classList.toggle("bt-toggle--on", state.checked);
+		toggleEl.setAttribute("aria-checked", state.checked ? "true" : "false");
+		if (hiddenInput) hiddenInput.value = state.checked ? "true" : "false";
 
 		return {
 			isChecked: () => state.checked,

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -162,7 +162,9 @@
 			}
 		}
 		if (optionsData === undefined) {
-			optionsData = config.options && config.options.length ? config.options : parseDomOptions();
+			// config.options 도 배열이면(빈 배열 포함) 존중 - data-options 와 동일하게 명시적 빈
+			// 배열을 "옵션 없음"으로 처리하고 DOM 파싱으로 덮지 않는다.
+			optionsData = Array.isArray(config.options) ? config.options : parseDomOptions();
 		}
 
 		state.options = optionsData;

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -769,10 +769,14 @@
 		// HTML) hidden input 을 형제(sibling)로 삽입한다. 서버 템플릿이 미리 렌더링해둔 hidden
 		// input(자식이든 형제든)이 있으면 재사용한다.
 		const fieldName = config.name || toggleEl.dataset.name || null;
+		// 직계 형제만 탐색 - parentNode.querySelector 는 하위 트리 전체를 뒤져 같은 부모를 공유하는
+		// 다른 토글(예: 테이블 행 안 여러 토글)의 hidden input 을 잘못 집을 수 있다.
 		let hiddenInput =
 			toggleEl.querySelector('input[type="hidden"]') ||
 			(fieldName && toggleEl.parentNode
-				? toggleEl.parentNode.querySelector(`input[type="hidden"][name="${fieldName}"]`)
+				? Array.from(toggleEl.parentNode.children).find(
+						(el) => el.tagName === "INPUT" && el.type === "hidden" && el.name === fieldName,
+					)
 				: null);
 		if (!hiddenInput && fieldName) {
 			hiddenInput = document.createElement("input");

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -61,6 +61,36 @@
 		return Array.from(context.querySelectorAll(selector));
 	}
 
+	/** 포커스 가능한 요소 셀렉터 (React useFocusTrap 과 동일 기준) */
+	const FOCUSABLE_SELECTORS = [
+		"a[href]",
+		"button:not([disabled])",
+		"input:not([disabled])",
+		"select:not([disabled])",
+		"textarea:not([disabled])",
+		'[tabindex]:not([tabindex="-1"])',
+	].join(", ");
+
+	/**
+	 * 바디 스크롤 잠금 카운터 - Modal 위 Alert 처럼 오버레이가 겹칠 때
+	 * 하나만 닫혀도 배경 스크롤이 풀리던 문제 방지 (React 쪽 data-open-modals 와 동일 패턴)
+	 */
+	function lockScroll() {
+		const n = parseInt(document.body.dataset.btOpenModals || "0", 10);
+		if (n === 0) document.body.style.overflow = "hidden";
+		document.body.dataset.btOpenModals = String(n + 1);
+	}
+
+	function unlockScroll() {
+		const n = parseInt(document.body.dataset.btOpenModals || "1", 10) - 1;
+		if (n <= 0) {
+			document.body.style.overflow = "";
+			delete document.body.dataset.btOpenModals;
+		} else {
+			document.body.dataset.btOpenModals = String(n);
+		}
+	}
+
 	/* ========================================
      Select Component
      ======================================== */
@@ -115,6 +145,20 @@
 
 		state.options = optionsData;
 
+		// Combobox ARIA (WAI-ARIA APG select-only combobox) - React Dropdown 과 패리티
+		list.id = list.id || _listId;
+		list.setAttribute("role", "listbox");
+		control.setAttribute("role", "combobox");
+		control.setAttribute("aria-haspopup", "listbox");
+		control.setAttribute("aria-expanded", "false");
+		control.setAttribute("aria-controls", list.id);
+		$$(".bt-select__option", list).forEach((el, i) => {
+			el.id = el.id || `${controlId}_option_${i}`;
+			el.setAttribute("role", "option");
+			el.setAttribute("aria-selected", "false");
+			if (state.options[i]?.disabled) el.setAttribute("aria-disabled", "true");
+		});
+
 		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 값을 노출한다.
 		// 서버 템플릿(th:field 등)이 미리 렌더링한 hidden input 이 있으면 그대로 재사용 -
 		// name/초기값을 서버 바인딩에서 이어받는다.
@@ -152,7 +196,9 @@
 
 			// Update selected state in list
 			$$(".bt-select__option", list).forEach((el, i) => {
-				el.classList.toggle("is-selected", state.options[i]?.value === newValue);
+				const selected = state.options[i]?.value === newValue;
+				el.classList.toggle("is-selected", selected);
+				el.setAttribute("aria-selected", selected ? "true" : "false");
 			});
 
 			if (config.onChange) {
@@ -165,6 +211,7 @@
 
 			state.isOpen = true;
 			control.classList.add("is-open");
+			control.setAttribute("aria-expanded", "true");
 			list.style.display = "block";
 
 			// Calculate position (auto-flip)
@@ -192,6 +239,8 @@
 		function close() {
 			state.isOpen = false;
 			control.classList.remove("is-open");
+			control.setAttribute("aria-expanded", "false");
+			control.removeAttribute("aria-activedescendant");
 			list.style.display = "none";
 
 			const icon = control.querySelector(".bt-select__icon");
@@ -208,7 +257,10 @@
 
 		function updateActiveOption() {
 			$$(".bt-select__option", list).forEach((el, i) => {
-				el.classList.toggle("is-active", i === state.activeIndex);
+				const active = i === state.activeIndex;
+				el.classList.toggle("is-active", active);
+				// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음)
+				if (active) control.setAttribute("aria-activedescendant", el.id);
 			});
 		}
 
@@ -384,12 +436,31 @@
 			isOpen: false,
 		};
 
-		const _panel = modal.querySelector(".bt-modal__panel");
+		const panel = modal.querySelector(".bt-modal__panel");
+		let previousFocus = null;
+
+		// Dialog ARIA - React Modal 과 패리티
+		if (panel) {
+			panel.setAttribute("role", "dialog");
+			panel.setAttribute("aria-modal", "true");
+		}
 
 		function open() {
 			state.isOpen = true;
 			modal.classList.add("is-open");
-			document.body.style.overflow = "hidden";
+			lockScroll();
+
+			// 포커스 이동 - 이전 포커스 저장 후 패널 첫 focusable(없으면 패널 자체)로 (WCAG 2.4.3)
+			previousFocus = document.activeElement;
+			if (panel) {
+				const first = panel.querySelector(FOCUSABLE_SELECTORS);
+				if (first) {
+					first.focus();
+				} else {
+					panel.setAttribute("tabindex", "-1");
+					panel.focus();
+				}
+			}
 
 			if (config.onOpen) {
 				config.onOpen();
@@ -399,7 +470,13 @@
 		function close() {
 			state.isOpen = false;
 			modal.classList.remove("is-open");
-			document.body.style.overflow = "";
+			unlockScroll();
+
+			// 포커스 복원
+			if (previousFocus && typeof previousFocus.focus === "function") {
+				previousFocus.focus();
+			}
+			previousFocus = null;
 
 			if (config.onClose) {
 				config.onClose();
@@ -413,8 +490,27 @@
 		}
 
 		function onKeyDown(e) {
-			if (config.closeOnEscape && e.key === "Escape" && state.isOpen) {
+			if (!state.isOpen) return;
+			if (config.closeOnEscape && e.key === "Escape") {
 				close();
+				return;
+			}
+			// Tab 트랩 - 포커스가 패널 밖으로 빠지지 않게 순환 (WAI-ARIA APG Dialog)
+			if (e.key === "Tab" && panel) {
+				const focusables = $$(FOCUSABLE_SELECTORS, panel);
+				if (focusables.length === 0) {
+					e.preventDefault();
+					return;
+				}
+				const first = focusables[0];
+				const last = focusables[focusables.length - 1];
+				if (e.shiftKey && document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				} else if (!e.shiftKey && document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
 			}
 		}
 
@@ -436,7 +532,8 @@
 				cleanups.forEach((cleanup) => {
 					cleanup();
 				});
-				document.body.style.overflow = "";
+				// 열린 채 destroy 되면 카운터 정합 유지를 위해 잠금 해제
+				if (state.isOpen) unlockScroll();
 			},
 		};
 	}
@@ -488,14 +585,39 @@
       </div>
     `;
 
+		// Alertdialog ARIA + 포커스 관리 (React Alert 와 패리티)
+		const alertPanel = overlay.querySelector(".bt-alert__modal");
+		if (alertPanel) {
+			alertPanel.setAttribute("role", "alertdialog");
+			alertPanel.setAttribute("aria-modal", "true");
+			const titleEl = overlay.querySelector(".bt-alert__title");
+			const messageEl = overlay.querySelector(".bt-alert__message");
+			if (titleEl) {
+				titleEl.id = generateId("alert_title");
+				alertPanel.setAttribute("aria-labelledby", titleEl.id);
+			}
+			if (messageEl) {
+				messageEl.id = generateId("alert_message");
+				alertPanel.setAttribute("aria-describedby", messageEl.id);
+			}
+		}
+
+		const previousFocus = document.activeElement;
+
 		document.body.appendChild(overlay);
-		document.body.style.overflow = "hidden";
+		lockScroll();
 
 		function close() {
+			// Escape 리스너를 닫힘 경로 공통에서 해제 - 버튼/오버레이로 닫을 때
+			// 리스너가 남아 누수되던 문제 방지
+			document.removeEventListener("keydown", onKeyDown);
 			overlay.classList.remove("is-open");
+			if (previousFocus && typeof previousFocus.focus === "function") {
+				previousFocus.focus();
+			}
 			setTimeout(() => {
 				overlay.remove();
-				document.body.style.overflow = "";
+				unlockScroll();
 			}, 200);
 		}
 
@@ -524,14 +646,16 @@
 			}
 		});
 
-		// Close on Escape
-		const onKeyDown = (e) => {
+		// Close on Escape (해제는 close() 공통 경로에서)
+		function onKeyDown(e) {
 			if (e.key === "Escape") {
 				close();
-				document.removeEventListener("keydown", onKeyDown);
 			}
-		};
+		}
 		document.addEventListener("keydown", onKeyDown);
+
+		// 초기 포커스 - 확인 버튼 (APG alertdialog: 열릴 때 포커스를 내부로 이동)
+		if (confirmBtn) confirmBtn.focus();
 
 		return { close };
 	}
@@ -785,11 +909,13 @@
 			}
 		});
 
-		// Modal triggers
+		// Modal triggers - init() 재호출 시 리스너 중복 바인딩 방지 가드
 		$$("[data-bt-modal-open]").forEach((btn) => {
+			if (btn.dataset.btBound) return;
 			const targetId = btn.dataset.btModalOpen;
 			const modal = $(`#${targetId}`);
 			if (modal?._btModal) {
+				btn.dataset.btBound = "true";
 				btn.addEventListener("click", () => modal._btModal.open());
 			}
 		});

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -76,18 +76,26 @@
 	 * 하나만 닫혀도 배경 스크롤이 풀리던 문제 방지 (React 쪽 data-open-modals 와 동일 패턴)
 	 */
 	function lockScroll() {
-		const n = parseInt(document.body.dataset.btOpenModals || "0", 10);
-		if (n === 0) document.body.style.overflow = "hidden";
-		document.body.dataset.btOpenModals = String(n + 1);
+		const body = document.body;
+		const n = parseInt(body.dataset.btOpenModals || "0", 10);
+		if (n === 0) {
+			// 소비자가 인라인으로 지정해둔 overflow 를 저장했다가 마지막 unlock 때 복원
+			// (React Modal 의 dataset.originalOverflow 와 동일 동작).
+			body.dataset.btOriginalOverflow = body.style.overflow;
+			body.style.overflow = "hidden";
+		}
+		body.dataset.btOpenModals = String(n + 1);
 	}
 
 	function unlockScroll() {
-		const n = parseInt(document.body.dataset.btOpenModals || "1", 10) - 1;
+		const body = document.body;
+		const n = parseInt(body.dataset.btOpenModals || "1", 10) - 1;
 		if (n <= 0) {
-			document.body.style.overflow = "";
-			delete document.body.dataset.btOpenModals;
+			body.style.overflow = body.dataset.btOriginalOverflow || "";
+			delete body.dataset.btOpenModals;
+			delete body.dataset.btOriginalOverflow;
 		} else {
-			document.body.dataset.btOpenModals = String(n);
+			body.dataset.btOpenModals = String(n);
 		}
 	}
 
@@ -256,12 +264,19 @@
 		}
 
 		function updateActiveOption() {
+			let activeId = null;
 			$$(".bt-select__option", list).forEach((el, i) => {
 				const active = i === state.activeIndex;
 				el.classList.toggle("is-active", active);
-				// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음)
-				if (active) control.setAttribute("aria-activedescendant", el.id);
+				if (active) activeId = el.id;
 			});
+			// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음).
+			// 활성 옵션이 없으면(activeIndex=-1 등) 잘못된 참조가 남지 않게 속성을 제거.
+			if (activeId) {
+				control.setAttribute("aria-activedescendant", activeId);
+			} else {
+				control.removeAttribute("aria-activedescendant");
+			}
 		}
 
 		function moveActive(dir) {
@@ -438,14 +453,26 @@
 
 		const panel = modal.querySelector(".bt-modal__panel");
 		let previousFocus = null;
+		let panelTabindexAdded = false;
 
-		// Dialog ARIA - React Modal 과 패리티
+		// Dialog ARIA - React Modal 과 패리티. 접근 가능한 이름(aria-labelledby/label)도 연결한다
+		// (없으면 axe aria-dialog-name 실패). 헤더가 있으면 그 id 로, 없으면 aria-label fallback.
 		if (panel) {
 			panel.setAttribute("role", "dialog");
 			panel.setAttribute("aria-modal", "true");
+			if (!panel.hasAttribute("aria-label") && !panel.hasAttribute("aria-labelledby")) {
+				const header = panel.querySelector(".bt-modal__header");
+				if (header) {
+					header.id = header.id || generateId("modal_title");
+					panel.setAttribute("aria-labelledby", header.id);
+				} else {
+					panel.setAttribute("aria-label", "Dialog");
+				}
+			}
 		}
 
 		function open() {
+			if (state.isOpen) return; // 이미 열림 - 중복 lockScroll 방지
 			state.isOpen = true;
 			modal.classList.add("is-open");
 			lockScroll();
@@ -458,6 +485,7 @@
 					first.focus();
 				} else {
 					panel.setAttribute("tabindex", "-1");
+					panelTabindexAdded = true;
 					panel.focus();
 				}
 			}
@@ -468,9 +496,16 @@
 		}
 
 		function close() {
+			if (!state.isOpen) return; // 이미 닫힘 - 중복 unlockScroll 방지
 			state.isOpen = false;
 			modal.classList.remove("is-open");
 			unlockScroll();
+
+			// 우리가 추가한 tabindex 정리 (React useFocusTrap 의 wasTabIndexAdded 와 동일)
+			if (panelTabindexAdded && panel) {
+				panel.removeAttribute("tabindex");
+				panelTabindexAdded = false;
+			}
 
 			// 포커스 복원
 			if (previousFocus && typeof previousFocus.focus === "function") {
@@ -607,7 +642,13 @@
 		document.body.appendChild(overlay);
 		lockScroll();
 
+		let isOpen = true;
+
 		function close() {
+			// 중복 호출 방지 - 버튼/오버레이/Escape 연타 시 unlockScroll 이 여러 번 불려
+			// 스크롤 잠금 카운터가 오동작하지 않도록 최초 1회만 실행.
+			if (!isOpen) return;
+			isOpen = false;
 			// Escape 리스너를 닫힘 경로 공통에서 해제 - 버튼/오버레이로 닫을 때
 			// 리스너가 남아 누수되던 문제 방지
 			document.removeEventListener("keydown", onKeyDown);
@@ -646,10 +687,27 @@
 			}
 		});
 
-		// Close on Escape (해제는 close() 공통 경로에서)
+		// Close on Escape + Tab 포커스 트랩 (WAI-ARIA APG Dialog) - Modal 과 동일 패턴
 		function onKeyDown(e) {
 			if (e.key === "Escape") {
 				close();
+				return;
+			}
+			if (e.key === "Tab" && alertPanel) {
+				const focusables = $$(FOCUSABLE_SELECTORS, alertPanel);
+				if (focusables.length === 0) {
+					e.preventDefault();
+					return;
+				}
+				const first = focusables[0];
+				const last = focusables[focusables.length - 1];
+				if (e.shiftKey && document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				} else if (!e.shiftKey && document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
 			}
 		}
 		document.addEventListener("keydown", onKeyDown);

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -726,6 +726,9 @@
   }
 
   &__list {
+    // 기본 숨김 - JS 초기화 전/JS 비활성 시 드롭다운이 펼쳐진 채 렌더링(FOUC)되지 않게.
+    // 열림/닫힘은 JS 가 inline display 로 토글한다.
+    display: none;
     position: absolute;
     z-index: var(--bt-z-modal);
     top: 100%;

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -5,6 +5,12 @@
 
 @use "../styles/token" as token;
 
+// theme.scss 를 반드시 포함한다. 색상 SCSS 토큰(token.$color_*)은 리터럴이 아니라
+// `var(--bt-color-*)` 간접 참조라, 그 var 정의(:root light + dark 테마)가 theme 에 있다.
+// 없으면 아래 :root 의 색 토큰이 전부 미정의 var 로 무효화된다 (자기참조 순환 포함).
+// 포함하면 [data-theme="dark"] / prefers-color-scheme 다크 테마도 함께 동작한다.
+@use "../styles/theme";
+
 /* ========================================
    CSS Custom Properties (Design Tokens)
    ======================================== */
@@ -15,24 +21,19 @@
 
   /* Colors - Accent (light=검정/dark=흰 자동 반전 - indicator/checked/focus 강조) */
   --bt-color-accent: #{token.$color_accent_default};
-  --bt-color-accent-on-surface: #{token.$color_accent_on_surface};
 
   /* Colors - Background */
   --bt-color-background: #{token.$color_bg_solid};
   --bt-color-background-dim: #{token.$color_bg_solid_dim};
   --bt-color-background-overlay: #{token.$color_bg_overlay};
 
-  /* Colors - Text */
-  --bt-color-text-heading: #{token.$color_text_heading};
-  --bt-color-text-body: #{token.$color_text_body};
-  --bt-color-text-caption: #{token.$color_text_caption};
-  --bt-color-text-inverse: #{token.$color_text_inverse};
-  --bt-color-text-disabled: #{token.$color_text_disabled};
+  /* Colors - Text/Border 원 토큰(--bt-color-text-heading, --bt-color-border-subtle 등)은
+     theme.scss 가 정의한다. 여기서 같은 이름으로 재선언하면
+     `--bt-color-text-heading: var(--bt-color-text-heading)` 자기참조 순환이 되어
+     theme 정의까지 덮어 무효화되므로 재선언 금지 (아래 Semantic alias 로만 노출). */
 
   /* Colors - Border */
   --bt-color-border: #{token.$color_border_default};
-  --bt-color-border-subtle: #{token.$color_border_subtle};
-  --bt-color-border-focus: #{token.$color_border_focus};
 
   /* Colors - Text Semantic */
   --bt-color-text-primary: var(--bt-color-text-heading);

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -288,7 +288,7 @@
           <div class="bt-card__title">Card Title</div>
           <p>This is a card component with bordered style and medium padding.</p>
         </div>
-        <div class="bt-card bt-card--shadow-md bt-card--p-md" style="width: 300px;">
+        <div class="bt-card bt-card--elevation-2 bt-card--p-md" style="width: 300px;">
           <div class="bt-card__title">Shadow Card</div>
           <p>This card uses shadow instead of border.</p>
         </div>


### PR DESCRIPTION
## 작업 개요

`v3.4.1` 이후 develop 에 머지된 10개 PR(#373~#382)을 **v3.5.0** 으로 릴리즈. 전체 컴포넌트 접근성 감사 + 후속 수정이 중심.

## 포함 사항 (CHANGELOG 3.5.0 미러)
- **a11y 대규모 개선**: Alert 포커스 트랩, Tooltip WCAG 1.4.13, Toast 타이밍 조정(2.2.1), Tabs 로빙 tabindex, Checkbox·OTP aria-invalid, Chip·ListItem 선택 상태, NavBar menuitemradio, Table aria-busy
- **Button `as`/`href`**: anchor 렌더 + disabled 대응, Hero CTA 재사용
- **새 prop**: Dropdown `name`(폼 제출), Alert `closeOnOverlay`, Chip `removeLabel`
- **오버레이 Escape 통일**: `useOverlayEscape`/`registerOverlay` 공유 스택(최상단만 닫힘)
- **Modal·Drawer 포털화**: transform 조상 아래 position:fixed 정상화
- **Vanilla 번들**: 토큰 자기참조 해소·다크테마·Select 서버마크업 파싱·폼 참여·combobox ARIA·Modal 포커스·FOUC
- **reduced-motion**: Modal/Alert/Toast

## 버전 판정
- 새 export(`registerOverlay`/`useOverlayEscape`)·새 prop(Dropdown name, Alert closeOnOverlay, Chip removeLabel, Button as/href/disabled) 추가 → **minor(3.5.0)**
- ⚠️ `ButtonProps` interface→union: 런타임/공개 prop 100% 호환, 타입 레벨 `extends ButtonProps` 만 불가(내부 사용처 0). CHANGELOG 에 caveat 명시

## 릴리즈 절차 (머지 후)
1. 리뷰어 approve → 머지
2. main 에서 `git tag -a v3.5.0 -m "v3.5.0"` → `git push origin v3.5.0`
3. `release.yml` 이 npm publish --provenance + GitHub Release 자동 생성 (릴리즈 노트는 조직 공통 양식)

## 검증
- 유닛 744 passed / 9 skip, 빌드(React + Vanilla) 통과
