### PR TITLE
fix/a11y-accessible-names

### DIFF
--- a/src/ui/general/icon-button/IconButton.test.tsx
+++ b/src/ui/general/icon-button/IconButton.test.tsx
@@ -75,4 +75,28 @@ describe("IconButton", () => {
 		expect(node).toBeInstanceOf(HTMLButtonElement);
 	});
 
+	describe("accessible name", () => {
+		it("accepts aria-labelledby instead of aria-label", () => {
+			render(
+				<>
+					<span id="icon-button-label">저장</span>
+					<IconButton icon={<TestIcon />} aria-labelledby="icon-button-label" />
+				</>,
+			);
+			expect(screen.getByRole("button", { name: "저장" })).toBeInTheDocument();
+		});
+
+		it("keeps the icon hidden from the accessibility tree", () => {
+			render(<IconButton icon={<TestIcon />} aria-label="action" />);
+			expect(screen.getByTestId("test-icon").parentElement).toHaveAttribute("aria-hidden", "true");
+		});
+
+		// 타입 레벨 회귀 방지 - 접근성 이름 없는 IconButton 은 컴파일되면 안 된다.
+		// 아래 무시 지시자가 "불필요"로 판정되면 tsc 가 실패하므로 이 단언은 tsc 가 검증한다.
+		it("requires aria-label or aria-labelledby at the type level", () => {
+			// @ts-expect-error - aria-label / aria-labelledby 둘 다 없으면 타입 에러여야 한다.
+			const nameless = <IconButton icon={<TestIcon />} />;
+			expect(nameless).toBeTruthy();
+		});
+	});
 });

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -7,7 +7,9 @@ import "./style.scss";
 export type IconButtonVariant = "standard" | "filled" | "tonal" | "outlined";
 export type IconButtonSize = "sm" | "md";
 
-export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+/** 접근성 이름을 제외한 IconButton 공통 props */
+interface IconButtonBaseProps
+	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "aria-label" | "aria-labelledby"> {
 	/** 아이콘 버튼 스타일 변형 (기본값: "standard") */
 	variant?: IconButtonVariant;
 	/** 아이콘 버튼 크기 (기본값: "md") */
@@ -18,9 +20,43 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
 	ref?: React.Ref<HTMLButtonElement>;
 }
 
+/** `aria-label` 로 접근성 이름을 직접 지정 */
+export interface IconButtonWithAriaLabel extends IconButtonBaseProps {
+	/** 아이콘 버튼의 접근성 이름 (필수) */
+	"aria-label": string;
+	/** 접근성 이름을 제공하는 요소 id (선택) */
+	"aria-labelledby"?: string;
+}
+
+/** `aria-labelledby` 로 외부 요소를 참조해 접근성 이름을 지정 */
+export interface IconButtonWithAriaLabelledBy extends IconButtonBaseProps {
+	/** 아이콘 버튼의 접근성 이름 (선택) */
+	"aria-label"?: string;
+	/** 접근성 이름을 제공하는 요소 id (필수) */
+	"aria-labelledby": string;
+}
+
+/**
+ * IconButton props - 접근성 이름을 타입 레벨에서 강제하는 union.
+ * `icon` 은 항상 `aria-hidden` 으로 감싸지므로 `aria-label` 또는 `aria-labelledby` 중
+ * 최소 하나를 반드시 지정해야 한다 (WCAG 2.1 SC 4.1.2 Name, Role, Value).
+ *
+ * @deprecated 형태의 주의 - v3.7.0 이하에서는 두 속성 모두 optional 이었다.
+ * 접근성 이름 없이 `<IconButton icon={<X />} />` 로 사용하던 코드는 이제 **타입 에러**가 난다.
+ * 런타임 렌더링은 바뀌지 않았으므로 `aria-label`(또는 `aria-labelledby`)만 추가하면 된다.
+ * ```tsx
+ * // before (타입 에러 - 접근성 이름 없음)
+ * <IconButton icon={<X />} />
+ * // after
+ * <IconButton icon={<X />} aria-label="닫기" />
+ * ```
+ */
+export type IconButtonProps = IconButtonWithAriaLabel | IconButtonWithAriaLabelledBy;
+
 /**
  * 아이콘만 표시하는 버튼을 렌더링한다.
  * Figma DS 기준 4가지 variant(standard/filled/tonal/outlined)와 2가지 size(sm/md)를 지원한다.
+ * 아이콘은 `aria-hidden` 이므로 `aria-label` 또는 `aria-labelledby` 가 타입 레벨에서 필수다.
  * @param props 아이콘 버튼 속성
  * @returns 렌더링된 아이콘 버튼 요소
  */

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -41,7 +41,7 @@ export interface IconButtonWithAriaLabelledBy extends IconButtonBaseProps {
  * `icon` 은 항상 `aria-hidden` 으로 감싸지므로 `aria-label` 또는 `aria-labelledby` 중
  * 최소 하나를 반드시 지정해야 한다 (WCAG 2.1 SC 4.1.2 Name, Role, Value).
  *
- * @deprecated 형태의 주의 - v3.7.0 이하에서는 두 속성 모두 optional 이었다.
+ * @remarks **Breaking change (타입 레벨)** - v3.7.0 이하에서는 두 속성 모두 optional 이었다.
  * 접근성 이름 없이 `<IconButton icon={<X />} />` 로 사용하던 코드는 이제 **타입 에러**가 난다.
  * 런타임 렌더링은 바뀌지 않았으므로 `aria-label`(또는 `aria-labelledby`)만 추가하면 된다.
  * ```tsx

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -32,7 +32,7 @@ export interface MenuProps {
  * @example
  * ```tsx
  * <Menu
- *   trigger={<IconButton icon={<MoreIcon />} />}
+ *   trigger={<IconButton icon={<MoreIcon />} aria-label="더보기" />}
  *   items={[
  *     { key: "edit", label: "편집", onSelect: handleEdit },
  *     { key: "del", label: "삭제", onSelect: handleDel, destructive: true },

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -72,6 +72,29 @@ describe("NavBar", () => {
 			expect(items[1]).toHaveFocus();
 		});
 
+		it("trigger has an accessible name matching the visible label", () => {
+			render(<NavBar locale={makeLocale()} />);
+			expect(screen.getByRole("button", { name: "한국어" })).toBeInTheDocument();
+		});
+
+		it("trigger keeps an accessible name when hideLabel hides the text", () => {
+			render(<NavBar locale={{ ...makeLocale(), hideLabel: true }} />);
+			const trigger = screen.getByRole("button", { name: "한국어" });
+			// 라벨 텍스트는 렌더되지 않지만 접근성 이름은 남아 있어야 한다.
+			expect(trigger).toHaveTextContent("");
+			expect(trigger).toHaveAttribute("aria-label", "한국어");
+		});
+
+		it("falls back to the uppercased current code when no option matches", () => {
+			render(<NavBar locale={{ current: "ja", options: [], hideLabel: true }} />);
+			expect(screen.getByRole("button", { name: "JA" })).toBeInTheDocument();
+		});
+
+		it("ariaLabel overrides the derived accessible name", () => {
+			render(<NavBar locale={{ ...makeLocale(), hideLabel: true, ariaLabel: "언어 선택" }} />);
+			expect(screen.getByRole("button", { name: "언어 선택" })).toBeInTheDocument();
+		});
+
 		it("Escape closes and returns focus to the trigger", () => {
 			render(<NavBar locale={makeLocale()} />);
 			const trigger = screen.getByRole("button");

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -29,6 +29,10 @@ export interface NavBarLocaleConfig {
 	/**
 	 * locale 트리거 버튼의 접근성 이름 (기본값: 현재 옵션의 label, 없으면 `current` 대문자).
 	 * `hideLabel` 이 true 면 버튼 안이 아이콘뿐이라 이 값이 유일한 접근성 이름이 된다.
+	 *
+	 * ⚠️ `hideLabel` 이 false(기본값)일 때는 이 값이 화면에 보이는 라벨을 덮어쓰므로,
+	 * 보이는 라벨 텍스트를 **포함**하는 문자열이어야 한다. 그렇지 않으면 음성 제어 사용자가
+	 * 보이는 대로 말해도 버튼이 잡히지 않는다 (WCAG 2.1 SC 2.5.3 Label in Name 위반).
 	 */
 	ariaLabel?: string;
 }

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -26,6 +26,11 @@ export interface NavBarLocaleConfig {
 	onChange?: (next: string) => void;
 	/** 표시 라벨 - 기본은 옵션의 label, 미지정 시 short code 표시 */
 	hideLabel?: boolean;
+	/**
+	 * locale 트리거 버튼의 접근성 이름 (기본값: 현재 옵션의 label, 없으면 `current` 대문자).
+	 * `hideLabel` 이 true 면 버튼 안이 아이콘뿐이라 이 값이 유일한 접근성 이름이 된다.
+	 */
+	ariaLabel?: string;
 }
 
 export interface NavBarProps extends React.HTMLAttributes<HTMLElement> {
@@ -181,6 +186,8 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	const menuId = useId();
 
 	const currentOption = locale.options.find((o) => o.value === locale.current);
+	// 트리거에 보이는 라벨. hideLabel 이면 렌더되지 않으므로 aria-label 로만 노출된다.
+	const currentLabel = currentOption?.label ?? locale.current.toUpperCase();
 
 	useEffect(() => {
 		if (!open) return;
@@ -264,14 +271,13 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 				aria-haspopup="menu"
 				aria-expanded={open}
 				aria-controls={menuId}
+				// Globe/Chevron 은 aria-hidden 이라 hideLabel 이면 버튼에 접근성 이름이 전혀 없다.
+				// 보이는 라벨과 동일한 문자열을 쓰므로 label-in-name(WCAG 2.5.3)도 유지된다.
+				aria-label={locale.ariaLabel ?? currentLabel}
 				onClick={() => setOpen((p) => !p)}
 			>
 				<Globe size={iconSize.sm} aria-hidden="true" />
-				{!locale.hideLabel && (
-					<span className="nav_bar_locale_label">
-						{currentOption?.label ?? locale.current.toUpperCase()}
-					</span>
-				)}
+				{!locale.hideLabel && <span className="nav_bar_locale_label">{currentLabel}</span>}
 				<ChevronDown
 					size={iconSize.xs}
 					aria-hidden="true"

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -178,6 +178,33 @@ describe("Popover", () => {
 		expect(screen.getByRole("dialog", { name: "필터 옵션" })).toBeInTheDocument();
 	});
 
+	it('falls back to a "Dialog" accessible name when no label is given', () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog", { name: "Dialog" })).toBeInTheDocument();
+	});
+
+	it("does not add the fallback label when aria-labelledby is provided", () => {
+		render(
+			<>
+				<h2 id="popover-title">필터</h2>
+				<Popover
+					trigger={<button type="button">Open</button>}
+					content={<span>Panel content</span>}
+					aria-labelledby="popover-title"
+				/>
+			</>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const dialog = screen.getByRole("dialog", { name: "필터" });
+		expect(dialog).not.toHaveAttribute("aria-label");
+	});
+
 	it("preserves the trigger's own onClick handler", () => {
 		const onClick = vi.fn();
 		render(

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -33,7 +33,7 @@ export interface PopoverProps {
 	defaultOpen?: boolean;
 	/** 열림 상태 변경 콜백 */
 	onOpenChange?: (open: boolean) => void;
-	/** dialog 의 접근성 라벨 - content 에 제목이 없을 때 권장 */
+	/** 팝오버 접근성 레이블(기본값: "Dialog") - content 에 제목이 없을 때 권장 */
 	"aria-label"?: string;
 	/** dialog 의 접근성 라벨 요소 id */
 	"aria-labelledby"?: string;
@@ -188,7 +188,9 @@ export const Popover = ({
 							ref={popoverRef}
 							role="dialog"
 							tabIndex={-1}
-							aria-label={ariaLabel}
+							// aria-labelledby 가 없으면 이름 없는 dialog 가 되므로 Modal/Drawer 와 동일하게
+							// "Dialog" 로 폴백한다 (WCAG 2.1 SC 4.1.2).
+							aria-label={ariaLabelledby ? ariaLabel : (ariaLabel ?? "Dialog")}
 							aria-labelledby={ariaLabelledby}
 							style={style}
 							className={cn("popover", className)}

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -32,7 +32,7 @@ export interface TooltipProps {
  * @example
  * ```tsx
  * <Tooltip content="저장하기">
- *   <IconButton icon={<SaveIcon />} />
+ *   <IconButton icon={<SaveIcon />} aria-label="저장" />
  * </Tooltip>
  * ```
  */


### PR DESCRIPTION
## 작업 개요

검증된 접근성 이름(accessible name) 누락 3건을 수정했다. 세 케이스 모두 스크린리더에서 버튼/다이얼로그가 이름 없이 읽히던 문제로, WCAG 2.1 SC 4.1.2 (Name, Role, Value) 위반이다.

## 작업한 내용

- [x] **NavBar locale 트리거** (`src/ui/navigation/nav-bar/index.tsx`) - `locale.hideLabel` 이 true 면 버튼 안이 `aria-hidden` 처리된 Globe + ChevronDown 아이콘뿐이라 접근성 이름이 **전혀 없었다**. 현재 옵션의 label(없으면 `current` 대문자)에서 파생한 `aria-label` 을 추가했다. 보이는 라벨과 동일한 문자열이라 `hideLabel=false` 일 때의 기존 동작과 label-in-name(SC 2.5.3)이 그대로 유지된다.
- [x] **NavBarLocaleConfig.ariaLabel 추가** - 소비자가 트리거 이름을 직접 지정할 수 있는 optional 필드. 미지정 시 위 파생값 사용.
- [x] **IconButton 접근성 이름 타입 강제** (`src/ui/general/icon-button/index.tsx`) - `icon` 은 항상 `aria-hidden="true"` 래퍼로 감싸지는데 이름을 요구하는 장치가 없어 `<IconButton icon={<X />} />` 가 타입 통과 후 이름 없는 버튼으로 출고됐다. `ButtonProps` 와 동일한 union 패턴으로 `IconButtonProps` 를 `IconButtonWithAriaLabel | IconButtonWithAriaLabelledBy` 로 바꿔 `aria-label` 또는 `aria-labelledby` 중 하나를 타입 레벨에서 필수화했다. **런타임 렌더링은 변경 없음.**
- [x] **Popover dialog 폴백** (`src/ui/overlay/popover/index.tsx`) - `role="dialog"` 인데 `aria-label` / `aria-labelledby` 가 둘 다 optional 이고 폴백이 없어 이름 없는 dialog 가 됐다. Modal(`index.tsx:155`) / Drawer 와 동일하게 `"Dialog"` 로 폴백한다. `aria-labelledby` 가 있으면 폴백을 붙이지 않아 중복 이름을 만들지 않는다.
- [x] **JSDoc `@example` 갱신** (`src/ui/overlay/tooltip/index.tsx`, `src/ui/navigation/menu/index.tsx`) - 두 `@example` 블록이 `<IconButton icon={...} />` 를 `aria-label` 없이 보여주고 있었다. 위 타입 변경으로 더는 컴파일되지 않는 호출이라 각각 `aria-label="저장"` / `aria-label="더보기"` 를 추가했다. 주석 한 줄씩만 변경.
- [x] **테스트 9건 추가** - NavBar 4건(보이는 라벨과 일치 / hideLabel 시에도 이름 유지 / 옵션 미매칭 시 대문자 폴백 / `ariaLabel` 오버라이드), Popover 2건(`"Dialog"` 폴백 / `aria-labelledby` 시 폴백 미적용), IconButton 3건(`aria-labelledby` 단독 사용 / 아이콘 `aria-hidden` 유지 / 이름 없는 사용이 컴파일되지 않음을 tsc 가 검증).

## 검증

| 항목 | 결과 |
|---|---|
| `npx tsc --noEmit -p tsconfig.json` | 통과 (0 errors) |
| `npx vitest run --project unit` | 통과 (55 files / 788 passed, 9 skipped) |
| `npx biome check <변경 파일 8개>` | 신규 지적 0건 (남은 지적은 모두 이번 변경 이전부터 존재) |

IconButton 타입 회귀 테스트는 `@ts-expect-error` 로 작성해 tsc 가 직접 검증한다 - 이름 없는 사용이 다시 컴파일되기 시작하면 "불필요한 무시 지시자"로 판정되어 타입체크가 깨진다.

## 주의

**IconButton 은 타입 레벨 breaking change 다.** `IconButtonProps` 가 union 이 되면서 `aria-label` / `aria-labelledby` 를 모두 생략하던 소비자 코드는 이제 **컴파일 에러**가 난다.

```tsx
// before (v3.7.0 이하 - 통과했지만 이름 없는 버튼이 출고됨)
<IconButton icon={<X />} />

// after - 둘 중 하나 필수
<IconButton icon={<X />} aria-label="닫기" />
<IconButton icon={<X />} aria-labelledby="close-label" />
```

- 실제 버그를 막기 위한 의도된 변경이다. 런타임 렌더링/DOM 출력은 **동일**하므로 마이그레이션은 속성 하나 추가로 끝난다.
- `IconButtonProps` 에 마이그레이션 안내 JSDoc 을 달아 에디터 툴팁에서 바로 보이게 했다.
- 릴리즈 시 SemVer **major** 후보로 플래그가 필요하다 (`package.json` `exports` 표면인 React export 의 공개 타입 시그니처 변경).
- 레포 내 기존 `<IconButton>` 사용처는 모두 이미 `aria-label` 을 넘기고 있어 이번 변경으로 깨진 곳은 없다.

## 전달할 추가 이슈

- `src/ui/general/icon-button/IconButton.test.tsx:74`, `NavBar.test.tsx` 의 빈 줄, `nav-bar/index.tsx` 의 JSX 줄바꿈, `menu/index.tsx:87` 의 삼항 줄바꿈, `tooltip/index.tsx:157` 의 `lint/a11y/noStaticElementInteractions` 에 기존 biome 지적이 남아 있다 (모두 이번 변경 이전부터 존재, 범위 밖이라 건드리지 않음).

