### PR TITLE
fix/brand-dark-tokens

### DIFF
--- a/src/ui/forms/file/style.scss
+++ b/src/ui/forms/file/style.scss
@@ -39,7 +39,7 @@
 
   &_control:focus-visible + .file_input_label {
     box-shadow: token.$focus_ring;
-    border-color: token.$color_brand_primary;
+    border-color: token.$color_accent_default;
   }
 
   &_helper {

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -72,8 +72,10 @@
   // ── Variant: Filled ──────────────────────────────────────────────────────
 
   &_variant_filled {
-    background: token.$color_brand_primary;
-    color: token.$color_brand_on_primary;
+    // accent 계열: light #121212(brand 와 동일) / dark #FFFFFF - 다크에서 채움이 페이지에 묻히지
+    // 않게 테마 분기 토큰 사용(#415). 라이트 렌더는 brand 와 값이 같아 변화 없음.
+    background: token.$color_accent_default;
+    color: token.$color_accent_on_surface;
 
     &:hover:not(:disabled)::before {
       background: token.$color_state_hover_on_dark;

--- a/src/ui/general/icon-button/style.scss
+++ b/src/ui/general/icon-button/style.scss
@@ -67,8 +67,9 @@
   // ── Variant: Filled ─────────────────────────────────────────────────────
 
   &_variant_filled {
-    background: token.$color_brand_primary;
-    color: token.$color_brand_on_primary;
+    // 다크에서 채움이 페이지에 묻히지 않게 테마 분기 accent 사용(#415, 라이트 값은 brand 와 동일)
+    background: token.$color_accent_default;
+    color: token.$color_accent_on_surface;
 
     &:hover:not(:disabled)::before {
       background: token.$color_state_hover_on_dark;
@@ -84,7 +85,7 @@
 
     &:disabled {
       background: token.$color_bg_disabled;
-      color: token.$color_brand_primary;
+      color: token.$color_accent_default;
       opacity: token.$opacity_38;
     }
   }
@@ -109,7 +110,7 @@
 
     &:disabled {
       background: token.$color_bg_disabled;
-      color: token.$color_brand_primary;
+      color: token.$color_accent_default;
       opacity: token.$opacity_38;
     }
   }
@@ -135,7 +136,7 @@
 
     &:disabled {
       border-color: token.$color_border_default;
-      color: token.$color_brand_primary;
+      color: token.$color_accent_default;
       opacity: token.$opacity_38;
     }
   }

--- a/src/ui/navigation/nav-bar/style.scss
+++ b/src/ui/navigation/nav-bar/style.scss
@@ -239,9 +239,8 @@
   // (accent_default 는 light=검정/dark=흰 반전 토큰이라 navbar 에 부적합)
 
   &_variant_accent {
-    // 다크에서 채움이 페이지에 묻히지 않게 테마 분기 accent 사용(#415, 라이트 값은 brand 와 동일)
-    background: token.$color_accent_default;
-    color: token.$color_accent_on_surface;
+    background: token.$color_brand_primary;
+    color: token.$color_brand_on_primary;
 
     .nav_bar_link {
       color: rgba(255, 255, 255, 0.7);

--- a/src/ui/navigation/nav-bar/style.scss
+++ b/src/ui/navigation/nav-bar/style.scss
@@ -239,8 +239,9 @@
   // (accent_default 는 light=검정/dark=흰 반전 토큰이라 navbar 에 부적합)
 
   &_variant_accent {
-    background: token.$color_brand_primary;
-    color: token.$color_brand_on_primary;
+    // 다크에서 채움이 페이지에 묻히지 않게 테마 분기 accent 사용(#415, 라이트 값은 brand 와 동일)
+    background: token.$color_accent_default;
+    color: token.$color_accent_on_surface;
 
     .nav_bar_link {
       color: rgba(255, 255, 255, 0.7);

--- a/src/ui/navigation/pagination/style.scss
+++ b/src/ui/navigation/pagination/style.scss
@@ -32,7 +32,7 @@
 
     &:focus-visible {
       box-shadow: token.$focus_ring;
-      border-color: token.$color_brand_primary;
+      border-color: token.$color_accent_default;
     }
   }
 

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -118,8 +118,8 @@
 
     // active - 검정 fill + 흰 텍스트 (brand 강조)
     &_active {
-      background: token.$color_brand_primary;
-      color: token.$color_brand_on_primary;
+      background: token.$color_accent_default;
+      color: token.$color_accent_on_surface;
     }
 
     &_icon {
@@ -175,9 +175,9 @@
       transform token.$transition_fast;
 
     &:hover {
-      background: token.$color_brand_primary;
-      color: token.$color_brand_on_primary;
-      border-color: token.$color_brand_primary;
+      background: token.$color_accent_default;
+      color: token.$color_accent_on_surface;
+      border-color: token.$color_accent_default;
       transform: scale(1.05);
     }
 
@@ -311,8 +311,8 @@
         color: token.$color_text_heading;
 
         .sidebar_item_icon {
-          background: token.$color_brand_primary;
-          color: token.$color_brand_on_primary;
+          background: token.$color_accent_default;
+          color: token.$color_accent_on_surface;
           border-radius: token.$radius_full;  // 완전한 pill
           padding: 0 token.$spacing_16;
           width: auto;                        // rail 24px 고정 width override


### PR DESCRIPTION
Closes #415

## 작업 개요

`$color_brand_primary`(#121212 고정, 다크 override 없음)를 **채움/보더/전경**으로 쓰던 컴포넌트들이 다크에서 페이지(#0A0A0A)와 1.06:1 로 묻히던 문제를 수정합니다.

## 수정 방식

surface 로 쓰인 `$color_brand_primary` → **`$color_accent_default`**(테마 분기: light #121212 = brand 와 동일 / **dark #FFFFFF**), 그 위 글자·아이콘은 **`$color_accent_on_surface`**. → **라이트 불변, 다크만 고쳐짐.**

## 변경 파일 (5)

| 파일 | 위치 |
| --- | --- |
| `button/style.scss` | filled 채움+글자 |
| `icon-button/style.scss` | filled 채움+글자, disabled 잉크 3곳 |
| `sidebar/style.scss` | active/hover/icon 채움 3 + 글자 3 + 보더 |
| `pagination/style.scss` | 현재 페이지 포커스 보더 |
| `file/style.scss` | 포커스 보더 |

## 의도적으로 제외 (테마 무관 케이스)

- **`hero/style.scss:53`** (`overlay_light` 제목) — 테마 무관 밝은 스크림.
- **`nav-bar/style.scss` `_variant_accent`** — 테마 무관 다크 마케팅 헤더(자식 링크/인디케이터/버튼이 고정 흰색). 리뷰 지적으로 초기 변경을 되돌림(973fced) — `$color_brand_primary`/`$color_brand_on_primary` 유지.
- `brand_on_primary` 가 다른 bg 위(danger 빨간 채움, media-card/card, toggle thumb 등)는 그대로.

## 검증

- `pnpm build` + `stylelint` 통과
- dist: 다크 `--bt-color-accent-default: #FFFFFF`, filled 버튼이 accent 참조