### PR TITLE
fix/release-review

### DIFF
--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, Bell, CheckCircle2, Info, X, XCircle } from "lucide-reac
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useSpringPresence } from "../../../utils";
+import { cn, useIsMounted, useSpringPresence } from "../../../utils";
 import "./style.scss";
 
 export type ToastVariant = "success" | "error" | "warning" | "info" | "default";
@@ -133,11 +133,8 @@ export const ToastProvider = ({
 	closeAriaLabel = "Close",
 }: ToastProviderProps) => {
 	const [toasts, setToasts] = React.useState<ToastItem[]>([]);
-	const [isMounted, setIsMounted] = React.useState(false);
-
-	React.useEffect(() => {
-		setIsMounted(true);
-	}, []);
+	// 포털은 클라이언트 마운트 후에만 렌더 (SSR/hydration 안전) - 공유 훅
+	const isMounted = useIsMounted();
 
 	/**
 	 * 토스트를 큐에 추가한다. maxCount를 초과하면 가장 오래된 항목을 제거한다.

--- a/src/ui/forms/otp-input/index.tsx
+++ b/src/ui/forms/otp-input/index.tsx
@@ -72,7 +72,9 @@ export const OtpInput = ({
 
 		// SMS/키체인 자동입력(autocomplete="one-time-code")은 첫 박스의 onChange 로 전체 코드가
 		// 한 번에 들어온다. 단일 숫자 정규식에 걸려 무시되지 않도록 handlePaste 처럼 각 자리에 분배.
-		if (nextDigit.length > 1) {
+		// index 0 에서만 처리 - 분배가 항상 0번부터 채우므로, 다른 박스에서 멀티문자 change 가
+		// 발생해도(브라우저별 자동완성 차이 등) 기존 자릿수를 밀지 않도록 트리거 위치를 명시 가드.
+		if (index === 0 && nextDigit.length > 1) {
 			const filled = nextDigit.replace(/\D/g, "").slice(0, length);
 			if (!filled) return;
 			const newDigits = [...digits];

--- a/src/ui/forms/radio-group/RadioGroup.test.tsx
+++ b/src/ui/forms/radio-group/RadioGroup.test.tsx
@@ -173,4 +173,17 @@ describe("Radio standalone (no RadioGroup) — 기존 동작 보존", () => {
 		expect(screen.getByRole("radio", { name: "One" })).toBeChecked();
 		expect(screen.getByRole("radio", { name: "Two" })).not.toBeChecked();
 	});
+
+	it("does not check a value=\"null\" radio when the group value is null", () => {
+		// 회귀: group.value 가 null 이면 String(null)==="null" 이라 value=\"null\" Radio 가 선택되던
+		// 문제 - group.value != null 로 null/undefined 모두 방어
+		render(
+			<RadioGroup label="g" value={null as unknown as string}>
+				<Radio value="null" label="Null" />
+				<Radio value="a" label="A" />
+			</RadioGroup>,
+		);
+		expect(screen.getByRole("radio", { name: "Null" })).not.toBeChecked();
+		expect(screen.getByRole("radio", { name: "A" })).not.toBeChecked();
+	});
 });

--- a/src/ui/forms/radio-group/RadioGroup.test.tsx
+++ b/src/ui/forms/radio-group/RadioGroup.test.tsx
@@ -159,4 +159,18 @@ describe("Radio standalone (no RadioGroup) — 기존 동작 보존", () => {
 		expect(screen.getByRole("radio", { name: "A" })).not.toBeChecked();
 		expect(screen.getByRole("radio", { name: "B" })).not.toBeChecked();
 	});
+
+	it("keeps a numeric-value radio checked after selecting it", () => {
+		// 회귀: handleChange 가 group.onChange(String(value)) 로 문자열을 넘기는데 비교가
+		// group.value === value 이면 "1" === 1 → false 라 클릭 직후 선택 해제되던 버그
+		render(
+			<RadioGroup label="g">
+				<Radio value={1} label="One" />
+				<Radio value={2} label="Two" />
+			</RadioGroup>,
+		);
+		fireEvent.click(screen.getByRole("radio", { name: "One" }));
+		expect(screen.getByRole("radio", { name: "One" })).toBeChecked();
+		expect(screen.getByRole("radio", { name: "Two" })).not.toBeChecked();
+	});
 });

--- a/src/ui/forms/radio/index.tsx
+++ b/src/ui/forms/radio/index.tsx
@@ -44,7 +44,7 @@ export const Radio = ({
 	// 넘기므로, 숫자 value 를 그대로 비교하면(예: "1" === 1) 클릭 직후 선택 해제되는 버그가 있어
 	// 양쪽 String() 으로 강제 비교한다.
 	const resolvedChecked = group
-		? value !== undefined && group.value !== undefined && String(group.value) === String(value)
+		? value !== undefined && group.value != null && String(group.value) === String(value)
 		: checked;
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/forms/radio/index.tsx
+++ b/src/ui/forms/radio/index.tsx
@@ -39,9 +39,13 @@ export const Radio = ({
 	const size = sizeProp ?? group?.size ?? "md";
 	const name = nameProp ?? group?.name;
 	const disabled = disabledProp ?? group?.disabled;
-	// value 없는 Radio 가 그룹 미선택 상태(group.value === undefined)에서
-	// undefined === undefined 로 전부 checked 렌더되지 않도록 value 존재를 먼저 확인.
-	const resolvedChecked = group ? value !== undefined && group.value === value : checked;
+	// value 없는 Radio 가 그룹 미선택 상태(group.value === undefined)에서 전부 checked 되지 않도록
+	// value 존재를 먼저 확인. 또 handleChange 가 group.onChange(String(value)) 로 항상 문자열을
+	// 넘기므로, 숫자 value 를 그대로 비교하면(예: "1" === 1) 클릭 직후 선택 해제되는 버그가 있어
+	// 양쪽 String() 으로 강제 비교한다.
+	const resolvedChecked = group
+		? value !== undefined && group.value !== undefined && String(group.value) === String(value)
+		: checked;
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		if (group && value !== undefined) group.onChange(String(value));

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -222,6 +222,18 @@ describe("Drawer", () => {
 		expect(panel?.contains(document.activeElement)).toBe(true);
 	});
 
+	it("renders the portal and traps focus when mounted already open (isMounted gate)", () => {
+		// 마운트 시점부터 open=true - isMounted 게이트가 걸려도 mount effect 이후 포털+트랩 활성화
+		render(
+			<Drawer open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Drawer>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".drawer_panel");
+		expect(panel).not.toBeNull();
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	// ── Accessibility ────────────────────────────────────────────────────────
 
 	it("has dialog role and modal accessibility attributes", () => {

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -5,7 +5,14 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useOverlayEscape, useReducedMotion, useSpringPresence } from "../../../utils";
+import {
+	cn,
+	useFocusTrap,
+	useIsMounted,
+	useOverlayEscape,
+	useReducedMotion,
+	useSpringPresence,
+} from "../../../utils";
 import "./style.scss";
 
 /** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
@@ -72,18 +79,16 @@ export const Drawer = ({
 	const [shouldRender, setShouldRender] = React.useState(open);
 	const reduced = useReducedMotion();
 	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
-	// mismatch(서버 null vs 클라 포털)를 피한다 (Modal/Toast/Alert 와 동일 패턴).
-	const [isMounted, setIsMounted] = React.useState(false);
-	React.useEffect(() => {
-		setIsMounted(true);
-	}, []);
+	// mismatch(서버 null vs 클라 포털)를 피한다 (Modal/Toast/Alert 와 동일 패턴을 훅으로 공유).
+	const isMounted = useIsMounted();
 
 	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
 	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Modal/Popover/Tooltip 등과 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
-	useOverlayEscape(open, () => onClose?.());
+	// 마운트 전(하이드레이션)엔 등록하지 않아 화면에 없는 드로어가 Escape 스택 순서를 교란하지 않게 한다.
+	useOverlayEscape(open && isMounted, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -71,9 +71,15 @@ export const Drawer = ({
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
 	const reduced = useReducedMotion();
+	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
+	// mismatch(서버 null vs 클라 포털)를 피한다 (Modal/Toast/Alert 와 동일 패턴).
+	const [isMounted, setIsMounted] = React.useState(false);
+	React.useEffect(() => {
+		setIsMounted(true);
+	}, []);
 
-	// 포커스 트랩
-	useFocusTrap(panelRef, open);
+	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
+	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Modal/Popover/Tooltip 등과 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
@@ -139,8 +145,9 @@ export const Drawer = ({
 	// 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
-	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다.
-	if (typeof document === "undefined") return null;
+	// SSR/하이드레이션 가드 - 서버(document 없음) 및 클라이언트 첫 렌더(isMounted=false)에서는
+	// null 을 반환해 서버/클라 출력을 일치시킨다(hydration mismatch 방지).
+	if (typeof document === "undefined" || !isMounted) return null;
 
 	const hasTitle = !!title;
 	const sizeValue = typeof size === "number" ? `${size}px` : size;

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -190,6 +190,20 @@ describe("Modal", () => {
 		expect(panel?.contains(document.activeElement)).toBe(true);
 	});
 
+	it("renders the portal and traps focus when mounted already open (isMounted gate)", () => {
+		// 마운트 시점부터 open=true - isMounted 게이트가 걸려 서버/첫 렌더엔 null 이지만,
+		// mount effect 이후 포털이 붙고 focus trap 이 활성화되어야 한다. (가드가 영구 null 로
+		// 깨지면 dialog 가 안 뜨고 이 테스트가 실패한다.)
+		render(
+			<Modal open onClose={() => {}} title="Trap">
+				<button type="button">First action</button>
+			</Modal>,
+		);
+		const panel = screen.getByRole("dialog").querySelector(".modal_panel");
+		expect(panel).not.toBeNull();
+		expect(panel?.contains(document.activeElement)).toBe(true);
+	});
+
 	it("calls onClose once on Escape from inside the modal (no duplicate handler)", () => {
 		const handleClose = vi.fn();
 		render(

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -5,7 +5,7 @@ import { X } from "lucide-react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { iconSize } from "../../../styles/icon";
-import { cn, useFocusTrap, useOverlayEscape, useReducedMotion } from "../../../utils";
+import { cn, useFocusTrap, useIsMounted, useOverlayEscape, useReducedMotion } from "../../../utils";
 import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
@@ -64,18 +64,16 @@ export const Modal = ({
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
 	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
-	// mismatch(서버 null vs 클라 포털)를 피한다. Toast/Alert 와 동일한 isMounted 패턴.
-	const [isMounted, setIsMounted] = React.useState(false);
-	React.useEffect(() => {
-		setIsMounted(true);
-	}, []);
+	// mismatch(서버 null vs 클라 포털)를 피한다. Toast/Alert 와 동일한 패턴을 훅으로 공유.
+	const isMounted = useIsMounted();
 
 	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
 	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Tooltip/Popover 등 다른 오버레이와 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
-	useOverlayEscape(open, () => onClose?.());
+	// 마운트 전(하이드레이션)엔 등록하지 않아 화면에 없는 모달이 Escape 스택 순서를 교란하지 않게 한다.
+	useOverlayEscape(open && isMounted, () => onClose?.());
 
 	// open 이 true 가 되면 렌더 단계에서 즉시 마운트 플래그를 켠다. effect 로 미루면 (a) 불필요한
 	// double render 가 생기고, (b) open 이 곧바로 false 로 바뀌는 극단 케이스에서 shouldRender 가 미처

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -63,9 +63,15 @@ export const Modal = ({
 	const panelRef = React.useRef<HTMLDivElement>(null);
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
+	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
+	// mismatch(서버 null vs 클라 포털)를 피한다. Toast/Alert 와 동일한 isMounted 패턴.
+	const [isMounted, setIsMounted] = React.useState(false);
+	React.useEffect(() => {
+		setIsMounted(true);
+	}, []);
 
-	// 포커스 트랩
-	useFocusTrap(panelRef, open);
+	// 포커스 트랩 - 포털이 실제로 마운트된 뒤(isMounted) 활성화해야 panelRef 가 붙어 있다.
+	useFocusTrap(panelRef, open && isMounted);
 
 	// Escape 닫기 - 공유 오버레이 스택에 등록해 최상단일 때만 닫는다 (overlay-stack.ts 참고).
 	// Tooltip/Popover 등 다른 오버레이와 조합될 때도 "최상단만 닫힘"(APG)이 일관되게 지켜진다.
@@ -131,9 +137,10 @@ export const Modal = ({
 	// 마운트가 한 렌더 늦어 트랩이 걸리지 않는다. shouldRender 는 퇴출 애니메이션 동안 마운트 유지용.
 	if (!open && !shouldRender) return null;
 
-	// SSR 가드 - 포털 대상(document.body)이 서버에는 없다. 클라이언트 하이드레이션 후
-	// 첫 렌더부터 포털이 붙으므로(commit 시점, effect 이전) 포커스 트랩 타이밍은 유지된다.
-	if (typeof document === "undefined") return null;
+	// SSR/하이드레이션 가드 - 서버(document 없음) 및 클라이언트 첫 렌더(isMounted=false)에서는
+	// null 을 반환해 서버/클라 출력을 일치시킨다(hydration mismatch 방지). 마운트 후 open&&isMounted
+	// 가 되는 렌더에서 패널이 붙고 useFocusTrap 이 그 시점에 활성화된다.
+	if (typeof document === "undefined" || !isMounted) return null;
 
 	const hasTitle = !!title;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export { useFocusTrap } from "./use-focus-trap";
+export { useIsMounted } from "./use-is-mounted";
 export { useReducedMotion } from "./use-reduced-motion";
 export { useSafeLayoutEffect } from "./use-safe-layout-effect";
 export { useSpringHover } from "./use-spring-hover";

--- a/src/utils/use-is-mounted.test.ts
+++ b/src/utils/use-is-mounted.test.ts
@@ -1,0 +1,17 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useIsMounted } from "./use-is-mounted";
+
+describe("useIsMounted", () => {
+	it("returns true after mount effect runs", () => {
+		const { result } = renderHook(() => useIsMounted());
+		// renderHook 은 act 로 effect 를 flush 하므로 마운트 후 true
+		expect(result.current).toBe(true);
+	});
+
+	it("stays true across re-renders", () => {
+		const { result, rerender } = renderHook(() => useIsMounted());
+		rerender();
+		expect(result.current).toBe(true);
+	});
+});

--- a/src/utils/use-is-mounted.ts
+++ b/src/utils/use-is-mounted.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * 클라이언트 마운트 여부를 반환한다.
+ *
+ * 서버 렌더 및 클라이언트 하이드레이션 첫 렌더에서는 `false`, 마운트 effect 실행 후 `true`.
+ * SSR 에서 `document`(포털 대상)가 없거나, open 상태로 마운트되는 오버레이가 서버 `null` /
+ * 클라 포털로 갈려 hydration mismatch 가 나는 것을 막을 때 쓴다.
+ *
+ * @example
+ * ```tsx
+ * const isMounted = useIsMounted();
+ * if (typeof document === "undefined" || !isMounted) return null;
+ * return createPortal(..., document.body);
+ * ```
+ */
+export function useIsMounted(): boolean {
+	const [mounted, setMounted] = React.useState(false);
+	React.useEffect(() => {
+		setMounted(true);
+	}, []);
+	return mounted;
+}

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -149,17 +149,19 @@
 				disabled: el.classList.contains("is-disabled"),
 			}));
 
+		// data-options 가 유효한 배열이면(빈 배열 포함) 그대로 존중 - 명시적 빈 배열은 "옵션 없음"
+		// 의도이므로 DOM 파싱으로 덮지 않는다. undefined(속성 없음/파싱 실패)일 때만 폴백.
 		let optionsData;
 		if (wrapper.dataset.options) {
 			try {
 				const parsed = JSON.parse(wrapper.dataset.options);
-				optionsData = Array.isArray(parsed) ? parsed : (console.warn("Select: data-options is not a JSON array"), []);
+				if (Array.isArray(parsed)) optionsData = parsed;
+				else console.warn("Select: data-options is not a JSON array");
 			} catch (e) {
 				console.warn("Select: invalid JSON in data-options", e);
-				optionsData = [];
 			}
 		}
-		if (!optionsData || optionsData.length === 0) {
+		if (optionsData === undefined) {
 			optionsData = config.options && config.options.length ? config.options : parseDomOptions();
 		}
 

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -162,7 +162,9 @@
 			}
 		}
 		if (optionsData === undefined) {
-			optionsData = config.options && config.options.length ? config.options : parseDomOptions();
+			// config.options 도 배열이면(빈 배열 포함) 존중 - data-options 와 동일하게 명시적 빈
+			// 배열을 "옵션 없음"으로 처리하고 DOM 파싱으로 덮지 않는다.
+			optionsData = Array.isArray(config.options) ? config.options : parseDomOptions();
 		}
 
 		state.options = optionsData;

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -769,10 +769,14 @@
 		// HTML) hidden input 을 형제(sibling)로 삽입한다. 서버 템플릿이 미리 렌더링해둔 hidden
 		// input(자식이든 형제든)이 있으면 재사용한다.
 		const fieldName = config.name || toggleEl.dataset.name || null;
+		// 직계 형제만 탐색 - parentNode.querySelector 는 하위 트리 전체를 뒤져 같은 부모를 공유하는
+		// 다른 토글(예: 테이블 행 안 여러 토글)의 hidden input 을 잘못 집을 수 있다.
 		let hiddenInput =
 			toggleEl.querySelector('input[type="hidden"]') ||
 			(fieldName && toggleEl.parentNode
-				? toggleEl.parentNode.querySelector(`input[type="hidden"][name="${fieldName}"]`)
+				? Array.from(toggleEl.parentNode.children).find(
+						(el) => el.tagName === "INPUT" && el.type === "hidden" && el.name === fieldName,
+					)
 				: null);
 		if (!hiddenInput && fieldName) {
 			hiddenInput = document.createElement("input");


### PR DESCRIPTION
## 작업 개요

릴리즈 PR(#383, dev→main v3.5.0) 리뷰에서 gemini 가 지적한 **이미 머지된 코드의 결함 3건** 수정. release 브랜치에만 넣으면 develop 과 갈리므로 develop 대상으로 처리.

## 작업한 내용
- [x] **Radio 숫자 value 버그(HIGH)**: 그룹 안 Radio 의 `handleChange` 가 `group.onChange(String(value))` 로 항상 문자열을 넘기는데 비교가 `group.value === value` 라, 숫자 value(`<Radio value={1}>`) 시 `"1" === 1 → false` 로 클릭 직후 선택 해제되던 버그 → 양쪽 `String()` 비교. 회귀 테스트 추가
- [x] **Vanilla Toggle 형제 탐색(MEDIUM)**: 서버 렌더 hidden input 재사용 시 `parentNode.querySelector` 는 하위 트리 전체를 뒤져 같은 부모의 다른 토글 hidden input 을 오집 가능 → 직계 형제(`Array.from(parent.children).find`)만 탐색
- [x] **Modal/Drawer hydration(MEDIUM)**: `isMounted` 상태(useEffect)로 포털을 게이팅해 서버·클라 첫 렌더 모두 null 반환(hydration mismatch 방지). 포커스 트랩은 `open && isMounted` 로 묶어 마운트 렌더에서 정상 활성화(open-later 케이스 무회귀)

## 검증
- 유닛 745 passed / 9 skip (Radio 숫자 회귀 신규), tsc 신규 0, Vanilla 빌드·`node --check` 통과
- Modal/Drawer 기존 focus-trap/controlled 테스트 전부 통과

## 후속
- 이 PR 머지 후 release/3.5.0 을 develop 최신으로 갱신 → #383(dev→main)에 반영


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - OTP 입력 시 다른 칸의 기존 값이 잘못 밀리는 문제를 수정했습니다.
  - 숫자 값 라디오 버튼이 클릭 직후 선택 해제되거나, `null` 값 라디오가 잘못 선택되는 문제를 해결했습니다.
  - Select의 빈 옵션 목록을 올바르게 처리하고, Toggle이 잘못된 숨은 입력 필드를 참조하지 않도록 개선했습니다.
  - Modal과 Drawer가 초기 로드 시에도 포털, 포커스 트랩, Escape 동작을 안정적으로 처리합니다.

- **개선**
  - SSR 및 초기 하이드레이션 환경에서 오버레이와 알림 표시의 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->