### PR TITLE
fix/develop-version-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.5.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.5.0) - 2026-07-16
+
+- 접근성(a11y) 대규모 개선 - 전체 컴포넌트 감사 후 WAI-ARIA/WCAG 위반 수정: Alert 포커스 트랩, Tooltip dismissable·hoverable(WCAG 1.4.13), Toast 자동 닫힘 hover/focus 일시정지(WCAG 2.2.1), Tabs 로빙 tabindex, Checkbox·OTP `aria-invalid`, Chip·ListItem 선택 상태 노출, NavBar locale `menuitemradio`, Table `aria-busy`
+- Button `as`/`href` 지원 - `<Button as="a" href="...">` 로 동일 스타일의 anchor 렌더링(링크 시맨틱), `disabled` anchor 대응. Hero CTA 가 이를 재사용
+- 폼 참여 prop 추가 - Dropdown `name`(hidden input 으로 네이티브 폼 제출), Alert `closeOnOverlay`, Chip `removeLabel`(삭제 버튼 레이블 커스터마이즈)
+- 오버레이 Escape 통일 - `useOverlayEscape`/`registerOverlay` 공유 스택으로 "최상단 오버레이만 닫힘"(APG) 보장, 자식 요소 Escape 우선 처리
+- Modal · Drawer 포털 렌더링 - `createPortal(document.body)` 로 transform/filter 조상 아래에서도 `position: fixed` 정상 동작 (기존 인라인 렌더 → body 포털; 후손 선택자 스타일링 시 영향 가능)
+- Vanilla 번들 대폭 수정 - 색상 토큰 자기참조/미정의 해소(+다크 테마), Select `<li data-value>` 서버 마크업 파싱, Select/Toggle 폼 제출 참여(`data-name`)·combobox ARIA·Modal 포커스 트랩·스크롤 잠금 카운터·FOUC 방지
+- reduced-motion(WCAG 2.3.3) - Modal/Alert 진입·퇴출, Toast progress 를 `prefers-reduced-motion` 대응
+- (주의) `ButtonProps` 가 discriminated union(`ButtonAsButton | ButtonAsAnchor`)으로 변경 - 런타임/공개 prop 은 100% 호환이나, 타입 레벨에서 `interface X extends ButtonProps` 확장은 불가(union 확장 불가). 확장이 필요하면 `ButtonBaseProps` 또는 `ComponentProps<typeof Button>` 사용
+
 ## [3.4.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.4.1) - 2026-07-10
 
 - Modal · Drawer: 소비자 `style`/`className`/`data-*` 는 반영하되 컴포넌트의 애니메이션 style · `onClick`/`onKeyDown`(stopPropagation·Escape) · `role` 이 항상 우선하도록 정리 (소비자 style 이 오버레이 동작을 덮던 문제 수정)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.4.1",
+	"version": "3.5.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## 작업 개요

develop 의 `package.json`/`CHANGELOG.md` 가 v3.5.0 릴리즈 후 역동기화되지 않아 **3.4.1 로 뒤처져 있던** 문제를 정정합니다. 공개된 main/npm(3.5.0)과 develop 릴리즈 메타데이터를 맞춥니다.

## 작업한 내용

- [x] `package.json` version **3.4.1 → 3.5.0**
- [x] `CHANGELOG.md` — develop 에 누락됐던 **3.5.0 항목 backfill** (main 기준 미러, semver 내림차순)
- [x] 코드/공개 API 변화 없음 (메타데이터만)

## 비고

- 이후 실제 릴리즈 시 이 3.5.0 을 기준으로 정상적인 SemVer bump 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * `Button`에서 링크(`href`)와 다양한 렌더링 방식을 지원합니다.
  * 폼 참여를 위한 속성이 추가되었습니다.

* **개선 사항**
  * Alert, Tooltip, Toast, Tabs, Checkbox, OTP 등 주요 컴포넌트의 접근성과 ARIA 동작을 개선했습니다.
  * Modal·Drawer의 포털 렌더링, Escape 키 동작, 포커스 트랩과 스크롤 잠금을 일관되게 정비했습니다.
  * 키보드 탐색 및 `prefers-reduced-motion` 지원을 강화했습니다.
  * Vanilla 번들의 색상 토큰, Select 마크업, 폼 제출 동작을 개선했습니다.

* **호환성**
  * `ButtonProps` 타입이 변경되어 일부 타입 확장이 제한될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->