### PR TITLE
fix/image-cropper-wheel

### DIFF
--- a/src/ui/forms/image-cropper/ImageCropper.test.tsx
+++ b/src/ui/forms/image-cropper/ImageCropper.test.tsx
@@ -54,3 +54,42 @@ describe("ImageCropper wheel zoom", () => {
 		expect(wheelOverViewport()).toBe(true);
 	});
 });
+
+describe("ImageCropper labels", () => {
+	it("기본 문구는 한국어다", () => {
+		render(<ImageCropper src={file()} />);
+
+		expect(screen.getByRole("group", { name: "이미지 위치와 배율 조정" })).toBeInTheDocument();
+		expect(screen.getByLabelText("확대")).toBeInTheDocument();
+	});
+
+	it("모든 문구를 소비자 로케일로 갈아 끼울 수 있다", () => {
+		// 다국어 앱에서 한국어가 그대로 낭독되던 자리들 — 전부 prop 으로 열려 있어야 한다.
+		render(
+			<ImageCropper
+				src={file()}
+				label="Adjust image position and zoom"
+				hint="Drag to move, scroll to zoom."
+				zoomOutLabel="Zoom out"
+				zoomLabel="Zoom"
+				zoomInLabel="Zoom in"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("group", { name: "Adjust image position and zoom" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("Drag to move, scroll to zoom.")).toBeInTheDocument();
+		expect(screen.getByLabelText("Zoom out")).toBeInTheDocument();
+		expect(screen.getByLabelText("Zoom")).toBeInTheDocument();
+		expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
+	});
+
+	it("이동 여유가 없다는 안내도 갈아 끼울 수 있다", () => {
+		render(<ImageCropper src={file()} noPanHint="No room to pan." />);
+		// 정사각 원본은 뷰포트를 꽉 채워 이동 여유가 없다.
+		loadImage(400, 400);
+
+		expect(screen.getByText("No room to pan.")).toBeInTheDocument();
+	});
+});

--- a/src/ui/forms/image-cropper/ImageCropper.test.tsx
+++ b/src/ui/forms/image-cropper/ImageCropper.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+import { ImageCropper } from "./index";
+
+/**
+ * 휠 줌은 기본 스크롤을 막아야 한다 — React 의 `onWheel` 은 루트에 `passive: true` 로 위임되므로
+ * 그 안의 `preventDefault()` 가 무시되고("Unable to preventDefault inside passive event listener
+ * invocation") 확대하는 동안 뒤 페이지가 함께 스크롤됐다. 네이티브 `passive: false` 등록으로 고쳤다.
+ */
+
+beforeAll(() => {
+	URL.createObjectURL = () => "blob:preview";
+	URL.revokeObjectURL = () => {};
+});
+
+const file = () => new File(["x"], "photo.png", { type: "image/png" });
+
+/** jsdom 은 natural 크기를 0 으로 주므로 심어 준 뒤 load 를 발생시킨다. */
+const loadImage = (width = 800, height = 600) => {
+	const image = document.querySelector(".image_cropper_image") as HTMLImageElement;
+	Object.defineProperty(image, "naturalWidth", { value: width, configurable: true });
+	Object.defineProperty(image, "naturalHeight", { value: height, configurable: true });
+	fireEvent.load(image);
+};
+
+/** 휠을 굴린다. `fireEvent` 는 이벤트가 취소되지 않았을 때만 true 를 돌려준다. */
+const wheelOverViewport = () => fireEvent.wheel(screen.getByRole("group"), { deltaY: -120 });
+
+describe("ImageCropper wheel zoom", () => {
+	it("preventDefault 가 먹는 리스너로 휠을 받는다", () => {
+		render(<ImageCropper src={file()} />);
+		loadImage();
+
+		// passive 리스너였다면 preventDefault 가 무시돼 이벤트가 취소되지 않는다(= true).
+		expect(wheelOverViewport()).toBe(false);
+	});
+
+	it("휠로 배율이 올라간다", () => {
+		render(<ImageCropper src={file()} />);
+		loadImage();
+
+		const zoomSlider = screen.getByLabelText("배율") as HTMLInputElement;
+		const before = Number(zoomSlider.value);
+
+		wheelOverViewport();
+
+		expect(Number(zoomSlider.value)).toBeGreaterThan(before);
+	});
+
+	it("이미지가 로드되기 전 휠은 아무것도 하지 않는다", () => {
+		render(<ImageCropper src={file()} />);
+
+		// 리스너 자체가 붙지 않으므로 기본 스크롤을 막지 않는다.
+		expect(wheelOverViewport()).toBe(true);
+	});
+});

--- a/src/ui/forms/image-cropper/image-cropper.stories.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.stories.tsx
@@ -78,6 +78,31 @@ const meta = {
 			control: { type: "number", min: 1, max: 6, step: 0.5 },
 			description: "최대 배율. / Max zoom.",
 		},
+		label: {
+			control: "text",
+			description: "뷰포트 접근성 레이블. / Viewport accessibility label.",
+		},
+		hint: {
+			control: "text",
+			description: "뷰포트 아래 조작 안내 문구. / Operation hint under the viewport.",
+		},
+		zoomOutLabel: {
+			control: "text",
+			description: "축소 버튼 레이블. / Zoom-out button label.",
+		},
+		zoomLabel: {
+			control: "text",
+			description: "배율 슬라이더 레이블. / Zoom slider label.",
+		},
+		zoomInLabel: {
+			control: "text",
+			description: "확대 버튼 레이블. / Zoom-in button label.",
+		},
+		noPanHint: {
+			control: "text",
+			description:
+				"이동 여유가 없을 때 스크린리더로 알리는 문구. / Announced when the image has no room to pan.",
+		},
 		ref: { table: { disable: true } },
 		onReady: { table: { disable: true } },
 		onError: { table: { disable: true } },
@@ -112,6 +137,28 @@ export const LandscapeSource: Story = {
 
 /** 세로가 긴 원본 — 위아래로만 드래그. / Portrait source: pan vertically. */
 export const PortraitSource: Story = { args: { src: PORTRAIT } };
+
+/** 모든 문구를 소비자 로케일로 교체한 예. / Every string replaced with the consumer's locale. */
+export const Localized: Story = {
+	args: {
+		src: SQUARE,
+		circular: true,
+		label: "Adjust image position and zoom",
+		hint: "Drag (or use arrow keys) to move, scroll or use the slider to zoom.",
+		zoomOutLabel: "Zoom out",
+		zoomLabel: "Zoom",
+		zoomInLabel: "Zoom in",
+		noPanHint: "The image fills the viewport, so there is no room to pan.",
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"기본값은 한국어라, 다국어 앱은 이 prop 들로 갈아 끼운다. / Defaults are Korean, so multilingual apps swap them through these props.",
+			},
+		},
+	},
+};
 
 /** 적용/초기화 버튼과 함께 쓰는 실제 패턴 — `ref.crop()` 결과를 원형으로 미리본다. */
 export const WithApply: Story = {

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -151,7 +151,10 @@ export function ImageCropper({
 	const [imageSize, setImageSize] = useState<CropImageSize | null>(null);
 	const [zoom, setZoom] = useState(minZoom);
 	// 휠 핸들러가 최신 배율을 읽되, 배율이 바뀔 때마다 리스너를 다시 붙이지는 않게 한다.
+	// 렌더 중 직접 동기화 — useEffect 는 커밋 후 실행돼 트랙패드 플릭처럼 wheel 이 연달아
+	// 들어오면 한 틱 뒤처진 배율로 계산돼 줌 델타가 유실될 수 있다.
 	const zoomRef = useRef(zoom);
+	zoomRef.current = zoom;
 	const [offset, setOffset] = useState<CropOffset>({ x: 0, y: 0 });
 	const [dragging, setDragging] = useState(false);
 
@@ -219,10 +222,6 @@ export function ImageCropper({
 			setDragging(false);
 		}
 	};
-
-	useEffect(() => {
-		zoomRef.current = zoom;
-	}, [zoom]);
 
 	// 휠 줌은 React 의 onWheel 이 아니라 네이티브 리스너로 붙인다 — React 는 wheel 을 루트에
 	// `passive: true` 로 위임하므로 핸들러 안의 preventDefault 가 무시되고("Unable to

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -67,6 +67,16 @@ export interface ImageCropperProps {
 	className?: string;
 	/** 뷰포트 접근성 레이블. 기본 "이미지 위치와 배율 조정". */
 	label?: string;
+	/** 뷰포트 아래 조작 안내 문구. 기본 "드래그(또는 방향키)로 위치, 휠·슬라이더로 배율을 맞추세요." */
+	hint?: string;
+	/** 축소 버튼 접근성 레이블. 기본 "축소". */
+	zoomOutLabel?: string;
+	/** 배율 슬라이더 접근성 레이블. 기본 "배율". */
+	zoomLabel?: string;
+	/** 확대 버튼 접근성 레이블. 기본 "확대". */
+	zoomInLabel?: string;
+	/** 이동 여유가 없을 때 스크린리더로 알리는 문구. 기본 "이미지가 뷰포트를 딱 채워 이동 여유가 없습니다." */
+	noPanHint?: string;
 }
 
 const resolveOutputType = (
@@ -106,6 +116,11 @@ export function ImageCropper({
 	onError,
 	className,
 	label = "이미지 위치와 배율 조정",
+	hint = "드래그(또는 방향키)로 위치, 휠·슬라이더로 배율을 맞추세요.",
+	zoomOutLabel = "축소",
+	zoomLabel = "배율",
+	zoomInLabel = "확대",
+	noPanHint = "이미지가 뷰포트를 딱 채워 이동 여유가 없습니다.",
 }: ImageCropperProps) {
 	const imageRef = useRef<HTMLImageElement>(null);
 	// 휠 리스너를 네이티브로 붙일 대상 — 아래 wheel effect 참고.
@@ -351,14 +366,14 @@ export function ImageCropper({
 			</div>
 
 			<p id="image_cropper_hint" className="image_cropper_hint">
-				드래그(또는 방향키)로 위치, 휠·슬라이더로 배율을 맞추세요.
+				{hint}
 			</p>
 
 			<div className="image_cropper_zoom">
 				<button
 					type="button"
 					className="image_cropper_zoom_button"
-					aria-label="축소"
+					aria-label={zoomOutLabel}
 					disabled={!imageSize || zoom <= minZoom}
 					onClick={() => applyZoom(zoom - ZOOM_KEY_STEP)}
 				>
@@ -367,7 +382,7 @@ export function ImageCropper({
 				<input
 					type="range"
 					className="image_cropper_zoom_slider"
-					aria-label="배율"
+					aria-label={zoomLabel}
 					min={minZoom}
 					max={maxZoom}
 					step={ZOOM_STEP}
@@ -378,7 +393,7 @@ export function ImageCropper({
 				<button
 					type="button"
 					className="image_cropper_zoom_button"
-					aria-label="확대"
+					aria-label={zoomInLabel}
 					disabled={!imageSize || zoom >= maxZoom}
 					onClick={() => applyZoom(zoom + ZOOM_KEY_STEP)}
 				>
@@ -387,7 +402,7 @@ export function ImageCropper({
 			</div>
 			{/* 위치 슬라이더가 없어도 미세 조정이 가능하도록 상태만 노출(스크린리더에 여유 안내) */}
 			<span className="image_cropper_sr_only" aria-live="polite">
-				{imageSize && !canPan ? "이미지가 뷰포트를 딱 채워 이동 여유가 없습니다." : ""}
+				{imageSize && !canPan ? noPanHint : ""}
 			</span>
 		</div>
 	);

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -11,7 +11,6 @@ import {
 	useImperativeHandle,
 	useRef,
 	useState,
-	type WheelEvent,
 } from "react";
 import { cn } from "../../../utils";
 import {
@@ -109,6 +108,8 @@ export function ImageCropper({
 	label = "이미지 위치와 배율 조정",
 }: ImageCropperProps) {
 	const imageRef = useRef<HTMLImageElement>(null);
+	// 휠 리스너를 네이티브로 붙일 대상 — 아래 wheel effect 참고.
+	const viewportRef = useRef<HTMLDivElement>(null);
 	// pointerdown 시점의 좌표/이동량을 담아 두고 move 에서 차이만 더한다.
 	const dragRef = useRef<{ pointerId: number; x: number; y: number; offset: CropOffset } | null>(
 		null,
@@ -131,6 +132,8 @@ export function ImageCropper({
 
 	const [imageSize, setImageSize] = useState<CropImageSize | null>(null);
 	const [zoom, setZoom] = useState(minZoom);
+	// 휠 핸들러가 최신 배율을 읽되, 배율이 바뀔 때마다 리스너를 다시 붙이지는 않게 한다.
+	const zoomRef = useRef(zoom);
 	const [offset, setOffset] = useState<CropOffset>({ x: 0, y: 0 });
 	const [dragging, setDragging] = useState(false);
 
@@ -199,11 +202,26 @@ export function ImageCropper({
 		}
 	};
 
-	const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
-		if (!imageSize) return;
-		event.preventDefault();
-		applyZoom(zoom - event.deltaY * WHEEL_ZOOM_FACTOR * zoom);
-	};
+	useEffect(() => {
+		zoomRef.current = zoom;
+	}, [zoom]);
+
+	// 휠 줌은 React 의 onWheel 이 아니라 네이티브 리스너로 붙인다 — React 는 wheel 을 루트에
+	// `passive: true` 로 위임하므로 핸들러 안의 preventDefault 가 무시되고("Unable to
+	// preventDefault inside passive event listener invocation") 확대하는 동안 뒤 페이지가 함께
+	// 스크롤된다. `passive: false` 로 직접 등록해야 기본 스크롤을 막을 수 있다.
+	useEffect(() => {
+		const viewport = viewportRef.current;
+		if (!viewport || !imageSize) return;
+
+		const handleWheel = (event: globalThis.WheelEvent) => {
+			event.preventDefault();
+			applyZoom(zoomRef.current - event.deltaY * WHEEL_ZOOM_FACTOR * zoomRef.current);
+		};
+
+		viewport.addEventListener("wheel", handleWheel, { passive: false });
+		return () => viewport.removeEventListener("wheel", handleWheel);
+	}, [imageSize, applyZoom]);
 
 	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
 		if (!imageSize) return;
@@ -297,6 +315,7 @@ export function ImageCropper({
 		<div className={cn("image_cropper", className)}>
 			{/* biome-ignore lint/a11y/useSemanticElements: 드래그+방향키 조작 표면이라 role=group + 안내 텍스트로 처리 */}
 			<div
+				ref={viewportRef}
 				className={cn("image_cropper_viewport", dragging && "image_cropper_viewport_dragging")}
 				style={viewportStyle}
 				role="group"
@@ -307,7 +326,6 @@ export function ImageCropper({
 				onPointerMove={handlePointerMove}
 				onPointerUp={handlePointerEnd}
 				onPointerCancel={handlePointerEnd}
-				onWheel={handleWheel}
 				onKeyDown={handleKeyDown}
 			>
 				{/* biome-ignore lint/performance/noImgElement: DS is framework-agnostic - local blob preview needs natural size + canvas access, next/image doesn't apply */}

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -151,10 +151,9 @@ export function ImageCropper({
 	const [imageSize, setImageSize] = useState<CropImageSize | null>(null);
 	const [zoom, setZoom] = useState(minZoom);
 	// 휠 핸들러가 최신 배율을 읽되, 배율이 바뀔 때마다 리스너를 다시 붙이지는 않게 한다.
-	// 렌더 중 직접 동기화 — useEffect 는 커밋 후 실행돼 트랙패드 플릭처럼 wheel 이 연달아
-	// 들어오면 한 틱 뒤처진 배율로 계산돼 줌 델타가 유실될 수 있다.
+	// zoom 을 바꾸는 곳(applyZoom·리셋)에서 setZoom 과 함께 즉시 동기화한다 — 렌더 중 대입은
+	// (중단된 렌더가 커밋 안 되는 값을 남길 수 있어) 피하고, useEffect(커밋 후)의 한 틱 지연도 없앤다.
 	const zoomRef = useRef(zoom);
-	zoomRef.current = zoom;
 	const [offset, setOffset] = useState<CropOffset>({ x: 0, y: 0 });
 	const [dragging, setDragging] = useState(false);
 
@@ -165,6 +164,7 @@ export function ImageCropper({
 	useEffect(() => {
 		setImageSize(null);
 		setZoom(minZoom);
+		zoomRef.current = minZoom;
 		setOffset({ x: 0, y: 0 });
 	}, [src, minZoom]);
 
@@ -181,6 +181,7 @@ export function ImageCropper({
 		(next: number) => {
 			const clampedZoom = Math.min(maxZoom, Math.max(minZoom, next));
 			setZoom(clampedZoom);
+			zoomRef.current = clampedZoom;
 			if (imageSize) {
 				setOffset((prev) => clampCropOffset(prev, imageSize, viewportSize, clampedZoom));
 			}
@@ -274,6 +275,7 @@ export function ImageCropper({
 		() => ({
 			reset: () => {
 				setZoom(minZoom);
+				zoomRef.current = minZoom;
 				setOffset({ x: 0, y: 0 });
 			},
 			crop: () =>

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -8,6 +8,7 @@ import {
 	type SyntheticEvent,
 	useCallback,
 	useEffect,
+	useId,
 	useImperativeHandle,
 	useRef,
 	useState,
@@ -129,6 +130,8 @@ export function ImageCropper({
 	const dragRef = useRef<{ pointerId: number; x: number; y: number; offset: CropOffset } | null>(
 		null,
 	);
+	// 한 화면에 크로퍼가 여러 개여도 aria-describedby 가 충돌하지 않도록 인스턴스별 고유 id.
+	const hintId = useId();
 
 	// File/Blob 은 objectURL 로, 문자열은 그대로. objectURL 은 언마운트 시 해제한다.
 	const [previewUrl, setPreviewUrl] = useState<string>("");
@@ -335,7 +338,7 @@ export function ImageCropper({
 				style={viewportStyle}
 				role="group"
 				aria-label={label}
-				aria-describedby="image_cropper_hint"
+				aria-describedby={hintId}
 				tabIndex={imageSize ? 0 : -1}
 				onPointerDown={handlePointerDown}
 				onPointerMove={handlePointerMove}
@@ -365,7 +368,7 @@ export function ImageCropper({
 				/>
 			</div>
 
-			<p id="image_cropper_hint" className="image_cropper_hint">
+			<p id={hintId} className="image_cropper_hint">
 				{hint}
 			</p>
 


### PR DESCRIPTION
## 작업 개요

ImageCropper 사용 중 발견된 버그 3건 수정 + 하드코딩 문구 prop 화.

## 작업한 내용

- [x] **휠 줌 시 페이지 스크롤/콘솔 에러** (`fb3e4b6`) - 뷰포트 위 휠 이벤트가 페이지 스크롤로 새던 문제. 네이티브 non-passive 리스너로 `preventDefault` 처리
- [x] **하드코딩 한국어 문구 prop 화** (`4ed78b4`) - 줌 aria-label·hint·no-pan 안내가 전부 하드코딩 한국어라 다국어 앱에서 스크린리더에 한국어가 읽히던 문제. `hint`/`zoomOutLabel`/`zoomLabel`/`zoomInLabel`/`noPanHint` prop 추가(각각 기존 문구 기본값 → 기존 호출부 동일 렌더). Storybook 컨트롤 + Localized 스토리 추가
- [x] **hint 고정 id 충돌** (`f5f6e4f`) - hint `<p>` 와 뷰포트 `aria-describedby` 가 고정 `id=\"image_cropper_hint\"` 를 써서, 한 화면에 크로퍼 2개면 id 중복 → 모든 뷰포트가 첫 hint 만 가리킴. `useId()` 로 인스턴스별 고유 id

## 검증

- tsc 클린, unit 769 pass (pre-commit)
- CSS 는 class(`.image_cropper_hint`)로 걸려 id 변경 영향 없음

## 전달할 추가 이슈

- Modal 로 크로퍼 감쌀 때 Modal `description` 과 크로퍼 `hint` 가 같은 문구 중복 → 소비자에서 Modal description 빼고 `hint` 로 넘기는 정리 필요(소비자 코드, 이 PR 스코프 밖)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 이미지 크롭퍼의 안내 문구와 확대·축소 버튼 레이블을 사용자 지정할 수 있습니다.
  * 이동 불가 안내 문구와 접근성 텍스트의 다국어 설정을 지원합니다.
  * 확대·축소 시 페이지의 기본 스크롤 동작을 방지하고, 크롭 영역 조작 경험을 개선했습니다.
* **테스트**
  * 이미지 로딩, 확대·축소, 휠 동작 및 다국어 문구에 대한 테스트를 추가했습니다.
* **문서**
  * 원형 크롭과 다국어 설정을 포함한 Storybook 예제를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->