### PR TITLE
docs/migration-3.5.0

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,7 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 ## 목차
 
 - [개요](#개요)
+- [v3.5.0](#v350)
 - [v3.3.0](#v330)
 - [v3.0.0](#v300)
 - [v2.4.0](#v240)
@@ -18,9 +19,62 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 ## 개요
 
 - `@deprecated` 로 표시된 prop 은 삭제되지 않고 계속 동작합니다. 실제 제거는 다음 major 릴리즈에서 이루어집니다.
+- deprecated prop 외에, **동작·타입 레벨 변경**(예: 렌더링 위치 변경, 타입 형태 변경)도 소비자에게 영향이 있으면 해당 버전 섹션에 함께 정리합니다 (v3.5.0 참고).
 - 변경 콜백(`onChange` 계열) 은 신규(canonical) prop 과 구(deprecated) prop 을 동시에 넘겨도 안전합니다. 컴포넌트 내부는 `canonical ?? deprecated` 순서로 우선 적용하므로, 신규 prop 을 넘기면 그 값만 호출되고 신규 prop 이 없을 때만 구 prop 이 fallback 으로 호출됩니다.
 - 이 문서는 `grep -rn "@deprecated" src/ui --include=index.tsx` 로 코드에 실제 존재하는 deprecated prop 전체를 기준으로 작성했습니다 (React 컴포넌트 공개 prop 기준 - Vanilla JS 패키지는 별도).
 - 버전은 semver 내림차순으로 정렬되어 있습니다.
+
+---
+
+## v3.5.0
+
+v3.5.0 은 deprecated prop 제거는 없지만, **소비자에게 영향이 있을 수 있는 동작·타입 변경 2건**이 있습니다. (신규 추가 prop/export 는 비파괴 — 맨 아래 표 참고.)
+
+### 1. Modal · Drawer 가 `document.body` 포털로 렌더링 (동작 변경)
+
+기존에는 트리거 위치에 인라인 렌더됐으나, `transform`/`filter` 조상 아래에서 `position: fixed` 가 깨지는 문제 때문에 이제 `createPortal(document.body)` 로 body 끝에 렌더링됩니다 (Alert/Toast 와 동일).
+
+- **영향**: 패널을 **후손 선택자**로 스타일링하던 코드가 조용히 깨집니다. 패널이 더 이상 감싸던 래퍼의 자식이 아니기 때문입니다.
+  ```css
+  /* ❌ 이제 매칭 안 됨 - .modal_panel 이 body 로 이동 */
+  .my-wrapper .modal_panel { ... }
+  ```
+- **해결**: (a) 패널 스타일은 `className` prop 으로 직접 넘기거나, (b) 래퍼 종속 없는 전역 셀렉터를 쓰세요.
+  ```tsx
+  // ✅ className 으로 패널에 직접 적용
+  <Modal open={open} onClose={close} className="my-modal-panel">...</Modal>
+  ```
+  ```css
+  /* ✅ 또는 래퍼 없이 전역으로 */
+  .modal_panel.my-modal-panel { ... }
+  ```
+- SSR: 서버·하이드레이션 첫 렌더에서는 `null` 을 반환하고 마운트 후 포털이 붙습니다(`useIsMounted` 게이트). open 상태로 첫 페인트되는 경우에도 hydration mismatch 가 없습니다.
+
+### 2. `ButtonProps` 가 discriminated union 으로 변경 (타입 레벨)
+
+Button 이 `as`/`href` 로 anchor 렌더링을 지원하면서 `ButtonProps` 가 `ButtonAsButton | ButtonAsAnchor` union 이 됐습니다.
+
+- **런타임·공개 prop 은 100% 호환** — 기존 `<Button variant size onClick disabled>` 사용은 그대로 동작합니다.
+- **타입 레벨만 영향**: TS interface 는 union 을 확장할 수 없어 `interface X extends ButtonProps {}` 형태가 깨집니다.
+- **해결**: 스타일 props 만 확장하려면 공통 베이스 `ButtonBaseProps` 를, 전체 prop 을 참조하려면 `React.ComponentProps<typeof Button>` 을 쓰세요.
+  ```tsx
+  // ❌ An interface can only extend an object type...
+  interface MyButtonProps extends ButtonProps { extra?: string }
+  // ✅
+  type MyButtonProps = React.ComponentProps<typeof Button> & { extra?: string };
+  ```
+
+### 신규 추가 (비파괴 — 마이그레이션 불필요, 참고용)
+
+| 컴포넌트/모듈 | 추가 | 설명 |
+|------|------|------|
+| Button | `as` / `href` / `target` / `rel` / `disabled` | `as="a"`(또는 `href`) 시 동일 스타일 anchor 렌더. anchor disabled 는 `aria-disabled`+클릭 차단 |
+| Dropdown | `name` | hidden input 으로 네이티브 폼 제출 참여 |
+| Alert | `closeOnOverlay` | 오버레이 클릭 닫힘 on/off (기본 true) |
+| Chip | `removeLabel` | 삭제 버튼 접근성 레이블 커스터마이즈 (기본 `"{label} 제거"`) |
+| utils | `useOverlayEscape` / `registerOverlay` / `useIsMounted` | 공유 오버레이 Escape 스택, 클라이언트 마운트 훅 |
+
+> Vanilla JS 패키지도 폼 참여(`data-name` on Select/Toggle)·combobox ARIA 등이 추가됐습니다. HTML/CSS/JS 환경 사용법은 [docs/VANILLA.md](./VANILLA.md) 참고.
 
 ---
 


### PR DESCRIPTION
## 작업 개요

MIGRATION.md 에 v3.5.0 섹션 추가. 3.5.0 은 deprecated prop 제거는 없지만 **소비자 영향 있는 동작·타입 변경 2건**이 있어 안내가 필요.

## 작업한 내용
- [x] **Modal/Drawer 포털화(동작 변경)**: 후손 선택자(`.wrapper .modal_panel`)로 패널 스타일링하던 코드가 조용히 깨짐 → `className` prop 또는 전역 셀렉터로 우회하는 법 명시. SSR/hydration(isMounted) 동작도 설명
- [x] **`ButtonProps` union(타입 레벨)**: 런타임 호환이나 `interface X extends ButtonProps` 불가 → `ButtonBaseProps` / `ComponentProps<typeof Button>` 대안 명시
- [x] 신규 추가(비파괴) prop/export 표: Button `as`/`href`/`disabled`, Dropdown `name`, Alert `closeOnOverlay`, Chip `removeLabel`, `useOverlayEscape`/`registerOverlay`/`useIsMounted` + Vanilla 폼 참여 안내
- [x] 목차/개요 갱신 (deprecated 외 동작·타입 변경도 다룬다고 명시)

## 배경
v3.5.0 릴리즈 평가 중, 이미 배포돼 소비자(notiiv 3.5.0)가 부딪힐 수 있는 유일한 실질 리스크가 Modal/Drawer 포털 동작 변경이라 마이그레이션 안내를 우선 추가.

## 검증
- 문서 변경만 - 유닛 750 pass (pre-commit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - v3.5.0 마이그레이션 가이드를 추가했습니다.
  - Modal과 Drawer의 렌더링 위치 변경에 따른 스타일 선택자 및 SSR/하이드레이션 영향을 안내합니다.
  - Button 타입 변경으로 `interface` 확장 시 발생할 수 있는 TypeScript 호환성 문제와 대안을 설명합니다.
  - 신규 콜백 및 deprecated prop 안내를 정리하고, Button·Dropdown·Alert·Chip과 유틸리티의 추가 기능을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->