### PR TITLE
feat/image-cropper-native-attrs

### DIFF
--- a/src/ui/forms/image-cropper/image-cropper.stories.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.stories.tsx
@@ -204,3 +204,21 @@ export const WithApply: Story = {
 		},
 	},
 };
+
+export const WithForwardedAttributes: Story = {
+	args: { src: SQUARE },
+	render: (args) => (
+		<ImageCropper {...args} id="avatar-cropper" data-section="profile" aria-label="프로필 이미지" />
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: [
+					'`ImageCropperProps` 는 `Omit<HTMLAttributes<HTMLDivElement>, "onError">` 를 확장해 표준 div 속성(`id`·`data-*`·`aria-*`·`style` 등)을 **루트 요소**로 전달합니다. 폼/오버레이가 크로퍼를 식별하거나 라벨을 연결할 때 씁니다. `onError` 는 이미지 디코드 실패 콜백으로 그대로 유지됩니다.',
+					"",
+					'`ImageCropperProps` extends `Omit<HTMLAttributes<HTMLDivElement>, "onError">`, forwarding standard div attributes (`id`, `data-*`, `aria-*`, `style`, …) onto the **root element**. `onError` stays the image-decode callback.',
+				].join("\n"),
+			},
+		},
+	},
+};

--- a/src/ui/forms/image-cropper/image-cropper.stories.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.stories.tsx
@@ -214,9 +214,9 @@ export const WithForwardedAttributes: Story = {
 		docs: {
 			description: {
 				story: [
-					'`ImageCropperProps` 는 `Omit<HTMLAttributes<HTMLDivElement>, "onError">` 를 확장해 표준 div 속성(`id`·`data-*`·`aria-*`·`style` 등)을 **루트 요소**로 전달합니다. 폼/오버레이가 크로퍼를 식별하거나 라벨을 연결할 때 씁니다. `onError` 는 이미지 디코드 실패 콜백으로 그대로 유지됩니다.',
+					'`ImageCropperProps` 는 `Omit<HTMLAttributes<HTMLDivElement>, "onError" | "children" | "dangerouslySetInnerHTML">` 를 확장해 표준 div 속성(`id`·`data-*`·`aria-*`·`style` 등)을 **루트 요소**로 전달합니다. 폼/오버레이가 크로퍼를 식별하거나 라벨을 연결할 때 씁니다. `onError` 는 이미지 디코드 실패 콜백으로 유지되고, `children`·`dangerouslySetInnerHTML` 은 컴포넌트가 자체 렌더하므로 제외됩니다.',
 					"",
-					'`ImageCropperProps` extends `Omit<HTMLAttributes<HTMLDivElement>, "onError">`, forwarding standard div attributes (`id`, `data-*`, `aria-*`, `style`, …) onto the **root element**. `onError` stays the image-decode callback.',
+					'`ImageCropperProps` extends `Omit<HTMLAttributes<HTMLDivElement>, "onError" | "children" | "dangerouslySetInnerHTML">`, forwarding standard div attributes (`id`, `data-*`, `aria-*`, `style`, …) onto the **root element**. `onError` stays the image-decode callback; `children`/`dangerouslySetInnerHTML` are excluded since the component renders its own content.',
 				].join("\n"),
 			},
 		},

--- a/src/ui/forms/image-cropper/image-cropper.test.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ImageCropper } from "./index";
+
+/**
+ * ImageCropperProps 가 Omit<HTMLAttributes<HTMLDivElement>, "onError" | "children"> 를 확장해
+ * 소비자의 표준 div 속성을 루트로 전달하되, 내부 className·공개 onError(이미지) 는 보존하는지 검증.
+ */
+describe("ImageCropper native attribute forwarding", () => {
+	it("forwards id/data-*/aria-* to the root while keeping the base class", () => {
+		const { container } = render(
+			<ImageCropper
+				src="data:image/png;base64,"
+				id="avatar-cropper"
+				data-testid="cropper-root"
+				aria-hidden="true"
+				className="custom"
+			/>,
+		);
+		const root = container.querySelector(".image_cropper");
+		expect(root).not.toBeNull();
+		expect(root).toHaveAttribute("id", "avatar-cropper");
+		expect(root).toHaveAttribute("data-testid", "cropper-root");
+		expect(root).toHaveAttribute("aria-hidden", "true");
+		// 소비자 className 은 합쳐지되 기반 클래스는 유지
+		expect(root).toHaveClass("image_cropper", "custom");
+	});
+
+	it("keeps onError as the image-decode callback, not a div handler", () => {
+		// 타입/런타임 모두 () => void 이미지 콜백으로 통과해야 한다(div onError 로 치환되지 않음).
+		const onError = () => {};
+		const { container } = render(<ImageCropper src="data:image/png;base64," onError={onError} />);
+		expect(container.querySelector(".image_cropper")).not.toBeNull();
+	});
+});

--- a/src/ui/forms/image-cropper/image-cropper.test.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.test.tsx
@@ -1,5 +1,5 @@
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { ImageCropper } from "./index";
 
 /**
@@ -26,10 +26,14 @@ describe("ImageCropper native attribute forwarding", () => {
 		expect(root).toHaveClass("image_cropper", "custom");
 	});
 
-	it("keeps onError as the image-decode callback, not a div handler", () => {
-		// 타입/런타임 모두 () => void 이미지 콜백으로 통과해야 한다(div onError 로 치환되지 않음).
-		const onError = () => {};
+	it("wires onError to the image element's error event, not a div handler", () => {
+		const onError = vi.fn();
 		const { container } = render(<ImageCropper src="data:image/png;base64," onError={onError} />);
-		expect(container.querySelector(".image_cropper")).not.toBeNull();
+		const img = container.querySelector(".image_cropper_image");
+		expect(img).not.toBeNull();
+		// 이미지 디코드 실패 시에만 불려야 한다 — 렌더만으로는 호출되지 않음.
+		expect(onError).not.toHaveBeenCalled();
+		fireEvent.error(img as HTMLImageElement);
+		expect(onError).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -44,10 +44,11 @@ export interface ImageCropperHandle {
 }
 
 // 소비자가 붙이는 표준 div 속성(id·data-*·aria-*·style 등)을 루트로 전달한다.
-// onError 는 이미지 디코드 실패 콜백(공개 API)이라 div 의 onError 와 충돌하지 않게 Omit,
-// children 은 컴포넌트가 자체 렌더하므로 Omit 한다.
+// onError 는 이미지 디코드 실패 콜백(공개 API)이라 div 의 onError 와 충돌하지 않게 Omit.
+// children·dangerouslySetInnerHTML 은 루트가 항상 자체 JSX 자식(뷰포트/힌트/줌)을 렌더하므로
+// 넘어오면 "Can only set one of children or dangerouslySetInnerHTML" 런타임 에러 → 둘 다 Omit.
 export interface ImageCropperProps
-	extends Omit<HTMLAttributes<HTMLDivElement>, "onError" | "children"> {
+	extends Omit<HTMLAttributes<HTMLDivElement>, "onError" | "children" | "dangerouslySetInnerHTML"> {
 	/** 크롭/리셋을 호출할 imperative 핸들 (React 19 ref-as-prop). */
 	ref?: Ref<ImageCropperHandle>;
 	/** 크롭할 이미지. `File`/`Blob`(로컬) 또는 이미지 URL 문자열. */

--- a/src/ui/forms/image-cropper/index.tsx
+++ b/src/ui/forms/image-cropper/index.tsx
@@ -2,6 +2,7 @@
 
 import {
 	type CSSProperties,
+	type HTMLAttributes,
 	type KeyboardEvent,
 	type PointerEvent,
 	type Ref,
@@ -42,7 +43,11 @@ export interface ImageCropperHandle {
 	reset: () => void;
 }
 
-export interface ImageCropperProps {
+// 소비자가 붙이는 표준 div 속성(id·data-*·aria-*·style 등)을 루트로 전달한다.
+// onError 는 이미지 디코드 실패 콜백(공개 API)이라 div 의 onError 와 충돌하지 않게 Omit,
+// children 은 컴포넌트가 자체 렌더하므로 Omit 한다.
+export interface ImageCropperProps
+	extends Omit<HTMLAttributes<HTMLDivElement>, "onError" | "children"> {
 	/** 크롭/리셋을 호출할 imperative 핸들 (React 19 ref-as-prop). */
 	ref?: Ref<ImageCropperHandle>;
 	/** 크롭할 이미지. `File`/`Blob`(로컬) 또는 이미지 URL 문자열. */
@@ -122,6 +127,7 @@ export function ImageCropper({
 	zoomLabel = "배율",
 	zoomInLabel = "확대",
 	noPanHint = "이미지가 뷰포트를 딱 채워 이동 여유가 없습니다.",
+	...rest
 }: ImageCropperProps) {
 	const imageRef = useRef<HTMLImageElement>(null);
 	// 휠 리스너를 네이티브로 붙일 대상 — 아래 wheel effect 참고.
@@ -331,7 +337,8 @@ export function ImageCropper({
 		: { visibility: "hidden" };
 
 	return (
-		<div className={cn("image_cropper", className)}>
+		// 내부 className 이 항상 이기도록 spread 뒤에 지정한다.
+		<div {...rest} className={cn("image_cropper", className)}>
 			{/* biome-ignore lint/a11y/useSemanticElements: 드래그+방향키 조작 표면이라 role=group + 안내 텍스트로 처리 */}
 			<div
 				ref={viewportRef}


### PR DESCRIPTION
## 작업 개요

이슈 #426 구현 — `ImageCropper` 가 소비자의 표준 `div` 속성(`id`·`data-*`·`aria-*`·`style` 등)을 전달하도록 확장. 폼/오버레이 조합 시 외부에서 식별자·접근성 속성을 붙일 수 있다. (#425 머지 완료 → develop 기준 단독 PR)

## 작업한 내용

- [x] `ImageCropperProps extends Omit<HTMLAttributes<HTMLDivElement>, "onError" | "children">`
- [x] 크로퍼 전용 prop 과 네이티브 속성 분리(`...rest`) → **루트 요소**에 spread (`className` 과 같은 요소, 내부 className 이 항상 우선)
- [x] `onError`(이미지 디코드 콜백, v3.6.0 공개 API) 보존 — `Omit` 으로 div `onError` 충돌 회피
- [x] `children` 은 컴포넌트가 자체 렌더하므로 `Omit`
- [x] forwarding 테스트(`image-cropper.test.tsx`) — root 에 `id`/`data-*`/`aria-*` 전달 + 내부 class 유지 + `onError` 콜백 보존
- [x] Storybook `WithForwardedAttributes` 스토리 + 예시

## 설계 노트

- **루트 spread 선택**: coderabbit 은 뷰포트 div 제안했으나, `className` 이 이미 루트로 가므로 일관성(소비자 `id`/`className`/`style` 이 한 요소에)을 위해 루트로 전달. 인터랙션·a11y 핵심 속성(role/aria-label/aria-describedby/tabIndex/pointer·key 핸들러)은 내부 뷰포트가 소유.
- **SemVer**: 순수 additive(기존 호출부 무영향) → minor. CHANGELOG 는 릴리즈(dev→main) PR 에서 반영.

## 검증

- tsc 클린, biome 클린(baseline warning 2건은 기존 useExhaustiveDependencies), cropper 유닛 21 pass

Closes #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - ImageCropper가 `id`, `data-*`, `aria-*`, `style`, 사용자 지정 `className` 등 표준 속성을 루트 요소에 전달합니다.
  - 기존 기본 스타일 클래스는 유지되며 사용자 지정 클래스와 함께 적용됩니다.
  - 이미지 디코드 오류 처리를 위한 `onError` 동작은 기존과 동일하게 유지됩니다.

- **문서**
  - 표준 속성 전달 사용 예시를 스토리에 추가했습니다.

- **버그 수정**
  - ImageCropper의 접근성 및 사용자 지정 속성 전달 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->