### PR TITLE
config/release-hygiene

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,53 @@
+# Bigtablet Inc. Open Source License
+
+## Table of Contents / 목차
+- [English Version](#english-version)
+- [한국어 버전](#한국어-버전)
+
+---
+
+## English Version
+
+This license is issued by **Bigtablet Inc.** (hereinafter referred to as the "Copyright Holder") and is intended to provide the source code to developers, researchers, and other users (hereinafter referred to as "Users").  
+Any use that contradicts the purposes stated below is strictly prohibited.
+
+### Terms and Conditions
+
+1. All copyrights for the source code and files opened within this GitHub organization belong to the Copyright Holder.  
+2. All open-source materials are, by default, permitted for **non-commercial use only**.  
+3. Any User who uses, modifies, processes, redistributes, or conducts research with part or all of the open source must clearly indicate the source by referencing the link to the original GitHub repository.  
+4. Commercial use of the open source without explicit or implicit permission from the Copyright Holder is strictly prohibited. For inquiries regarding commercial use, please contact the email address provided in the profile.  
+5. Users are obligated to report any issues, errors, or security vulnerabilities discovered or encountered while using the open source to the Copyright Holder, and are prohibited from exploiting or disclosing them to external parties. 
+6. If unauthorized commercial use is detected, the Copyright Holder reserves the right to take legal action.  
+7. By cloning, forking, or otherwise copying and using a repository containing this open source, the User is deemed to have fully understood and agreed to all the terms of this license.  
+8. This license shall take effect from **September 9, 2025**, and shall have legal force and effect from that date.  
+9. For any additional inquiries, please contact the email address listed in the profile.  
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+## 한국어 버전
+
+본 라이선스는 **Bigtablet Inc.**(이하 “저작권자”)에서 발행하였으며, 개발자, 연구자 등 (이하 “사용자”)에게 소스코드를 제공하기 위한 목적으로 공개합니다.  
+아래에 기재된 목적에 반하는 사용은 엄격히 금지됩니다.
+
+### 조항
+
+1. 본 GitHub 조직에 공개된 모든 소스코드와 파일에 대한 저작권은 저작권자에게 있습니다.  
+2. 모든 오픈소스는 원칙적으로 **비상업적 목적**으로만 이용할 수 있습니다.  
+3. 모든 사용자는 오픈소스의 일부 또는 전체를 사용, 수정, 가공, 재배포, 연구할 경우 반드시 해당 GitHub 저장소 링크를 통해 출처를 명시해야 합니다.  
+4. 저작권자의 명시적 또는 묵시적 허가 없이 오픈소스를 상업적 목적으로 이용하는 것을 금합니다. 상업적 이용 문의는 프로필에 기재된 이메일로 연락하시기 바랍니다.  
+5. 사용자는 오픈소스를 이용하는 중 발견되거나 발생한 문제, 오류, 보안 취약점을 저작권자에게 보고할 의무가 있으며 이를 악용하거나 외부로 공유하는 것을 금합니다.  
+6. 무단으로 상업적 이용이 적발될 경우 저작권자는 법적 조치를 취할 권리를 가집니다.  
+7. 오픈소스가 포함된 저장소를 clone, fork 또는 기타 방법으로 복제하여 이용하는 경우, 사용자는 본 라이선스의 모든 조항을 충분히 숙지하였으며 이에 동의한 것으로 간주됩니다.  
+8. 본 라이선스는 **2025년 9월 9일**부터 발효되며, 해당 시점부터 법적 효력을 가집니다.  
+9. 기타 문의 사항은 프로필에 기재된 이메일로 연락하시기 바랍니다.  
+
+### 면책 조항
+
+이 소프트웨어는 **“있는 그대로(As-Is)”** 제공되며, 상품성, 특정 목적에의 적합성, 비침해를 포함하되 이에 국한되지 않는 어떠한 형태의 명시적 또는 묵시적 보증도 하지 않습니다.  
+저작권자 또는 기여자는 계약, 불법행위, 기타 어떠한 법적 근거에 의한 것이든 간에, 본 소프트웨어 또는 이를 사용하거나 다른 방식으로 이용함으로 인해 발생하는 모든 청구, 손해, 기타 법적 책임에 대해 책임을 지지 않습니다.

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -818,4 +818,4 @@ cleanup();  // 리스너 제거
 
 ## 라이센스
 
-[MIT License](../LICENSE)
+[Bigtablet Inc. Open Source License](../LICENSE)

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
 		"@types/node": "^25.9.1",
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.4",
-		"@vitest/browser-playwright": "^4.1.6",
-		"@vitest/coverage-v8": "^4.1.6",
+		"@vitest/browser-playwright": "^4.1.10",
+		"@vitest/coverage-v8": "^4.1.10",
 		"esbuild-sass-plugin": "^3.7.0",
 		"husky": "^9.1.7",
 		"jsdom": "^29.1.1",
@@ -110,7 +110,7 @@
 		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
 		"vite": "^8.1.0",
-		"vitest": "^4.1.6"
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public",
@@ -119,7 +119,8 @@
 	"size-limit": [
 		{
 			"path": "dist/index.js",
-			"limit": "50 kB"
+			"limit": "60 kB",
+			"message": "Raised 50 kB -> 60 kB on 2026-08-05: measured baseline was 49.34 kB (1.3% headroom), so the next component addition would have failed CI. Re-measure before raising again."
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"css"
 	],
 	"author": "sangmin",
-	"license": "MIT",
+	"license": "SEE LICENSE IN LICENSE",
 	"packageManager": "pnpm@10.20.0",
 	"peerDependencies": {
 		"lucide-react": ">=0.552.0",
@@ -120,7 +120,7 @@
 		{
 			"path": "dist/index.js",
 			"limit": "60 kB",
-			"message": "Raised 50 kB -> 60 kB on 2026-08-05: measured baseline was 49.34 kB (1.3% headroom), so the next component addition would have failed CI. Re-measure before raising again."
+			"message": "Raised 50 kB -> 60 kB on 2026-08-05: baseline was 49.34 kB, leaving 0.66 kB (1.3%) under the old 50 kB limit. The current limit leaves 10.66 kB. Re-measure before raising again."
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 10.5.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
       '@storybook/addon-vitest':
         specifier: ^10.4.6
-        version: 10.5.3(@vitest/browser-playwright@4.1.6)(@vitest/browser@4.1.10)(@vitest/runner@4.1.6)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.6)
+        version: 10.5.3(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.10)
       '@storybook/react':
         specifier: ^10.4.6
         version: 10.5.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(typescript@6.0.3)
@@ -70,11 +70,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
       '@vitest/browser-playwright':
-        specifier: ^4.1.6
-        version: 4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
       '@vitest/coverage-v8':
-        specifier: ^4.1.6
-        version: 4.1.6(@vitest/browser@4.1.10)(vitest@4.1.6)
+        specifier: ^4.1.10
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       esbuild-sass-plugin:
         specifier: ^3.7.0
         version: 3.7.0(esbuild@0.28.1)(sass-embedded@1.100.0)
@@ -127,8 +127,8 @@ importers:
         specifier: ^8.1.0
         version: 8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)
       vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
 
 packages:
 
@@ -188,10 +188,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -212,11 +208,6 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
@@ -232,10 +223,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -1714,22 +1701,22 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
-  '@vitest/browser-playwright@4.1.6':
-    resolution: {integrity: sha512-4csoeyl/qwHyxU2zNL0++WaoDr8YJDXOQPwWPNJoTZ+QzcdO3INYKgF5Zfz730Io7zbkuv914aZmfQ+QE+1Hvw==}
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.6
+      vitest: 4.1.10
 
   '@vitest/browser@4.1.10':
     resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
     peerDependencies:
       vitest: 4.1.10
 
-  '@vitest/coverage-v8@4.1.6':
-    resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
       '@vitest/browser': ^4.1.10
-      vitest: 4.1.6
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -1737,22 +1724,11 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
   '@vitest/mocker@4.1.10':
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1768,14 +1744,11 @@ packages:
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
-
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
@@ -1783,17 +1756,11 @@ packages:
   '@vitest/spy@4.1.10':
     resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
-
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
-
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
@@ -3165,10 +3132,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -3341,20 +3304,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3548,8 +3511,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -3562,10 +3523,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.3':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -3590,11 +3547,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -4590,16 +4542,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.5.3(@vitest/browser-playwright@4.1.6)(@vitest/browser@4.1.10)(@vitest/runner@4.1.6)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.6)':
+  '@storybook/addon-vitest@10.5.3(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.1.0(react@19.2.8)
       storybook: 10.5.3(@types/react@19.2.18)(react@19.2.8)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/browser-playwright': 4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/runner': 4.1.6
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/runner': 4.1.10
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
     transitivePeerDependencies:
       - react
 
@@ -4774,20 +4726,20 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
-  '@vitest/browser-playwright@4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/mocker': 4.1.6(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
       playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)':
+  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
@@ -4796,7 +4748,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -4804,10 +4756,10 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.6(@vitest/browser@4.1.10)(vitest@4.1.6)':
+  '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.10
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -4816,9 +4768,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -4828,26 +4780,18 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@4.1.6':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
   '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))':
     dependencies:
       '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)
-
-  '@vitest/mocker@4.1.6(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))':
-    dependencies:
-      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -4861,19 +4805,15 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/pretty-format@4.1.6':
+  '@vitest/runner@4.1.10':
     dependencies:
-      tinyrainbow: 3.1.0
-
-  '@vitest/runner@4.1.6':
-    dependencies:
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.6':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -4882,8 +4822,6 @@ snapshots:
       tinyspy: 4.0.4
 
   '@vitest/spy@4.1.10': {}
-
-  '@vitest/spy@4.1.6': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -4894,12 +4832,6 @@ snapshots:
   '@vitest/utils@4.1.10':
     dependencies:
       '@vitest/pretty-format': 4.1.10
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.6':
-    dependencies:
-      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -5535,8 +5467,8 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -6254,8 +6186,6 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.1.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
@@ -6389,32 +6319,32 @@ snapshots:
       sass-embedded: 1.100.0
       tsx: 4.23.1
 
-  vitest@4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)):
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)):
     dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
-      '@vitest/browser-playwright': 4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/coverage-v8': 4.1.6(@vitest/browser@4.1.10)(vitest@4.1.6)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,13 @@ export type { AccordionItem, AccordionProps } from "./ui/display/accordion";
 export { Accordion } from "./ui/display/accordion";
 export type { AvatarProps, AvatarShape, AvatarSize } from "./ui/display/avatar";
 export { Avatar } from "./ui/display/avatar";
-export type { BadgeProps, BadgeShape, BadgeSize, BadgeVariant } from "./ui/display/badge";
+export type {
+	BadgeAppearance,
+	BadgeProps,
+	BadgeShape,
+	BadgeSize,
+	BadgeVariant,
+} from "./ui/display/badge";
 export { Badge } from "./ui/display/badge";
 export type { EmptyStateProps } from "./ui/feedback/empty-state";
 export { EmptyState } from "./ui/feedback/empty-state";
@@ -100,6 +106,7 @@ export type {
 	TableSortDirection,
 } from "./ui/display/table";
 export { Table } from "./ui/display/table";
+export type { AlertActionsAlign, AlertOptions, AlertVariant } from "./ui/feedback/alert";
 export { AlertProvider, useAlert } from "./ui/feedback/alert";
 export type { LinearProgressProps } from "./ui/feedback/linear-progress";
 export { LinearProgress } from "./ui/feedback/linear-progress";
@@ -107,6 +114,7 @@ export type { SkeletonProps, SkeletonVariant } from "./ui/feedback/skeleton";
 export { Skeleton } from "./ui/feedback/skeleton";
 export type { SpinnerProps } from "./ui/feedback/spinner";
 export { Spinner } from "./ui/feedback/spinner";
+export type { ToastProviderProps, ToastVariant } from "./ui/feedback/toast";
 export { ToastProvider } from "./ui/feedback/toast";
 export { useToast } from "./ui/feedback/toast/use-toast";
 export type { TopLoadingProps } from "./ui/feedback/top-loading";
@@ -115,9 +123,15 @@ export type { CheckboxProps } from "./ui/forms/checkbox";
 export { Checkbox } from "./ui/forms/checkbox";
 export type { DatePickerProps } from "./ui/forms/date-picker";
 export { DatePicker } from "./ui/forms/date-picker";
-export type { DropdownOption, DropdownProps, DropdownSize } from "./ui/forms/dropdown";
+export type {
+	DropdownMultipleProps,
+	DropdownOption,
+	DropdownProps,
+	DropdownSingleProps,
+	DropdownSize,
+} from "./ui/forms/dropdown";
 export { Dropdown } from "./ui/forms/dropdown";
-export type { FileInputProps } from "./ui/forms/file";
+export type { FileInputProps, FileInputVariant } from "./ui/forms/file";
 export { FileInput } from "./ui/forms/file";
 export type {
 	CropImageSize,
@@ -132,11 +146,12 @@ export { OtpInput } from "./ui/forms/otp-input";
 export type { RadioProps } from "./ui/forms/radio";
 export { Radio } from "./ui/forms/radio";
 export type {
+	RadioGroupContextValue,
 	RadioGroupOrientation,
 	RadioGroupProps,
 	RadioGroupSize,
 } from "./ui/forms/radio-group";
-export { RadioGroup } from "./ui/forms/radio-group";
+export { RadioGroup, useRadioGroupContext } from "./ui/forms/radio-group";
 export type {
 	TextareaProps,
 	TextareaResize,
@@ -147,7 +162,13 @@ export type { ImeStrategy, TextFieldProps, TextFieldSize } from "./ui/forms/text
 export { TextField } from "./ui/forms/textfield";
 export type { ToggleProps } from "./ui/forms/toggle";
 export { Toggle } from "./ui/forms/toggle";
-export type { ButtonProps } from "./ui/general/button";
+export type {
+	ButtonAsAnchor,
+	ButtonAsButton,
+	ButtonProps,
+	ButtonSize,
+	ButtonVariant,
+} from "./ui/general/button";
 export { Button } from "./ui/general/button";
 export type { IconButtonProps, IconButtonSize, IconButtonVariant } from "./ui/general/icon-button";
 export { IconButton } from "./ui/general/icon-button";
@@ -155,7 +176,7 @@ export type { PaginationProps } from "./ui/navigation/pagination";
 export { Pagination } from "./ui/navigation/pagination";
 export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
 export { Drawer } from "./ui/overlay/drawer";
-export type { ModalProps } from "./ui/overlay/modal";
+export type { ModalFooterAlign, ModalProps } from "./ui/overlay/modal";
 export { Modal } from "./ui/overlay/modal";
 export type { ResolvedTheme, ThemeMode, ThemeProviderProps } from "./ui/system/theme-provider";
 export { ThemeProvider, useTheme } from "./ui/system/theme-provider";

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -3,7 +3,8 @@
  * For use with plain HTML/CSS/JS, Thymeleaf, JSP, etc.
  *
  * @version 1.0.0
- * @license MIT
+ * @license Bigtablet Inc. Open Source License - see LICENSE at the repo root
+ *          (https://github.com/Bigtablet/.github/blob/main/BIGTABLET_LICENSE.md)
  */
 
 ((global, factory) => {


### PR DESCRIPTION
## 작업 개요

배포/툴링 위생 점검에서 발견된 결함 4건을 처리했습니다.

라이선스 건은 최초 요청이 "MIT LICENSE 추가" 였으나 레포 내 표기가 충돌하여 보류 후 오너 확인을 거쳤고, **조직 라이선스로 통일**하는 것으로 결정되어 반영했습니다.

## 작업한 내용

- [x] **라이선스 통일** - `LICENSE` 파일 추가 + MIT 표기 3곳 정정 (아래 상세)
- [x] **vitest 버전 불일치 해소** - `vitest`, `@vitest/coverage-v8`, `@vitest/browser-playwright` 를 `^4.1.6` → `^4.1.10` 으로 올려 `pnpm-workspace.yaml` 의 `"@vitest/browser": ^4.1.10` 보안 override 와 트리를 일치시킴. 보안 override 자체는 그대로 유지. 락파일 재생성(`pnpm install --lockfile-only` → `pnpm install`).
- [x] **size-limit 여유 확보** - `dist/index.js` limit 을 50 kB → 60 kB 로 상향. 나머지 두 항목(vanilla min.js 5 kB, index.css 130 kB)은 손대지 않음.
- [x] **배럴 미노출 public 타입 16개 re-export** - `src/index.ts` 에 추가. 순수 추가(제거/이름변경 없음) → minor 등급.

### 라이선스 통일 상세

`package.json` 은 MIT 를 선언하는데 `LICENSE` 파일이 존재하지 않았습니다. `files` 에는 `LICENSE` 가 들어 있어서 **배포 tarball 에 라이선스 본문이 통째로 빠져 있었습니다.**

게다가 레포 안에서 표기가 두 갈래로 갈려 있었습니다. 오너 확인 결과 **조직 라이선스가 맞다**는 결정을 받아 아래와 같이 통일했습니다:

| 위치 | 변경 전 | 변경 후 |
|---|---|---|
| `LICENSE` | (파일 없음) | **신규 추가** - 조직 정본 verbatim 복사 |
| `package.json` | `"license": "MIT"` | `"license": "SEE LICENSE IN LICENSE"` |
| `src/vanilla/bigtablet.js:6` | `@license MIT` | Bigtablet 라이선스 명시 + 정본 링크 |
| `docs/VANILLA.md:821` | `[MIT License](../LICENSE)` | `[Bigtablet Inc. Open Source License](../LICENSE)` |
| `README.md:188` / `README_KR.md:186` | (이미 정상) | 손대지 않음 |

`LICENSE` 는 `Bigtablet/.github` 의 `BIGTABLET_LICENSE.md` 를 API 로 직접 받아 그대로 기록했습니다 (영문 + 한국어 양쪽 섹션, 저작권 문구, 2025-09-09 발효일 모두 보존 / 53줄). `"license"` 값은 비 SPDX 커스텀 라이선스에 대한 npm 관례인 `SEE LICENSE IN LICENSE` 를 사용했습니다.

### re-export 추가된 타입

`ButtonVariant`, `ButtonSize`, `ButtonAsButton`, `ButtonAsAnchor`, `AlertVariant`, `AlertActionsAlign`, `AlertOptions`, `ToastVariant`, `ToastProviderProps`, `FileInputVariant`, `ModalFooterAlign`, `BadgeAppearance`, `DropdownSingleProps`, `DropdownMultipleProps`, `RadioGroupContextValue`, `useRadioGroupContext`(훅, 값 export)

### size-limit 근거 주석 위치

`package.json` 은 순수 JSON 이라 주석을 넣을 수 없어, size-limit 이 공식 지원하는 `message` 필드에 측정 기준과 날짜를 기록했습니다. 이 문자열은 limit 초과 시 출력되므로 다음에 한도를 만졌을 때 맥락이 바로 보입니다.

## 주의

이 패키지는 현재 npm 에 **MIT 로 선언된 채 공개 배포**되어 있습니다 (`access: public`, v3.7.0 까지). 따라서 이번 변경은 **앞으로 배포될 버전에 대한 라이선스 정정**입니다.

- 이미 MIT 로 표기된 버전을 받아간 소비자는 **해당 버전에 대해서는 MIT 조건을 그대로 유지**합니다. 소급 적용되지 않습니다.
- 정정된 라이선스는 이 PR 이 머지된 뒤 배포되는 버전부터 적용됩니다.
- 조직 라이선스는 **비상업적 사용만 허용**하므로, 기존에 MIT 를 전제로 이 패키지를 상업적으로 쓰고 있던 내부/외부 소비자가 있다면 릴리즈 전에 별도 고지가 필요할 수 있습니다.

## 검증

전 항목 통과:

| 검증 | 결과 |
|---|---|
| `npx tsc --noEmit -p tsconfig.json` | 통과 (exit 0) |
| `npx vitest run --project unit` | 55 파일 / 779 통과, 9 skip |
| `npx vitest run --project storybook` | 68 파일 / 284 통과 |
| `pnpm build` | 성공 |
| `pnpm size` | 통과 |
| `npx stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss'` | 통과 (exit 0) |
| `npm pack --dry-run` | **`4.7kB LICENSE`** 포함 확인 (총 23 files, 101.2 kB) |

### size 변화 (before → after)

| 항목 | before | after |
|---|---|---|
| `dist/index.js` | **49.34 kB** / limit 50 kB (여유 0.66 kB, 1.3%) | **49.34 kB** / limit **60 kB** (여유 10.66 kB) |
| `dist/vanilla/bigtablet.min.js` | 3.98 kB / 5 kB | 3.98 kB / 5 kB (변경 없음) |
| `dist/index.css` | 12.1 kB / 130 kB | 12.1 kB / 130 kB (변경 없음) |

번들 실측치는 그대로입니다. 추가한 export 는 타입이라 컴파일 시 소거되고, `useRadioGroupContext` 는 이미 그래프에 있던 함수라 증가분이 없습니다.

### vitest mixed-version 경고 - 해소 확인

수정 전 (`--project storybook`):

```
RUN  v4.1.6
Loaded  vitest@4.1.6  and  @vitest/browser@4.1.10 .
Running mixed versions is not supported and may lead into bugs
Update your dependencies and make sure the versions match.
```

수정 후:

```
RUN  v4.1.10
(경고 없음)
```

경고 3줄이 모두 사라졌습니다. `@vitest/browser` 보안 override 는 `^4.1.10` 로 유지됩니다.

### dist/index.d.ts 노출 확인

빌드 후 `dist/index.d.ts` 최종 export 문에 16개 이름이 모두 `type` 으로(훅은 값으로) 포함된 것을 확인했습니다.

## 전달할 추가 이슈

- **`dist/vanilla/bigtablet.min.js` 에 라이선스 배너가 없습니다** (기존부터 그랬고 이번 변경으로 생긴 문제 아님). `tsup.config.ts` 의 vanilla 번들이 `minify: true` 인데 esbuild 는 minify 시 `legalComments` 기본값이 `none` 이라 `@license` 주석을 제거합니다. 소스와 `dist/vanilla/bigtablet.js` 에는 배너가 정상 반영되지만, **`files` 설정상 실제 배포되는 vanilla 산출물은 `.min.js` 뿐**이라 배포본 JS 에는 라이선스 표기가 없는 상태입니다. `tsup.config.ts` 의 기존 `esbuildOptions` 콜백에 `options.legalComments = "inline"` 한 줄이면 해결됩니다. 이번 PR 범위를 넘어서 별도 처리 제안드립니다.
- 이번 변경은 새 public export 추가를 포함하므로 다음 릴리즈는 **minor** 등급이 적절합니다 (`3.7.0` → `3.8.0`).
