### PR TITLE
fix/overlay-collision-positioning

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1555,7 +1555,7 @@ span.tooltip_wrapper           ← position: relative; display: inline-flex
     └── span.tooltip           ← role="tooltip", spring transform
 ```
 
-Portal을 **쓰지 않음** → 트리거의 `position: relative` 조상 기준으로 absolute 배치. `overflow: hidden`인 컨테이너 안에서는 잘릴 수 있으니 주의 (필요 시 컨테이너의 overflow를 풀거나 Popover 사용).
+`document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition`이 계산한 좌표로 배치되므로, 트리거의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5`.
 
 **Usage**
 
@@ -1698,7 +1698,7 @@ span.menu_wrapper                  ← position: relative; ref 부착 (외부 �
         └── span.menu_item_label   ← ellipsis
 ```
 
-Portal을 **쓰지 않음** → trigger의 `position: relative` 조상 기준 absolute. `overflow: hidden` 컨테이너 안에서 잘릴 수 있으니 주의. `z-index`는 `z_level5` 사용.
+`document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition` 좌표로 배치되므로 trigger의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5` 사용.
 
 **Usage**
 
@@ -1835,7 +1835,7 @@ span.popover_wrapper               ← position: relative; ref 부착 (외부 �
     └── div.popover                ← role="dialog", spring transform
 ```
 
-Portal을 **쓰지 않음** → trigger의 `position: relative` 조상 기준 absolute. `overflow: hidden` 컨테이너 안에서 잘릴 수 있으니 주의. `z-index`는 `z_level5` 사용.
+`document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition` 좌표로 배치되므로 trigger의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5` 사용.
 
 **Usage**
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1499,7 +1499,7 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 - `"bottom"` - 트리거가 화면 상단에 가깝거나, 위에 다른 패널이 있을 때.
 - `"left"` / `"right"` - 가로 리스트(아이콘 툴바)에서 항목별 라벨, 또는 위/아래 공간이 부족할 때.
 
-> ℹ️ 현재 구현은 **자동 flipping이 없으니** 뷰포트 경계 근처라면 placement를 직접 지정하라.
+> ℹ️ `placement`는 **선호값**이다. 뷰포트를 벗어나면 반대편으로 **flip**, 교차축으로 **shift**, 그래도 넘치면 `max-width` 축소가 자동 적용되고 `body`로 포탈된다(Radix `side` + `collisionPadding` 계약). 경계 근처라도 직접 조정할 필요가 없다.
 
 **delay 가이드**
 - 200ms (기본) - 마우스가 잠깐 머무를 때만 노출, 빠른 휙휙 이동에는 안 뜸
@@ -1551,8 +1551,8 @@ Tooltip은 **dismissable 오버레이가 아님**:
 ```
 span.tooltip_wrapper           ← position: relative; display: inline-flex
 ├── {children}                 ← cloneElement로 핸들러/aria 주입된 trigger
-└── span.tooltip               ← position: absolute, role="tooltip"
-    └── tooltip_placement_*    ← top|bottom|left|right
+└── span.tooltip_position      ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
+    └── span.tooltip           ← role="tooltip", spring transform
 ```
 
 Portal을 **쓰지 않음** → 트리거의 `position: relative` 조상 기준으로 absolute 배치. `overflow: hidden`인 컨테이너 안에서는 잘릴 수 있으니 주의 (필요 시 컨테이너의 overflow를 풀거나 Popover 사용).
@@ -1776,7 +1776,7 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 - `"top"` - trigger가 화면 하단에 가까울 때.
 - `"left"` / `"right"` - 가로 공간이 충분하고 위/아래가 막혔을 때.
 
-> ℹ️ 현재 구현은 **자동 flipping이 없으니** 뷰포트 경계 근처라면 placement를 직접 지정하라.
+> ℹ️ `placement`는 **선호값**이다. 뷰포트를 벗어나면 반대편으로 **flip**, 교차축으로 **shift**, 그래도 넘치면 `max-width` 축소가 자동 적용되고 `body`로 포탈된다(Radix `side` + `collisionPadding` 계약). 경계 근처라도 직접 조정할 필요가 없다.
 
 **제어 / 비제어**
 - 비제어 (기본) - `defaultOpen`만 주고 내부 state로 토글. 가장 간단.
@@ -1831,9 +1831,8 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 ```
 span.popover_wrapper               ← position: relative; ref 부착 (외부 클릭 판정)
 ├── {trigger}                      ← cloneElement로 onClick/aria 주입
-└── span.popover_position          ← position: absolute, placement별 정렬
-    └── popover_placement_*        ← top|bottom|left|right
-        └── div.popover            ← role="dialog", spring transform
+└── div.popover_position           ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
+    └── div.popover                ← role="dialog", spring transform
 ```
 
 Portal을 **쓰지 않음** → trigger의 `position: relative` 조상 기준 absolute. `overflow: hidden` 컨테이너 안에서 잘릴 수 있으니 주의. `z-index`는 `z_level5` 사용.

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { Popover } from "./index";
 
@@ -149,8 +148,9 @@ describe("Popover", () => {
 		expect(trigger).not.toHaveAttribute("aria-controls");
 	});
 
-	it("applies placement class (default bottom)", () => {
-		const { rerender } = render(
+	it("portals the panel to the body and positions it fixed", () => {
+		// placement 는 이제 CSS 클래스가 아니라 useAnchoredPosition 이 계산한 fixed 좌표로 적용된다.
+		const { container } = render(
 			<Popover
 				trigger={<button type="button">Open</button>}
 				content={<span>Panel content</span>}
@@ -158,19 +158,12 @@ describe("Popover", () => {
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		expect(screen.getByRole("dialog").parentElement).toHaveClass("popover_placement_bottom");
-
-		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		rerender(
-			<Popover
-				trigger={<button type="button">Open</button>}
-				content={<span>Panel content</span>}
-				placement="right"
-				aria-label="popover"
-			/>,
-		);
-		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		expect(screen.getByRole("dialog").parentElement).toHaveClass("popover_placement_right");
+		const dialog = screen.getByRole("dialog");
+		// 포탈 - 트리거 wrapper 밖(body)으로 렌더된다.
+		expect(container.querySelector(".popover_wrapper")?.contains(dialog)).toBe(false);
+		// 위치 컨테이너는 fixed.
+		const position = dialog.closest(".popover_position") as HTMLElement;
+		expect(position.style.position).toBe("fixed");
 	});
 
 	it("propagates aria-label to the dialog", () => {

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -2,8 +2,12 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
+import { createPortal } from "react-dom";
+import { cn, useAnchoredPosition, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
+
+/** 트리거와 팝오버 사이 간격(px). */
+const POPOVER_GAP = 8;
 
 export type PopoverPlacement = "top" | "bottom" | "left" | "right";
 
@@ -12,7 +16,10 @@ export interface PopoverProps {
 	trigger: React.ReactElement;
 	/** 팝오버 내부 콘텐츠 - 임의 ReactNode (폼/설명/액션 조합) */
 	content: React.ReactNode;
-	/** 위치 (기본값: "bottom") */
+	/**
+	 * 선호 위치 (기본값: "bottom"). 뷰포트를 벗어나면 반대편으로 flip 되고 교차축으로 shift 되므로
+	 * 실제 위치는 계산 결과를 따른다(Radix `side` + `collisionPadding` 계약). body 로 포탈된다.
+	 */
 	placement?: PopoverPlacement;
 	/** 제어 모드 - 열림 상태 */
 	open?: boolean;
@@ -75,6 +82,7 @@ export const Popover = ({
 	if (open && !shouldRender) setShouldRender(true);
 
 	const wrapperRef = React.useRef<HTMLDivElement>(null);
+	const positionRef = React.useRef<HTMLDivElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
 	/** 팝오버 열기 직전의 포커스 요소 (보통 trigger) - Esc 닫힘 시 복귀 대상 */
 	const previousFocusRef = React.useRef<HTMLElement | null>(null);
@@ -88,8 +96,19 @@ export const Popover = ({
 		[isControlled, onOpenChange],
 	);
 
+	// 열릴 때 트리거 rect + 뷰포트로 flip/shift/shrink 를 계산해 body 로 포탈(fixed).
+	// shouldRender 로 게이트해 퇴장 애니메이션 동안에도 위치를 유지한다.
+	const pos = useAnchoredPosition({
+		open: shouldRender,
+		anchorRef: wrapperRef,
+		floatingRef: positionRef,
+		placement,
+		gap: POPOVER_GAP,
+		padding: 8,
+	});
+
 	const fromTransform = (() => {
-		switch (placement) {
+		switch (pos.placement) {
 			case "top":
 				return "translateY(4px)";
 			case "bottom":
@@ -101,7 +120,11 @@ export const Popover = ({
 		}
 	})();
 
-	const style = useSpringPresence({ visible: open, from: fromTransform, onExitComplete: () => setShouldRender(false) });
+	const style = useSpringPresence({
+		visible: open,
+		from: fromTransform,
+		onExitComplete: () => setShouldRender(false),
+	});
 
 	// 열릴 때 content 첫 focusable(없으면 패널 자체)로 포커스 이동
 	React.useEffect(() => {
@@ -117,7 +140,11 @@ export const Popover = ({
 	React.useEffect(() => {
 		if (!open) return;
 		const handleClick = (e: MouseEvent) => {
-			if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+			const target = e.target as Node;
+			// 팝오버가 body 로 포탈되므로 wrapper(트리거) + popover 패널 둘 다 "내부"로 본다.
+			if (!wrapperRef.current?.contains(target) && !popoverRef.current?.contains(target)) {
+				setOpen(false);
+			}
 		};
 		document.addEventListener("mousedown", handleClick);
 		return () => document.removeEventListener("mousedown", handleClick);
@@ -151,22 +178,35 @@ export const Popover = ({
 	return (
 		<div className="popover_wrapper" ref={wrapperRef}>
 			{triggerWithProps}
-			{shouldRender && (
-				<div className={cn("popover_position", `popover_placement_${placement}`)}>
-					<animated.div
-						id={popoverId}
-						ref={popoverRef}
-						role="dialog"
-						tabIndex={-1}
-						aria-label={ariaLabel}
-						aria-labelledby={ariaLabelledby}
-						style={style}
-						className={cn("popover", className)}
+			{shouldRender &&
+				typeof document !== "undefined" &&
+				createPortal(
+					<div
+						ref={positionRef}
+						className="popover_position"
+						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
+						style={{
+							position: "fixed",
+							left: pos.x,
+							top: pos.y,
+							visibility: pos.ready ? undefined : "hidden",
+						}}
 					>
-						{content}
-					</animated.div>
-				</div>
-			)}
+						<animated.div
+							id={popoverId}
+							ref={popoverRef}
+							role="dialog"
+							tabIndex={-1}
+							aria-label={ariaLabel}
+							aria-labelledby={ariaLabelledby}
+							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
+							className={cn("popover", className)}
+						>
+							{content}
+						</animated.div>
+					</div>,
+					document.body,
+				)}
 		</div>
 	);
 };

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -3,7 +3,13 @@
 import { animated } from "@react-spring/web";
 import * as React from "react";
 import { createPortal } from "react-dom";
-import { cn, useAnchoredPosition, useOverlayEscape, useSpringPresence } from "../../../utils";
+import {
+	cn,
+	useAnchoredPosition,
+	useFocusTrap,
+	useOverlayEscape,
+	useSpringPresence,
+} from "../../../utils";
 import "./style.scss";
 
 /** 트리거와 팝오버 사이 간격(px). */
@@ -34,15 +40,6 @@ export interface PopoverProps {
 	/** 추가 className - 팝오버 패널에 적용 */
 	className?: string;
 }
-
-const FOCUSABLE_SELECTORS = [
-	"a[href]",
-	"button:not([disabled])",
-	"input:not([disabled])",
-	"select:not([disabled])",
-	"textarea:not([disabled])",
-	'[tabindex]:not([tabindex="-1"])',
-].join(", ");
 
 /**
  * 클릭 트리거로 임의의 interactive content 를 띄우는 범용 non-modal 팝오버.
@@ -84,8 +81,6 @@ export const Popover = ({
 	const wrapperRef = React.useRef<HTMLDivElement>(null);
 	const positionRef = React.useRef<HTMLDivElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
-	/** 팝오버 열기 직전의 포커스 요소 (보통 trigger) - Esc 닫힘 시 복귀 대상 */
-	const previousFocusRef = React.useRef<HTMLElement | null>(null);
 	const popoverId = React.useId();
 
 	const setOpen = React.useCallback(
@@ -126,15 +121,9 @@ export const Popover = ({
 		onExitComplete: () => setShouldRender(false),
 	});
 
-	// 열릴 때 content 첫 focusable(없으면 패널 자체)로 포커스 이동
-	React.useEffect(() => {
-		if (!open) return;
-		previousFocusRef.current = document.activeElement as HTMLElement | null;
-		const node = popoverRef.current;
-		if (!node) return;
-		const focusable = node.querySelector<HTMLElement>(FOCUSABLE_SELECTORS);
-		(focusable ?? node).focus();
-	}, [open]);
+	// body 로 포탈되면 트리거 뒤 tab 순서가 끊기므로 다른 포탈 오버레이(Modal/Drawer/Alert)와 동일하게
+	// 포커스를 패널 안에 트랩한다 - 열릴 때 첫 focusable 로 이동, Tab 순환, 닫힐 때 트리거로 복귀.
+	useFocusTrap(popoverRef, open);
 
 	// 외부 클릭으로 닫기. Escape 는 아래 wrapper 의 React onKeyDown 에서 처리한다.
 	React.useEffect(() => {
@@ -156,9 +145,9 @@ export const Popover = ({
 	// 하면 이벤트가 document 까지 오지 않아 Popover 는 닫히지 않는다(자식 우선 - 이전 리뷰 critical).
 	// 아무도 소비하지 않고 document 까지 오면 최상단(=이 Popover)만 닫고, 상위 Modal 이나 소비자
 	// 앱으로의 전파를 끊어 "최상단만 닫힘"(APG)을 지킨다.
+	// 포커스 복귀(트리거로)는 useFocusTrap 의 cleanup 이 담당한다.
 	useOverlayEscape(open, () => {
 		setOpen(false);
-		previousFocusRef.current?.focus();
 	});
 
 	const triggerWithProps = React.cloneElement(
@@ -184,11 +173,13 @@ export const Popover = ({
 					<div
 						ref={positionRef}
 						className="popover_position"
+						// 측정 대상(이 컨테이너)에 max-width 상한을 걸어 자식이 좁아져도 측정값이 진동하지 않게 한다.
 						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
 						style={{
 							position: "fixed",
 							left: pos.x,
 							top: pos.y,
+							maxWidth: pos.maxWidth,
 							visibility: pos.ready ? undefined : "hidden",
 						}}
 					>
@@ -199,7 +190,7 @@ export const Popover = ({
 							tabIndex={-1}
 							aria-label={ariaLabel}
 							aria-labelledby={ariaLabelledby}
-							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
+							style={style}
 							className={cn("popover", className)}
 						>
 							{content}

--- a/src/ui/overlay/popover/popover.stories.tsx
+++ b/src/ui/overlay/popover/popover.stories.tsx
@@ -89,7 +89,9 @@ export const Placements: Story = {
 					placement={placement}
 					aria-label={`${placement} 팝오버`}
 					trigger={<Button variant="outline">{placement}</Button>}
-					content={<div style={{ color: "var(--bt-color-text-body)" }}>{}</div>}
+					content={
+						<div style={{ color: "var(--bt-color-text-body)" }}>{`placement="${placement}"`}</div>
+					}
 				/>
 			))}
 		</div>

--- a/src/ui/overlay/popover/popover.stories.tsx
+++ b/src/ui/overlay/popover/popover.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
-import { Button } from "../../general/button";
 import { Checkbox } from "../../forms/checkbox";
+import { Button } from "../../general/button";
 import { Stack } from "../../layout/stack";
 import { Popover } from ".";
 
@@ -13,7 +13,8 @@ const meta: Meta<typeof Popover> = {
 		placement: {
 			control: "select",
 			options: ["top", "bottom", "left", "right"],
-			description: "trigger 기준 위치. / Position relative to the trigger.",
+			description:
+				"선호 위치. 뷰포트를 벗어나면 자동 flip/shift, body 로 포탈. / Preferred side — auto flip/shift on viewport overflow, portaled to body.",
 		},
 		trigger: {
 			control: false,
@@ -88,11 +89,7 @@ export const Placements: Story = {
 					placement={placement}
 					aria-label={`${placement} 팝오버`}
 					trigger={<Button variant="outline">{placement}</Button>}
-					content={
-						<div style={{ color: "var(--bt-color-text-body)" }}>
-							{}
-						</div>
-					}
+					content={<div style={{ color: "var(--bt-color-text-body)" }}>{}</div>}
 				/>
 			))}
 		</div>
@@ -112,9 +109,7 @@ export const RichContent: Story = {
 						<strong id="pop-title" style={{ color: "var(--bt-color-text-heading)" }}>
 							박상민
 						</strong>
-						<span style={{ color: "var(--bt-color-text-caption)" }}>
-							sangmin@bigtablet.com
-						</span>
+						<span style={{ color: "var(--bt-color-text-caption)" }}>sangmin@bigtablet.com</span>
 						<Stack direction="horizontal" gap={8}>
 							<Button size="sm" variant="outline">
 								메시지

--- a/src/ui/overlay/popover/style.scss
+++ b/src/ui/overlay/popover/style.scss
@@ -5,37 +5,13 @@
   display: inline-flex;
 }
 
-// 위치 정렬 wrapper - placement 별 translateX/Y 로 trigger 기준 중앙 잡음.
+// body 로 포탈된 위치 컨테이너 - left/top 은 useAnchoredPosition 이 inline(fixed)으로 지정.
 // 안의 .popover 는 spring 으로 entrance transform 사용 - 두 transform context 분리해서 충돌 X.
 // Tooltip 과 달리 interactive content 라 pointer-events 유지.
 .popover_position {
-  position: absolute;
+  // position/left/top 은 컴포넌트에서 inline 으로 지정(fixed). 여기선 나머지만.
   z-index: token.$z_level5;
   width: max-content;
-
-  &.popover_placement_top {
-    bottom: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.popover_placement_bottom {
-    top: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.popover_placement_left {
-    right: calc(100% + 8px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
-
-  &.popover_placement_right {
-    left: calc(100% + 8px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
 }
 
 .popover {

--- a/src/ui/overlay/tooltip/Tooltip.test.tsx
+++ b/src/ui/overlay/tooltip/Tooltip.test.tsx
@@ -109,8 +109,9 @@ describe("Tooltip", () => {
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
-	it("applies placement class", () => {
-		render(
+	it("portals the tooltip to the body and positions it fixed", () => {
+		// placement 는 이제 CSS 클래스가 아니라 useAnchoredPosition 이 계산한 fixed 좌표로 적용된다.
+		const { container } = render(
 			<Tooltip content="hint" delay={0} placement="bottom">
 				<button type="button">btn</button>
 			</Tooltip>,
@@ -119,6 +120,11 @@ describe("Tooltip", () => {
 		act(() => {
 			vi.advanceTimersByTime(10);
 		});
-		expect(screen.getByRole("tooltip")).toHaveClass("tooltip_placement_bottom");
+		const tip = screen.getByRole("tooltip");
+		// 포탈 - 트리거 wrapper 밖(body)으로 렌더된다.
+		expect(container.querySelector(".tooltip_wrapper")?.contains(tip)).toBe(false);
+		// 위치 컨테이너는 fixed 로 배치된다.
+		const position = tip.closest(".tooltip_position") as HTMLElement;
+		expect(position.style.position).toBe("fixed");
 	});
 });

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -2,15 +2,22 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
+import { createPortal } from "react-dom";
+import { useAnchoredPosition, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
+
+/** 트리거와 툴팁 사이 간격(px). */
+const TOOLTIP_GAP = 6;
 
 export type TooltipPlacement = "top" | "bottom" | "left" | "right";
 
 export interface TooltipProps {
 	/** 툴팁 콘텐츠 */
 	content: React.ReactNode;
-	/** 위치 (기본값: "top") */
+	/**
+	 * 선호 위치 (기본값: "top"). 뷰포트를 벗어나면 반대편으로 flip 되고 교차축으로 shift 되므로
+	 * 실제 위치는 계산 결과를 따른다(Radix `side` + `collisionPadding` 계약). body 로 포탈된다.
+	 */
 	placement?: TooltipPlacement;
 	/** hover 후 지연 시간 ms (기본 200) */
 	delay?: number;
@@ -39,6 +46,9 @@ export const Tooltip = ({
 	const [open, setOpen] = React.useState(false);
 	const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const tooltipId = React.useId();
+	// wrapper = 앵커(트리거) 측정 대상, position = 플로팅(뷰포트 fixed 배치) 측정 대상.
+	const wrapperRef = React.useRef<HTMLSpanElement>(null);
+	const positionRef = React.useRef<HTMLSpanElement>(null);
 
 	// 포인터가 trigger→tooltip 사이 갭(6px)을 건널 시간 (WCAG 1.4.13 Hoverable)
 	const HIDE_DELAY = 120;
@@ -77,8 +87,18 @@ export const Tooltip = ({
 	// 레지스트리가 그 역할을 대신한다.
 	useOverlayEscape(open, hideNow);
 
+	// 열릴 때 트리거 rect + 뷰포트로 flip/shift/shrink 를 계산해 body 로 포탈(fixed).
+	const pos = useAnchoredPosition({
+		open,
+		anchorRef: wrapperRef,
+		floatingRef: positionRef,
+		placement,
+		gap: TOOLTIP_GAP,
+		padding: 8,
+	});
+
 	const fromTransform = (() => {
-		switch (placement) {
+		switch (pos.placement) {
 			case "top":
 				return "translateY(4px)";
 			case "bottom":
@@ -121,25 +141,36 @@ export const Tooltip = ({
 	if (disabled) return children;
 
 	return (
-		<span className="tooltip_wrapper">
+		<span className="tooltip_wrapper" ref={wrapperRef}>
 			{trigger}
-			{open && (
-				<span
-					className={cn("tooltip_position", `tooltip_placement_${placement}`)}
-					// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
-					onMouseEnter={cancelHide}
-					onMouseLeave={hide}
-				>
-					<animated.span
-						id={tooltipId}
-						role="tooltip"
-						style={style}
-						className={cn("tooltip", `tooltip_placement_${placement}`)}
+			{open &&
+				typeof document !== "undefined" &&
+				createPortal(
+					<span
+						ref={positionRef}
+						className="tooltip_position"
+						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
+						style={{
+							position: "fixed",
+							left: pos.x,
+							top: pos.y,
+							visibility: pos.ready ? undefined : "hidden",
+						}}
+						// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
+						onMouseEnter={cancelHide}
+						onMouseLeave={hide}
 					>
-						{content}
-					</animated.span>
-				</span>
-			)}
+						<animated.span
+							id={tooltipId}
+							role="tooltip"
+							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
+							className="tooltip"
+						>
+							{content}
+						</animated.span>
+					</span>,
+					document.body,
+				)}
 		</span>
 	);
 };

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -149,23 +149,20 @@ export const Tooltip = ({
 					<span
 						ref={positionRef}
 						className="tooltip_position"
+						// 측정 대상(이 컨테이너)에 max-width 상한을 걸어 자식이 좁아져도 측정값이 진동하지 않게 한다.
 						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
 						style={{
 							position: "fixed",
 							left: pos.x,
 							top: pos.y,
+							maxWidth: pos.maxWidth,
 							visibility: pos.ready ? undefined : "hidden",
 						}}
 						// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
 						onMouseEnter={cancelHide}
 						onMouseLeave={hide}
 					>
-						<animated.span
-							id={tooltipId}
-							role="tooltip"
-							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
-							className="tooltip"
-						>
+						<animated.span id={tooltipId} role="tooltip" style={style} className="tooltip">
 							{content}
 						</animated.span>
 					</span>,

--- a/src/ui/overlay/tooltip/style.scss
+++ b/src/ui/overlay/tooltip/style.scss
@@ -6,39 +6,15 @@
   vertical-align: middle; // baseline 정렬로 인한 미세 offset 제거
 }
 
-// 위치 정렬 wrapper - placement 별 translateX/Y 로 trigger 기준 중앙 잡음.
+// body 로 포탈된 위치 컨테이너 - left/top 은 useAnchoredPosition 이 inline(fixed)으로 지정.
 // 안의 .tooltip 은 spring 으로 entrance transform 사용 - 두 transform context 분리해서 충돌 X.
 .tooltip_position {
-  position: absolute;
+  // position/left/top 은 컴포넌트에서 inline 으로 지정(fixed). 여기선 나머지만.
   z-index: token.$z_level5;
   // pointer-events 를 살려 둔다 - WCAG 1.4.13 Hoverable: 포인터를 툴팁 위로
   // 옮겨 내용을 읽을 수 있어야 함 (none 이면 mouseenter 가 발화하지 않아 즉시 닫힘)
   display: block;
-  width: max-content; // 내부 .tooltip 의 max-content 와 일치 - translateX(-50%) 정확
-
-  &.tooltip_placement_top {
-    bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.tooltip_placement_bottom {
-    top: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.tooltip_placement_left {
-    right: calc(100% + 6px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
-
-  &.tooltip_placement_right {
-    left: calc(100% + 6px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
+  width: max-content; // 내부 .tooltip 의 max-content 와 일치
 }
 
 .tooltip {

--- a/src/ui/overlay/tooltip/tooltip.stories.tsx
+++ b/src/ui/overlay/tooltip/tooltip.stories.tsx
@@ -13,7 +13,8 @@ const meta: Meta<typeof Tooltip> = {
 		placement: {
 			control: "select",
 			options: ["top", "bottom", "left", "right"],
-			description: "trigger 기준 툴팁 위치. 자동 flipping 없음.",
+			description:
+				"선호 위치. 뷰포트를 벗어나면 반대편으로 flip + 교차축 shift 되어 실제 위치는 계산 결과를 따른다.",
 		},
 		delay: {
 			control: "number",
@@ -40,7 +41,7 @@ const meta: Meta<typeof Tooltip> = {
 				component: `
 **Tooltip** - Non-blocking supplementary description on hover/focus. For click interactions use Popover. / hover/focus 시 비차단 보조 설명. 클릭 상호작용은 Popover.
 
-Key props: \`content\`, \`placement\` (\`top\`/\`bottom\`/\`left\`/\`right\`, no auto-flip), \`delay\` (default 200ms), \`disabled\`. / 주요 prop: \`content\`, \`placement\` (\`top\`/\`bottom\`/\`left\`/\`right\`, 자동 flip 없음), \`delay\` (기본 200ms), \`disabled\`.
+Key props: \`content\`, \`placement\` (preferred side — auto flip/shift when it would overflow the viewport; portaled to \`body\`), \`delay\` (default 200ms), \`disabled\`. / 주요 prop: \`content\`, \`placement\` (선호 위치 — 뷰포트를 벗어나면 자동 flip/shift, \`body\` 로 포탈), \`delay\` (기본 200ms), \`disabled\`.
 \`role="tooltip"\` + \`aria-describedby\` set automatically. / \`role="tooltip"\` + \`aria-describedby\` 자동.
 				`.trim(),
 			},
@@ -97,6 +98,37 @@ export const Placements: Story = {
 					</Tooltip>
 				</div>
 			))}
+		</div>
+	),
+};
+
+export const ViewportCollision: Story = {
+	name: "뷰포트 경계 (flip/shift)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'화면 왼쪽 끝 트리거에 `placement="left"`. left 로 두면 화면 밖이라 자동으로 right 로 flip 되어 온전히 보인다. 좁은 뷰포트(모바일 프리뷰)에서 확인. / Trigger at the left edge with `placement="left"` auto-flips to `right` so it stays fully visible.',
+			},
+		},
+	},
+	render: () => (
+		<div style={{ display: "flex", justifyContent: "flex-start", padding: "80px 0 0 4px" }}>
+			<Tooltip content="왼쪽 끝이라 right 로 flip 됩니다" placement="left">
+				<button
+					type="button"
+					style={{
+						padding: "8px 16px",
+						background: "var(--bt-color-bg-solid-dim)",
+						border: "1px solid var(--bt-color-border-default)",
+						color: "var(--bt-color-text-heading)",
+						borderRadius: 8,
+						cursor: "pointer",
+					}}
+				>
+					왼쪽 끝
+				</button>
+			</Tooltip>
 		</div>
 	),
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,11 +1,16 @@
 export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export {
+	type AnchoredOptions,
 	type AnchoredResult,
 	type AnchoredSide,
 	type AnchoredState,
+	type AnchorRect,
 	computeAnchoredPosition,
+	type FloatingSize,
+	type UseAnchoredPositionArgs,
 	useAnchoredPosition,
+	type Viewport,
 } from "./use-anchored-position";
 export { useFocusTrap } from "./use-focus-trap";
 export { useIsMounted } from "./use-is-mounted";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,12 @@
 export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
+export {
+	type AnchoredResult,
+	type AnchoredSide,
+	type AnchoredState,
+	computeAnchoredPosition,
+	useAnchoredPosition,
+} from "./use-anchored-position";
 export { useFocusTrap } from "./use-focus-trap";
 export { useIsMounted } from "./use-is-mounted";
 export { useReducedMotion } from "./use-reduced-motion";

--- a/src/utils/use-anchored-position.test.ts
+++ b/src/utils/use-anchored-position.test.ts
@@ -14,7 +14,24 @@ describe("computeAnchoredPosition", () => {
 		expect(r.placement).toBe("top");
 		expect(r.y).toBe(300 - 8 - 40); // anchor.top - gap - height
 		expect(r.x).toBe(400 + 20 - 60); // 중앙정렬: center(420) - width/2(60)
-		expect(r.maxWidth).toBeNull();
+		expect(r.maxWidth).toBe(1024 - 16); // 항상 가용 폭(상한). 240 등 컴포넌트 max-width 안에서만 의미.
+	});
+
+	it("is idempotent — feeding the already-capped width back yields the same maxWidth (no oscillation)", () => {
+		// 측정폭이 available 로 줄어든 뒤 다시 계산해도 maxWidth 가 null 로 튀지 않아야 RO 루프가 안 생긴다.
+		const anchor: AnchorRect = { top: 300, left: 90, width: 20, height: 20 };
+		const first = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(200, 800), {
+			placement: "top",
+			padding: 8,
+		});
+		const second = computeAnchoredPosition(
+			anchor,
+			{ width: first.maxWidth, height: 40 },
+			vp(200, 800),
+			{ placement: "top", padding: 8 },
+		);
+		expect(second.maxWidth).toBe(first.maxWidth);
+		expect(second.x).toBe(first.x);
 	});
 
 	it("flips left → right when the preferred side overflows the viewport (issue #429 repro)", () => {

--- a/src/utils/use-anchored-position.test.ts
+++ b/src/utils/use-anchored-position.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { type AnchorRect, computeAnchoredPosition } from "./use-anchored-position";
+
+const vp = (width: number, height: number) => ({ width, height });
+
+describe("computeAnchoredPosition", () => {
+	it("keeps the preferred side when it fits", () => {
+		// 넉넉한 뷰포트 중앙 트리거 — top 선호가 그대로 유지된다.
+		const anchor: AnchorRect = { top: 300, left: 400, width: 40, height: 40 };
+		const r = computeAnchoredPosition(anchor, { width: 120, height: 40 }, vp(1024, 768), {
+			placement: "top",
+			gap: 8,
+		});
+		expect(r.placement).toBe("top");
+		expect(r.y).toBe(300 - 8 - 40); // anchor.top - gap - height
+		expect(r.x).toBe(400 + 20 - 60); // 중앙정렬: center(420) - width/2(60)
+		expect(r.maxWidth).toBeNull();
+	});
+
+	it("flips left → right when the preferred side overflows the viewport (issue #429 repro)", () => {
+		// 375px 뷰포트, 트리거 x=16 폭32, 툴팁 240. left 는 x=-230 로 화면 밖 → right 로 flip.
+		const anchor: AnchorRect = { top: 100, left: 16, width: 32, height: 32 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 34 }, vp(375, 812), {
+			placement: "left",
+			gap: 6,
+			padding: 8,
+		});
+		expect(r.placement).toBe("right");
+		expect(r.x).toBe(16 + 32 + 6); // 트리거 오른쪽: left + width + gap = 54
+		expect(r.x).toBeGreaterThanOrEqual(8);
+		expect(r.x + 240).toBeLessThanOrEqual(375 - 8); // 오른쪽 여백 안에 들어옴
+	});
+
+	it("flips top → bottom near the top edge", () => {
+		const anchor: AnchorRect = { top: 4, left: 200, width: 40, height: 24 };
+		const r = computeAnchoredPosition(anchor, { width: 100, height: 60 }, vp(800, 600), {
+			placement: "top",
+			gap: 8,
+		});
+		expect(r.placement).toBe("bottom");
+		expect(r.y).toBe(4 + 24 + 8); // anchor 아래
+	});
+
+	it("shifts a centered tooltip back inside when it would clip the left edge", () => {
+		// top 배치, 트리거가 왼쪽 끝(중심 x=32) → 중앙정렬이면 왼쪽 -88, padding 으로 shift.
+		const anchor: AnchorRect = { top: 300, left: 16, width: 32, height: 32 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(375, 812), {
+			placement: "top",
+			gap: 8,
+			padding: 8,
+		});
+		expect(r.placement).toBe("top");
+		expect(r.x).toBe(8); // 왼쪽 여백으로 밀림
+	});
+
+	it("shifts back inside when it would clip the right edge", () => {
+		const anchor: AnchorRect = { top: 300, left: 350, width: 32, height: 32 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(375, 812), {
+			placement: "top",
+			padding: 8,
+		});
+		expect(r.x).toBe(375 - 8 - 240); // 오른쪽 여백에 맞춰 밀림 = 127
+	});
+
+	it("shrinks max-width when the floating is wider than the viewport", () => {
+		const anchor: AnchorRect = { top: 300, left: 90, width: 20, height: 20 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(200, 800), {
+			placement: "top",
+			padding: 8,
+		});
+		expect(r.maxWidth).toBe(200 - 16); // viewport - padding*2 = 184
+		expect(r.x).toBe(8); // 줄인 폭으로도 왼쪽 여백에 고정
+	});
+
+	it("keeps the preferred side when neither side fits (no worse than before)", () => {
+		// 좌우 모두 넘치는 경우 flip 하지 않고 선호 유지.
+		const anchor: AnchorRect = { top: 300, left: 100, width: 40, height: 40 };
+		const r = computeAnchoredPosition(anchor, { width: 300, height: 40 }, vp(360, 800), {
+			placement: "left",
+			gap: 8,
+		});
+		expect(r.placement).toBe("left");
+	});
+});

--- a/src/utils/use-anchored-position.ts
+++ b/src/utils/use-anchored-position.ts
@@ -40,8 +40,8 @@ export interface AnchoredResult {
 	y: number;
 	/** flip 반영된 실제 배치. */
 	placement: AnchoredSide;
-	/** 가용 폭보다 넓어 줄여야 하면 그 값, 아니면 null. */
-	maxWidth: number | null;
+	/** 뷰포트 가용 폭(px) - max-width 상한. 컴포넌트 기본 max-width 안에서만 의미. */
+	maxWidth: number;
 }
 
 const OPPOSITE: Record<AnchoredSide, AnchoredSide> = {
@@ -116,15 +116,16 @@ export function computeAnchoredPosition(
 	const gap = options.gap ?? 8;
 	const padding = options.padding ?? 8;
 
-	// 1. shrink — 가용 폭 초과 시 max-width 축소
+	// 1. shrink — max-width 는 항상 가용 폭(available)으로 돌려준다. 상수(뷰포트만 의존)라 idempotent:
+	// 측정된 폭을 임계값과 비교하면(축소 → 재측정 축소 → …) max-content 컨테이너에서 진동/무한 루프가
+	// 난다. available 을 max-width **상한**으로 걸면 컴포넌트 기본 max-width(예: 240) 안에서 콘텐츠
+	// 폭은 그대로고, 좁은 뷰포트에서만 실제로 좁아진다.
 	const available = viewport.width - padding * 2;
-	let maxWidth: number | null = null;
-	let width = floating.width;
-	if (width > available) {
-		width = available;
-		maxWidth = available;
-	}
-	const sized: FloatingSize = { width, height: floating.height };
+	const maxWidth = available;
+	const sized: FloatingSize = {
+		width: Math.min(floating.width, available),
+		height: floating.height,
+	};
 
 	// 2. flip — 선호가 안 맞고 반대편이 맞으면 뒤집기
 	let side = options.placement;
@@ -181,7 +182,7 @@ export function useAnchoredPosition({
 		x: 0,
 		y: 0,
 		placement,
-		maxWidth: null,
+		maxWidth: 0,
 		ready: false,
 	});
 
@@ -206,16 +207,29 @@ export function useAnchoredPosition({
 			setState({ ...result, ready: true });
 		};
 
-		update();
+		// scroll/resize/observer 는 rAF 로 배칭 - 잦은 스크롤에도 프레임당 한 번만 재계산.
+		let frame = 0;
+		const schedule = () => {
+			if (frame) return;
+			frame = requestAnimationFrame(() => {
+				frame = 0;
+				update();
+			});
+		};
+
+		update(); // 최초는 페인트 전 동기 배치.
 		// capture=true 로 스크롤 조상까지 잡는다(스크롤 이벤트는 버블링하지 않음).
-		window.addEventListener("scroll", update, true);
-		window.addEventListener("resize", update);
-		const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+		window.addEventListener("scroll", schedule, true);
+		window.addEventListener("resize", schedule);
+		// 앵커·플로팅 둘 다 관찰 - 트리거 자체 크기 변화(폰트 로드·리플로우)도 반영.
+		const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(schedule) : null;
 		observer?.observe(floating);
+		observer?.observe(anchor);
 
 		return () => {
-			window.removeEventListener("scroll", update, true);
-			window.removeEventListener("resize", update);
+			if (frame) cancelAnimationFrame(frame);
+			window.removeEventListener("scroll", schedule, true);
+			window.removeEventListener("resize", schedule);
 			observer?.disconnect();
 		};
 	}, [open, placement, gap, padding, anchorRef, floatingRef]);

--- a/src/utils/use-anchored-position.ts
+++ b/src/utils/use-anchored-position.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import * as React from "react";
+import { useSafeLayoutEffect } from "./use-safe-layout-effect";
+
+/** 앵커(트리거) 기준 선호 배치 방향. 넘칠 때 반대편으로 flip 될 수 있다. */
+export type AnchoredSide = "top" | "bottom" | "left" | "right";
+
+/** getBoundingClientRect 에서 필요한 값만. 뷰포트 기준 좌표(fixed). */
+export interface AnchorRect {
+	top: number;
+	left: number;
+	width: number;
+	height: number;
+}
+
+export interface FloatingSize {
+	width: number;
+	height: number;
+}
+
+export interface Viewport {
+	width: number;
+	height: number;
+}
+
+export interface AnchoredOptions {
+	/** 선호 배치. 넘치면 반대편으로 뒤집힐 수 있다. */
+	placement: AnchoredSide;
+	/** 앵커와 플로팅 사이 간격(px). 기본 8. */
+	gap?: number;
+	/** 뷰포트 가장자리 최소 여백(px, collisionPadding). 기본 8. */
+	padding?: number;
+}
+
+export interface AnchoredResult {
+	/** fixed left(px). */
+	x: number;
+	/** fixed top(px). */
+	y: number;
+	/** flip 반영된 실제 배치. */
+	placement: AnchoredSide;
+	/** 가용 폭보다 넓어 줄여야 하면 그 값, 아니면 null. */
+	maxWidth: number | null;
+}
+
+const OPPOSITE: Record<AnchoredSide, AnchoredSide> = {
+	top: "bottom",
+	bottom: "top",
+	left: "right",
+	right: "left",
+};
+
+const isVertical = (side: AnchoredSide) => side === "top" || side === "bottom";
+
+const clamp = (value: number, min: number, max: number) =>
+	// max < min(가용 공간이 플로팅보다 작을 때)이면 min(가장자리 여백)에 고정.
+	Math.max(min, Math.min(max, value));
+
+/** 주축(placement 방향) 좌표 — 플로팅 top-left 의 x 또는 y. */
+const mainAxisStart = (
+	side: AnchoredSide,
+	anchor: AnchorRect,
+	floating: FloatingSize,
+	gap: number,
+): number => {
+	switch (side) {
+		case "top":
+			return anchor.top - gap - floating.height;
+		case "bottom":
+			return anchor.top + anchor.height + gap;
+		case "left":
+			return anchor.left - gap - floating.width;
+		case "right":
+			return anchor.left + anchor.width + gap;
+	}
+};
+
+/** 해당 side 로 뒀을 때 주축이 뷰포트(여백 포함) 안에 들어오는가. */
+const fitsMainAxis = (
+	side: AnchoredSide,
+	anchor: AnchorRect,
+	floating: FloatingSize,
+	viewport: Viewport,
+	gap: number,
+	padding: number,
+): boolean => {
+	const start = mainAxisStart(side, anchor, floating, gap);
+	switch (side) {
+		case "top":
+			return start >= padding;
+		case "bottom":
+			return start + floating.height <= viewport.height - padding;
+		case "left":
+			return start >= padding;
+		case "right":
+			return start + floating.width <= viewport.width - padding;
+	}
+};
+
+/**
+ * 순수 배치 계산 — 앵커/플로팅/뷰포트 rect 로 fixed 좌표를 낸다. DOM·React 의존 없음(테스트 용이).
+ *
+ * 1. **shrink** — 플로팅이 뷰포트 가용 폭보다 넓으면 `maxWidth` 로 줄인다.
+ * 2. **flip** — 선호 side 가 주축으로 넘치고 반대편은 맞으면 반대편으로 뒤집는다.
+ * 3. **shift** — 교차축(중앙 정렬)이 뷰포트를 벗어나면 여백 안으로 민다.
+ *
+ * `placement` 는 선호값이고 결과의 `placement` 가 실제 적용된 방향(Radix `side` + `collisionPadding` 계약).
+ */
+export function computeAnchoredPosition(
+	anchor: AnchorRect,
+	floating: FloatingSize,
+	viewport: Viewport,
+	options: AnchoredOptions,
+): AnchoredResult {
+	const gap = options.gap ?? 8;
+	const padding = options.padding ?? 8;
+
+	// 1. shrink — 가용 폭 초과 시 max-width 축소
+	const available = viewport.width - padding * 2;
+	let maxWidth: number | null = null;
+	let width = floating.width;
+	if (width > available) {
+		width = available;
+		maxWidth = available;
+	}
+	const sized: FloatingSize = { width, height: floating.height };
+
+	// 2. flip — 선호가 안 맞고 반대편이 맞으면 뒤집기
+	let side = options.placement;
+	if (
+		!fitsMainAxis(side, anchor, sized, viewport, gap, padding) &&
+		fitsMainAxis(OPPOSITE[side], anchor, sized, viewport, gap, padding)
+	) {
+		side = OPPOSITE[side];
+	}
+
+	// 3. 주축 좌표 + 교차축 중앙정렬 후 shift(clamp)
+	let x: number;
+	let y: number;
+	if (isVertical(side)) {
+		y = mainAxisStart(side, anchor, sized, gap);
+		x = anchor.left + anchor.width / 2 - sized.width / 2;
+		x = clamp(x, padding, viewport.width - padding - sized.width);
+	} else {
+		x = mainAxisStart(side, anchor, sized, gap);
+		y = anchor.top + anchor.height / 2 - sized.height / 2;
+		y = clamp(y, padding, viewport.height - padding - sized.height);
+	}
+
+	return { x, y, placement: side, maxWidth };
+}
+
+export interface UseAnchoredPositionArgs extends AnchoredOptions {
+	/** 열림 상태 — false 면 계산을 멈추고 ready 를 내린다. */
+	open: boolean;
+	/** 앵커(트리거) 요소 ref. */
+	anchorRef: React.RefObject<HTMLElement | null>;
+	/** 측정할 플로팅 요소 ref. */
+	floatingRef: React.RefObject<HTMLElement | null>;
+}
+
+export interface AnchoredState extends AnchoredResult {
+	/** 최초 측정 전에는 false — 이때 플로팅을 숨겨 (0,0) 깜빡임을 막는다. */
+	ready: boolean;
+}
+
+/**
+ * 앵커/플로팅 ref 를 재서 fixed 좌표를 돌려주는 훅. 열려 있는 동안 scroll(캡처)·resize·플로팅
+ * 크기 변화(ResizeObserver)에 재계산한다. 실제 배치는 {@link computeAnchoredPosition} 가 담당.
+ */
+export function useAnchoredPosition({
+	open,
+	anchorRef,
+	floatingRef,
+	placement,
+	gap,
+	padding,
+}: UseAnchoredPositionArgs): AnchoredState {
+	const [state, setState] = React.useState<AnchoredState>({
+		x: 0,
+		y: 0,
+		placement,
+		maxWidth: null,
+		ready: false,
+	});
+
+	useSafeLayoutEffect(() => {
+		if (!open) {
+			setState((prev) => (prev.ready ? { ...prev, ready: false } : prev));
+			return;
+		}
+		const anchor = anchorRef.current;
+		const floating = floatingRef.current;
+		if (!anchor || !floating) return;
+
+		const update = () => {
+			const a = anchor.getBoundingClientRect();
+			const f = floating.getBoundingClientRect();
+			const result = computeAnchoredPosition(
+				{ top: a.top, left: a.left, width: a.width, height: a.height },
+				{ width: f.width, height: f.height },
+				{ width: window.innerWidth, height: window.innerHeight },
+				{ placement, gap, padding },
+			);
+			setState({ ...result, ready: true });
+		};
+
+		update();
+		// capture=true 로 스크롤 조상까지 잡는다(스크롤 이벤트는 버블링하지 않음).
+		window.addEventListener("scroll", update, true);
+		window.addEventListener("resize", update);
+		const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+		observer?.observe(floating);
+
+		return () => {
+			window.removeEventListener("scroll", update, true);
+			window.removeEventListener("resize", update);
+			observer?.disconnect();
+		};
+	}, [open, placement, gap, padding, anchorRef, floatingRef]);
+
+	return state;
+}


### PR DESCRIPTION
## 작업 개요

이슈 #429 — `Tooltip`/`Popover` 가 뷰포트 경계를 무시하고 화면 밖에서 열리던 문제 수정. 순수 CSS absolute 오프셋 배치라 트리거가 가장자리면 패널이 화면 밖으로 나가고, 소비자가 폭마다 `placement` 를 손으로 골라야 했음(모바일에선 고를 값이 없기도).

## 작업한 내용

- [x] **공유 배치 유틸** `src/utils/use-anchored-position.ts`
  - `computeAnchoredPosition(anchor, floating, viewport, opts)` — **순수 함수**(DOM/React 무관): shrink(가용폭 초과 시 `max-width` 축소) → flip(선호 side 넘치면 반대편) → shift(교차축 중앙정렬을 여백 안으로 clamp). 결과 `placement` 가 실제 적용 방향.
  - `useAnchoredPosition(...)` — ref 측정 + `scroll`(capture)·`resize`·`ResizeObserver` 재계산. `useSafeLayoutEffect` 로 페인트 전 배치(깜빡임 방지 `ready` 게이트).
- [x] **Tooltip / Popover** — `createPortal(document.body)` + `position: fixed`(조상 `overflow`/`transform` 탈출), 계산 좌표 inline 적용. placement 별 CSS 오프셋 블록 제거.
- [x] **Popover 외부 클릭** — 패널이 body 로 포탈되므로 wrapper + 패널 둘 다 "내부"로 판정(포탈 후 클릭 시 즉시 닫히던 버그 방지).
- [x] `placement` 를 **선호값**으로 재정의(JSDoc·argTypes·COMPONENTS.md, Radix `side`+`collisionPadding` 계약).
- [x] **테스트** — `use-anchored-position.test.ts` 7 케이스(이슈 375px repro 포함: left→right flip, top→bottom flip, 좌/우 shift, max-width shrink, 양쪽 불가 시 유지). Tooltip/Popover 기존 "placement class" 테스트를 포탈+fixed 검증으로 갱신.
- [x] Storybook: Tooltip `ViewportCollision` 스토리 추가, placement 설명 갱신.

## 검증

- tsc 클린, unit 778 pass, biome 클린(툴팁 static-handler 경고는 develop 기존)

## 전달할 추가 이슈

- 같은 배치 계약을 `Menu`/`Dropdown` 에도 확대할 수 있음(이번은 Tooltip/Popover 로 한정, 유틸은 재사용 가능하게 분리).

Closes #429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 툴팁과 팝오버가 화면 경계를 자동으로 감지해 위치를 전환하거나 보정합니다.
  * 공간이 부족할 경우 너비를 자동으로 줄여 콘텐츠가 화면 밖으로 벗어나는 현상을 줄였습니다.
  * 화면 전체 기준으로 안정적으로 표시되며, 초기 위치 계산 전 깜박임이 방지됩니다.
  * 스크롤, 창 크기 변경 및 주변 요소 크기 변경 시 위치가 자동으로 갱신됩니다.

* **문서**
  * 배치 옵션과 자동 위치 보정 동작에 대한 설명을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->