### PR TITLE
feat/image-cropper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,14 @@ export type { AvatarProps, AvatarShape, AvatarSize } from "./ui/display/avatar";
 export { Avatar } from "./ui/display/avatar";
 export type { BadgeProps, BadgeShape, BadgeSize, BadgeVariant } from "./ui/display/badge";
 export { Badge } from "./ui/display/badge";
-export type { BottomNavItemProps, BottomNavProps } from "./ui/navigation/bottom-nav";
-export { BottomNav, BottomNavItem, BottomNavSpacer } from "./ui/navigation/bottom-nav";
-export type { BreadcrumbItem, BreadcrumbProps } from "./ui/navigation/breadcrumb";
-export { Breadcrumb } from "./ui/navigation/breadcrumb";
 export type { EmptyStateProps } from "./ui/feedback/empty-state";
 export { EmptyState } from "./ui/feedback/empty-state";
 export type { ErrorStateProps, ErrorStateVariant } from "./ui/feedback/error-state";
 export { ErrorState } from "./ui/feedback/error-state";
+export type { BottomNavItemProps, BottomNavProps } from "./ui/navigation/bottom-nav";
+export { BottomNav, BottomNavItem, BottomNavSpacer } from "./ui/navigation/bottom-nav";
+export type { BreadcrumbItem, BreadcrumbProps } from "./ui/navigation/breadcrumb";
+export { Breadcrumb } from "./ui/navigation/breadcrumb";
 export type { MenuItem, MenuProps } from "./ui/navigation/menu";
 export { Menu } from "./ui/navigation/menu";
 export type {
@@ -73,33 +73,16 @@ export { zIndex } from "./styles/z-index";
 
 // Components
 
-export { AlertProvider, useAlert } from "./ui/feedback/alert";
-export type { ButtonProps } from "./ui/general/button";
-export { Button } from "./ui/general/button";
 export type { CardFooterAlign, CardProps, CardVariant } from "./ui/display/card";
 export { Card } from "./ui/display/card";
-export type { CheckboxProps } from "./ui/forms/checkbox";
-export { Checkbox } from "./ui/forms/checkbox";
 export type { ChipProps, ChipSize, ChipTone, ChipType } from "./ui/display/chip";
 export { Chip } from "./ui/display/chip";
-export type { DatePickerProps } from "./ui/forms/date-picker";
-export { DatePicker } from "./ui/forms/date-picker";
 export type { DividerProps } from "./ui/display/divider";
 export { Divider } from "./ui/display/divider";
-export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
-export { Drawer } from "./ui/overlay/drawer";
-export type { DropdownOption, DropdownProps, DropdownSize } from "./ui/forms/dropdown";
-export { Dropdown } from "./ui/forms/dropdown";
-export type { FileInputProps } from "./ui/forms/file";
-export { FileInput } from "./ui/forms/file";
 export type { HeroAction, HeroAlign, HeroHeight, HeroOverlay, HeroProps } from "./ui/display/hero";
 export { Hero } from "./ui/display/hero";
 export type { IconProps, LucideIcon, LucideProps } from "./ui/display/icon";
 export { Icon } from "./ui/display/icon";
-export type { IconButtonProps, IconButtonSize, IconButtonVariant } from "./ui/general/icon-button";
-export { IconButton } from "./ui/general/icon-button";
-export type { LinearProgressProps } from "./ui/feedback/linear-progress";
-export { LinearProgress } from "./ui/feedback/linear-progress";
 export type { ListItemProps } from "./ui/display/list-item";
 export { ListItem } from "./ui/display/list-item";
 export type {
@@ -109,24 +92,6 @@ export type {
 	MediaCardShadow,
 } from "./ui/display/media-card";
 export { MediaCard } from "./ui/display/media-card";
-export type { ModalProps } from "./ui/overlay/modal";
-export { Modal } from "./ui/overlay/modal";
-export type { OtpInputProps } from "./ui/forms/otp-input";
-export { OtpInput } from "./ui/forms/otp-input";
-export type { PaginationProps } from "./ui/navigation/pagination";
-export { Pagination } from "./ui/navigation/pagination";
-export type { RadioProps } from "./ui/forms/radio";
-export { Radio } from "./ui/forms/radio";
-export type {
-	RadioGroupOrientation,
-	RadioGroupProps,
-	RadioGroupSize,
-} from "./ui/forms/radio-group";
-export { RadioGroup } from "./ui/forms/radio-group";
-export type { SkeletonProps, SkeletonVariant } from "./ui/feedback/skeleton";
-export { Skeleton } from "./ui/feedback/skeleton";
-export type { SpinnerProps } from "./ui/feedback/spinner";
-export { Spinner } from "./ui/feedback/spinner";
 export type {
 	TableColumn,
 	TableProps,
@@ -135,30 +100,80 @@ export type {
 	TableSortDirection,
 } from "./ui/display/table";
 export { Table } from "./ui/display/table";
-export type { ResolvedTheme, ThemeMode, ThemeProviderProps } from "./ui/system/theme-provider";
-export { ThemeProvider, useTheme } from "./ui/system/theme-provider";
-export type { ImeStrategy, TextFieldProps, TextFieldSize } from "./ui/forms/textfield";
-export { TextField } from "./ui/forms/textfield";
+export { AlertProvider, useAlert } from "./ui/feedback/alert";
+export type { LinearProgressProps } from "./ui/feedback/linear-progress";
+export { LinearProgress } from "./ui/feedback/linear-progress";
+export type { SkeletonProps, SkeletonVariant } from "./ui/feedback/skeleton";
+export { Skeleton } from "./ui/feedback/skeleton";
+export type { SpinnerProps } from "./ui/feedback/spinner";
+export { Spinner } from "./ui/feedback/spinner";
+export { ToastProvider } from "./ui/feedback/toast";
+export { useToast } from "./ui/feedback/toast/use-toast";
+export type { TopLoadingProps } from "./ui/feedback/top-loading";
+export { TopLoading } from "./ui/feedback/top-loading";
+export type { CheckboxProps } from "./ui/forms/checkbox";
+export { Checkbox } from "./ui/forms/checkbox";
+export type { DatePickerProps } from "./ui/forms/date-picker";
+export { DatePicker } from "./ui/forms/date-picker";
+export type { DropdownOption, DropdownProps, DropdownSize } from "./ui/forms/dropdown";
+export { Dropdown } from "./ui/forms/dropdown";
+export type { FileInputProps } from "./ui/forms/file";
+export { FileInput } from "./ui/forms/file";
+export type {
+	CropImageSize,
+	CropOffset,
+	CropRect,
+	ImageCropperHandle,
+	ImageCropperProps,
+} from "./ui/forms/image-cropper";
+export { ImageCropper } from "./ui/forms/image-cropper";
+export type { OtpInputProps } from "./ui/forms/otp-input";
+export { OtpInput } from "./ui/forms/otp-input";
+export type { RadioProps } from "./ui/forms/radio";
+export { Radio } from "./ui/forms/radio";
+export type {
+	RadioGroupOrientation,
+	RadioGroupProps,
+	RadioGroupSize,
+} from "./ui/forms/radio-group";
+export { RadioGroup } from "./ui/forms/radio-group";
 export type {
 	TextareaProps,
 	TextareaResize,
 	TextareaSize,
 } from "./ui/forms/textarea";
 export { Textarea } from "./ui/forms/textarea";
-export { ToastProvider } from "./ui/feedback/toast";
-export { useToast } from "./ui/feedback/toast/use-toast";
+export type { ImeStrategy, TextFieldProps, TextFieldSize } from "./ui/forms/textfield";
+export { TextField } from "./ui/forms/textfield";
 export type { ToggleProps } from "./ui/forms/toggle";
 export { Toggle } from "./ui/forms/toggle";
-export type { TopLoadingProps } from "./ui/feedback/top-loading";
-export { TopLoading } from "./ui/feedback/top-loading";
+export type { ButtonProps } from "./ui/general/button";
+export { Button } from "./ui/general/button";
+export type { IconButtonProps, IconButtonSize, IconButtonVariant } from "./ui/general/icon-button";
+export { IconButton } from "./ui/general/icon-button";
+export type { PaginationProps } from "./ui/navigation/pagination";
+export { Pagination } from "./ui/navigation/pagination";
+export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
+export { Drawer } from "./ui/overlay/drawer";
+export type { ModalProps } from "./ui/overlay/modal";
+export { Modal } from "./ui/overlay/modal";
+export type { ResolvedTheme, ThemeMode, ThemeProviderProps } from "./ui/system/theme-provider";
+export { ThemeProvider, useTheme } from "./ui/system/theme-provider";
 
 // Layout Primitives (v3.0)
 
 export type { ContainerProps, ContainerSize } from "./ui/layout/container";
 export { Container } from "./ui/layout/container";
-export type { SectionBg, SectionProps, SectionSpacing } from "./ui/layout/section";
-export { Section } from "./ui/layout/section";
-export type { StackAlign, StackDirection, StackGap, StackJustify, StackProps, StackWrap } from "./ui/layout/stack";
-export { Stack } from "./ui/layout/stack";
 export type { GridCols, GridGap, GridProps } from "./ui/layout/grid";
 export { Grid } from "./ui/layout/grid";
+export type { SectionBg, SectionProps, SectionSpacing } from "./ui/layout/section";
+export { Section } from "./ui/layout/section";
+export type {
+	StackAlign,
+	StackDirection,
+	StackGap,
+	StackJustify,
+	StackProps,
+	StackWrap,
+} from "./ui/layout/stack";
+export { Stack } from "./ui/layout/stack";

--- a/src/ui/forms/image-cropper/crop.util.test.ts
+++ b/src/ui/forms/image-cropper/crop.util.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { clampCropOffset, getCoverScale, getCropRect, getOffsetLimits } from "./crop.util";
+
+const square = { width: 400, height: 400 };
+const landscape = { width: 800, height: 400 };
+const portrait = { width: 400, height: 800 };
+const VIEWPORT = 200;
+
+describe("getCoverScale", () => {
+	it("정사각 원본은 짧은 변 기준 배율이 그대로 나온다", () => {
+		expect(getCoverScale(square, VIEWPORT)).toBe(0.5);
+	});
+	it("가로가 긴 원본은 세로(짧은 변)를 채우는 배율을 쓴다", () => {
+		expect(getCoverScale(landscape, VIEWPORT)).toBe(0.5);
+	});
+	it("원본이 뷰포트보다 작으면 1보다 큰 배율로 확대한다", () => {
+		expect(getCoverScale({ width: 100, height: 50 }, VIEWPORT)).toBe(4);
+	});
+});
+
+describe("getOffsetLimits", () => {
+	it("zoom=1 정사각 원본은 두 축 모두 여유가 없다", () => {
+		expect(getOffsetLimits(square, VIEWPORT, 1)).toEqual({ x: 0, y: 0 });
+	});
+	it("가로가 긴 원본은 가로에만 여유가 생긴다", () => {
+		// 800×400 을 0.5배 → 400×200. 가로 여유 (400-200)/2 = 100.
+		expect(getOffsetLimits(landscape, VIEWPORT, 1)).toEqual({ x: 100, y: 0 });
+	});
+	it("세로가 긴 원본은 세로에만 여유가 생긴다", () => {
+		expect(getOffsetLimits(portrait, VIEWPORT, 1)).toEqual({ x: 0, y: 100 });
+	});
+	it("zoom 을 올리면 여유가 커진다", () => {
+		expect(getOffsetLimits(square, VIEWPORT, 2)).toEqual({ x: 100, y: 100 });
+	});
+});
+
+describe("clampCropOffset", () => {
+	it("한계 안의 값은 그대로 둔다", () => {
+		expect(clampCropOffset({ x: 40, y: -40 }, square, VIEWPORT, 2)).toEqual({ x: 40, y: -40 });
+	});
+	it("한계를 넘으면 잘린다", () => {
+		expect(clampCropOffset({ x: 999, y: -999 }, square, VIEWPORT, 2)).toEqual({ x: 100, y: -100 });
+	});
+	it("여유가 없으면 0 으로 고정하고 -0 을 만들지 않는다", () => {
+		const result = clampCropOffset({ x: -5, y: 5 }, square, VIEWPORT, 1);
+		expect(result).toEqual({ x: 0, y: 0 });
+		expect(Object.is(result.x, -0)).toBe(false);
+	});
+});
+
+describe("getCropRect", () => {
+	it("zoom=1 정사각 원본은 원본 전체가 크롭 영역", () => {
+		expect(getCropRect(square, VIEWPORT, 1, { x: 0, y: 0 })).toEqual({ x: 0, y: 0, size: 400 });
+	});
+	it("가로 원본은 중앙 정사각을 자른다", () => {
+		// 800×400 → cover 0.5, size=200/0.5=400, x=(800-400)/2=200
+		expect(getCropRect(landscape, VIEWPORT, 1, { x: 0, y: 0 })).toEqual({
+			x: 200,
+			y: 0,
+			size: 400,
+		});
+	});
+	it("범위를 넘는 offset 을 넘겨도 이미지 바깥이 잘리지 않는다(내부 재제한)", () => {
+		const rect = getCropRect(landscape, VIEWPORT, 1, { x: 99999, y: 0 });
+		expect(rect.x).toBeGreaterThanOrEqual(0);
+		expect(rect.x + rect.size).toBeLessThanOrEqual(landscape.width);
+	});
+});

--- a/src/ui/forms/image-cropper/crop.util.ts
+++ b/src/ui/forms/image-cropper/crop.util.ts
@@ -1,0 +1,97 @@
+/**
+ * 정사각 이미지 크롭의 좌표 계산. 화면 조작(드래그 이동량 + 확대 배율)을 원본 픽셀 기준
+ * 정사각 영역으로 환산하는 순수 함수만 모은다 — canvas / DOM 을 모르므로 그대로 단위 테스트
+ * 할 수 있다.
+ *
+ * 좌표 규약:
+ * - 뷰포트는 한 변이 `viewportSize` 인 정사각형이고, 이미지는 그 중앙을 기준으로 놓인다.
+ * - `offset` 은 이미지 중심이 뷰포트 중심에서 얼마나 밀렸는지(CSS px). 오른쪽/아래가 +.
+ * - 배율은 항상 `cover` 배율 × zoom 이라 zoom=1 이면 이미지가 뷰포트를 정확히 덮는다.
+ */
+
+/** 이미지 중심의 이동량(CSS px) */
+export interface CropOffset {
+	x: number;
+	y: number;
+}
+
+/** 원본 이미지의 natural 크기(px) */
+export interface CropImageSize {
+	width: number;
+	height: number;
+}
+
+/** 원본 픽셀 기준 정사각 크롭 영역 (`canvas.drawImage` 의 source 인자로 그대로 사용) */
+export interface CropRect {
+	x: number;
+	y: number;
+	size: number;
+}
+
+/**
+ * 이미지가 뷰포트를 빈틈없이 덮는 최소 배율(`object-fit: cover` 와 같은 계산).
+ */
+export const getCoverScale = (image: CropImageSize, viewportSize: number): number =>
+	Math.max(viewportSize / image.width, viewportSize / image.height);
+
+/**
+ * 값을 `[-limit, limit]` 로 자른다. limit 이 0 이면 부호 있는 0(`-0`)이 나올 수 있어 0 으로
+ * 정규화한다 — 그대로 두면 `translate(-0px)` 처럼 표기에 새어 나간다.
+ */
+const clampSymmetric = (value: number, limit: number): number => {
+	const clamped = Math.min(limit, Math.max(-limit, value));
+	return clamped === 0 ? 0 : clamped;
+};
+
+/**
+ * 축별로 움직일 수 있는 최대 이동량. 이보다 더 밀면 이미지가 뷰포트를 덮지 못해 가장자리에
+ * 빈 영역이 생긴다.
+ */
+export const getOffsetLimits = (
+	image: CropImageSize,
+	viewportSize: number,
+	zoom: number,
+): CropOffset => {
+	const scale = getCoverScale(image, viewportSize) * zoom;
+	return {
+		x: Math.max(0, (image.width * scale - viewportSize) / 2),
+		y: Math.max(0, (image.height * scale - viewportSize) / 2),
+	};
+};
+
+/**
+ * 이동량을 "이미지가 뷰포트를 계속 덮는" 범위로 제한한다. 제한이 없으면 가장자리를 넘겨 빈
+ * 영역이 그대로 크롭 결과에 들어간다.
+ */
+export const clampCropOffset = (
+	offset: CropOffset,
+	image: CropImageSize,
+	viewportSize: number,
+	zoom: number,
+): CropOffset => {
+	const limits = getOffsetLimits(image, viewportSize, zoom);
+	return {
+		x: clampSymmetric(offset.x, limits.x),
+		y: clampSymmetric(offset.y, limits.y),
+	};
+};
+
+/**
+ * 화면 조작 결과를 원본 픽셀 기준 크롭 영역으로 환산한다. 이동량은 항상 내부에서 다시
+ * 제한하므로, 호출부가 범위를 벗어난 값을 넘겨도 이미지 바깥이 잘리지 않는다.
+ */
+export const getCropRect = (
+	image: CropImageSize,
+	viewportSize: number,
+	zoom: number,
+	offset: CropOffset,
+): CropRect => {
+	const scale = getCoverScale(image, viewportSize) * zoom;
+	const size = viewportSize / scale;
+	const clamped = clampCropOffset(offset, image, viewportSize, zoom);
+	return {
+		x: (image.width - size) / 2 - clamped.x / scale,
+		y: (image.height - size) / 2 - clamped.y / scale,
+		size,
+	};
+};

--- a/src/ui/forms/image-cropper/image-cropper.stories.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useRef, useState } from "react";
+import { Button } from "../../general/button";
+import { ImageCropper, type ImageCropperHandle } from "./index";
+
+// 데모용 샘플 이미지 (외부 네트워크 없이 렌더되도록 인라인 SVG data URL - 가로가 긴 그라디언트).
+const SAMPLE =
+	"data:image/svg+xml;utf8," +
+	encodeURIComponent(
+		`<svg xmlns="http://www.w3.org/2000/svg" width="640" height="400">
+      <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#7AA5D2"/><stop offset="1" stop-color="#47555E"/>
+      </linearGradient></defs>
+      <rect width="640" height="400" fill="url(#g)"/>
+      <circle cx="200" cy="150" r="90" fill="#fff" opacity="0.85"/>
+      <text x="320" y="360" fill="#fff" font-size="28" text-anchor="middle">640 × 400</text>
+    </svg>`,
+	);
+
+const meta = {
+	title: "Components/Forms/ImageCropper",
+	component: ImageCropper,
+	parameters: {
+		layout: "centered",
+		docs: {
+			description: {
+				component:
+					"업로드 전에 이미지에서 보일 정사각 영역을 정하는 크로퍼. 드래그/방향키로 위치, 휠·슬라이더·＋/－ 로 배율을 맞추고, 소비자가 `ref.crop()` 으로 Blob 을 받아 `Modal` 등으로 감싼다. / An image cropper: drag or arrow keys to reposition, wheel/slider/±to zoom; the consumer calls `ref.crop()` for a Blob and wraps it in a Modal.",
+			},
+		},
+	},
+	tags: ["autodocs"],
+} satisfies Meta<typeof ImageCropper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Square: Story = {
+	args: { src: SAMPLE },
+};
+
+export const Circular: Story = {
+	args: { src: SAMPLE, circular: true },
+	parameters: {
+		docs: { description: { story: "아바타용 원형 가이드. / Circular guide for avatars." } },
+	},
+};
+
+export const WithApply: Story = {
+	args: { src: SAMPLE, circular: true },
+	render: (args) => {
+		const ref = useRef<ImageCropperHandle>(null);
+		const [result, setResult] = useState<string | null>(null);
+		return (
+			<div style={{ display: "flex", flexDirection: "column", gap: 16, alignItems: "center" }}>
+				<ImageCropper {...args} ref={ref} />
+				<div style={{ display: "flex", gap: 8 }}>
+					<Button variant="outline" onClick={() => ref.current?.reset()}>
+						초기화
+					</Button>
+					<Button
+						onClick={async () => {
+							const blob = await ref.current?.crop();
+							if (blob) setResult(URL.createObjectURL(blob));
+						}}
+					>
+						적용
+					</Button>
+				</div>
+				{result && (
+					// biome-ignore lint/performance/noImgElement: 데모 결과 미리보기
+					<img
+						src={result}
+						alt="크롭 결과"
+						width={96}
+						height={96}
+						style={{ borderRadius: "50%" }}
+					/>
+				)}
+			</div>
+		);
+	},
+};

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import {
+	type CSSProperties,
+	forwardRef,
+	type KeyboardEvent,
+	type PointerEvent,
+	type SyntheticEvent,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+	useState,
+	type WheelEvent,
+} from "react";
+import { cn } from "../../../utils";
+import {
+	type CropImageSize,
+	type CropOffset,
+	clampCropOffset,
+	getCoverScale,
+	getCropRect,
+	getOffsetLimits,
+} from "./crop.util";
+import "./style.scss";
+
+export type { CropImageSize, CropOffset, CropRect } from "./crop.util";
+
+/** 크롭 배율 슬라이더 눈금 — 연속값이라 화면상 부드럽게 움직이게 둔다. */
+const ZOOM_STEP = 0.01;
+/** 키보드 방향키 한 번의 위치 이동량(px). */
+const PAN_STEP = 8;
+/** 키보드 `+`/`-` 한 번의 배율 변화량. */
+const ZOOM_KEY_STEP = 0.1;
+/** 마우스 휠 한 번의 배율 변화 계수. */
+const WHEEL_ZOOM_FACTOR = 0.0015;
+
+export interface ImageCropperHandle {
+	/** 현재 보이는 정사각 영역을 잘라 Blob 으로 돌려준다. 소비자의 "적용" 버튼에서 호출. */
+	crop: () => Promise<Blob>;
+	/** 배율·위치를 초기 상태(전체가 보이는 zoom=min, 중앙)로 되돌린다. */
+	reset: () => void;
+}
+
+export interface ImageCropperProps {
+	/** 크롭할 이미지. `File`/`Blob`(로컬) 또는 이미지 URL 문자열. */
+	src: File | Blob | string;
+	/** 결과물 한 변 길이(px). 기본 512. */
+	outputSize?: number;
+	/** 결과 MIME. `"auto"`(기본)는 PNG 는 PNG 로, 나머지는 JPEG 로 통일. */
+	outputType?: "auto" | "image/jpeg" | "image/png" | "image/webp";
+	/** JPEG/WebP 인코딩 품질(0~1). 기본 0.92. */
+	quality?: number;
+	/** 원형 가이드(아바타용). 기본 false(둥근 사각형 가이드). */
+	circular?: boolean;
+	/** 뷰포트 한 변 길이(px). 기본 240. */
+	viewportSize?: number;
+	/** 최소 배율. 기본 1(이미지가 뷰포트를 딱 덮음). */
+	minZoom?: number;
+	/** 최대 배율. 기본 3. */
+	maxZoom?: number;
+	/** 이미지 로드 완료 시. */
+	onReady?: (size: CropImageSize) => void;
+	/** 이미지 디코딩 실패 시(손상 파일 등). */
+	onError?: () => void;
+	className?: string;
+	/** 뷰포트 접근성 레이블. 기본 "이미지 위치와 배율 조정". */
+	label?: string;
+}
+
+const resolveOutputType = (
+	srcType: string,
+	outputType: NonNullable<ImageCropperProps["outputType"]>,
+): string => {
+	if (outputType !== "auto") return outputType;
+	return srcType === "image/png" ? "image/png" : "image/jpeg";
+};
+
+/**
+ * 업로드 전에 이미지에서 보일 정사각 영역을 정하는 크로퍼. 뷰포트 안에서 **드래그(또는 방향키)**
+ * 로 위치를, **휠·슬라이더·＋/－ 버튼(또는 `+`/`-` 키)** 으로 배율을 맞춘다. 모달은 포함하지
+ * 않으므로 소비자가 `Modal` 등으로 감싸고, 적용 버튼에서 `ref.crop()` 을 호출해 Blob 을 받는다.
+ *
+ * ```tsx
+ * const cropperRef = useRef<ImageCropperHandle>(null);
+ * <ImageCropper ref={cropperRef} src={file} circular />
+ * // 적용:
+ * const blob = await cropperRef.current!.crop();
+ * ```
+ *
+ * 원격 URL 을 넘기면 `canvas.drawImage` 가 서버의 CORS(`Access-Control-Allow-Origin`)에
+ * 의존한다 — 확실히 자르려면 로컬 `File`/`Blob` 을 권장한다.
+ */
+export const ImageCropper = forwardRef<ImageCropperHandle, ImageCropperProps>(function ImageCropper(
+	{
+		src,
+		outputSize = 512,
+		outputType = "auto",
+		quality = 0.92,
+		circular = false,
+		viewportSize = 240,
+		minZoom = 1,
+		maxZoom = 3,
+		onReady,
+		onError,
+		className,
+		label = "이미지 위치와 배율 조정",
+	},
+	ref,
+) {
+	const imageRef = useRef<HTMLImageElement>(null);
+	// pointerdown 시점의 좌표/이동량을 담아 두고 move 에서 차이만 더한다.
+	const dragRef = useRef<{ pointerId: number; x: number; y: number; offset: CropOffset } | null>(
+		null,
+	);
+
+	// File/Blob 은 objectURL 로, 문자열은 그대로. objectURL 은 언마운트 시 해제한다.
+	const [previewUrl, setPreviewUrl] = useState<string>("");
+	const [srcType, setSrcType] = useState<string>("");
+	useEffect(() => {
+		if (typeof src === "string") {
+			setPreviewUrl(src);
+			setSrcType("");
+			return;
+		}
+		const url = URL.createObjectURL(src);
+		setPreviewUrl(url);
+		setSrcType(src.type);
+		return () => URL.revokeObjectURL(url);
+	}, [src]);
+
+	const [imageSize, setImageSize] = useState<CropImageSize | null>(null);
+	const [zoom, setZoom] = useState(minZoom);
+	const [offset, setOffset] = useState<CropOffset>({ x: 0, y: 0 });
+	const [dragging, setDragging] = useState(false);
+
+	// src 가 바뀌면 조작 상태를 리셋한다.
+	useEffect(() => {
+		setImageSize(null);
+		setZoom(minZoom);
+		setOffset({ x: 0, y: 0 });
+	}, [minZoom]);
+
+	const handleImageLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+		const size = {
+			width: event.currentTarget.naturalWidth,
+			height: event.currentTarget.naturalHeight,
+		};
+		setImageSize(size);
+		onReady?.(size);
+	};
+
+	const applyZoom = useCallback(
+		(next: number) => {
+			const clampedZoom = Math.min(maxZoom, Math.max(minZoom, next));
+			setZoom(clampedZoom);
+			if (imageSize) {
+				setOffset((prev) => clampCropOffset(prev, imageSize, viewportSize, clampedZoom));
+			}
+		},
+		[imageSize, maxZoom, minZoom, viewportSize],
+	);
+
+	const panBy = useCallback(
+		(dx: number, dy: number) => {
+			if (!imageSize) return;
+			setOffset((prev) =>
+				clampCropOffset({ x: prev.x + dx, y: prev.y + dy }, imageSize, viewportSize, zoom),
+			);
+		},
+		[imageSize, viewportSize, zoom],
+	);
+
+	const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+		if (!imageSize) return;
+		event.currentTarget.setPointerCapture(event.pointerId);
+		dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY, offset };
+		setDragging(true);
+	};
+
+	const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+		const drag = dragRef.current;
+		if (!drag || !imageSize || drag.pointerId !== event.pointerId) return;
+		const moved = {
+			x: drag.offset.x + (event.clientX - drag.x),
+			y: drag.offset.y + (event.clientY - drag.y),
+		};
+		setOffset(clampCropOffset(moved, imageSize, viewportSize, zoom));
+	};
+
+	// pointer capture 는 pointerup/cancel 에서 브라우저가 자동 해제하므로 추적만 끊는다.
+	const handlePointerEnd = (event: PointerEvent<HTMLDivElement>) => {
+		if (dragRef.current?.pointerId === event.pointerId) {
+			dragRef.current = null;
+			setDragging(false);
+		}
+	};
+
+	const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+		if (!imageSize) return;
+		event.preventDefault();
+		applyZoom(zoom - event.deltaY * WHEEL_ZOOM_FACTOR * zoom);
+	};
+
+	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (!imageSize) return;
+		switch (event.key) {
+			case "ArrowLeft":
+				panBy(-PAN_STEP, 0);
+				break;
+			case "ArrowRight":
+				panBy(PAN_STEP, 0);
+				break;
+			case "ArrowUp":
+				panBy(0, -PAN_STEP);
+				break;
+			case "ArrowDown":
+				panBy(0, PAN_STEP);
+				break;
+			case "+":
+			case "=":
+				applyZoom(zoom + ZOOM_KEY_STEP);
+				break;
+			case "-":
+			case "_":
+				applyZoom(zoom - ZOOM_KEY_STEP);
+				break;
+			default:
+				return;
+		}
+		event.preventDefault();
+	};
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			reset: () => {
+				setZoom(minZoom);
+				setOffset({ x: 0, y: 0 });
+			},
+			crop: () =>
+				new Promise<Blob>((resolve, reject) => {
+					const image = imageRef.current;
+					if (!image || !imageSize) {
+						reject(new Error("ImageCropper: image not loaded"));
+						return;
+					}
+					const rect = getCropRect(imageSize, viewportSize, zoom, offset);
+					const canvas = document.createElement("canvas");
+					canvas.width = outputSize;
+					canvas.height = outputSize;
+					const context = canvas.getContext("2d");
+					if (!context) {
+						reject(new Error("ImageCropper: 2d context unavailable"));
+						return;
+					}
+					context.drawImage(
+						image,
+						rect.x,
+						rect.y,
+						rect.size,
+						rect.size,
+						0,
+						0,
+						outputSize,
+						outputSize,
+					);
+					const type = resolveOutputType(srcType, outputType);
+					canvas.toBlob(
+						(blob) =>
+							blob ? resolve(blob) : reject(new Error("ImageCropper: toBlob returned null")),
+						type,
+						quality,
+					);
+				}),
+		}),
+		[imageSize, offset, outputSize, outputType, quality, srcType, viewportSize, zoom, minZoom],
+	);
+
+	const scale = imageSize ? getCoverScale(imageSize, viewportSize) * zoom : 1;
+	const limits = imageSize ? getOffsetLimits(imageSize, viewportSize, zoom) : { x: 0, y: 0 };
+	const canPan = limits.x > 0 || limits.y > 0;
+
+	const viewportStyle: CSSProperties = { width: viewportSize, height: viewportSize };
+	const imageStyle: CSSProperties = imageSize
+		? {
+				width: imageSize.width * scale,
+				height: imageSize.height * scale,
+				transform: `translate(calc(-50% + ${offset.x}px), calc(-50% + ${offset.y}px))`,
+			}
+		: { visibility: "hidden" };
+
+	return (
+		<div className={cn("image_cropper", className)}>
+			{/* biome-ignore lint/a11y/useSemanticElements: 드래그+방향키 조작 표면이라 role=group + 안내 텍스트로 처리 */}
+			<div
+				className={cn("image_cropper_viewport", dragging && "image_cropper_viewport_dragging")}
+				style={viewportStyle}
+				role="group"
+				aria-label={label}
+				aria-describedby="image_cropper_hint"
+				tabIndex={imageSize ? 0 : -1}
+				onPointerDown={handlePointerDown}
+				onPointerMove={handlePointerMove}
+				onPointerUp={handlePointerEnd}
+				onPointerCancel={handlePointerEnd}
+				onWheel={handleWheel}
+				onKeyDown={handleKeyDown}
+			>
+				{/* biome-ignore lint/performance/noImgElement: DS is framework-agnostic - local blob preview needs natural size + canvas access, next/image doesn't apply */}
+				<img
+					ref={imageRef}
+					src={previewUrl || undefined}
+					alt=""
+					className="image_cropper_image"
+					draggable={false}
+					crossOrigin={typeof src === "string" ? "anonymous" : undefined}
+					onLoad={handleImageLoad}
+					onError={onError}
+					style={imageStyle}
+				/>
+				<div
+					className={cn(
+						"image_cropper_mask",
+						circular && "image_cropper_mask_circular",
+						dragging && "image_cropper_mask_active",
+					)}
+					aria-hidden="true"
+				/>
+			</div>
+
+			<p id="image_cropper_hint" className="image_cropper_hint">
+				드래그(또는 방향키)로 위치, 휠·슬라이더로 배율을 맞추세요.
+			</p>
+
+			<div className="image_cropper_zoom">
+				<button
+					type="button"
+					className="image_cropper_zoom_button"
+					aria-label="축소"
+					disabled={!imageSize || zoom <= minZoom}
+					onClick={() => applyZoom(zoom - ZOOM_KEY_STEP)}
+				>
+					−
+				</button>
+				<input
+					type="range"
+					className="image_cropper_zoom_slider"
+					aria-label="배율"
+					min={minZoom}
+					max={maxZoom}
+					step={ZOOM_STEP}
+					value={zoom}
+					disabled={!imageSize}
+					onChange={(event) => applyZoom(Number(event.target.value))}
+				/>
+				<button
+					type="button"
+					className="image_cropper_zoom_button"
+					aria-label="확대"
+					disabled={!imageSize || zoom >= maxZoom}
+					onClick={() => applyZoom(zoom + ZOOM_KEY_STEP)}
+				>
+					＋
+				</button>
+			</div>
+			{/* 위치 슬라이더가 없어도 미세 조정이 가능하도록 상태만 노출(스크린리더에 여유 안내) */}
+			<span className="image_cropper_sr_only" aria-live="polite">
+				{imageSize && !canPan ? "이미지가 뷰포트를 딱 채워 이동 여유가 없습니다." : ""}
+			</span>
+		</div>
+	);
+});

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -2,9 +2,9 @@
 
 import {
 	type CSSProperties,
-	forwardRef,
 	type KeyboardEvent,
 	type PointerEvent,
+	type Ref,
 	type SyntheticEvent,
 	useCallback,
 	useEffect,
@@ -43,6 +43,8 @@ export interface ImageCropperHandle {
 }
 
 export interface ImageCropperProps {
+	/** 크롭/리셋을 호출할 imperative 핸들 (React 19 ref-as-prop). */
+	ref?: Ref<ImageCropperHandle>;
 	/** 크롭할 이미지. `File`/`Blob`(로컬) 또는 이미지 URL 문자열. */
 	src: File | Blob | string;
 	/** 결과물 한 변 길이(px). 기본 512. */
@@ -91,23 +93,21 @@ const resolveOutputType = (
  * 원격 URL 을 넘기면 `canvas.drawImage` 가 서버의 CORS(`Access-Control-Allow-Origin`)에
  * 의존한다 — 확실히 자르려면 로컬 `File`/`Blob` 을 권장한다.
  */
-export const ImageCropper = forwardRef<ImageCropperHandle, ImageCropperProps>(function ImageCropper(
-	{
-		src,
-		outputSize = 512,
-		outputType = "auto",
-		quality = 0.92,
-		circular = false,
-		viewportSize = 240,
-		minZoom = 1,
-		maxZoom = 3,
-		onReady,
-		onError,
-		className,
-		label = "이미지 위치와 배율 조정",
-	},
+export function ImageCropper({
 	ref,
-) {
+	src,
+	outputSize = 512,
+	outputType = "auto",
+	quality = 0.92,
+	circular = false,
+	viewportSize = 240,
+	minZoom = 1,
+	maxZoom = 3,
+	onReady,
+	onError,
+	className,
+	label = "이미지 위치와 배율 조정",
+}: ImageCropperProps) {
 	const imageRef = useRef<HTMLImageElement>(null);
 	// pointerdown 시점의 좌표/이동량을 담아 두고 move 에서 차이만 더한다.
 	const dragRef = useRef<{ pointerId: number; x: number; y: number; offset: CropOffset } | null>(
@@ -134,12 +134,15 @@ export const ImageCropper = forwardRef<ImageCropperHandle, ImageCropperProps>(fu
 	const [offset, setOffset] = useState<CropOffset>({ x: 0, y: 0 });
 	const [dragging, setDragging] = useState(false);
 
-	// src 가 바뀌면 조작 상태를 리셋한다.
+	// src(또는 minZoom)가 바뀌면 조작 상태를 리셋한다. imageSize=null 로 되돌리면 새 이미지의
+	// onLoad 에서 다시 기록된다.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: src 는 body 에서 읽지 않지만 새
+	// 이미지로 교체 시 리셋을 걸기 위한 의도적 트리거 의존성이다.
 	useEffect(() => {
 		setImageSize(null);
 		setZoom(minZoom);
 		setOffset({ x: 0, y: 0 });
-	}, [minZoom]);
+	}, [src, minZoom]);
 
 	const handleImageLoad = (event: SyntheticEvent<HTMLImageElement>) => {
 		const size = {
@@ -370,4 +373,4 @@ export const ImageCropper = forwardRef<ImageCropperHandle, ImageCropperProps>(fu
 			</span>
 		</div>
 	);
-});
+}

--- a/src/ui/forms/image-cropper/style.scss
+++ b/src/ui/forms/image-cropper/style.scss
@@ -153,7 +153,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.image_cropper_mask::before {
+	.image_cropper_mask::before,
+	.image_cropper_zoom_button {
 		transition: none;
 	}
 }

--- a/src/ui/forms/image-cropper/style.scss
+++ b/src/ui/forms/image-cropper/style.scss
@@ -1,0 +1,159 @@
+@use "src/styles/token" as token;
+
+.image_cropper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: token.$spacing_16;
+
+	// ── 뷰포트 (드래그 표면 = 크롭 영역) ──────────────────────────────────
+	&_viewport {
+		position: relative;
+		overflow: hidden;
+		border-radius: token.$radius_lg;
+		background-color: token.$color_bg_inverse_surface;
+		cursor: grab;
+		touch-action: none; // 브라우저 팬/줌 제스처가 드래그를 가로채지 않게
+		user-select: none;
+
+		&_dragging {
+			cursor: grabbing;
+		}
+
+		&:focus-visible {
+			outline: token.$border_width_thick solid token.$color_border_focus;
+			outline-offset: token.$spacing_2;
+		}
+	}
+
+	&_image {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		max-width: none;
+		user-select: none;
+		-webkit-user-drag: none;
+		// transform 은 이동량이 실시간으로 바뀌므로 컴포넌트가 inline 으로 지정한다.
+	}
+
+	// ── 마스크 (크롭 경계 안내) ──────────────────────────────────────────
+	// 아래 깔리는 건 사용자 이미지라 테마별 표면색이 아니라 고정 알파(base) 토큰을 쓴다 -
+	// 라이트/다크 어느 쪽에서도 같은 대비로 보여야 한다.
+	&_mask {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		border-radius: token.$radius_lg;
+		// 사각(기본): 안쪽 테두리만. 전체 뷰포트가 크롭이라 바깥을 어둡게 하지 않는다.
+		box-shadow: inset 0 0 0 token.$border_width_standard token.$color_base_alpha_white_38;
+
+		// 격자(3분할) - 조작 중에만 살짝 보여 구도 잡기 도움
+		&::before {
+			content: "";
+			position: absolute;
+			inset: 0;
+			background-image:
+				linear-gradient(to right, token.$color_base_alpha_white_38 token.$border_width_standard, transparent token.$border_width_standard),
+				linear-gradient(to bottom, token.$color_base_alpha_white_38 token.$border_width_standard, transparent token.$border_width_standard);
+			background-size: 33.333% 33.333%;
+			background-position: 33.333% 33.333%;
+			background-repeat: no-repeat;
+			opacity: 0;
+			transition: opacity token.$transition_base;
+		}
+
+		// 원형(아바타): 원 바깥 코너를 큰 spread box-shadow 로 덮는다
+		&_circular {
+			border-radius: token.$radius_full;
+			box-shadow:
+				0 0 0 token.$radius_full token.$color_base_alpha_black_50,
+				inset 0 0 0 token.$border_width_standard token.$color_base_alpha_white_38;
+
+			&::before {
+				border-radius: token.$radius_full;
+			}
+		}
+
+		&_active::before {
+			opacity: 1;
+		}
+	}
+
+	// ── 안내 문구 ────────────────────────────────────────────────────────
+	&_hint {
+		margin: 0;
+		font-size: token.$font_size_12;
+		line-height: token.$line_height_16;
+		color: token.$color_text_caption;
+		text-align: center;
+	}
+
+	// ── 배율 조작 (− 슬라이더 +) ─────────────────────────────────────────
+	&_zoom {
+		display: flex;
+		align-items: center;
+		gap: token.$spacing_12;
+		width: 100%;
+	}
+
+	&_zoom_button {
+		flex-shrink: 0;
+		width: token.$spacing_32;
+		height: token.$spacing_32;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: token.$border_width_standard solid token.$color_border_default;
+		border-radius: token.$radius_full;
+		background: token.$color_bg_solid;
+		color: token.$color_text_heading;
+		font-size: token.$font_size_18;
+		line-height: 1;
+		cursor: pointer;
+		transition: background token.$transition_fast, border-color token.$transition_fast;
+
+		&:hover:not(:disabled) {
+			background: token.$color_state_hover_on_light;
+		}
+
+		&:focus-visible {
+			outline: none;
+			box-shadow: token.$focus_ring;
+		}
+
+		&:disabled {
+			cursor: not-allowed;
+			opacity: token.$opacity_38;
+		}
+	}
+
+	&_zoom_slider {
+		flex: 1;
+		min-width: 0;
+		accent-color: token.$color_accent_default;
+		cursor: pointer;
+
+		&:disabled {
+			cursor: not-allowed;
+			opacity: token.$opacity_38;
+		}
+	}
+
+	&_sr_only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.image_cropper_mask::before {
+		transition: none;
+	}
+}


### PR DESCRIPTION
Closes #416

## 작업 개요

notiiv owner 프로필 이미지 크로퍼를 DS 재사용 컴포넌트로 승격했습니다. **일반 사용자가 쓰기 쉽게 UX 를 개선**했습니다.

## API (기본값 확정대로)

정사각 크롭 · `<ImageCropper>` 순수 크롭 영역(모달 미포함, 소비자가 `Modal` 로 감쌈) · `ref.crop()` 으로 Blob 반환.

```tsx
const ref = useRef<ImageCropperHandle>(null);
<ImageCropper ref={ref} src={file} circular />
// 적용 버튼:
const blob = await ref.current!.crop();
```

주요 prop: `src`(File/Blob/URL) · `circular` · `outputSize`(512) · `outputType`("auto") · `quality`(0.92) · `viewportSize`(240) · `minZoom`/`maxZoom` · `onReady`/`onError`.

## UX 개선 (기존 notiiv 대비)

기존은 **슬라이더 3개**(확대·가로위치·세로위치)라 일반 사용자에게 낯설고 위치 슬라이더가 드래그와 중복이었습니다.

- ❌ 가로/세로 위치 슬라이더 제거 → ✅ **직접 드래그**(포인터+터치)로 위치
- ✅ 배율: **휠 + 슬라이더 + −/＋ 버튼** (원하는 방식으로)
- ✅ 조작 중 **3분할 격자** 오버레이로 구도 잡기 도움
- ✅ `circular` 로 아바타용 **원형 가이드**
- ✅ 키보드 경로 유지: 뷰포트 포커스 → **방향키 이동 / `+`·`-` 배율**, `aria-label`+안내문, reduced-motion 가드

## 구성

| 파일 | 역할 |
|---|---|
| `crop.util.ts` | 순수 좌표 계산(canvas/DOM 무관) |
| `crop.util.test.ts` | 유닛 테스트 13개 |
| `index.tsx` | forwardRef 컴포넌트 + `ImageCropperHandle` |
| `style.scss` | global SCSS + 토큰(하드코딩 0) |
| `image-cropper.stories.tsx` | Square / Circular / WithApply |

## 검증

- `pnpm test` **763 pass**(신규 util 13 포함) · `tsc --noEmit` OK · `biome` 0 · `stylelint` OK · `pnpm build` OK
- a11y 스토리북은 CI 에서 확정

## 참고
- 원격 URL 은 `canvas.drawImage` 가 CORS 의존 → 확실히 자르려면 로컬 `File`/`Blob` 권장(문서화됨)
- notiiv 는 이후 이 컴포넌트로 교체 가능(현재 위젯 삭제 → DS `ImageCropper` + 소비 앱 Modal)