### PR TITLE
fix/file-input-tooltip

### DIFF
--- a/src/ui/forms/file/style.scss
+++ b/src/ui/forms/file/style.scss
@@ -126,7 +126,9 @@
       gap: token.$spacing_8;
       padding: token.$spacing_16;
       box-sizing: border-box;
-      color: token.$color_text_caption;
+      // 미리보기 dim 배경(#f2f2f2) 위에서 caption(#6f6f6f)은 4.48:1 로 WCAG AA(4.5:1) 미달 -
+      // body(neutral_700 #666)로 한 단계 진하게 해 대비 충족(라이트/다크 테마 모두 토큰이 처리).
+      color: token.$color_text_body;
 
       &_text {
         @include token.body_small;

--- a/src/ui/forms/file/style.scss
+++ b/src/ui/forms/file/style.scss
@@ -17,6 +17,10 @@
     top: 0; right: 0; bottom: 0; left: 0;
     opacity: 0;
     cursor: pointer;
+    // 포인터는 label 이 받는다 — 투명 input 이 위를 덮고 있으면 브라우저가 파일 input 기본 툴팁
+    // (선택한 파일명)을 hover 시 띄운다. label 에 htmlFor 가 있어 클릭은 그대로 열리고,
+    // 키보드 포커스·Space 는 pointer-events 와 무관하게 유지된다.
+    pointer-events: none;
   }
 
   &_label {


### PR DESCRIPTION
Closes #413

## 제목
fix/file-input-tooltip

## 작업한 내용
- [x] 파일을 고른 뒤 선택 버튼에 hover 하면 브라우저 기본 툴팁으로 파일명이 노출되던 문제를 고쳤다 (owner 명함 이미지 선택, QA 71). 투명 native input 이 컴포넌트 전체를 덮고 있어 포인터가 라벨이 아니라 input 에 닿고, 커서 아래 파일 input 이 있으면 브라우저가 선택 파일명 툴팁을 띄운다
- [x] 라벨에 이미 `htmlFor` 가 있어 클릭 경로에 오버레이가 필요 없다 — `pointer-events: none` 으로 hover·click 을 라벨에 넘겼다. `pointer-events` 는 키보드 경로와 무관하므로 Tab·Space 로 열기와 focus ring 은 그대로다

```scss
&_control {
  position: absolute;
  inset: 0;
  opacity: 0;
+ pointer-events: none;
}
```

## 검증

빌드된 `dist/index.css` 로 chromium 실측(before 는 같은 스크립트를 develop CSS 로 실행):

```
before  라벨 중앙 hover 대상 = input.file_input_control   ← 툴팁 출처
after   라벨 중앙 hover 대상 = label.file_input_label
        파일 선택 후에도 동일 (input 이 값을 들고 있어도 hover 가 닿지 않음)
공통    라벨 클릭 → filechooser 열림 / input 은 계속 focusable(tabIndex 0)
        preview variant: hover 는 라벨 내용, 클릭 정상
        disabled: 클릭해도 열리지 않음(기존과 동일)
```

게이트: `pnpm lint:css` 통과, `pnpm test` 750 passed / 9 skipped, `pnpm build` 성공, `tsc --noEmit` 통과.

## 전달할 추가 이슈
- 부수 변화: 보조 문구(`file_input_helper`)와 썸네일 영역 클릭으로도 파일 선택 창이 열리던 동작이 사라진다. 오버레이가 덮고 있던 부수 효과였고, 클릭 대상은 라벨(버튼)로 한정되는 편이 맞다고 보고 그대로 두었다.