### PR TITLE
fix/reduced-motion-vanilla-layout

### DIFF
--- a/src/styles/layout/_index.scss
+++ b/src/styles/layout/_index.scss
@@ -1,3 +1,5 @@
+@use "../motion" as motion;
+
 /* Flex Utilities */
 @mixin flex_center { display: flex; align-items: center; justify-content: center; }
 @mixin flex_left { display: flex; align-items: center; justify-content: flex-start; }
@@ -32,22 +34,34 @@
 }
 
 /* Hover Lift Effect */
+// motion.$transition_lift = transform/box-shadow 0.25s $ease_out_expo (= $easing_enter) -
+// 기존 하드코딩 값과 동일한 전용 토큰.
 @mixin hover_lift($y: -4px, $shadow: 0 12px 24px rgba(0, 0, 0, 0.15)) {
-  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1),
-              box-shadow 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: motion.$transition_lift;
 
   &:hover {
     transform: translateY($y);
     box-shadow: $shadow;
   }
+
+  // WCAG 2.1 SC 2.3.3 - mixin 은 호출 지점을 모르므로 guard 를 body 안에 둔다.
+  // Sass 가 @media 를 호출 선택자와 함께 밖으로 빼주어 소비처마다 자동 적용된다.
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 /* Glow on Hover */
 @mixin hover_glow($color: rgba(59, 130, 246, 0.4)) {
-  transition: box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: box-shadow motion.$duration_slow motion.$easing_enter;
 
   &:hover {
     box-shadow: 0 0 30px $color;
+  }
+
+  // WCAG 2.1 SC 2.3.3 - hover_lift 와 동일하게 mixin body 안에서 guard.
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
   }
 }
 

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1214,3 +1214,36 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* ========================================
+   Reduced Motion (WCAG 2.1 SC 2.3.3)
+   ======================================== */
+/* 이 번들은 컴포넌트별 파일이 아닌 단일 플랫 스타일시트라 마지막에 한 블록으로 모아 처리한다.
+   Button / TextField / Checkbox / Radio / Toggle / Select / Modal / Pagination /
+   DatePicker / FileInput 의 transition 은 전부 --bt-transition-* 를 경유하므로,
+   선택자를 나열하는 대신 토큰 자체를 0s 로 눌러 일괄 무효화한다.
+   (이후 추가되는 규칙과, 같은 var 를 쓰는 소비자 커스텀 스타일까지 자동으로 커버된다.) */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --bt-transition-fast: 0s;
+    --bt-transition-base: 0s;
+    --bt-transition-slow: 0s;
+  }
+
+  /* Alert 진입 모션 - 장식 목적이고 bigtablet.js 가 animationend 에 의존하지 않는다.
+     keyframe 종료 상태(opacity:1 / translateY(0))가 요소의 기본값이라
+     animation 을 제거해도 최종 표시 상태는 동일하다. */
+  .bt-alert__overlay,
+  .bt-alert__modal {
+    animation: none;
+  }
+
+  /* Spinner 는 끄지 않는다 - 회전 자체가 "로딩 중"이라는 상태 정보라
+     animation:none 이면 멈춘 위젯처럼 보여 의미를 잃는다.
+     회전을 크게 늦춰(0.8s → 2.4s) 전정기관 자극만 줄인다.
+     (Toast progress 를 정적 keyframe 으로 바꿔 타이머를 살려두는 React 쪽과 같은 판단 -
+      모션만 줄이고 기능은 유지) */
+  .bt-spinner {
+    animation-duration: 2.4s;
+  }
+}


### PR DESCRIPTION
## 작업 개요

`src/ui` 밖에 남아 있던 reduced-motion / motion 토큰 미준수 2건을 수정합니다.
(`src/ui` 내부 7개 파일은 별도 PR #433 이 담당하므로 이 PR 에서 건드리지 않았습니다.)

1. **Vanilla 번들에 reduced-motion 처리가 전혀 없음** — `src/vanilla/bigtablet.scss` 에 `transition:`/`animation:` 규칙이 16개 있는데 `prefers-reduced-motion` 블록은 0개였습니다. 빌드 산출물 `dist/vanilla/bigtablet.css` 도 매치 0건. Thymeleaf/JSP/PHP 소비자에게 그대로 배포되는 표면이라 WCAG 2.1 SC 2.3.3 위반이 실제로 출하되고 있었습니다.
2. **`src/styles/layout/_index.scss` 의 공개 mixin 이 duration/easing 하드코딩** — `hover_lift`(`:36`), `hover_glow`(`:47`) 가 `0.25s cubic-bezier(0.16, 1, 0.3, 1)` 등을 직접 박아 썼습니다. 두 mixin 은 `token.scss` 의 `@forward "./layout"` 로 소비자에게 노출되므로, 소비자가 가져다 쓰면 토큰화도 guard 도 없는 transition 을 그대로 받게 됩니다.

## 작업한 내용

- [x] `src/vanilla/bigtablet.scss` 끝에 `@media (prefers-reduced-motion: reduce)` 블록 1개 추가 (컴포넌트별 파일이 아닌 단일 플랫 스타일시트라 한 곳에 모음)
- [x] `--bt-transition-fast/base/slow` 를 `0s` 로 재정의 — Button/TextField/Checkbox/Radio/Toggle/Select/Modal/Pagination/DatePicker/FileInput 의 transition 14개가 전부 이 var 를 경유하므로 선택자 나열 대신 토큰을 눌러 일괄 무효화. 이후 추가되는 규칙과 같은 var 를 쓰는 소비자 커스텀 스타일까지 자동 커버됩니다
- [x] Alert 진입 애니메이션(`bt-alert-fade-in` / `bt-alert-slide-up`) `animation: none` — 순수 장식이고 `bigtablet.js` 가 `animationend` 에 의존하지 않는 점을 확인했습니다. keyframe 종료 상태(`opacity:1` / `translateY(0)`)가 요소 기본값이라 최종 표시 상태는 동일합니다
- [x] **Spinner 는 끄지 않고 늦춤** (`0.8s` → `2.4s`) — 회전 자체가 "로딩 중"이라는 상태 정보라 `animation: none` 이면 멈춘 위젯처럼 보여 의미를 잃습니다. Toast 가 `animation-name` 만 정적 keyframe 으로 바꿔 `onAnimationEnd` 타이머를 살려두는 React 쪽 판단과 동일하게, 모션만 줄이고 기능은 유지했습니다
- [x] `hover_lift` → `motion.$transition_lift` (`transform`/`box-shadow` `0.25s $ease_out_expo` 전용 토큰)
- [x] `hover_glow` → `box-shadow motion.$duration_slow motion.$easing_enter` (composite 토큰에 easing 을 덧붙이면 CSS 파싱이 깨지므로 `duration + easing` 조합 사용)
- [x] 두 mixin body 안에 `@media (prefers-reduced-motion: reduce) { transition: none; }` 중첩 — mixin 은 호출 지점을 알 수 없으므로, Sass 가 @media 를 호출 선택자와 함께 빼주는 성질을 이용해 guard 가 소비처마다 따라가도록 했습니다

## 검증

- [x] `npx stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss'` — 통과 (에러 0)
- [x] `npx tsc --noEmit -p tsconfig.json` — 통과
- [x] `npx vitest run --project unit` — 55 파일 / 779 통과, 9 skip (husky pre-commit 에서도 재실행 통과)
- [x] `pnpm build` — 성공
- [x] **빌드 산출물에 guard 반영 확인** — `dist/vanilla/bigtablet.css`, `dist/vanilla/bigtablet.min.css` 양쪽 모두 `prefers-reduced-motion` 매치 **0건 → 1블록**. min.css 실제 출력:
  ```css
  @media (prefers-reduced-motion: reduce){:root{--bt-transition-fast: 0s;--bt-transition-base: 0s;--bt-transition-slow: 0s}.bt-alert__overlay,.bt-alert__modal{animation:none}.bt-spinner{animation-duration:2.4s}}
  ```
- [x] **mixin 무회귀 확인** — probe 컴파일 결과 `hover_lift`/`hover_glow` 의 transition 출력이 기존 하드코딩 값과 **바이트 단위로 동일** (`transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.25s cubic-bezier(0.16, 1, 0.3, 1)` / `box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1)`). guard 만 추가됩니다
- [x] 두 mixin 은 레포 내부에서 사용처가 없어(소비자 전용) `src/ui` 산출물 변화 없음

## 전달할 추가 이슈

- `src/styles/layout/_index.scss` 에 `rgba(...)` 리터럴이 남아 있습니다 — glass mixin 3종(`glass_light` `:13`/`:16`, `glass_dark` `:20`/`:23`, `glass_card` `:27`/`:30`/`:31`)과 `hover_lift` 의 `$shadow` 기본값(`:39`), `hover_glow` 의 `$color` 기본값(`:55`). 별도 토큰 정리 작업 범위라 이번 PR 에서는 손대지 않았습니다.
- `scripts/build-vanilla.sh` 는 완료 로그에 `dist/vanilla/bigtablet.min.js` 를 출력하지만 실제로는 `bigtablet.js` 만 복사합니다 (min.js 미생성). 로그와 산출물이 불일치합니다.
