### PR TITLE
fix/test-isolation

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,18 @@
 import "@testing-library/jest-dom";
 import { Globals } from "@react-spring/web";
+import { afterEach } from "vitest";
 
 // jsdom 환경에서 react-spring 애니메이션 즉시 완료 (onRest 트리거 보장)
 // - 진입/퇴출 unmount 타이밍 의존 테스트가 RAF 없이 동작
 Globals.assign({ skipAnimation: true });
+
+// Modal/Drawer/Alert 는 document.body 에 스크롤락 카운터(dataset.openModals)와
+// overflow 를 공유한다(여러 오버레이 동시 오픈 조율용 - production 의도된 설계).
+// 이 전역이 테스트 파일 간 누수되면 특정 실행 순서에서 스크롤락 상태가 새어 flaky 해진다.
+// RTL 자동 cleanup(afterEach, LIFO 로 먼저 실행되어 언마운트+카운터 정리) 이후 이 훅이
+// 실행되므로, 정상 케이스엔 no-op 안전망이고 누수 시엔 다음 테스트를 깨끗한 상태로 격리한다.
+afterEach(() => {
+	document.body.style.overflow = "";
+	delete document.body.dataset.openModals;
+	delete document.body.dataset.originalOverflow;
+});


### PR DESCRIPTION
## 작업 개요

오버레이(Modal/Drawer/Alert)가 공유하는 `document.body` 스크롤락 전역 상태가 테스트 파일 간 누수되어 특정 실행 순서에서 flaky 해지는 문제를 격리했습니다.

dependabot storybook 그룹 bump PR(#385)이 test 실행 순서를 바꾸면서 Alert `locks body scroll` 단언이 `expected 'hidden' to be ''` 로 실패했는데, 원인은 dependency 자체가 아니라 **테스트 격리 부재**(잠재 결함)였습니다. develop 기본 순서에선 우연히 통과했지만 언제든 재현 가능한 flake 입니다.

## 근본 원인

Modal/Drawer/Alert 는 여러 오버레이 동시 오픈 시 스크롤락을 조율하려고 `document.body.dataset.openModals`(카운터) + `style.overflow` + `dataset.originalOverflow` 를 **공유 전역**으로 쓴다 (production 의도된 설계 - 변경 대상 아님). 어떤 테스트가 이 카운터를 0 으로 되돌리지 못한 채 끝나면, 다음 파일의 테스트가 오염된 상태에서 시작해 스크롤락 단언이 어긋난다.

## 작업한 내용

- [x] `src/test/setup.ts` 에 전역 `afterEach` 추가 — 각 테스트 후 body 스크롤락 전역(`overflow`, `openModals`, `originalOverflow`) 초기화
- [x] RTL 자동 cleanup(`afterEach`, LIFO 로 먼저 실행되어 언마운트+카운터 정리) **이후** 실행되도록 배치 → 정상 케이스엔 no-op 안전망, 누수 시엔 다음 테스트를 깨끗하게 격리
- [x] 컴포넌트 런타임 로직은 손대지 않음 (공유 카운터 설계는 정상)

## 검증

- `pnpm test` → 52 파일 / 750 pass (9 skipped)
- 이 PR 머지 후 #385(storybook bump) `@dependabot rebase` 하면 green

## 전달할 추가 이슈

- (선택) 향후 오버레이 스크롤락을 공유 body dataset 대신 모듈 스코프 ref 카운터로 리팩터하면 전역 오염 표면 자체가 줄어듦 - 별도 과제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 테스트 종료 후 모달·드로어·알림 오버레이로 인한 스크롤 잠금 상태를 자동으로 초기화하도록 개선했습니다.
  * 테스트 간 스타일 및 상태 누수를 방지해 테스트 격리와 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->