### PR TITLE
fix/tooltip-exit-animation

### DIFF
--- a/src/ui/overlay/overlay-escape.test.tsx
+++ b/src/ui/overlay/overlay-escape.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Modal } from "./modal";
 import { Popover } from "./popover";
@@ -9,44 +9,37 @@ import { Tooltip } from "./tooltip";
  * 컴포넌트 조합에서도 보장하는지, 그리고 자식 요소의 자체 Escape 처리(critical)를 막지 않는지 검증.
  */
 describe("overlay Escape composition (shared stack)", () => {
-	it("Tooltip over Popover: Escape closes only the topmost (Tooltip), Popover stays; next Escape closes Popover", () => {
-		vi.useFakeTimers();
-		try {
-			const onOpenChange = vi.fn();
-			render(
-				<Popover
-					defaultOpen
-					onOpenChange={onOpenChange}
-					trigger={<button type="button">trigger</button>}
-					aria-label="pop"
-					content={
-						<Tooltip content="tip" delay={0}>
-							<button type="button">inner</button>
-						</Tooltip>
-					}
-				/>,
-			);
+	it("Tooltip over Popover: Escape closes only the topmost (Tooltip), Popover stays; next Escape closes Popover", async () => {
+		// Tooltip 은 퇴장 애니메이션 후 언마운트하므로 real timer + waitFor 로 검증한다.
+		const onOpenChange = vi.fn();
+		render(
+			<Popover
+				defaultOpen
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">trigger</button>}
+				aria-label="pop"
+				content={
+					<Tooltip content="tip" delay={0}>
+						<button type="button">inner</button>
+					</Tooltip>
+				}
+			/>,
+		);
 
-			// Popover 는 이미 열림. inner 버튼에 hover 해 Tooltip 을 나중에 연다 → Tooltip 이 최상단.
-			expect(screen.getByRole("dialog")).toBeInTheDocument();
-			fireEvent.mouseEnter(screen.getByRole("button", { name: "inner" }));
-			act(() => {
-				vi.advanceTimersByTime(10);
-			});
-			expect(screen.getByRole("tooltip")).toBeInTheDocument();
+		// Popover 는 이미 열림. inner 버튼에 hover 해 Tooltip 을 나중에 연다 → Tooltip 이 최상단.
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		fireEvent.mouseEnter(screen.getByRole("button", { name: "inner" }));
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
 
-			// 1차 Escape - 최상단(Tooltip)만 닫히고 Popover 는 유지, onOpenChange 도 안 불림
-			fireEvent.keyDown(document.body, { key: "Escape" });
-			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-			expect(screen.getByRole("dialog")).toBeInTheDocument();
-			expect(onOpenChange).not.toHaveBeenCalled();
+		// 1차 Escape - 최상단(Tooltip)만 닫히고 Popover 는 유지, onOpenChange 도 안 불림
+		fireEvent.keyDown(document.body, { key: "Escape" });
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(onOpenChange).not.toHaveBeenCalled();
 
-			// 2차 Escape - 이제 최상단이 된 Popover 가 닫힌다
-			fireEvent.keyDown(document.body, { key: "Escape" });
-			expect(onOpenChange).toHaveBeenCalledWith(false);
-		} finally {
-			vi.useRealTimers();
-		}
+		// 2차 Escape - 이제 최상단이 된 Popover 가 닫힌다
+		fireEvent.keyDown(document.body, { key: "Escape" });
+		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
 
 	it("Popover inside Modal: Escape closes only the Popover, Modal stays (topmost)", () => {

--- a/src/ui/overlay/tooltip/Tooltip.test.tsx
+++ b/src/ui/overlay/tooltip/Tooltip.test.tsx
@@ -1,14 +1,9 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import { Tooltip } from "./index";
 
-beforeEach(() => {
-	vi.useFakeTimers();
-});
-
-afterEach(() => {
-	vi.useRealTimers();
-});
+// react-spring 은 setup.ts 에서 skipAnimation 이지만 퇴장 언마운트(onExitComplete)는 한 tick 늦게
+// 스케줄되므로, 열림/닫힘은 fake timer 동기 단언 대신 real timer + waitFor 로 검증한다 (Popover 패턴).
 
 describe("Tooltip", () => {
 	it("does not show tooltip initially", () => {
@@ -20,80 +15,64 @@ describe("Tooltip", () => {
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
-	it("shows tooltip after delay on mouseEnter", () => {
+	it("shows tooltip after delay on mouseEnter", async () => {
 		render(
-			<Tooltip content="hint" delay={100}>
+			<Tooltip content="hint" delay={50}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
+		// delay 전에는 아직 안 보인다.
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-		act(() => {
-			vi.advanceTimersByTime(150);
-		});
-		expect(screen.getByRole("tooltip")).toHaveTextContent("hint");
+		await waitFor(() => expect(screen.getByRole("tooltip")).toHaveTextContent("hint"));
 	});
 
-	it("hides on mouseLeave (after the hoverable grace period)", () => {
+	it("hides on mouseLeave (after the hoverable grace period)", async () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
-		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
 		fireEvent.mouseLeave(screen.getByRole("button"));
 		// WCAG 1.4.13 Hoverable - 포인터가 툴팁으로 건너갈 유예(120ms) 동안은 유지
 		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
-		act(() => {
-			vi.advanceTimersByTime(150);
-		});
-		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
 	});
 
-	it("stays open while the pointer is over the tooltip itself (WCAG 1.4.13 Hoverable)", () => {
+	it("stays open while the pointer is over the tooltip itself (WCAG 1.4.13 Hoverable)", async () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
 		fireEvent.mouseLeave(screen.getByRole("button"));
-		// 유예 시간 안에 툴팁 위로 포인터 이동 → 열림 유지
+		// 유예 시간 안에 툴팁 위로 포인터 이동 → 닫힘 타이머 취소, 열림 유지
 		const positionWrap = screen.getByRole("tooltip").parentElement as HTMLElement;
 		fireEvent.mouseEnter(positionWrap);
-		act(() => {
-			vi.advanceTimersByTime(500);
-		});
 		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+
 		// 툴팁에서 떠나면 유예 후 닫힘
 		fireEvent.mouseLeave(positionWrap);
-		act(() => {
-			vi.advanceTimersByTime(150);
-		});
-		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
 	});
 
-	it("dismisses with Escape without moving the pointer (WCAG 1.4.13 Dismissable)", () => {
+	it("dismisses with Escape without moving the pointer (WCAG 1.4.13 Dismissable)", async () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
-		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
 
 		fireEvent.keyDown(document.body, { key: "Escape" });
-		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
 	});
 
 	it("disabled=true: never shows tooltip", () => {
@@ -102,14 +81,12 @@ describe("Tooltip", () => {
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
+		// disabled 는 children 만 렌더 - Tooltip 로직 자체가 없어 hover 해도 마운트되지 않는다.
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(500);
-		});
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
-	it("portals the tooltip to the body and positions it fixed", () => {
+	it("portals the tooltip to the body and positions it fixed", async () => {
 		// placement 는 이제 CSS 클래스가 아니라 useAnchoredPosition 이 계산한 fixed 좌표로 적용된다.
 		const { container } = render(
 			<Tooltip content="hint" delay={0} placement="bottom">
@@ -117,9 +94,8 @@ describe("Tooltip", () => {
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
 		const tip = screen.getByRole("tooltip");
 		// 포탈 - 트리거 wrapper 밖(body)으로 렌더된다.
 		expect(container.querySelector(".tooltip_wrapper")?.contains(tip)).toBe(false);

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -44,6 +44,9 @@ export const Tooltip = ({
 	children,
 }: TooltipProps) => {
 	const [open, setOpen] = React.useState(false);
+	// 퇴장 스프링이 끝난 뒤 언마운트 - open&& 로 바로 지우면 fade+slide 퇴장 모션이 잘린다 (Popover 와 동일).
+	const [shouldRender, setShouldRender] = React.useState(false);
+	if (open && !shouldRender) setShouldRender(true);
 	const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const tooltipId = React.useId();
 	// wrapper = 앵커(트리거) 측정 대상, position = 플로팅(뷰포트 fixed 배치) 측정 대상.
@@ -88,8 +91,9 @@ export const Tooltip = ({
 	useOverlayEscape(open, hideNow);
 
 	// 열릴 때 트리거 rect + 뷰포트로 flip/shift/shrink 를 계산해 body 로 포탈(fixed).
+	// shouldRender 로 게이트해 퇴장 애니메이션 동안에도 위치를 유지한다.
 	const pos = useAnchoredPosition({
-		open,
+		open: shouldRender,
 		anchorRef: wrapperRef,
 		floatingRef: positionRef,
 		placement,
@@ -110,7 +114,11 @@ export const Tooltip = ({
 		}
 	})();
 
-	const style = useSpringPresence({ visible: open, from: fromTransform });
+	const style = useSpringPresence({
+		visible: open,
+		from: fromTransform,
+		onExitComplete: () => setShouldRender(false),
+	});
 
 	const child = children as React.ReactElement<React.HTMLAttributes<HTMLElement>>;
 	const childProps = child.props;
@@ -143,7 +151,7 @@ export const Tooltip = ({
 	return (
 		<span className="tooltip_wrapper" ref={wrapperRef}>
 			{trigger}
-			{open &&
+			{shouldRender &&
 				typeof document !== "undefined" &&
 				createPortal(
 					<span


### PR DESCRIPTION
## 작업 개요

이슈 #431 — `Tooltip` 이 exit 애니메이션 없이 즉시 언마운트되던 문제(Popover 와 비대칭) 수정. (#430 머지 완료 → develop 기준 단독 PR)

## 작업한 내용

- [x] Tooltip 에 `shouldRender` + `useSpringPresence({ onExitComplete })` 도입 (Popover 패턴) — `open&&` 즉시 언마운트 대신 fade+slide 퇴장 재생 후 unmount
- [x] `useAnchoredPosition` open 인자를 `shouldRender` 로 (퇴장 중 위치 유지)
- [x] `Tooltip.test.tsx` fake timers → **real timers + `await waitFor`** 전환 (skipAnimation 이라도 exit onExitComplete 가 한 tick 늦어 동기 단언 불가 — Popover 테스트와 동일 패턴)
- [x] `overlay-escape.test.tsx` 의 Tooltip-over-Popover Escape 합성 테스트도 동일 전환

## 검증

- tsc 클린, unit 779 pass, biome 클린(툴팁 position span static-handler 경고는 develop 기존)
- `prefers-reduced-motion` 은 useSpringPresence 가 처리(즉시 완료)

Closes #431