### PR TITLE
delete/gemini-code-review

### DIFF
--- a/.claude/docs/claude-review.md
+++ b/.claude/docs/claude-review.md
@@ -4,7 +4,7 @@
 GitHub App 없이 레포 secret 으로 Claude(OAuth 토큰)를 호출해 요약 + 라인별 인라인 코멘트를 남기고,
 심각도에 따라 approve / request-changes 정식 리뷰를 제출한다.
 
-CodeRabbit(`.coderabbit.yaml`) / Gemini Code Assist 는 그대로 병행한다 (중복 리뷰 허용).
+CodeRabbit(`.coderabbit.yaml`) 는 그대로 병행한다 (중복 리뷰 허용).
 중복이 부담되면 나중에 하나로 정리한다.
 
 ## 사전 준비 (1회, 사람 작업)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,7 +9,7 @@ name: Claude PR Review
 #    커밋 SHA 를 남겨 staleness 를 추적한다
 # GitHub App 없이 레포 secret(CLAUDE_CODE_REVIEW_API_KEY)으로 직접 인증한다.
 # 코멘트 트리거는 author_association(OWNER/MEMBER/COLLABORATOR)로 제한해 외부 트리거를 막는다.
-# CodeRabbit(.coderabbit.yaml) / Gemini Code Assist 는 그대로 병행한다 (중복 리뷰 허용).
+# CodeRabbit(.coderabbit.yaml) 는 그대로 병행한다 (중복 리뷰 허용).
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,12 +628,12 @@ EOF
 
 ## 코드 리뷰 응대 규칙 (AI Assistant)
 
-PR 에 리뷰 봇/리뷰어(`@gemini-code-assist`, `@coderabbitai`, 사람 리뷰어)가 코멘트를 달면 AI 어시스턴트는 **항상** 다음을 수행한다:
+PR 에 리뷰 봇/리뷰어(`@coderabbitai`, Claude 리뷰, 사람 리뷰어)가 코멘트를 달면 AI 어시스턴트는 **항상** 다음을 수행한다:
 
 1. **재확인** - 지적 사항을 현재 소스로 검증한다. `실재 / 무관 / 이미수정` 판정 후 움직인다. 봇 지적이라고 무조건 따르지 않는다.
 2. **수정** - actionable 한 지적은 반영한다. 보류 시 그 이유를 답글에 명시한다.
 3. **답글 (멘션 필수)** - 처리한 각 인라인 코멘트(`comment_id` 가 있는 것)마다:
-   - 리뷰어를 **반드시 멘션** (`@gemini-code-assist` / `@coderabbitai` 등) - 봇이 학습·추적할 수 있도록.
+   - 리뷰어를 **반드시 멘션** (`@coderabbitai` 등) - 봇이 학습·추적할 수 있도록.
    - 무엇을 바꿨는지(또는 왜 안 했는지) 한 줄 + 반영 커밋 해시.
    - `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -X POST -f body='...'` 사용.
 4. **resolve** - 처리 완료한 thread 는 GraphQL `resolveReviewThread` mutation 으로 닫는다.
@@ -644,4 +644,4 @@ PR 에 리뷰 봇/리뷰어(`@gemini-code-assist`, `@coderabbitai`, 사람 리�
    `threadId` 는 REST 의 `comment_id` 가 아닌 GraphQL 노드 ID(`PRRT_` 접두사) - `pullRequest.reviewThreads` 쿼리의 thread `id` 필드로 얻는다 (`comment_id` → thread 매핑).
 5. **skip 기준** - acknowledgment-only(감사/확인 답신) / status notice(`comment_id` 없는 봇 공지, 예: Chromatic 한도, 빌드 상태) 는 답글·resolve 불필요. 답글 루프 방지.
 
-> CodeRabbit 은 `.coderabbit.yaml` 로 `develop` 대상 PR 도 자동 리뷰된다. Gemini 는 `.yml`/`.json` 등 일부 파일 타입은 리뷰를 skip 한다 (정상).
+> CodeRabbit 은 `.coderabbit.yaml` 로 `develop` 대상 PR 도 자동 리뷰된다.


### PR DESCRIPTION
## 제목
Gemini Code Assist 제거 (서비스 종료)

## 작업한 내용
- [x] Claude 리뷰 워크플로 재리뷰 트리거에서 `@gemini review` 제거 — 남는 트리거는 `@claude review` / `@claude re-review`
- [x] 봇 응대 규칙 문서를 남은 리뷰어(CodeRabbit / Claude 리뷰 / 사람) 기준으로 정리
- [x] 레포에 남아 있던 Gemini 전용 파일·문구 제거

변경 파일:
- `.claude/docs/claude-review.md` (M)
- `.github/workflows/claude-review.yml` (M)
- `CLAUDE.md` (M)

## 전달할 추가 이슈
- **org 레벨 `gemini-code-assist` GitHub App 언인스톨은 별도 작업** (Organization Settings → GitHub Apps, admin 권한 필요). 앱이 남아 있으면 PR 에 Gemini 리뷰가 계속 붙습니다.
- 제품 코드에서 **LLM 으로 쓰는 Gemini(요약 API 등)는 건드리지 않았습니다.**
- 과거 리뷰 이력(CHANGELOG, 코드 주석의 "Gemini PR review" 표기)은 히스토리라 그대로 남겼습니다.

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 자동 코드 리뷰 관련 안내를 업데이트했습니다.
  * 병행 리뷰 도구 안내를 정리하고, 인라인 리뷰 댓글 답변 시 리뷰어 멘션 규칙을 명확히 했습니다.
  * 불필요한 리뷰 도구별 예외 안내를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->