### PR TITLE
docs/api-sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ return <animated.div style={style}>...</animated.div>;
 
 - **Test Runner**: Vitest (multi-project: `unit` + `storybook`)
 - **a11y Testing**: axe-core via `@storybook/addon-a11y` + Playwright (headless Chromium)
-- **Coverage**: 86%
+- **Coverage**: 90% (stmts 90.01 / branch 85.59 / funcs 90.07 / lines 91.97 - 자세한 표는 [docs/TESTING.md](./docs/TESTING.md#커버리지))
 - **Commands**:
   ```bash
   pnpm test              # Run unit tests
@@ -253,10 +253,10 @@ For non-React environments (Thymeleaf, JSP, PHP, Django, etc.)
 ### Build Output
 ```
 dist/vanilla/
-├── bigtablet.css       # Full CSS (27KB)
-├── bigtablet.min.css   # Minified CSS (21KB)
-├── bigtablet.js        # Full JS (20KB)
-├── bigtablet.min.js    # Minified JS (9KB)
+├── bigtablet.css       # Full CSS (~38KB)
+├── bigtablet.min.css   # Minified CSS (~31KB)
+├── bigtablet.js        # Full JS (~30KB)
+├── bigtablet.min.js    # Minified JS (~13KB)
 └── examples/           # HTML examples
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A complete React + TypeScript design system maintained by Bigtablet for internal
 ## What's inside
 
 - **40+ components** across forms, display, feedback, navigation, overlay, and layout<br />
-- **11 token domains** - colors, typography, spacing, motion, radius, elevation, and more - exposed as SCSS variables and CSS custom properties<br />
+- **13 token domains** - colors, typography, spacing, motion, radius, elevation, and more - exposed as SCSS variables and CSS custom properties (plus a SCSS-only `layout` domain)<br />
 - **Light + dark mode** out of the box. `[data-theme="dark"]` or `prefers-color-scheme`, no theme provider required (but available via `ThemeProvider` for runtime toggling)<br />
 - **Vanilla JS bundle** for non-React backends - Thymeleaf, JSP, PHP, Django<br />
 - **Accessibility tested** with axe-core in CI · keyboard nav · ARIA throughout
@@ -58,7 +58,7 @@ A complete React + TypeScript design system maintained by Bigtablet for internal
 pnpm add @bigtablet/design-system react@^19 react-dom@^19 lucide-react
 ```
 
-Requires React 19 + lucide-react ≥ 0.552. Compatible with Next.js 13+.
+Requires React 19 + lucide-react ≥ 0.552. Next.js is an optional peer dependency at `>=15`.
 
 <details>
 <summary><b>One-line setup</b> - auto-detect package manager + framework</summary>
@@ -102,12 +102,13 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 ## Components
 
 <table>
-<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Textarea · Checkbox · Radio · Toggle · Dropdown · DatePicker · FileInput · OTPInput</td></tr>
+<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Textarea · Checkbox · Radio · RadioGroup · Toggle · Dropdown · DatePicker · FileInput · ImageCropper · OtpInput</td></tr>
 <tr><td><b>Display</b></td><td>Card · MediaCard · Hero · Avatar · Badge · Chip · ListItem · Table · Divider · Icon · Accordion</td></tr>
 <tr><td><b>Feedback</b></td><td>Alert · Toast · Spinner · TopLoading · LinearProgress · Skeleton · EmptyState · ErrorState</td></tr>
 <tr><td><b>Navigation</b></td><td>Tabs · Sidebar · BottomNav · NavBar · Breadcrumb · Menu · Pagination</td></tr>
-<tr><td><b>Overlay</b></td><td>Modal · Tooltip</td></tr>
+<tr><td><b>Overlay</b></td><td>Modal · Drawer · Tooltip · Popover</td></tr>
 <tr><td><b>Layout</b></td><td>Container · Section · Stack · Grid</td></tr>
+<tr><td><b>System</b></td><td>ThemeProvider</td></tr>
 </table>
 
 →&nbsp;Full API · [`docs/COMPONENTS.md`](./docs/COMPONENTS.md)
@@ -117,7 +118,7 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 ## Design tokens
 
 ```scss
-@use "src/styles/token" as token;
+@use "@bigtablet/design-system/scss/token" as token;
 
 .card {
   background: token.$color_bg_solid;
@@ -129,16 +130,18 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 ```
 
 ```css
+/* from @bigtablet/design-system/style.css */
 .card {
   background: var(--bt-color-bg-solid);
   color: var(--bt-color-text-heading);
-  padding: var(--bt-spacing-16);
-  border-radius: var(--bt-radius-md);
+  border: 1px solid var(--bt-color-border-default);
   box-shadow: var(--bt-elevation-level1);
 }
 ```
 
-`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`a11y`
+> The React entry's `style.css` only emits `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, and `--bt-bottom-nav-*`. Spacing, radius, and typography are **SCSS-only** on this entry - use `scss/token` for them (`--bt-spacing-*` / `--bt-radius-*` exist only in the [Vanilla bundle](./docs/VANILLA.md)).
+
+`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS only</sup>
 
 <br />
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -45,7 +45,7 @@ Bigtablet 인하우스 React + TypeScript 디자인 시스템. 커뮤니티 참�
 ## 구성
 
 - **40+ 컴포넌트** - forms, display, feedback, navigation, overlay, layout<br />
-- **11 개 토큰 도메인** - colors, typography, spacing, motion, radius, elevation 등. SCSS 변수 + CSS custom property 양쪽 제공<br />
+- **13 개 토큰 도메인** - colors, typography, spacing, motion, radius, elevation 등. SCSS 변수 + CSS custom property 양쪽 제공 (SCSS 전용 `layout` 도메인 별도)<br />
 - **라이트 + 다크 모드** 기본 내장. `[data-theme="dark"]` 또는 `prefers-color-scheme` 만으로 동작. 런타임 토글이 필요하면 `ThemeProvider`<br />
 - **Vanilla JS 번들** - Thymeleaf, JSP, PHP, Django 등 서버 템플릿 환경 지원<br />
 - **접근성 테스트** - CI 에서 axe-core 자동 검증. 키보드 네비 + ARIA 속성 완비
@@ -58,7 +58,7 @@ Bigtablet 인하우스 React + TypeScript 디자인 시스템. 커뮤니티 참�
 pnpm add @bigtablet/design-system react@^19 react-dom@^19 lucide-react
 ```
 
-React 19 + lucide-react ≥ 0.552 필요. Next.js 13+ 호환.
+React 19 + lucide-react ≥ 0.552 필요. Next.js 는 optional peer dependency 로 `>=15`.
 
 <details>
 <summary><b>한 줄 설치</b> - 패키지 매니저 + 프레임워크 자동 감지</summary>
@@ -102,12 +102,13 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 ## 컴포넌트
 
 <table>
-<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Checkbox · Radio · Toggle · Dropdown · DatePicker · FileInput · OTPInput</td></tr>
+<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Textarea · Checkbox · Radio · RadioGroup · Toggle · Dropdown · DatePicker · FileInput · ImageCropper · OtpInput</td></tr>
 <tr><td><b>Display</b></td><td>Card · MediaCard · Hero · Avatar · Badge · Chip · ListItem · Table · Divider · Icon · Accordion</td></tr>
-<tr><td><b>Feedback</b></td><td>Alert · Toast · Spinner · TopLoading · LinearProgress · Skeleton · EmptyState</td></tr>
-<tr><td><b>Navigation</b></td><td>Tabs · Sidebar · NavBar · Breadcrumb · Menu · Pagination</td></tr>
-<tr><td><b>Overlay</b></td><td>Modal · Tooltip</td></tr>
+<tr><td><b>Feedback</b></td><td>Alert · Toast · Spinner · TopLoading · LinearProgress · Skeleton · EmptyState · ErrorState</td></tr>
+<tr><td><b>Navigation</b></td><td>Tabs · Sidebar · BottomNav · NavBar · Breadcrumb · Menu · Pagination</td></tr>
+<tr><td><b>Overlay</b></td><td>Modal · Drawer · Tooltip · Popover</td></tr>
 <tr><td><b>Layout</b></td><td>Container · Section · Stack · Grid</td></tr>
+<tr><td><b>System</b></td><td>ThemeProvider</td></tr>
 </table>
 
 →&nbsp;전체 API · [`docs/COMPONENTS.md`](./docs/COMPONENTS.md)
@@ -117,7 +118,7 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 ## 디자인 토큰
 
 ```scss
-@use "src/styles/token" as token;
+@use "@bigtablet/design-system/scss/token" as token;
 
 .card {
   background: token.$color_bg_solid;
@@ -129,16 +130,18 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 ```
 
 ```css
+/* @bigtablet/design-system/style.css 에서 제공 */
 .card {
   background: var(--bt-color-bg-solid);
   color: var(--bt-color-text-heading);
-  padding: var(--bt-spacing-16);
-  border-radius: var(--bt-radius-md);
+  border: 1px solid var(--bt-color-border-default);
   box-shadow: var(--bt-elevation-level1);
 }
 ```
 
-`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`a11y`
+> React entry 의 `style.css` 가 내보내는 CSS 변수는 `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*` 뿐이다. spacing / radius / typography 는 이 entry 에선 **SCSS 전용**이라 `scss/token` 을 써야 한다 (`--bt-spacing-*` / `--bt-radius-*` 는 [Vanilla 번들](./docs/VANILLA.md) 에만 존재).
+
+`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS 전용</sup>
 
 <br />
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,16 +24,19 @@ bigtablet-design-system/
 │   ├── ui/                  # UI 컴포넌트 - 8 카테고리 폴더 하위에 컴포넌트
 │   │   ├── display/         # accordion avatar badge card chip divider hero icon list-item media-card table
 │   │   ├── feedback/        # alert empty-state error-state linear-progress skeleton spinner toast top-loading
-│   │   ├── forms/           # checkbox date-picker dropdown file otp-input radio radio-group textarea textfield toggle
+│   │   ├── forms/           # checkbox date-picker dropdown file image-cropper otp-input radio radio-group textarea textfield toggle
 │   │   ├── general/         # button icon-button
 │   │   ├── layout/          # container grid section stack
 │   │   ├── navigation/      # bottom-nav breadcrumb menu nav-bar pagination sidebar tabs
-│   │   ├── overlay/         # modal popover tooltip
+│   │   ├── overlay/         # drawer modal popover tooltip
 │   │   └── system/          # theme-provider
 │   │
 │   ├── utils/               # cn + 훅
 │   │   ├── cn.ts
+│   │   ├── overlay-stack.ts        # 공유 오버레이 Escape 스택 (registerOverlay / useOverlayEscape)
+│   │   ├── use-anchored-position.ts
 │   │   ├── use-focus-trap.ts
+│   │   ├── use-is-mounted.ts
 │   │   ├── use-reduced-motion.ts
 │   │   ├── use-spring-presence.ts  /  use-spring-hover.ts
 │   │   ├── use-safe-layout-effect.ts
@@ -80,36 +83,72 @@ import type * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    variant?: "primary" | "secondary" | "ghost" | "danger";
-    size?: "sm" | "md" | "lg";
+export type ButtonVariant = "filled" | "tonal" | "outline" | "text";
+export type ButtonSize = "sm" | "md" | "lg" | "xl";
+
+/** button/anchor 공통 스타일·콘텐츠 props (export 하지 않는 내부 베이스) */
+interface ButtonBaseProps {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
     fullWidth?: boolean;
+    /** 위험한 액션 - variant 와 조합되는 boolean modifier */
+    danger?: boolean;
+    disabled?: boolean;
 }
 
-export const Button = ({
-    variant = "primary",
-    size = "md",
-    fullWidth,
-    className,
-    children,
-    ...props
-}: ButtonProps) => {
+export interface ButtonAsButton
+    extends ButtonBaseProps,
+        Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonBaseProps> {
+    as?: "button";
+    href?: never;
+    ref?: React.Ref<HTMLButtonElement>;
+}
+
+export interface ButtonAsAnchor
+    extends ButtonBaseProps,
+        Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof ButtonBaseProps> {
+    as?: "a";
+    href: string;
+    ref?: React.Ref<HTMLAnchorElement>;
+}
+
+/** `as`/`href` 로 button ↔ anchor 를 가르는 discriminated union */
+export type ButtonProps = ButtonAsButton | ButtonAsAnchor;
+
+export const Button = (props: ButtonProps) => {
+    const {
+        variant = "filled",
+        size = "md",
+        fullWidth = false,
+        danger = false,
+        disabled = false,
+        as,
+        className,
+        children,
+        ref,
+        ...rest
+    } = props;
+
+    const buttonClassName = cn(
+        "button",
+        `button_variant_${variant}`,
+        `button_size_${size}`,
+        fullWidth && "button_full_width",
+        danger && "button_danger",
+        disabled && "button_disabled",
+        className
+    );
+
+    // as="a" 또는 (as 미지정 + href 존재) 시 anchor 로 렌더링 (생략)
     return (
-        <button
-            className={cn(
-                "button",
-                `button_variant_${variant}`,
-                `button_size_${size}`,
-                fullWidth && "button_full_width",
-                className
-            )}
-            {...props}
-        >
+        <button ref={ref as React.Ref<HTMLButtonElement>} disabled={disabled} className={buttonClassName} {...rest}>
             {children}
         </button>
     );
 };
 ```
+
+> 여러 요소로 렌더될 수 있는 컴포넌트는 이렇게 **discriminated union** 으로 만든다. 대신 소비자가 `interface X extends ButtonProps` 로 확장할 수 없으므로 `React.ComponentProps<typeof Button>` 을 안내한다 ([MIGRATION.md](./MIGRATION.md) 참고).
 
 ---
 
@@ -131,18 +170,34 @@ export const Button = ({
     justify-content: center;
     border: none;
     cursor: pointer;
-    transition: all token.$transition_base;
+    border-radius: token.$radius_full;
+    // `transition: all` 금지 - 바뀌는 속성만 명시한다 (CLAUDE.md 애니메이션 규칙)
+    transition:
+        background-color token.$transition_fast,
+        color token.$transition_fast,
+        box-shadow token.$transition_fast;
+
+    &_variant_filled {
+        background-color: token.$color_brand_primary;
+        color: token.$color_brand_on_primary;
+    }
+
+    &_size_md {
+        height: 40px;
+        padding: 0 token.$spacing_16;
+        font-size: token.$font_size_15;
+    }
+
+    &_danger {
+        background-color: token.$color_status_error;
+        color: token.$color_status_error_on_default;
+    }
 }
 
-.variant_primary {
-    background-color: token.$color_primary;
-    color: token.$color_white;
-}
-
-.size_md {
-    height: 40px;
-    padding: 0 token.$spacing_lg;
-    font-size: token.$font_size_base;
+@media (prefers-reduced-motion: reduce) {
+    .button {
+        transition: none;
+    }
 }
 ```
 
@@ -173,12 +228,23 @@ cn(styles.button, styles[`size_${size}`], className);
 ### React / Next.js (`.`)
 
 ```ts
-// src/index.ts - 모든 컴포넌트·훅·유틸 re-export
-export * from "./ui/general/button";
-export * from "./ui/forms/textfield";
-export { cn, useReducedMotion } from "./utils";
-// ... 모든 컴포넌트 export
+// src/index.ts - 컴포넌트·타입·토큰을 명시적 named export 로 나열한다.
+// `export *` 는 쓰지 않는다 - 공개 API 표면이 파일 구조에 따라 조용히 늘어나는 걸 막기 위해서다.
+import "./styles/theme.scss"; // :root / [data-theme="dark"] CSS 변수 (dist/index.css 에 1회 포함)
+
+export { cn, useFocusTrap, useReducedMotion, useSpringHover, useSpringPresence } from "./utils";
+
+export type { ButtonProps } from "./ui/general/button";
+export { Button } from "./ui/general/button";
+export type { ImeStrategy, TextFieldProps, TextFieldSize } from "./ui/forms/textfield";
+export { TextField } from "./ui/forms/textfield";
+
+export { colors, baseColors } from "./styles/colors";
+export { spacing } from "./styles/spacing";
+// ... 나머지 컴포넌트 / 타입 / 토큰도 동일하게 명시적으로 나열
 ```
+
+> 새 컴포넌트를 추가하면 `src/index.ts` 에 **직접 export 를 추가해야** 소비자에게 노출된다. 반대로 `src/utils/index.ts` 에만 있고 `src/index.ts` 에 없는 항목(`registerOverlay` / `useOverlayEscape` / `useIsMounted` / `useAnchoredPosition`)은 **내부 전용**이다.
 
 별도 `/next` entry 는 없다. 컴포넌트가 `"use client"` 로 마킹되고(빌드 시 tsup 가 `dist/index.js` 선두에 자동 주입) `next` 가 optional peer dependency 라, 동일한 `.` export 로 Next.js App Router 에서 그대로 동작한다.
 
@@ -195,47 +261,79 @@ CDN 또는 직접 import로 사용:
 
 ## 디자인 토큰
 
+토큰은 **base(원시값) → semantic(용도별 별칭)** 2계층이다. 컴포넌트는 **semantic 만** 쓴다 - 다크 모드가 semantic 계층에서 갈리기 때문이다.
+
 ### TypeScript 토큰
 
 ```ts
 // src/styles/colors/index.ts
-export const colors = {
-    primary: "#000000",
-    primaryHover: "#333333",
-    error: "#ef4444",
-    success: "#047857",
+export const baseColors = {
+    brandPrimary: "#121212",
+    neutral0: "#FFFFFF",
+    neutral200: "#E5E5E5",
+    statusError: "#B91C1C",
     // ...
-};
+} as const;
+
+// semantic - 컴포넌트가 참조하는 계층 (용도별로 중첩)
+export const colors = {
+    brand:  { primary: baseColors.brandPrimary, onPrimary: baseColors.neutral0 },
+    text:   { heading: baseColors.neutral900, body: baseColors.neutral700, /* ... */ },
+    bg:     { solid: baseColors.neutral0, solidDim: baseColors.neutral50, /* ... */ },
+    border: { default: baseColors.neutral200, focus: baseColors.neutral900, /* ... */ },
+    // ...
+} as const;
+
+// src/styles/spacing/index.ts - 숫자 스케일 (px 값 문자열)
+export const spacing = { "4": "4px", "8": "8px", "16": "16px", "24": "24px", /* ... */ } as const;
 ```
 
 ### SCSS 토큰
 
+semantic 색상은 `var(--bt-*)` 를 가리킨다. SCSS 변수 자체가 CSS 변수 참조라서 `[data-theme="dark"]` 전환이 재컴파일 없이 그대로 따라온다.
+
 ```scss
-// src/styles/colors/_index.scss
-$color_primary: #000000;
-$color_primary_hover: #333333;
-$color_error: #ef4444;
-$color_success: #047857;
+// src/styles/colors/_index.scss - semantic 은 CSS 변수 참조
+$color_brand_primary:  var(--bt-color-brand-primary);
+$color_bg_solid:       var(--bt-color-bg-solid);
+$color_bg_solid_dim:   var(--bt-color-bg-solid-dim);
+$color_text_heading:   var(--bt-color-text-heading);
+$color_text_body:      var(--bt-color-text-body);
+$color_border_default: var(--bt-color-border-default);
+$color_status_error:   var(--bt-color-status-error);
 
-$spacing_xs: 0.25rem;
-$spacing_sm: 0.5rem;
-$spacing_md: 0.75rem;
-$spacing_lg: 1rem;
+// src/styles/spacing/_index.scss - 숫자 스케일 (t-shirt 사이즈 아님)
+$spacing_4:  4px;
+$spacing_8:  8px;
+$spacing_16: 16px;
+$spacing_24: 24px;
+$spacing_32: 32px;
 
-$font_size_sm: 0.875rem;
-$font_size_base: 0.9375rem;
-$font_size_md: 1rem;
+// src/styles/typography/_index.scss - 숫자 스케일
+$font_size_14: 14px;
+$font_size_15: 15px;
+$font_size_16: 16px;
+$font_weight_medium: 500;
 
-$radius_sm: 6px;
-$radius_md: 8px;
-$radius_lg: 12px;
+// src/styles/radius/_index.scss
+$radius_xs:   4px;
+$radius_sm:   6px;
+$radius_md:   8px;
+$radius_full: 9999px;
 
-$shadow_sm: 0 2px 4px rgba(0, 0, 0, 0.04);
-$shadow_md: 0 4px 12px rgba(0, 0, 0, 0.08);
+// src/styles/elevation/_index.scss - shadow 도 CSS 변수 참조 (다크 모드 대응)
+$elevation_level1: var(--bt-elevation-level1);
+$elevation_level2: var(--bt-elevation-level2);
 
-$transition_fast: 0.1s ease-in-out;
-$transition_base: 0.2s ease-in-out;
+// src/styles/motion/_index.scss
+$duration_base:   0.2s;
+$transition_fast: $duration_fast ease-in-out;
+$transition_base: $duration_base ease-in-out;
+$easing_enter:    cubic-bezier(0.16, 1, 0.3, 1);
+$easing_exit:     cubic-bezier(0.4, 0, 1, 1);
 ```
+
+> `$color_primary` / `$color_white` / `$spacing_xs|sm|md|lg` / `$shadow_sm|md` 같은 t-shirt·원시 네이밍 토큰은 **존재하지 않는다**. semantic 이름과 숫자 스케일만 쓴다.
 
 ---
 
@@ -318,8 +416,13 @@ describe("Button", () => {
     });
 
     it("applies variant class", () => {
-        const { container } = render(<Button variant="danger">Delete</Button>);
-        expect(container.firstChild).toHaveClass("variant_danger");
+        const { container } = render(<Button variant="outline">Delete</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_outline");
+    });
+
+    it("applies the danger modifier", () => {
+        const { container } = render(<Button danger>Delete</Button>);
+        expect(container.firstChild).toHaveClass("button_danger");
     });
 });
 ```
@@ -330,32 +433,36 @@ describe("Button", () => {
 
 ### GitHub Actions
 
-```yaml
-# .github/workflows/ci.yml
-name: CI
+정본은 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) 이다. 아래는 그 구조 요약이므로, 실제 값(액션 버전·Node 버전 등)은 워크플로 파일을 확인할 것.
 
-on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+**트리거**
+- `pull_request` → `develop`, `main`
+- `push` → `develop`
+- 양쪽 모두 `paths-ignore` 로 `**.md` · `docs/**` · `.github/ISSUE_TEMPLATE/**` · `LICENSE` 는 제외 (docs-only PR 은 CI 를 돌리지 않는다)
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "pnpm"
-      - run: pnpm install
-      - run: pnpm test
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm test:storybook
-      - run: pnpm build
-```
+**job 구성**
+
+| Job | 역할 |
+|------|------|
+| `changes` | `dorny/paths-filter` 로 `code` / `stories` / `deps` / `vanilla` 변경 여부를 한 번만 판정해 후속 step 의 조건으로 넘긴다 |
+| `test` | 위 4개 중 하나라도 변경됐을 때만 실행 |
+
+**`test` job 의 step (실행 조건 포함)**
+
+| Step | 조건 |
+|------|------|
+| Checkout (`actions/checkout@v6`, `fetch-depth: 0`) | 항상 |
+| Setup pnpm (`pnpm/action-setup@v4`) + Node (`actions/setup-node@v6`, `node-version: 22.14.0`, `cache: pnpm`) | 항상 |
+| `pnpm install --frozen-lockfile` | 항상 |
+| `pnpm exec commitlint` | `develop` 대상 PR 이고 dependabot 이 아닐 때 |
+| `pnpm lint:css` (Stylelint - raw hex / named color 금지) | `code` 또는 `stories` 변경 |
+| `pnpm test:coverage` | `code` 또는 `deps` 변경 |
+| `pnpm exec playwright install --with-deps chromium` → `pnpm test:storybook` | `code` 또는 `stories` 변경 (Chromium ~200MB 라 무겁다) |
+| `pnpm build` | 항상 |
+| `pnpm size` (size-limit - dist 산출물 기반) | 항상 |
+| `davelosert/vitest-coverage-report-action@v2` | PR 이면서 `code` 또는 `deps` 변경 |
+
+배포는 별도 워크플로다 - `v*` 태그 push 시 [`.github/workflows/release.yml`](../.github/workflows/release.yml) 이 `npm publish --provenance` + GitHub Release 를 처리한다.
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -23,12 +23,15 @@ Bigtablet Design System의 모든 React 컴포넌트 문서입니다.
   - [Toggle](#toggle)
   - [DatePicker](#datepicker)
   - [FileInput](#fileinput)
+  - [ImageCropper](#imagecropper)
+  - [OtpInput](#otpinput)
 - [Feedback](#feedback)
   - [Alert](#alert)
   - [Toast](#toast)
   - [Spinner](#spinner)
   - [TopLoading](#toploading)
   - [LinearProgress](#linearprogress)
+  - [Skeleton](#skeleton)
 - [Navigation](#navigation)
   - [Pagination](#pagination)
   - [Tabs](#tabs)
@@ -53,6 +56,8 @@ Bigtablet Design System의 모든 React 컴포넌트 문서입니다.
   - [EmptyState](#emptystate)
   - [ErrorState](#errorstate)
   - [Accordion](#accordion)
+  - [Table](#table)
+  - [Icon](#icon)
 - [Layout](#layout)
   - [Container](#container)
   - [Section](#section)
@@ -155,28 +160,47 @@ import { Button } from '@bigtablet/design-system';
 <Button>클릭</Button>
 
 // Variants
-<Button variant="primary">Primary</Button>
-<Button variant="secondary">Secondary</Button>
-<Button variant="ghost">Ghost</Button>
-<Button variant="danger">Danger</Button>
+<Button variant="filled">Filled</Button>
+<Button variant="tonal">Tonal</Button>
+<Button variant="outline">Outline</Button>
+<Button variant="text">Text</Button>
+
+// 위험한 액션 - variant 와 조합하는 boolean prop (variant="danger" 는 존재하지 않음)
+<Button danger>삭제</Button>
+<Button variant="outline" danger>삭제</Button>
 
 // Sizes
 <Button size="sm">Small</Button>
 <Button size="md">Medium</Button>
 <Button size="lg">Large</Button>
+<Button size="xl">XLarge</Button>
+
+// 아이콘
+import { Plus } from 'lucide-react';
+<Button leadingIcon={<Plus size={16} />}>추가</Button>
 
 // 너비 조절
-<Button width="200px">고정 너비</Button>
 <Button fullWidth>전체 너비</Button>
+
+// anchor 로 렌더링 - href 만 줘도 자동 분기
+<Button href="/pricing">요금제 보기</Button>
+<Button as="a" href="https://example.com" target="_blank" rel="noreferrer">외부 링크</Button>
 ```
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `variant` | `'primary' \| 'secondary' \| 'ghost' \| 'danger'` | `'primary'` | 버튼 스타일 |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 버튼 크기 |
-| `width` | `string` | - | 버튼 너비 |
+| `variant` | `'filled' \| 'tonal' \| 'outline' \| 'text'` | `'filled'` | 버튼 스타일 |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | 버튼 크기 |
+| `danger` | `boolean` | `false` | 위험한 액션(삭제/취소) 빨간 강조. `variant` 와 조합해서 사용 |
+| `leadingIcon` | `ReactNode` | - | 버튼 앞에 표시할 아이콘 |
+| `trailingIcon` | `ReactNode` | - | 버튼 뒤에 표시할 아이콘 |
+| `radius` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'full'` | border-radius 토큰 |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
-| `disabled` | `boolean` | `false` | 비활성화 |
+| `as` | `'button' \| 'a'` | `'button'` | 렌더링할 요소. `href` 만 줘도 anchor 로 분기 |
+| `href` | `string` | - | 링크 대상 (`as="a"` 일 때 필수) |
+| `disabled` | `boolean` | `false` | 비활성화. anchor 는 `aria-disabled` + 클릭 차단으로 처리 |
+
+> `ButtonProps` 는 `ButtonAsButton | ButtonAsAnchor` discriminated union 이라 `interface X extends ButtonProps` 로 확장할 수 없다. 확장이 필요하면 `React.ComponentProps<typeof Button>` 을 쓴다 ([MIGRATION.md](./MIGRATION.md) 참고).
 
 ---
 
@@ -220,18 +244,47 @@ const [fruit, setFruit] = useState<string | null>(null);
     { value: 'nyc', label: '뉴욕', supportingText: '미국' },
   ]}
 />
+
+// 검색 가능 (label 부분 일치 필터)
+<Dropdown options={options} searchable searchPlaceholder="과일 검색…" emptyText="일치하는 과일 없음" />
+
+// 다중 선택
+const [fruits, setFruits] = useState<string[]>([]);
+<Dropdown
+  multiple
+  options={options}
+  value={fruits}
+  onValueChange={(values, opts) => setFruits(values)}
+  selectedSummary={(count) => `${count}개 담김`}
+/>
+
+// 네이티브 폼 제출 참여 - 선택 값이 hidden input 으로 렌더됨
+<form action="/submit" method="post">
+  <Dropdown name="fruit" options={options} />
+</form>
 ```
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `options` | `DropdownOption[]` | required | 옵션 목록 |
-| `value` | `string \| null` | - | 선택된 값 (controlled) |
-| `defaultValue` | `string \| null` | `null` | 기본 선택값 |
-| `onValueChange` | `(value, option) => void` | - | 변경 핸들러 |
+| `value` | `string \| null` (single) · `string[]` (multiple) | - | 선택된 값 (controlled) |
+| `defaultValue` | `string \| null` (single) · `string[]` (multiple) | - | 기본 선택값 |
+| `onValueChange` | `(value, option) => void` (single) · `(values, options) => void` (multiple) | - | 변경 핸들러 (canonical) |
+| ~~`onChange`~~ | `onValueChange` 와 동일 시그니처 | - | **deprecated** (v3.3.0, `onValueChange` 의 alias). [MIGRATION.md](./MIGRATION.md) 참고 |
+| `multiple` | `boolean` | `false` | 다중 선택 모드. `value`/`onValueChange` 시그니처가 배열로 바뀜 |
+| `searchable` | `boolean` | `false` | 열린 패널 상단에 검색 입력 표시 (`label` 부분 일치 필터) |
+| `searchPlaceholder` | `string` | `'검색…'` | 검색 입력 플레이스홀더 |
+| `emptyText` | `string` | `'결과 없음'` | 필터 결과가 0개일 때 표시할 텍스트 |
+| `selectedSummary` | `(count: number) => string` | ``(count) => `${count}개 선택` `` | 다중 선택 요약 텍스트 |
 | `label` | `string` | - | 플로팅 라벨 (값 선택 시 또는 열릴 때 표시) |
 | `placeholder` | `string` | `'Select…'` | 플레이스홀더 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
+| `name` | `string` | - | 네이티브 폼 제출용 name. 선택 값이 hidden input 으로 렌더됨 (multiple 은 같은 name 반복) |
+| `id` | `string` | 자동 생성 | 드롭다운 요소 id |
+| `className` | `string` | - | 루트 요소에 추가할 className |
 | ~~`fullWidth`~~ | `boolean` | - | **deprecated** (v3.0.0, no-op - 항상 부모 너비를 채움). [MIGRATION.md](./MIGRATION.md) 참고 |
+| ~~`variant`~~ | `'outline' \| 'filled' \| 'ghost'` | - | **deprecated** (no-op - outline 스타일만 사용) |
+| ~~`textAlign`~~ | `'left' \| 'center'` | - | **deprecated** (no-op) |
 | `disabled` | `boolean` | `false` | 비활성화 |
 
 **DropdownOption:**
@@ -323,17 +376,14 @@ import { TextField } from '@bigtablet/design-system';
 
 // 상태 표시
 <TextField label="이메일" error supportingText="유효하지 않은 이메일입니다" />
-<TextField label="이메일" success supportingText="사용 가능한 이메일입니다" />
 
 // 아이콘
 import { Search, Eye } from 'lucide-react';
-<TextField leftIcon={<Search size={16} />} placeholder="검색..." />
-<TextField rightIcon={<Eye size={16} />} type="password" />
+<TextField leadingIcon={<Search size={16} />} placeholder="검색..." />
+<TextField trailingIcon={<Eye size={16} />} type="password" />
 
-// Variants
-<TextField variant="outline" label="Outline" />
-<TextField variant="filled" label="Filled" />
-<TextField variant="ghost" label="Ghost" />
+// 지우기 버튼
+<TextField label="검색어" clearable onValueChange={(v) => setQuery(v)} />
 
 // 값 변환 (자동 포맷팅)
 <TextField
@@ -346,17 +396,20 @@ import { Search, Eye } from 'lucide-react';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `label` | `string` | - | 라벨 |
+| `showLabel` | `boolean` | `true` | 라벨 표시 여부 (false 면 SR 전용) |
 | `supportingText` | `string` | - | 도움말 텍스트 |
 | `error` | `boolean` | `false` | 에러 상태 |
-| `success` | `boolean` | `false` | 성공 상태 |
-| `variant` | `'outline' \| 'filled' \| 'ghost'` | `'outline'` | 스타일 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
-| `leftIcon` | `ReactNode` | - | 왼쪽 아이콘 |
-| `rightIcon` | `ReactNode` | - | 오른쪽 아이콘 |
+| `leadingIcon` | `ReactNode` | - | 왼쪽 아이콘 |
+| `trailingIcon` | `ReactNode` | - | 오른쪽 아이콘 |
+| `clearable` | `boolean` | `false` | 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
 | `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 (호출 시점은 `imeStrategy` 에 따름) |
+| ~~`onChangeAction`~~ | `(value: string) => void` | - | **deprecated** (v3.3.0, `onValueChange` alias). Next 서버 액션 전달용 `Action` 접미사가 필요하면 계속 사용 가능 |
 | `imeStrategy` | `'delayed' \| 'immediate'` | `'delayed'` | IME 조합 중 콜백 전략 (v3.1). `immediate` = 조합 중에도 즉시 호출 |
 | `transformValue` | `(value: string) => string` | - | 값 변환 함수 |
+
+> TextField 에는 `variant` · `success` prop 이 없다. outline 스타일 하나만 제공하며, 성공 상태는 별도 표현이 없다 (에러만 `error` 로 표시).
 
 > **v3.0 변경**: 내부 마크업이 `<fieldset>` + `<legend>` 구조에서 standalone `<label htmlFor>` 구조로 변경되었습니다. 공개 props는 동일하지만, 커스텀 SCSS에서 `.text_field_legend` 같은 내부 셀렉터를 오버라이드했다면 점검이 필요합니다.
 
@@ -675,22 +728,180 @@ import { FileInput } from '@bigtablet/design-system';
   onFiles={(files) => console.log(files)}
 />
 
-// 여러 파일
+// 여러 파일 + 도움말
 <FileInput
   label="이미지 업로드"
   accept="image/*"
   multiple
+  supportingText="PNG, JPG 파일만 업로드 가능합니다"
+  onFiles={(files) => console.log(files)}
+/>
+
+// 썸네일 미리보기 (variant="button" + preview)
+<FileInput label="사진 첨부" accept="image/*" multiple preview />
+
+// 큰 박스 이미지 업로더 (아바타 패턴) - 단일 이미지
+<FileInput
+  variant="preview"
+  previewSize={120}
+  label="프로필 사진 선택"
+  accept="image/*"
   onFiles={(files) => console.log(files)}
 />
 ```
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `label` | `string` | `'파일 선택'` | 버튼 라벨 |
+| `label` | `string` | `'Choose file'` | 파일 선택 버튼 라벨 / `variant="preview"` 의 빈 상태 텍스트 |
+| `variant` | `'button' \| 'preview'` | `'button'` | 표시 형태. `preview` 는 큰 박스에 이미지를 채우는 단일 이미지 업로더 |
+| `previewSize` | `number` | `160` | `variant="preview"` 박스 한 변 크기 (px) |
+| `preview` | `boolean` | `false` | 이미지 선택 시 64×64 썸네일을 버튼 아래 나열 (`variant="button"` 전용) |
+| `supportingText` | `string` | - | 입력 아래 도움말 텍스트 |
 | `accept` | `string` | - | 허용 파일 타입 |
-| `onFiles` | `(files: FileList \| null) => void` | - | 파일 선택 핸들러 |
-| `multiple` | `boolean` | `false` | 다중 선택 |
+| `onFiles` | `(files: FileList \| null) => void` | - | 파일 선택 핸들러. 미리보기 제거 시 `null` 로 호출 |
+| `multiple` | `boolean` | `false` | 다중 선택 (`variant="preview"` 는 항상 단일 이미지) |
 | `disabled` | `boolean` | `false` | 비활성화 |
+
+> 나머지 `input[type=file]` 네이티브 속성(`name`, `required`, `onChange` 등)은 그대로 전달된다. `onChange` 를 함께 넘기면 `onFiles` 뒤에 이어서 호출된다.
+
+---
+
+### ImageCropper
+
+업로드 전에 이미지에서 **보일 정사각 영역**을 정하는 크로퍼 (v3.7.0). 뷰포트 안에서 드래그(또는 방향키)로 위치를, 휠·슬라이더·＋/－ 버튼(또는 <kbd>+</kbd>/<kbd>-</kbd> 키)으로 배율을 맞춘다.
+
+모달을 포함하지 않으므로 소비자가 [`Modal`](#modal) 등으로 감싸고, "적용" 버튼에서 `ref.crop()` 을 호출해 `Blob` 을 받는다.
+
+#### 언제 쓰는가
+
+| 상황 | 선택 |
+|------|------|
+| 프로필/아바타 이미지 업로드 전 원형 크롭 | ✅ ImageCropper (`circular`) |
+| 썸네일·커버 이미지의 정사각 영역 지정 | ✅ ImageCropper |
+| 자유 비율(16:9 등) 크롭 | ❌ 미지원 - 결과는 항상 정사각 |
+| 크롭 없이 단순 파일 선택 + 미리보기 | ❌ [FileInput](#fileinput) `variant="preview"` 권장 |
+
+**Props**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `src` | `File \| Blob \| string` | required | 크롭할 이미지. 로컬 `File`/`Blob` 또는 이미지 URL |
+| `ref` | `Ref<ImageCropperHandle>` | - | `crop()` / `reset()` 을 호출할 imperative 핸들 (React 19 ref-as-prop) |
+| `outputSize` | `number` | `512` | 결과물 한 변 길이 (px) |
+| `outputType` | `'auto' \| 'image/jpeg' \| 'image/png' \| 'image/webp'` | `'auto'` | 결과 MIME. `auto` 는 PNG 만 PNG 로, 나머지는 JPEG |
+| `quality` | `number` | `0.92` | JPEG/WebP 인코딩 품질 (0~1) |
+| `circular` | `boolean` | `false` | 원형 가이드 (아바타용). false 면 둥근 사각형 |
+| `viewportSize` | `number` | `240` | 뷰포트 한 변 길이 (px) |
+| `minZoom` | `number` | `1` | 최소 배율 (1 = 이미지가 뷰포트를 딱 덮음) |
+| `maxZoom` | `number` | `3` | 최대 배율 |
+| `onReady` | `(size: CropImageSize) => void` | - | 이미지 로드 완료 콜백 |
+| `onError` | `() => void` | - | 이미지 디코딩 실패 콜백 (손상 파일 등) |
+| `label` | `string` | `'이미지 위치와 배율 조정'` | 뷰포트 접근성 레이블 |
+| `hint` | `string` | `'드래그(또는 방향키)로 위치, 휠·슬라이더로 배율을 맞추세요.'` | 뷰포트 아래 조작 안내 문구 |
+| `zoomOutLabel` | `string` | `'축소'` | 축소 버튼 접근성 레이블 |
+| `zoomLabel` | `string` | `'배율'` | 배율 슬라이더 접근성 레이블 |
+| `zoomInLabel` | `string` | `'확대'` | 확대 버튼 접근성 레이블 |
+| `noPanHint` | `string` | `'이미지가 뷰포트를 딱 채워 이동 여유가 없습니다.'` | 이동 여유가 없을 때 SR 안내 문구 |
+| `className` | `string` | - | 루트 요소에 추가할 className |
+
+> 루트는 표준 `div` 속성(`id` / `data-*` / `aria-*` / `style` 등)을 그대로 전달받는다. 단 `onError` 는 이미지 디코드 실패 콜백으로 재정의되어 있고, `children` / `dangerouslySetInnerHTML` 은 루트가 항상 자체 자식을 렌더하므로 받지 않는다.
+
+**`ImageCropperHandle` (ref)**
+
+| 메서드 | Type | Description |
+|------|------|-------------|
+| `crop` | `() => Promise<Blob>` | 현재 보이는 정사각 영역을 잘라 `Blob` 반환. 소비자의 "적용" 버튼에서 호출 |
+| `reset` | `() => void` | 배율·위치를 초기 상태(zoom=min, 중앙)로 되돌림 |
+
+**Usage**
+
+```tsx
+import { useRef, useState } from "react";
+import { ImageCropper, Modal, Button, FileInput } from "@bigtablet/design-system";
+import type { ImageCropperHandle } from "@bigtablet/design-system";
+
+function AvatarUploader() {
+  const cropperRef = useRef<ImageCropperHandle>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleApply = async () => {
+    const blob = await cropperRef.current!.crop();
+    const form = new FormData();
+    form.append("avatar", blob, "avatar.jpg");
+    await fetch("/api/avatar", { method: "POST", body: form });
+    setFile(null);
+  };
+
+  return (
+    <>
+      <FileInput
+        accept="image/*"
+        label="프로필 사진 선택"
+        onFiles={(files) => setFile(files?.[0] ?? null)}
+      />
+
+      <Modal open={!!file} onClose={() => setFile(null)} title="사진 자르기">
+        {file && <ImageCropper ref={cropperRef} src={file} circular outputSize={256} />}
+        <Button variant="text" onClick={() => cropperRef.current?.reset()}>초기화</Button>
+        <Button onClick={handleApply}>적용</Button>
+      </Modal>
+    </>
+  );
+}
+```
+
+#### 키보드 / 포인터 조작
+
+| 입력 | 동작 |
+|------|------|
+| 드래그 (pointer) | 이미지 위치 이동 |
+| 방향키 | 8px 단위 위치 이동 |
+| <kbd>+</kbd> / <kbd>-</kbd> | 0.1 단위 배율 변경 |
+| 마우스 휠 | 연속 배율 변경 |
+| 슬라이더 / ＋·－ 버튼 | 배율 변경 |
+
+> ⚠️ 원격 URL 을 넘기면 `canvas.drawImage` 결과가 서버의 CORS(`Access-Control-Allow-Origin`) 설정에 의존한다. 확실하게 자르려면 로컬 `File`/`Blob` 을 넘겨라.
+
+---
+
+### OtpInput
+
+인증 코드(OTP) 입력. 각 자리를 개별 `input` 으로 분리하고 자동 포커스 이동·붙여넣기·SMS 자동완성(`autocomplete="one-time-code"`)을 지원한다.
+
+```tsx
+import { OtpInput } from '@bigtablet/design-system';
+
+const [code, setCode] = useState('');
+
+// 기본 (6자리)
+<OtpInput value={code} onValueChange={setCode} />
+
+// 4자리 + 자동 포커스
+<OtpInput length={4} value={code} onValueChange={setCode} autoFocus />
+
+// 에러 상태 + 도움말
+<OtpInput
+  value={code}
+  onValueChange={setCode}
+  error
+  supportingText="인증번호가 일치하지 않습니다"
+/>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `length` | `4 \| 6` | `6` | OTP 자릿수 |
+| `value` | `string` | `''` | 제어형 값 (controlled 전용) |
+| `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 (canonical) |
+| ~~`onChange`~~ | `(value: string) => void` | - | **deprecated** (v3.3.0, `onValueChange` alias). [MIGRATION.md](./MIGRATION.md) 참고 |
+| `error` | `boolean` | `false` | 에러 상태 |
+| `disabled` | `boolean` | `false` | 비활성화 |
+| `supportingText` | `string` | - | 하단 도움말 텍스트 |
+| `autoFocus` | `boolean` | `false` | 첫 번째 입력에 자동 포커스 |
+| `ariaLabel` | `string` | `'OTP 입력'` | 그룹 접근성 레이블 |
+| `className` | `string` | - | 루트 요소에 추가할 className |
+
+> **제어형 전용**: `value` + `onValueChange` 를 항상 함께 넘겨야 한다 (비제어 모드 없음). 전체 코드를 한 번에 붙여넣거나 SMS 자동완성으로 받으면 각 자리에 자동 분배된다.
 
 ---
 
@@ -839,6 +1050,46 @@ import { LinearProgress } from '@bigtablet/design-system';
 | `totalSteps` | `number` | required | 전체 단계 수 |
 | `currentStep` | `number` | required | 현재 단계 (0~totalSteps) |
 | `aria-label` | `string` | required | 접근성 라벨 (필수) |
+
+---
+
+### Skeleton
+
+콘텐츠가 로드되기 전 자리를 잡아 두는 플레이스홀더. 실제 콘텐츠와 **같은 크기·모양**으로 맞춰야 로드 후 레이아웃이 흔들리지 않는다.
+
+```tsx
+import { Skeleton } from '@bigtablet/design-system';
+
+// 텍스트 한 줄
+<Skeleton />
+<Skeleton width="60%" />
+
+// 제목
+<Skeleton variant="title" width={240} />
+
+// 아바타 (width 만 주면 height 자동 동일)
+<Skeleton variant="avatar" width={40} />
+
+// 임의 블록
+<Skeleton variant="rect" width="100%" height={180} radius="md" />
+
+// 카드 스켈레톤 조합
+<Stack gap={12}>
+  <Skeleton variant="rect" height={160} radius="md" />
+  <Skeleton variant="title" width="70%" />
+  <Skeleton width="100%" />
+  <Skeleton width="85%" />
+</Stack>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'text' \| 'title' \| 'avatar' \| 'rect'` | `'text'` | 스켈레톤 모양 |
+| `width` | `number \| string` | - | CSS width (`200` → `200px`, `'100%'`, `'16rem'`). `variant="avatar"` 는 height 미지정 시 width 와 동일하게 적용 |
+| `height` | `number \| string` | - | CSS height |
+| `radius` | `'sm' \| 'md' \| 'lg' \| 'full' \| string` | - | border-radius 토큰 또는 임의 CSS 값 |
+
+> 루트는 `div` 이고 `aria-hidden="true"` 가 자동으로 붙는다 (스크린리더 노이즈 방지). 로딩 상태 자체를 알려야 하면 부모에 `aria-busy` / `role="status"` 를 직접 걸어라. `children` 은 받지 않으며, 그 외 `div` 속성은 그대로 전달된다.
 
 ---
 
@@ -1281,7 +1532,7 @@ import { NavBar, NavLink, Button } from "@bigtablet/design-system";
 // default - 일반 마케팅 헤더
 <NavBar
   brand={<Logo />}
-  actions={<Button variant="primary">로그인</Button>}
+  actions={<Button variant="filled">로그인</Button>}
   sticky
 >
   <NavLink href="/about">소개</NavLink>
@@ -1484,13 +1735,13 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 | 아이콘 버튼의 의미를 짧게 설명 (Save / Delete 등) | ✅ Tooltip |
 | 잘린(ellipsis) 텍스트의 전체 내용 노출 | ✅ Tooltip |
 | 단축키 안내 (`Cmd+S`) | ✅ Tooltip |
-| 클릭/포커스가 필요한 상호작용 요소 (링크, 버튼) 포함 | ❌ Popover 권장 - tooltip은 `pointer-events: none` |
+| 클릭/포커스가 필요한 상호작용 요소 (링크, 버튼) 포함 | ❌ Popover 권장 - tooltip은 포커스를 받지 않는 보조 설명 |
 | 폼 필드 도움말 (상시 표시) | ❌ helper text 권장 |
 | 모바일 주 트리거 | ⚠️ hover가 없으므로 focus/long-press 시나리오 검토 |
 
 **Tooltip vs Popover**
-- **Tooltip**: hover/focus로 짧은 텍스트만, dismissable 아님, `pointer-events: none`
-- **Popover**: 클릭으로 열고 외부 클릭/Esc로 닫음, 상호작용 가능한 콘텐츠 (버튼/링크/입력) 포함 가능
+- **Tooltip**: hover/focus로 뜨는 **짧은 텍스트**. `role="tooltip"`, 포커스를 옮기지 않음. 포인터를 툴팁 위로 올려 읽을 수 있고 <kbd>Esc</kbd>로 닫힌다 (WCAG 1.4.13).
+- **Popover**: 클릭으로 열고 외부 클릭/Esc로 닫음. `role="dialog"`, 열릴 때 포커스가 패널로 이동. 상호작용 가능한 콘텐츠 (버튼/링크/입력) 포함 가능.
 
 #### 선택 가이드
 
@@ -1524,9 +1775,10 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 
 - 툴팁 노드: `role="tooltip"`, `id={useId()}`
 - 트리거: 열렸을 때 `aria-describedby={tooltipId}` 자동 주입 → 스크린리더가 보조 설명으로 읽음
-- **키보드**: <kbd>Tab</kbd>으로 트리거 포커스 → 자동 노출, <kbd>Tab</kbd>으로 벗어나면 닫힘
+- **키보드**: <kbd>Tab</kbd>으로 트리거 포커스 → 자동 노출, <kbd>Tab</kbd>으로 벗어나면 닫힘, <kbd>Esc</kbd>로 즉시 닫힘
 - focus / blur 모두 핸들링 - 키보드 전용 사용자도 동일하게 접근 가능
-- 툴팁 자체는 `pointer-events: none` → 마우스로 잡을 수 없음 (포커스 트랩 / 상호작용 요소 금지)
+- **WCAG 1.4.13 Hoverable**: 툴팁에 `pointer-events` 가 살아 있어 포인터를 툴팁 위로 옮겨도 닫히지 않는다 (`onMouseEnter` 로 지연 닫힘 취소). 다만 툴팁 안에 포커스 가능한 요소를 넣는 것은 여전히 금지 - `role="tooltip"` 은 포커스를 받지 않는다.
+- **WCAG 1.4.13 Dismissable**: 공유 오버레이 스택(`useOverlayEscape`)에 등록되어 최상단일 때만 <kbd>Esc</kbd>를 소비한다. 다른 오버레이나 소비자 앱의 Escape 핸들러를 삼키지 않는다.
 
 > 📌 트리거 자체에도 라벨이 필요하다. IconButton에는 `aria-label`을 따로 줘야 SR-only 환경에서도 의미가 전달된다 (tooltip은 보조이므로 시각 비의존 라벨이 우선).
 
@@ -1539,20 +1791,26 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 - **퇴출**: `clamp: true`로 진동 없이 빠르게 사라짐 (비대칭)
 - spring config: `tension: 280, friction: 28` (Vercel/Linear 톤)
 
-#### 외부 클릭/Esc 처리
+#### 닫힘 처리
 
-Tooltip은 **dismissable 오버레이가 아님**:
-- blur(focus 잃음) / mouseleave 시 즉시 닫힘
-- 외부 클릭 / Esc로 따로 닫는 로직 없음 (필요 없음 - pointer-events가 차단되어 있어 트랩 안 됨)
-- unmount 시 timer cleanup 자동 처리
+| 트리거 | 동작 |
+|------|------|
+| blur (트리거가 focus 잃음) | **즉시** 닫힘 |
+| <kbd>Esc</kbd> | **즉시** 닫힘 (`useOverlayEscape` - 스택 최상단일 때만) |
+| mouseleave (트리거 또는 툴팁) | **120ms 지연** 후 닫힘 (`HIDE_DELAY`) - 포인터가 트리거↔툴팁 사이 6px 갭을 건널 시간 |
+| 툴팁 위로 mouseenter | 지연 닫힘 **취소** (열림 유지) |
+
+- 외부 클릭으로 닫는 로직은 없다 (hover/focus 기반이라 불필요).
+- unmount 시 timer cleanup 자동 처리.
 
 #### DOM 구조 (SCSS override 시 참고)
 
 ```
-span.tooltip_wrapper           ← position: relative; display: inline-flex
+span.tooltip_wrapper           ← position: relative; display: inline-block
 ├── {children}                 ← cloneElement로 핸들러/aria 주입된 trigger
 └── span.tooltip_position      ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
-    └── span.tooltip           ← role="tooltip", spring transform
+    │                            pointer-events 유지 + onMouseEnter/onMouseLeave (WCAG 1.4.13 Hoverable)
+    └── span.tooltip           ← role="tooltip", spring transform, max-width 240px
 ```
 
 `document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition`이 계산한 좌표로 배치되므로, 트리거의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5`.
@@ -1580,7 +1838,7 @@ import { Save, Trash } from "lucide-react";
 
 // 4) 긴 텍스트 (max-width 240px에서 자동 줄바꿈)
 <Tooltip content="버튼을 누르면 데이터가 영구 삭제됩니다. 되돌릴 수 없습니다.">
-  <Button variant="danger">삭제</Button>
+  <Button danger>삭제</Button>
 </Tooltip>
 
 // 5) 지연 조정 - 빈번하게 hover되는 영역
@@ -1739,7 +1997,7 @@ import { MoreVertical, Edit, Copy, Trash, Share, Archive } from "lucide-react";
 
 // 4) 명시적 액션 그룹 - Button trigger
 <Menu
-  trigger={<Button variant="secondary">Actions ▾</Button>}
+  trigger={<Button variant="outline">Actions ▾</Button>}
   items={[
     { key: "export", label: "내보내기", onSelect: handleExport },
     { key: "import", label: "가져오기", onSelect: handleImport },
@@ -1760,14 +2018,14 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 | 클릭으로 여는 작은 폼/필터 (체크박스, 입력, 적용 버튼) | ✅ Popover |
 | 프로필 카드, 미리보기, 부가 설명 + 액션 버튼 | ✅ Popover |
 | 단순 액션 리스트 (Edit / Duplicate / Delete) | ❌ Menu 권장 |
-| hover로 뜨는 짧은 텍스트 라벨 | ❌ Tooltip 권장 (`pointer-events: none`) |
+| hover로 뜨는 짧은 텍스트 라벨 | ❌ Tooltip 권장 (포커스를 옮기지 않는 보조 설명) |
 | 화면 중앙 차단(modal) 다이얼로그 / 확인창 | ❌ Modal · `useAlert()` 권장 |
 | 폼 필드 상시 도움말 | ❌ helper text 권장 |
 
 **Popover vs Menu vs Tooltip**
 - **Popover**: 클릭으로 열고 외부 클릭/Esc로 닫음. `role="dialog"` (non-modal). 임의의 상호작용 콘텐츠. 열릴 때 포커스가 패널로 이동.
 - **Menu**: 클릭으로 열리는 **액션 리스트**. `role="menu"` + `menuitem`. 선택 시 사이드 이펙트.
-- **Tooltip**: hover/focus로 뜨는 **짧은 정보**. `pointer-events: none`, dismissable 아님.
+- **Tooltip**: hover/focus로 뜨는 **짧은 정보**. `role="tooltip"`, 포커스를 옮기지 않음. Esc 로 닫히고 툴팁 위 hover 도 가능하지만, 안에 상호작용 요소를 넣을 수는 없음.
 
 #### 선택 가이드
 
@@ -1829,7 +2087,7 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 #### DOM 구조 (SCSS override 시 참고)
 
 ```
-span.popover_wrapper               ← position: relative; ref 부착 (외부 클릭 판정)
+div.popover_wrapper                ← position: relative; display: inline-flex; ref 부착 (외부 클릭 판정)
 ├── {trigger}                      ← cloneElement로 onClick/aria 주입
 └── div.popover_position           ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
     └── div.popover                ← role="dialog", spring transform
@@ -2840,6 +3098,142 @@ const [open, setOpen] = useState<string[]>(initialFromUrl);
 
 ---
 
+### Table
+
+컬럼 정의 기반 데이터 테이블. 로딩 중에는 헤더를 유지한 채 바디만 [Skeleton](#skeleton) 행으로 대체하고, 정렬·행 선택·행 클릭을 지원한다.
+
+> DS 는 데이터를 **직접 정렬하지 않는다**. `sortable` 헤더 클릭 시 `onSortChange` 만 발화하므로, 소비자가 정렬된 `data` 를 다시 내려줘야 한다.
+
+**Props**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `columns` | `TableColumn<T>[]` | required | 컬럼 정의 |
+| `data` | `T[]` | required | 표시할 데이터 배열 |
+| `keyExtractor` | `(item: T, index: number) => string \| number` | required | 행의 고유 key 추출 함수 |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 테이블 크기 |
+| `emptyMessage` | `ReactNode` | `'데이터가 없습니다'` | 데이터가 없을 때 표시 |
+| `isLoading` | `boolean` | `false` | 로딩 상태 - 헤더 유지, 바디만 스켈레톤 |
+| `skeletonRows` | `number` | `5` | 로딩 시 스켈레톤 행 개수 |
+| `hoverable` | `boolean` | `true` | 행 hover 강조 |
+| `stickyHeader` | `boolean` | `false` | thead sticky 고정 |
+| `ariaLabel` | `string` | - | 스크린리더용 테이블 레이블 |
+| `onRowClick` | `(item: T, index: number) => void` | - | 행 클릭 콜백 |
+| `rowClickHint` | `string` | `'클릭 가능한 행'` | clickable 행에 `aria-describedby` 로 연결되는 동작 설명. `''` 면 힌트 미부착 |
+| `sort` | `TableSort` | - | 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 |
+| `onSortChange` | `(sort: TableSort \| undefined) => void` | - | 정렬 헤더 클릭 시 발화 (none→asc→desc→none 순환) |
+| `selectable` | `boolean` | `false` | 행 선택(체크박스 컬럼) 활성화. `true` 면 `rowKey` **필수** |
+| `rowKey` | `(row: T) => string` | - | 행 고유 key 추출 함수 (`selectable` 시 필수) |
+| `selectedKeys` | `string[]` | - | 선택된 행 key 배열 (제어형) |
+| `onSelectionChange` | `(keys: string[]) => void` | - | 선택 변경 콜백 |
+| `selectAllAriaLabel` | `string` | `'전체 선택'` | 전체 선택 체크박스 aria-label |
+| `selectRowAriaLabel` | `(index: number) => string` | ``(i) => `${i + 1}번째 행 선택` `` | 개별 행 체크박스 aria-label |
+| `className` | `string` | - | 루트 wrapper 에 추가할 className |
+
+**`TableColumn<T>`**
+
+| 필드 | Type | Default | Description |
+|------|------|---------|-------------|
+| `key` | `string` | required | 컬럼 식별자. `render` 가 없으면 `item[key]` 를 자동 렌더 |
+| `header` | `ReactNode` | required | thead 에 표시할 헤더 |
+| `render` | `(item: T, index: number) => ReactNode` | - | 셀 렌더 함수 |
+| `width` | `string` | - | CSS width 값 (예: `"120px"`, `"20%"`) |
+| `align` | `'left' \| 'center' \| 'right'` | `'left'` | 정렬 |
+| `sortable` | `boolean` | `false` | 정렬 가능 여부. 클릭 시 `onSortChange` 발화 |
+
+**`TableSort`**
+
+| 필드 | Type | Description |
+|------|------|-------------|
+| `key` | `string` | 정렬 중인 컬럼의 `TableColumn.key` |
+| `direction` | `'asc' \| 'desc'` | 정렬 방향 |
+
+**Usage**
+
+```tsx
+import { useMemo, useState } from "react";
+import { Table, Chip } from "@bigtablet/design-system";
+import type { TableColumn, TableSort } from "@bigtablet/design-system";
+
+type User = { id: string; name: string; email: string; active: boolean };
+
+const columns: TableColumn<User>[] = [
+  { key: "name", header: "이름", sortable: true, width: "180px" },
+  { key: "email", header: "이메일" },
+  {
+    key: "active",
+    header: "상태",
+    align: "center",
+    render: (u) => <Chip type="static" tone={u.active ? "success" : "default"} label={u.active ? "활성" : "휴면"} />,
+  },
+];
+
+function UserTable({ users, isLoading }: { users: User[]; isLoading: boolean }) {
+  const [sort, setSort] = useState<TableSort | undefined>();
+  const [selected, setSelected] = useState<string[]>([]);
+
+  // 정렬은 소비자 책임 - DS 는 상태만 알려준다
+  const rows = useMemo(() => (sort ? sortBy(users, sort) : users), [users, sort]);
+
+  return (
+    <Table
+      ariaLabel="사용자 목록"
+      columns={columns}
+      data={rows}
+      keyExtractor={(u) => u.id}
+      isLoading={isLoading}
+      stickyHeader
+      sort={sort}
+      onSortChange={setSort}
+      selectable
+      rowKey={(u) => u.id}
+      selectedKeys={selected}
+      onSelectionChange={setSelected}
+      onRowClick={(u) => router.push(`/users/${u.id}`)}
+      rowClickHint="선택하면 상세 화면으로 이동"
+    />
+  );
+}
+```
+
+#### 접근성
+
+- 정렬 헤더는 `<button>` 이고 현재 상태가 `aria-sort` 로 노출된다.
+- `onRowClick` 이 있는 행에는 `rowClickHint` 가 `aria-describedby` 로 연결된다. `<tr>` 에 `aria-label` / `role="button"` 을 쓰면 셀 데이터를 스크린리더가 못 읽으므로 의도적으로 `aria-describedby` 를 쓴다.
+- 선택 체크박스는 [Checkbox](#checkbox) 를 사용하며 `selectAllAriaLabel` / `selectRowAriaLabel` 로 레이블을 커스터마이즈한다.
+
+---
+
+### Icon
+
+[lucide-react](https://lucide.dev/icons/) 아이콘 래퍼. `aria-label` 이 없으면 `aria-hidden` + `focusable={false}` 를 자동 적용해 스크린리더 노이즈를 막는다.
+
+```tsx
+import { Icon } from '@bigtablet/design-system';
+import { Search, X } from 'lucide-react';
+
+// 장식용 - aria-hidden 자동
+<Icon icon={Search} size={20} />
+
+// 의미 있는 아이콘 - aria-label 을 주면 aria-hidden 이 붙지 않음
+<Icon icon={X} size={16} strokeWidth={2.5} aria-label="닫기" />
+
+// 토큰 사이즈와 함께
+import { iconSize } from '@bigtablet/design-system';
+<Icon icon={Search} size={iconSize.md} />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `icon` | `LucideIcon` | required | lucide-react 아이콘 컴포넌트 |
+| `size` | `number \| string` | `24` (lucide 기본) | 아이콘 크기 (px). `iconSize` 토큰 사용 권장 |
+| `strokeWidth` | `number \| string` | `2` (lucide 기본) | 선 두께 |
+| `color` | `string` | `currentColor` | 색상 |
+
+> 나머지 `LucideProps`(= SVG 속성)는 그대로 전달된다 (`ref` 제외). `iconSize` 토큰: `xs` 14 · `sm` 16 · `md` 18 · `lg` 20 · `xl` 32.
+
+---
+
 ## Layout
 
 페이지 레이아웃을 구성하는 4가지 프리미티브. 모두 토큰 기반의 일관된 spacing/breakpoint(compact 600 · expanded 840 · large 1200)를 사용합니다.
@@ -3162,8 +3556,8 @@ export function LandingPage() {
             <h1>가장 빠른 결제 솔루션</h1>
             <p>3분 안에 결제 시스템을 구축하세요.</p>
             <Stack direction="horizontal" gap={12}>
-              <Button variant="primary">시작하기</Button>
-              <Button variant="secondary">데모 보기</Button>
+              <Button variant="filled">시작하기</Button>
+              <Button variant="outline">데모 보기</Button>
             </Stack>
           </Stack>
         </Container>
@@ -3203,7 +3597,7 @@ export function LandingPage() {
         <Container size="md">
           <Stack gap={24} align="center">
             <h2>지금 시작하세요</h2>
-            <Button variant="primary">무료로 시작하기</Button>
+            <Button variant="filled">무료로 시작하기</Button>
           </Stack>
         </Container>
       </Section>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -181,17 +181,24 @@ export const Button = ({
     display: inline-flex;
     align-items: center;
     border-radius: token.$radius_md;
-    transition: all token.$transition_base;
+    // `transition: all` 금지 - 바뀌는 속성만 명시한다
+    transition: background-color token.$transition_fast, color token.$transition_fast;
+
+    &_variant_filled {
+        background-color: token.$color_brand_primary;
+        color: token.$color_brand_on_primary;
+    }
+
+    &_size_md {
+        height: 40px;
+        padding: 0 token.$spacing_16;
+    }
 }
 
-.variant_primary {
-    background-color: token.$color_primary;
-    color: token.$color_white;
-}
-
-.size_md {
-    height: 40px;
-    padding: 0 token.$spacing_lg;
+@media (prefers-reduced-motion: reduce) {
+    .button {
+        transition: none;
+    }
 }
 ```
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -56,7 +56,7 @@ Button 이 `as`/`href` 로 anchor 렌더링을 지원하면서 `ButtonProps` 가
 
 - **런타임·공개 prop 은 100% 호환** — 기존 `<Button variant size onClick disabled>` 사용은 그대로 동작합니다.
 - **타입 레벨만 영향**: TS interface 는 union 을 확장할 수 없어 `interface X extends ButtonProps {}` 형태가 깨집니다.
-- **해결**: 스타일 props 만 확장하려면 공통 베이스 `ButtonBaseProps` 를, 전체 prop 을 참조하려면 `React.ComponentProps<typeof Button>` 을 쓰세요.
+- **해결**: `React.ComponentProps<typeof Button>` 로 참조한 뒤 교차 타입(`&`) 으로 확장하세요. (내부 공통 베이스 `ButtonBaseProps` 는 export 되지 않으므로 소비자가 쓸 수 없습니다.)
   ```tsx
   // ❌ An interface can only extend an object type...
   interface MyButtonProps extends ButtonProps { extra?: string }
@@ -72,7 +72,6 @@ Button 이 `as`/`href` 로 anchor 렌더링을 지원하면서 `ButtonProps` 가
 | Dropdown | `name` | hidden input 으로 네이티브 폼 제출 참여 |
 | Alert | `closeOnOverlay` | 오버레이 클릭 닫힘 on/off (기본 true) |
 | Chip | `removeLabel` | 삭제 버튼 접근성 레이블 커스터마이즈 (기본 `"{label} 제거"`) |
-| utils | `useOverlayEscape` / `registerOverlay` / `useIsMounted` | 공유 오버레이 Escape 스택, 클라이언트 마운트 훅 |
 
 > Vanilla JS 패키지도 폼 참여(`data-name` on Select/Toggle)·combobox ARIA 등이 추가됐습니다. HTML/CSS/JS 환경 사용법은 [docs/VANILLA.md](./VANILLA.md) 참고.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -338,30 +338,56 @@ it("calls callback with correct arguments", () => {
 
 ### 현재 커버리지 현황
 
-| 카테고리 | 커버리지 |
-|----------|----------|
-| **전체** | 86% |
-| Button | 100% |
-| Card | 100% |
-| Radio | 100% |
-| Alert | 100% |
-| Spinner | 100% |
-| Pagination | 100% |
-| TopLoading | 100% |
-| FileInput | 100% |
-| Chip | 95% |
-| Modal | 97% |
-| Toggle | 93% |
-| Checkbox | 91% |
-| DatePicker | 90% |
-| Toast | 90% |
-| TextField | 74% |
-| Dropdown | 89% |
+`pnpm test:coverage` (v8, `unit` 프로젝트) 기준 - 55 test files / 779 passed · 9 skipped.
+
+| 전체 | Stmts | Branch | Funcs | Lines |
+|------|-------|--------|-------|-------|
+| **All files** | **90.01%** | **85.59%** | **90.07%** | **91.97%** |
+
+아래는 **100% 미만**인 파일만 나열한 것이다 (미표기 컴포넌트 = 전 지표 100%: Button · Card · Radio · Spinner · Pagination · TopLoading · Badge · Divider · Skeleton · Toggle · Breadcrumb · EmptyState · ErrorState · IconButton · Container/Section/Stack/Grid 등).
+
+| 파일 | Stmts | Branch | Funcs | Lines |
+|------|-------|--------|-------|-------|
+| ui/display/accordion | 100% | 80% | 100% | 100% |
+| ui/display/avatar | 84.61% | 88% | 66.66% | 90.9% |
+| ui/display/chip | 86.95% | 80.43% | 66.66% | 95.23% |
+| ui/display/hero | 92.85% | 88.88% | 100% | 100% |
+| **ui/display/icon** | **0%** | **0%** | **0%** | **0%** |
+| ui/display/list-item | 100% | 93.33% | 100% | 100% |
+| ui/display/media-card | 100% | 96.29% | 100% | 100% |
+| ui/display/table | 98.07% | 92.79% | 95.65% | 97.77% |
+| ui/feedback/alert | 96.92% | 93.44% | 100% | 98.27% |
+| ui/feedback/linear-progress | 100% | 66.66% | 100% | 100% |
+| ui/feedback/toast | 100% | 84.21% | 100% | 100% |
+| ui/forms/checkbox | 91.66% | 90% | 100% | 100% |
+| ui/forms/date-picker | 91.86% | 80.16% | 100% | 97.1% |
+| ui/forms/dropdown | 96.42% | 90.64% | 100% | 96.49% |
+| ui/forms/file | 80.43% | 65% | 83.33% | 80% |
+| **ui/forms/image-cropper** | **57.04%** | **55.29%** | **50%** | **58.33%** |
+| ui/forms/otp-input | 89.28% | 91.66% | 100% | 89.33% |
+| ui/forms/radio-group | 100% | 95.45% | 100% | 100% |
+| ui/forms/textarea | 88.33% | 74.69% | 100% | 92.85% |
+| ui/forms/textfield | 90.47% | 82.75% | 77.77% | 92.68% |
+| ui/navigation/bottom-nav | 94.73% | 95% | 100% | 94.73% |
+| ui/navigation/menu | 97.29% | 89.13% | 100% | 100% |
+| ui/navigation/nav-bar | 80.19% | 69.23% | 81.81% | 85.39% |
+| ui/navigation/sidebar | 83.33% | 88.63% | 75% | 86.95% |
+| ui/navigation/tabs | 91.42% | 78.18% | 88.88% | 100% |
+| ui/overlay/drawer | 97.91% | 95.16% | 100% | 100% |
+| ui/overlay/modal | 97.67% | 93.93% | 100% | 100% |
+| ui/overlay/popover | 91.3% | 83.87% | 100% | 92.68% |
+| ui/overlay/tooltip | 92.98% | 83.33% | 93.33% | 91.66% |
+| ui/system/theme-provider | 93.87% | 85.71% | 100% | 100% |
+| utils | 90.14% | 83.18% | 78.57% | 91.93% |
+
+> ⚠️ **80% 기준선 미달 (개선 필요)**
+> - **`ui/display/icon` — 0%**: 단위 테스트가 아예 없다. `aria-hidden` 자동 적용 / `aria-label` 지정 시 미적용 두 분기만이라도 커버해야 한다.
+> - **`ui/forms/image-cropper` — 57.04%**: canvas·pointer 조작 경로(`crop()`, 드래그, 휠 줌)가 jsdom 에서 대부분 미커버. `utils/use-spring-hover.ts` 도 10% 로 낮다.
 
 ### 커버리지 목표
 
 - 새 컴포넌트: 최소 80% 커버리지
-- 전체 목표: 85% 이상 유지
+- 전체 목표: 85% 이상 유지 (현재 90.01%)
 
 ### 커버리지 리포트 확인
 
@@ -395,19 +421,25 @@ describe("Button", () => {
     });
 
     it("applies variant classes", () => {
-        const { container, rerender } = render(<Button variant="primary">Test</Button>);
-        expect(container.firstChild).toHaveClass("variant_primary");
+        const { container, rerender } = render(<Button variant="filled">Test</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_filled");
 
-        rerender(<Button variant="danger">Test</Button>);
-        expect(container.firstChild).toHaveClass("variant_danger");
+        rerender(<Button variant="outline">Test</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_outline");
+    });
+
+    it("applies the danger modifier independently of variant", () => {
+        const { container } = render(<Button variant="outline" danger>Delete</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_outline");
+        expect(container.firstChild).toHaveClass("button_danger");
     });
 
     it("applies size classes", () => {
         const { container, rerender } = render(<Button size="sm">Test</Button>);
-        expect(container.firstChild).toHaveClass("size_sm");
+        expect(container.firstChild).toHaveClass("button_size_sm");
 
-        rerender(<Button size="lg">Test</Button>);
-        expect(container.firstChild).toHaveClass("size_lg");
+        rerender(<Button size="xl">Test</Button>);
+        expect(container.firstChild).toHaveClass("button_size_xl");
     });
 
     it("calls onClick when clicked", () => {


### PR DESCRIPTION
## 작업 개요

문서가 실제 소스 API 와 크게 어긋나 있어 전수 재검증 후 동기화했습니다. 감사 리스트의 각 항목을 현재 소스(`src/**/index.tsx`, `src/index.ts`, `package.json`, `.github/workflows/ci.yml`)와 대조해 확인했고, 커버리지·번들 크기는 직접 측정한 값으로 교체했습니다.

**소스 코드(`src/`)는 전혀 건드리지 않았습니다.** 변경 파일은 `.md` 8개뿐입니다.

## 작업한 내용

### docs/COMPONENTS.md — 컴파일 안 되는 잘못된 API

- [x] Button `variant` 를 `'filled' | 'tonal' | 'outline' | 'text'` (기본 `'filled'`) 로 정정. `danger` 는 별도 boolean prop 임을 명시
- [x] Button `size` 에 `'xl'` 추가, 존재하지 않는 `width` prop 행 + `<Button width="200px">` 예제 삭제
- [x] Button 표에 실제 prop `leadingIcon` / `trailingIcon` / `radius` / `as` / `href` 추가
- [x] 파일 전체 grep 후 `variant="primary|secondary|ghost|danger"` 예제 6곳(NavBar / Tooltip / Menu / 랜딩 합성 예제)을 실제 API 로 교체 (`danger` → boolean prop)
- [x] TextField `leftIcon`/`rightIcon` → `leadingIcon`/`trailingIcon` (표 + 예제 양쪽)
- [x] TextField 에 없는 `success` / `variant` prop 행 + 예제 삭제, 대신 실제 prop `showLabel` / `clearable` / deprecated `onChangeAction` 추가

### docs/COMPONENTS.md — 오해를 부르는 서술

- [x] FileInput `label` 기본값 `'파일 선택'` → 실제 `'Choose file'`
- [x] FileInput 표에 누락된 `supportingText` / `preview` / `variant` / `previewSize` 추가 + 예제 보강
- [x] Dropdown 표에 멀티셀렉트·검색 기능군 전체 추가 (`multiple` / `searchable` / `searchPlaceholder` / `emptyText` / `selectedSummary` / `name` / `id` / `className` / deprecated `onChange`·`variant`·`textAlign`) + 사용 예제 추가
- [x] "Tooltip 은 dismissable 아님 / Esc 로직 없음" 서술 정정 — 실제로는 `useOverlayEscape` 로 WCAG 1.4.13 Dismissable 을 구현하고 있음
- [x] "tooltip 은 `pointer-events: none`" 주장 5곳 제거 — SCSS 가 WCAG 1.4.13 Hoverable 을 위해 의도적으로 pointer-events 를 살려두고 있고 `onMouseEnter`/`onMouseLeave` 도 붙어 있음. 이 전제로 쓰여 있던 Tooltip vs Popover 가이드 문구도 다시 씀
- [x] "mouseleave 시 즉시 닫힘" → 실제 120ms `HIDE_DELAY`. blur / Escape 만 즉시임을 표로 정리
- [x] Tooltip DOM 다이어그램 `inline-flex` → `inline-block` (SCSS 기준), Popover wrapper `span` → `div`

### docs/COMPONENTS.md — 문서가 아예 없던 컴포넌트

- [x] **ImageCropper** 섹션 신규 (v3.7.0 헤드라인 기능 — props / `ImageCropperHandle` / Modal 조합 예제 / 키보드·포인터 조작 표 / CORS 주의)
- [x] **OtpInput** 섹션 신규
- [x] **Skeleton** 섹션 신규
- [x] **Table** 섹션 신규 (`TableColumn` / `TableSort` 하위 표 + 정렬·선택 예제 + 접근성)
- [x] **Icon** 섹션 신규
- [x] 위 5개 목차(TOC) 항목 추가

### README.md + README_KR.md

- [x] SCSS 예제의 내부 경로 `@use "src/styles/token"` → 배포 경로 `@bigtablet/design-system/scss/token`
- [x] CSS 예제의 `var(--bt-spacing-16)` / `var(--bt-radius-md)` 제거 — `dist/index.css` 는 `--bt-color-*` / `--bt-elevation-*` / `--bt-focus-*` / `--bt-sidebar-*` / `--bt-bottom-nav-*` 만 내보냄을 확인하고 실제 변수로 교체 + 한계 주석 추가
- [x] "Next.js 13+" → `package.json` 의 optional peer dependency `next: >=15`
- [x] 컴포넌트 표를 `src/index.ts` 기준으로 정정 — Overlay 에 Drawer·Popover, Forms 에 RadioGroup·ImageCropper (KR 은 Textarea 도), KR Feedback 에 ErrorState, KR Navigation 에 BottomNav, System 행 추가
- [x] "11 token domains" → TS export 를 가진 13개 + SCSS 전용 `layout`. 도메인 나열에 빠져 있던 `skeleton` / `icon` 추가

### docs/MIGRATION.md

- [x] export 되지 않는 `ButtonBaseProps` 확장 안내 삭제, `React.ComponentProps<typeof Button>` 안내만 유지
- [x] `useOverlayEscape` / `registerOverlay` / `useIsMounted` 신규 export 행 삭제 (`src/utils/index.ts` 에는 있으나 `src/index.ts` 에 없어 소비자에게 노출되지 않음 — 소스는 건드리지 않음)

### docs/TESTING.md + CLAUDE.md

- [x] `pnpm test:coverage` 직접 실행 후 커버리지 표 전면 교체 (전체 **stmts 90.01% / branch 85.59% / funcs 90.07% / lines 91.97%**, 55 test files / 779 passed · 9 skipped)
- [x] 문서 자체 기준선(80%) 미달 파일을 숨기지 않고 명시 — `ui/display/icon` **0%**, `ui/forms/image-cropper` **57.04%** (덤으로 `utils/use-spring-hover.ts` 10%)
- [x] Button 테스트 예제의 `variant="primary"` / `toHaveClass("variant_primary")` → `button_variant_filled` · `button_size_*` · `danger` boolean
- [x] CLAUDE.md 커버리지 86% → 측정값 90%, Vanilla 번들 크기 27/21/20/9KB → 실측 ~38/31/30/13KB (`pnpm build` 후 `ls -l dist/vanilla`)

### docs/ARCHITECTURE.md

- [x] 디자인 토큰 예제 전면 재작성 — `$color_primary` / `$color_white` / `$spacing_xs|sm|md|lg` / `$shadow_sm|md` 는 모두 존재하지 않는 토큰. 실제 base → semantic 2계층, `var(--bt-*)` 기반 semantic 색상, 숫자 spacing/typography 스케일, `$elevation_level1` 로 교체
- [x] Button 예제를 실제 discriminated union (`ButtonAsButton | ButtonAsAnchor`, `variant = "filled"`) 로 교체
- [x] 디렉터리 목록에 `forms/image-cropper`, `overlay/drawer`, `utils/overlay-stack.ts`·`use-is-mounted.ts`·`use-anchored-position.ts` 추가
- [x] 테스트 예제 `variant="danger"` / `toHaveClass("variant_danger")` → 실제 클래스명
- [x] `src/index.ts` 가 `export * from …` 을 쓴다는 서술 정정 — 명시적 named export 사용
- [x] SCSS 예제의 `transition: all` 제거 (CLAUDE.md 금지 규칙) + reduced-motion 블록 추가
- [x] 드리프트된 CI 스니펫을 실제 `.github/workflows/ci.yml` 구조 요약으로 교체 (node 22.14.0, checkout@v6, `paths-filter` 기반 조건부 job, commitlint / stylelint / size-limit / coverage report step)

### 추가로 발견해 함께 고친 것 (감사 리스트 외)

- [x] `docs/CONTRIBUTING.md` SCSS 예제도 동일하게 존재하지 않는 토큰(`$color_primary` / `$color_white` / `$spacing_lg`)과 `transition: all` 사용 중이라 같은 방식으로 정정

## 검증

- [x] `git status` — 변경 파일은 `.md` 8개뿐, `src/` 무변경
- [x] `npx vitest run --project unit` — **55 test files / 779 passed · 9 skipped** (커밋 3회 모두 husky pre-commit 통과)
- [x] 커버리지·번들 크기는 추정이 아니라 실행 결과(`pnpm test:coverage`, `pnpm build` → `ls -l dist/vanilla`)
- [x] 감사 리스트 31개 항목을 전부 현재 소스로 재확인 — 아래 3건은 **이미 정확해 수정하지 않음**
  - Tooltip DOM 다이어그램의 `span.tooltip_position` 레이어는 이미 존재 (같은 항목의 `inline-flex` 표기만 오류라 그것만 수정)
  - Popover 다이어그램의 `popover_position` / `popover` 는 이미 `div` 로 표기됨 (wrapper 한 줄만 `span` → `div`)
  - README EN 의 Display / Feedback / Navigation 컴포넌트 목록은 이미 `src/index.ts` 와 일치
- [x] 마크다운 코드펜스 짝 맞음, 표 셀 내 `|` 이스케이프 확인

## 전달할 추가 이슈

- ~~`docs/THEMING.md:169-170` 예제도 존재하지 않는 `token.$spacing_md` 를 사용 중입니다.~~ → **#438 에서 처리 완료.**
- 테스트 커버리지 관점에서 `ui/display/icon` 0% 와 `ui/forms/image-cropper` 57% 는 별도 이슈로 다루는 게 좋겠습니다. 특히 Icon 은 분기가 2개뿐이라 비용이 거의 없습니다.

---

> **후속 PR: #438** — 이 PR 이 머지된 뒤 아래 항목을 이어서 처리했습니다.
> - 위 THEMING.md 죽은 토큰 수정
> - 전 문서 죽은 토큰 전수 스윕 (`docs/VANILLA.md` 의 `--bt-shadow-*`, `docs/AGENT_GUIDE.md` 의 `--bt-radius-xs`·`--bt-spacing-*` 오기 추가 발견)
> - IconButton 접근성 이름 필수화(#434) props 표 반영
> - 이 PR 이후 develop 이 움직여 어긋난 커버리지·번들 크기 수치 재측정

