### PR TITLE
fix/test-isolation-round2

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { Globals } from "@react-spring/web";
-import { afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 
 // jsdom 환경에서 react-spring 애니메이션 즉시 완료 (onRest 트리거 보장)
 // - 진입/퇴출 unmount 타이밍 의존 테스트가 RAF 없이 동작
@@ -8,11 +8,18 @@ Globals.assign({ skipAnimation: true });
 
 // Modal/Drawer/Alert 는 document.body 에 스크롤락 카운터(dataset.openModals)와
 // overflow 를 공유한다(여러 오버레이 동시 오픈 조율용 - production 의도된 설계).
-// 이 전역이 테스트 파일 간 누수되면 특정 실행 순서에서 스크롤락 상태가 새어 flaky 해진다.
-// RTL 자동 cleanup(afterEach, LIFO 로 먼저 실행되어 언마운트+카운터 정리) 이후 이 훅이
-// 실행되므로, 정상 케이스엔 no-op 안전망이고 누수 시엔 다음 테스트를 깨끗한 상태로 격리한다.
-afterEach(() => {
+// 이 전역이 테스트 간 누수되면 스크롤락 상태가 새어 flaky 해진다:
+// react-spring 퇴출(useSpringPresence) 의 unmount 가 skipAnimation 이라도 onRest 스케줄
+// 때문에 한 tick 늦게 실행될 수 있어, 앞 테스트 오버레이의 스크롤락 cleanup 이 테스트
+// 경계를 넘어 body 를 더럽히는 경우가 있다(coverage 계측 타이밍에서 재현).
+//
+// beforeEach 가 결정적 방어선: 각 테스트 렌더 직전 body 스크롤락 전역을 초기화해, 오버레이가
+// originalOverflow 를 항상 깨끗한 값으로 저장하도록 보장한다. afterEach 는 teardown 위생용.
+function resetBodyScrollLock() {
 	document.body.style.overflow = "";
 	delete document.body.dataset.openModals;
 	delete document.body.dataset.originalOverflow;
-});
+}
+
+beforeEach(resetBodyScrollLock);
+afterEach(resetBodyScrollLock);


### PR DESCRIPTION
## 작업 개요

[#391](https://github.com/Bigtablet/bigtablet-design-system/pull/391)(afterEach 초기화)이 **불충분**했습니다. 머지 후에도 dependabot PR CI 에서 Alert `locks body scroll` 이 `expected 'hidden' to be ''` 로 간헐 실패(#387 rebase 후 재현). 로컬에서 정확한 CI 명령(`vitest run --project unit --coverage`)으로 **~1/6 확률 flake 재현** 성공 → 근본 원인 확정.

## 근본 원인

react-spring 퇴출 애니메이션(`useSpringPresence`)은 `skipAnimation` 이어도 `onRest` 스케줄 때문에 오버레이 **unmount 를 한 tick 늦게** 실행할 수 있다. 그 결과 앞 테스트 오버레이의 스크롤락 cleanup 이 **테스트 경계를 넘어** `document.body` 를 더럽히고(overflow='hidden' 잔존), 다음 테스트(Alert)가 오염된 body 에서 시작 → 오버레이가 `originalOverflow='hidden'` 을 저장 → close 시 복원이 'hidden' 을 써 단언 실패. coverage 계측 타이밍에서 특히 잘 드러남.

`afterEach` 는 teardown **이후** 실행이라 지연 unmount 가 그 뒤에 또 body 를 더럽히면 못 막는다.

## 작업한 내용

- [x] `beforeEach` 추가 — 각 테스트 **렌더 직전** body 스크롤락 전역(`overflow`/`openModals`/`originalOverflow`) 초기화 → 결정적 clean slate 보장(오버레이가 항상 깨끗한 `originalOverflow` 저장)
- [x] `afterEach` 는 teardown 위생용으로 유지, 공유 헬퍼 `resetBodyScrollLock()` 로 통합
- [x] 컴포넌트 런타임 로직 무변경

## 검증

- 정확한 CI 명령 `vitest run --project unit --coverage` **20회 연속 green** (수정 전 ~1/6 실패)
- 이 PR 머지 후 dependabot 5개 `@dependabot rebase` → 전부 green 예상