### PR TITLE
fix/file-input-label-cursor

### DIFF
--- a/src/ui/forms/file/style.scss
+++ b/src/ui/forms/file/style.scss
@@ -9,7 +9,6 @@
 
   &:hover .file_input_label {
     border-color: token.$color_border_hover;
-    cursor: pointer;
   }
 
   &_control {
@@ -24,6 +23,9 @@
   }
 
   &_label {
+    // <label> 은 부모 cursor 를 상속하지 않아(브라우저 기본 default) 직접 지정해야 라벨 위에서
+    // 포인터가 뜬다. 예전엔 &:hover 규칙으로만 걸어 hover 밖/특정 상태에서 default 로 샜다.
+    cursor: pointer;
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_md;
     background: token.$color_bg_solid;

--- a/src/ui/forms/file/style.scss
+++ b/src/ui/forms/file/style.scss
@@ -23,8 +23,9 @@
   }
 
   &_label {
-    // <label> 은 부모 cursor 를 상속하지 않아(브라우저 기본 default) 직접 지정해야 라벨 위에서
-    // 포인터가 뜬다. 예전엔 &:hover 규칙으로만 걸어 hover 밖/특정 상태에서 default 로 샜다.
+    // cursor 는 상속 속성이지만 브라우저 UA 스타일이 <label> 에 자체 cursor(default)를 지정해
+    // 부모의 pointer 를 덮는다. 라벨 위에서 포인터를 보장하려면 직접 선언해야 한다 - 예전엔
+    // &:hover 규칙으로만 걸어 hover 밖/특정 상태에서 default 로 샜다.
     cursor: pointer;
     border: token.$border_width_standard solid token.$color_border_default;
     border-radius: token.$radius_md;


### PR DESCRIPTION
## 작업 개요

FileInput 라벨(button variant)을 호버하면 커서가 포인터가 아니라 **기본 화살표**로 뜨던 문제를 수정합니다.

## 원인 (브라우저 실측)

`<label>` 은 부모의 `cursor` 를 **상속하지 않습니다**(브라우저 기본 `default`). `<span>` 은 상속하는 것과 대조 — chromium 확인:

```
부모 cursor:pointer 아래 bare <label> → default
                    bare <span>  → pointer
```

`.file_input_label` base 엔 cursor 선언이 없어, 포인터가 **오직 `.file_input:hover .file_input_label` 규칙**으로만 걸렸습니다. 그 규칙이 적용되지 않는 상태(또는 그 규칙이 없는 버전)에선 기본 화살표가 그대로 노출됩니다.

## 수정

- `.file_input_label` base 에 `cursor: pointer` 직접 지정 (상속 안 되니 명시)
- 이제 중복이 된 `:hover` 규칙의 `cursor: pointer` 제거 (border-color hover 는 유지)

## 검증 (chromium, dist 빌드 로드)

| 상태 | before | after |
| --- | --- | --- |
| 라벨 non-hover | `default` | **`pointer`** |
| 라벨 hover | pointer | pointer |
| preview variant | pointer | pointer |
| disabled | not-allowed | not-allowed (유지) |

`stylelint` 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 파일 선택 컨트롤의 클릭 동작과 커서 표시를 개선했습니다.
  * 파일 입력 라벨을 클릭 가능한 요소로 명확히 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->