### PR TITLE
fix/reduced-motion-guards

### DIFF
--- a/src/ui/display/chip/style.scss
+++ b/src/ui/display/chip/style.scss
@@ -249,3 +249,13 @@
         }
     }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+    .chip,
+    .chip::before,
+    .chip_content::before,
+    .chip_icon {
+        transition: none;
+    }
+}

--- a/src/ui/display/list-item/style.scss
+++ b/src/ui/display/list-item/style.scss
@@ -134,3 +134,8 @@
     pointer-events: none;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .list_item_interactive .list_item_state_layer::before { transition: none; }
+}

--- a/src/ui/forms/otp-input/style.scss
+++ b/src/ui/forms/otp-input/style.scss
@@ -85,3 +85,8 @@
     color: token.$color_status_error_on_surface;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .otp_input_box { transition: none; }
+}

--- a/src/ui/forms/textfield/style.scss
+++ b/src/ui/forms/textfield/style.scss
@@ -232,3 +232,13 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .text_field_label,
+  .text_field_container,
+  .text_field_clear,
+  .text_field_helper {
+    transition: none;
+  }
+}

--- a/src/ui/navigation/breadcrumb/style.scss
+++ b/src/ui/navigation/breadcrumb/style.scss
@@ -50,3 +50,8 @@
     color: token.$color_text_caption;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumb_link { transition: none; }
+}

--- a/src/ui/navigation/pagination/style.scss
+++ b/src/ui/navigation/pagination/style.scss
@@ -88,3 +88,11 @@
     color: token.$color_text_caption;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .pagination_item,
+  .pagination_page_button {
+    transition: none;
+  }
+}

--- a/src/ui/overlay/modal/style.scss
+++ b/src/ui/overlay/modal/style.scss
@@ -100,3 +100,8 @@
   }
 
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .modal_close { transition: none; }
+}


### PR DESCRIPTION
## 작업 개요

CLAUDE.md 규칙상 `transition` / `animation` 을 선언하는 컴포넌트 SCSS 는 파일 끝에 `@media (prefers-reduced-motion: reduce)` 가드를 반드시 포함해야 한다 (WCAG 2.1 SC 2.3.3). 전역 리셋이 없어 파일마다 자체적으로 가드를 걸어야 하는데, 아래 7개 파일이 transition 만 선언하고 가드가 누락되어 있었다.

기존 파일(`forms/file`, `feedback/toast`, `forms/image-cropper`, `display/table`, `navigation/tabs` 등)의 `// ── Reduced motion (WCAG 2.3.3) ──` 주석 포맷과 동일하게 맞췄고, 해당 컴포넌트의 애니메이션 대상 셀렉터만 지정했다 (전역 `*` 블랭킷 미사용). 기존 스타일 값 변경 없음, 하드코딩 값 추가 없음 — 순수 추가(48줄)만 있다.

## 작업한 내용

- [x] `src/ui/overlay/modal/style.scss` — `.modal_close` (background / color transition)
- [x] `src/ui/display/chip/style.scss` — `.chip`, `.chip::before`, `.chip_content::before`, `.chip_icon` (4-space 들여쓰기 파일이라 그에 맞춤)
- [x] `src/ui/display/list-item/style.scss` — `.list_item_interactive .list_item_state_layer::before` (state layer background transition)
- [x] `src/ui/forms/otp-input/style.scss` — `.otp_input_box` (border-color / box-shadow transition)
- [x] `src/ui/forms/textfield/style.scss` — `.text_field_label`, `.text_field_container`, `.text_field_clear`, `.text_field_helper`
- [x] `src/ui/navigation/pagination/style.scss` — `.pagination_item`, `.pagination_page_button`
- [x] `src/ui/navigation/breadcrumb/style.scss` — `.breadcrumb_link` (color transition)

## 검증

- [x] `npx stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss'` — 통과 (에러 0)
- [x] `npx vitest run --project unit` — 통과 (55 files / 779 passed, 9 skipped)
- [x] `npx tsc --noEmit -p tsconfig.json` — 통과 (에러 0)
- [x] husky pre-commit 유닛 스위트 통과
