### PR TITLE
fix/placeholder-dark-contrast

### DIFF
--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -135,7 +135,7 @@
     white-space: nowrap;
     text-align: start;
     @include token.body_small;
-    color: token.$color_text_body; // #666 (Figma: text/body)
+    color: token.$color_text_caption; // caption - 다크에서 선택값과 구분(#420, 라이트는 body 와 유사)
   }
 
   // ── Trailing icon ─────────────────────────────────────────────────────────────
@@ -223,7 +223,7 @@
     transition: box-shadow token.$transition_fast;
 
     &::placeholder {
-      color: token.$color_text_body;
+      color: token.$color_text_caption; // #420 - placeholder 통일(다크 구분)
     }
 
     &:focus-visible {

--- a/src/ui/forms/textarea/style.scss
+++ b/src/ui/forms/textarea/style.scss
@@ -68,7 +68,7 @@
     resize: vertical;
 
     &::placeholder {
-      color: token.$color_text_body;
+      color: token.$color_text_caption; // #420 - placeholder 통일(다크에서 입력값과 구분)
     }
 
     &:disabled {

--- a/src/ui/forms/textfield/style.scss
+++ b/src/ui/forms/textfield/style.scss
@@ -115,7 +115,9 @@
     color: token.$color_text_heading;
 
     &::placeholder {
-      color: token.$color_text_body; // Dropdown placeholder와 동일 (#666 - 더 진함)
+      // caption: 라이트는 body 와 거의 동일(#666→#6F6F6F)이나 다크에서 body(#B3B3B3)와 달리
+      // #808080 로 입력값(text-heading 95% 흰색)과 확실히 구분된다(#420). AA 5:1 충족.
+      color: token.$color_text_caption;
     }
 
     &:disabled {


### PR DESCRIPTION
Closes #420

## 작업 개요

입력 컴포넌트 플레이스홀더가 `$color_text_body` 를 써서, 다크에서 `#B3B3B3`(9.44:1)로 **입력값(text-heading 95% 흰색)과 밝기가 거의 같아** 플레이스홀더가 실제 입력처럼 보이던 문제를 수정합니다(다크 기본 앱 support/status 리포트).

## 수정

placeholder 색 `$color_text_body` → **`$color_text_caption`**
- 라이트: `#666 → #6F6F6F` (사실상 동일)
- 다크: `#B3B3B3 → #808080` (입력값과 확실히 구분, AA 5:1 충족)

## 변경 (한 폼 안 통일)

| 컴포넌트 | 위치 |
| --- | --- |
| `TextField` | `&::placeholder` |
| `Dropdown` | 선택 placeholder(`&_placeholder`) + 검색 input(`&::placeholder`) |
| `Textarea` | `&::placeholder` |

- `OtpInput` 은 텍스트 placeholder 없음 → 대상 아님
- placeholder 가 아닌 `text_body` 사용처(옵션/값/헬퍼 텍스트)는 그대로

## 검증
- `pnpm build` + `stylelint` 통과
- 다크 대비 CI a11y 로 확정