### PR TITLE
docs/api-sync-followup

### DIFF
--- a/.claude/docs/design-system.md
+++ b/.claude/docs/design-system.md
@@ -611,22 +611,35 @@ const items = [
 @use "@bigtablet/design-system/scss/token" as token;
 
 .my-class {
-  padding: token.$spacing_md;       // 0.75rem
-  color: token.$color_primary;      // #000000
-  border-radius: token.$radius_md;  // 8px
-  box-shadow: token.$shadow_sm;
+  padding: token.$spacing_16;            // 16px
+  color: token.$color_text_heading;
+  background: token.$color_bg_solid;
+  border-radius: token.$radius_md;       // 8px
+  box-shadow: token.$elevation_level1;
 }
 ```
 
 ### Token Reference
 
-**Spacing:** `$spacing_xs` (4px), `$spacing_sm` (8px), `$spacing_md` (12px), `$spacing_lg` (16px), `$spacing_xl` (20px), `$spacing_2xl` (24px)
+토큰 이름은 **숫자 스케일 + semantic** 이다. `xs/sm/md/lg` 같은 t-shirt spacing, `$color_primary` 같은 원시 색상, `$shadow_*` 는 **존재하지 않는다**.
 
-**Colors:** `$color_primary`, `$color_primary_hover`, `$color_error`, `$color_success`, `$color_warning`, `$color_info`, `$color_text_primary`, `$color_text_secondary`, `$color_border`, `$color_background`
+**Spacing** (숫자 = px): `$spacing_0` `$spacing_1` `$spacing_2` `$spacing_3` `$spacing_4` `$spacing_6` `$spacing_8` `$spacing_12` `$spacing_16` `$spacing_20` `$spacing_24` `$spacing_32` `$spacing_40` `$spacing_48`
 
-**Radius:** `$radius_sm` (6px), `$radius_md` (8px), `$radius_lg` (12px)
+**Colors** (semantic, `var(--bt-*)` 참조라 다크 모드 자동 대응):
+- brand: `$color_brand_primary`, `$color_brand_on_primary`, `$color_brand_primary_container`
+- text: `$color_text_heading`, `$color_text_body`, `$color_text_caption`, `$color_text_brand`, `$color_text_inverse`, `$color_text_disabled`
+- bg: `$color_bg_solid`, `$color_bg_solid_dim`, `$color_bg_additive`, `$color_bg_disabled`, `$color_bg_overlay`, `$color_bg_inverse_surface`
+- border: `$color_border_default`, `$color_border_hover`, `$color_border_subtle`, `$color_border_focus`, `$color_border_disabled`
+- status: `$color_status_error` / `_success` / `_warning` / `_info` (+ `_on_default`, `_container`, `_on_container`, `_on_surface` 변형)
+- state: `$color_state_hover_on_light` / `_pressed_on_light` / `_focus_on_light` (+ `_on_dark` 변형)
 
-**Shadows:** `$shadow_sm`, `$shadow_md`, `$shadow_lg`
+**Radius:** `$radius_none` (0), `$radius_xs` (4px), `$radius_sm` (6px), `$radius_md` (8px), `$radius_lg` (12px), `$radius_xl` (16px), `$radius_full` (9999px)
+
+**Elevation** (구 `$shadow_*` 아님): `$elevation_level1` ~ `$elevation_level5`
+
+**Typography** (숫자 = px): `$font_size_12` ~ `$font_size_48`, `$font_weight_regular` / `_medium` / `_semi_bold` / `_bold`
+
+**Motion:** `$duration_fast|base|slow`, `$transition_fast|base|slow`, `$easing_enter`, `$easing_exit`, `$transition_enter_*` / `$transition_exit_*` (composite - easing 포함되어 있으니 easing 을 또 붙이지 말 것)
 
 ### Layout Mixins
 
@@ -646,17 +659,25 @@ const items = [
 @use "@bigtablet/design-system/scss/token" as token;
 
 .component {
-  padding: token.$spacing_lg;
+  padding: token.$spacing_24;
 
-  @include token.mobile {
-    padding: token.$spacing_sm;
+  // 구간 지정 (compact 0~599 / medium 600~839 / expanded 840~1199 / large 1200~)
+  @include token.compact {
+    padding: token.$spacing_12;
   }
 
-  @include token.tablet {
-    padding: token.$spacing_md;
+  @include token.medium {
+    padding: token.$spacing_16;
+  }
+
+  // min-width 단축 mixin - from_medium / from_expanded / from_large
+  @include token.from_large {
+    padding: token.$spacing_32;
   }
 }
 ```
+
+> `token.mobile` / `token.tablet` 같은 mixin 은 없다. 구간은 `compact` / `medium` / `expanded` / `large`, min-width 단축은 `from_medium` / `from_expanded` / `from_large` 를 쓴다.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ return <animated.div style={style}>...</animated.div>;
 
 - **Test Runner**: Vitest (multi-project: `unit` + `storybook`)
 - **a11y Testing**: axe-core via `@storybook/addon-a11y` + Playwright (headless Chromium)
-- **Coverage**: 90% (stmts 90.01 / branch 85.59 / funcs 90.07 / lines 91.97 - 자세한 표는 [docs/TESTING.md](./docs/TESTING.md#커버리지))
+- **Coverage**: 90% (stmts 90.02 / branch 85.69 / funcs 90.07 / lines 91.97 - 자세한 표는 [docs/TESTING.md](./docs/TESTING.md#커버리지))
 - **Commands**:
   ```bash
   pnpm test              # Run unit tests
@@ -253,7 +253,7 @@ For non-React environments (Thymeleaf, JSP, PHP, Django, etc.)
 ### Build Output
 ```
 dist/vanilla/
-├── bigtablet.css       # Full CSS (~38KB)
+├── bigtablet.css       # Full CSS (~40KB)
 ├── bigtablet.min.css   # Minified CSS (~31KB)
 ├── bigtablet.js        # Full JS (~30KB)
 ├── bigtablet.min.js    # Minified JS (~13KB)

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -115,18 +115,30 @@ Composite shorthands `$transition_enter_*` / `$transition_exit_*` already includ
 
 ### Inline style usage
 
+**Prefer a `style.scss` rule with SCSS tokens.** It is the only place where every token - colour *and* spacing - is available by name:
+
+```scss
+// ✓ Best - both colour and spacing come from tokens
+.my-panel {
+  background: token.$color_bg_solid_dim;
+  padding: token.$spacing_16;
+}
+```
+
+Reach for an inline style only when the value is genuinely dynamic (computed at runtime). Then:
+
 ```tsx
-// ✓ Correct - --bt-color-* IS emitted by the React entry's style.css
-<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: 16 }} />
+// ✓ OK - --bt-color-* IS emitted by the React entry's style.css
+<div style={{ background: "var(--bt-color-bg-solid-dim)" }} />
 
 // ✗ Never - hardcoded hex breaks dark mode
-<div style={{ background: "#F2F5F8", padding: 16 }} />
+<div style={{ background: "#F2F5F8" }} />
 
 // ✗ Never - --bt-spacing-* is Vanilla-only, resolves to nothing in a React app
 <div style={{ padding: "var(--bt-spacing-16)" }} />
 ```
 
-Spacing in inline styles has no CSS var to reference on the React entry - prefer moving the rule into a `style.scss` and using `token.$spacing_16`.
+Spacing has no CSS var to reference on the React entry, so an inline `padding` has to be a bare number (`padding: 16`). That is a last resort - it is an untokenised literal. If you find yourself writing one, move the rule into `style.scss` and use `token.$spacing_16` instead.
 
 ---
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -52,7 +52,11 @@ Providers needed:
 
 ## Design Tokens
 
-All tokens are CSS custom properties prefixed with `--bt-color-*`, `--bt-spacing-*`, etc. Always reference them - never inline a hex value.
+Always reference tokens - never inline a hex value.
+
+Two surfaces, and they are **not** interchangeable:
+- **SCSS tokens** (`@use "src/styles/token" as token;` → `token.$spacing_16`) - the full set. Use these in component `style.scss`.
+- **CSS custom properties** (`var(--bt-color-bg-solid)`) - the React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`. Spacing / radius / typography CSS vars exist only in the Vanilla bundle.
 
 ### Color tokens
 
@@ -81,11 +85,15 @@ All tokens are CSS custom properties prefixed with `--bt-color-*`, `--bt-spacing
 
 ### Spacing
 
-`--bt-spacing-4` (4px) through `--bt-spacing-48` (48px). Standard scale: 4, 8, 12, 16, 20, 24, 32, 40, 48.
+SCSS: `$spacing_4` (4px) through `$spacing_48` (48px). Standard scale: 4, 8, 12, 16, 20, 24, 32, 40, 48.
+
+CSS vars (`--bt-spacing-4` … `--bt-spacing-48`) exist **only in the Vanilla bundle** - the React entry's `style.css` does not emit them. In React/Next code use the SCSS token.
 
 ### Radius
 
-`--bt-radius-xs` (2px), `-sm` (6px), `-md` (8px), `-lg` (12px), `-xl` (16px), `-full` (9999px).
+SCSS: `$radius_none` (0), `$radius_xs` (4px), `$radius_sm` (6px), `$radius_md` (8px), `$radius_lg` (12px), `$radius_xl` (16px), `$radius_full` (9999px).
+
+CSS vars exist **only in the Vanilla bundle**, and only for a subset: `--bt-radius-sm` / `-md` / `-lg` / `-full`. There is no `--bt-radius-xs` or `-xl`.
 
 ### Elevation
 
@@ -108,12 +116,17 @@ Composite shorthands `$transition_enter_*` / `$transition_exit_*` already includ
 ### Inline style usage
 
 ```tsx
-// ✓ Correct
-<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: "var(--bt-spacing-16)" }} />
+// ✓ Correct - --bt-color-* IS emitted by the React entry's style.css
+<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: 16 }} />
 
-// ✗ Never
+// ✗ Never - hardcoded hex breaks dark mode
 <div style={{ background: "#F2F5F8", padding: 16 }} />
+
+// ✗ Never - --bt-spacing-* is Vanilla-only, resolves to nothing in a React app
+<div style={{ padding: "var(--bt-spacing-16)" }} />
 ```
+
+Spacing in inline styles has no CSS var to reference on the React entry - prefer moving the rule into a `style.scss` and using `token.$spacing_16`.
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -360,7 +360,19 @@ import { Settings } from 'lucide-react';
 | `variant` | `'standard' \| 'filled' \| 'tonal' \| 'outlined'` | `'standard'` | 스타일 |
 | `size` | `'sm' \| 'md'` | `'md'` | 크기 |
 | `icon` | `ReactNode` | required | 표시할 아이콘 |
+| `aria-label` | `string` | **둘 중 하나 필수** | 아이콘 버튼의 접근성 이름 |
+| `aria-labelledby` | `string` | **둘 중 하나 필수** | 접근성 이름을 제공하는 외부 요소의 id |
 | `disabled` | `boolean` | `false` | 비활성화 |
+
+> ⚠️ **접근성 이름은 타입 레벨에서 필수다.** `icon` 은 항상 `aria-hidden="true"` span 으로 감싸지므로, `aria-label` / `aria-labelledby` 중 하나를 주지 않으면 버튼에 접근성 이름이 전혀 없다 (WCAG 2.1 SC 4.1.2 Name, Role, Value). `IconButtonProps` 는 이를 강제하는 `IconButtonWithAriaLabel | IconButtonWithAriaLabelledBy` union 이라 `<IconButton icon={<X />} />` 는 **컴파일되지 않는다**.
+>
+> ```tsx
+> // ❌ 타입 에러 - 접근성 이름 없음
+> <IconButton icon={<X />} />
+> // ✅
+> <IconButton icon={<X />} aria-label="닫기" />
+> <IconButton icon={<X />} aria-labelledby="dialog-title" />
+> ```
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -338,11 +338,11 @@ it("calls callback with correct arguments", () => {
 
 ### 현재 커버리지 현황
 
-`pnpm test:coverage` (v8, `unit` 프로젝트) 기준 - 55 test files / 779 passed · 9 skipped.
+`pnpm test:coverage` (v8, `unit` 프로젝트) 기준 - 55 test files / 788 passed · 9 skipped.
 
 | 전체 | Stmts | Branch | Funcs | Lines |
 |------|-------|--------|-------|-------|
-| **All files** | **90.01%** | **85.59%** | **90.07%** | **91.97%** |
+| **All files** | **90.02%** | **85.69%** | **90.07%** | **91.97%** |
 
 아래는 **100% 미만**인 파일만 나열한 것이다 (미표기 컴포넌트 = 전 지표 100%: Button · Card · Radio · Spinner · Pagination · TopLoading · Badge · Divider · Skeleton · Toggle · Breadcrumb · EmptyState · ErrorState · IconButton · Container/Section/Stack/Grid 등).
 
@@ -370,12 +370,12 @@ it("calls callback with correct arguments", () => {
 | ui/forms/textfield | 90.47% | 82.75% | 77.77% | 92.68% |
 | ui/navigation/bottom-nav | 94.73% | 95% | 100% | 94.73% |
 | ui/navigation/menu | 97.29% | 89.13% | 100% | 100% |
-| ui/navigation/nav-bar | 80.19% | 69.23% | 81.81% | 85.39% |
+| ui/navigation/nav-bar | 80.39% | 71.25% | 81.81% | 85.55% |
 | ui/navigation/sidebar | 83.33% | 88.63% | 75% | 86.95% |
 | ui/navigation/tabs | 91.42% | 78.18% | 88.88% | 100% |
 | ui/overlay/drawer | 97.91% | 95.16% | 100% | 100% |
 | ui/overlay/modal | 97.67% | 93.93% | 100% | 100% |
-| ui/overlay/popover | 91.3% | 83.87% | 100% | 92.68% |
+| ui/overlay/popover | 91.3% | 85.71% | 100% | 92.68% |
 | ui/overlay/tooltip | 92.98% | 83.33% | 93.33% | 91.66% |
 | ui/system/theme-provider | 93.87% | 85.71% | 100% | 100% |
 | utils | 90.14% | 83.18% | 78.57% | 91.93% |
@@ -387,7 +387,7 @@ it("calls callback with correct arguments", () => {
 ### 커버리지 목표
 
 - 새 컴포넌트: 최소 80% 커버리지
-- 전체 목표: 85% 이상 유지 (현재 90.01%)
+- 전체 목표: 85% 이상 유지 (현재 90.02%)
 
 ### 커버리지 리포트 확인
 

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -167,7 +167,7 @@ SCSS 변수/믹스인(spacing, radius, typography, motion 등)이 필요하면 �
 @use "@bigtablet/design-system/scss/token" as token;
 
 .my-component {
-  padding: token.$spacing_md;
+  padding: token.$spacing_16;
   border-radius: token.$radius_md;
 }
 ```

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -671,10 +671,12 @@ Alert는 JavaScript로만 사용합니다.
   --bt-radius-md: 8px;
   --bt-radius-lg: 12px;
 
-  /* Shadows */
-  --bt-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.04);
-  --bt-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --bt-shadow-lg: 0 8px 20px rgba(0, 0, 0, 0.12);
+  /* Elevation (구 --bt-shadow-* 는 존재하지 않음) */
+  --bt-elevation-1: var(--bt-elevation-level1);
+  --bt-elevation-2: var(--bt-elevation-level2);
+  --bt-elevation-3: var(--bt-elevation-level3);
+  --bt-elevation-4: var(--bt-elevation-level4);
+  --bt-elevation-5: var(--bt-elevation-level5);
 
   /* Transitions */
   --bt-transition-fast: 0.1s ease-in-out;

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -58,10 +58,10 @@ npm install @bigtablet/design-system
 
 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases)에서 다운로드:
 
-- `bigtablet.css` - 비압축 CSS (27KB)
-- `bigtablet.min.css` - 압축 CSS (21KB)
-- `bigtablet.js` - 비압축 JS (20KB)
-- `bigtablet.min.js` - 압축 JS (9KB)
+- `bigtablet.css` - 비압축 CSS (~40KB)
+- `bigtablet.min.css` - 압축 CSS (~31KB)
+- `bigtablet.js` - 비압축 JS (~30KB)
+- `bigtablet.min.js` - 압축 JS (~13KB)
 
 ---
 


### PR DESCRIPTION
## 작업 개요

[#437](https://github.com/Bigtablet/bigtablet-design-system/pull/437) 후속 작업입니다. #437 이 작업 도중 머지되어(그 뒤로 `fix/a11y-accessible-names`, `config/release-hygiene` 도 머지됨) **같은 PR 에 담지 못하고 새 브랜치로 분리**했습니다. 현재 `origin/develop` 기준으로 리베이스되어 있습니다.

내용은 세 가지입니다.
1. #437 에서 보고만 하고 넘겼던 `THEMING.md` 의 죽은 토큰 수정
2. 전 문서 대상 죽은 토큰 **전수 스윕** (같은 버그가 또 나오지 않도록)
3. IconButton 접근성 이름 필수화(#434) 문서 반영

**소스 코드(`src/`)는 건드리지 않았습니다.** 변경 파일은 `.md` 7개뿐입니다.

## 작업한 내용

### 1. 죽은 토큰 전수 스윕

`.md` 전체에서 `$토큰` / `--bt-*` 참조를 추출해 `src/styles/**/_index.scss` 정의 및 빌드 산출물(`dist/index.css`, `dist/vanilla/bigtablet.css`)과 대조했습니다. 결과적으로 **#437 에서 보고한 THEMING.md 1건 외에 2개 파일이 더 나왔습니다.**

- [x] `docs/THEMING.md` — `token.$spacing_md` → `token.$spacing_16` (숫자 스케일에 t-shirt 사이즈 없음)
- [x] `docs/VANILLA.md` — `--bt-shadow-sm/md/lg` 는 번들에 존재하지 않음. 실제 변수인 `--bt-elevation-1`~`-5` (`--bt-elevation-level1`~`5` 의 alias) 로 교체
- [x] `docs/AGENT_GUIDE.md` — 3건
  - "All tokens are CSS custom properties" 서술이 거짓. spacing/radius/typography CSS 변수는 **Vanilla 번들에만** 있고 React entry `style.css` 에는 없음 → 두 표면을 명시적으로 분리
  - `--bt-radius-xs` 는 존재하지 않고 표기된 **2px 도 틀림** (실제 `$radius_xs` 는 4px). `--bt-radius-xl` 도 CSS 변수로는 없음 → 실제 서브셋만 나열
  - 인라인 스타일 예제가 `var(--bt-spacing-16)` 사용을 권장하고 있었음. React 앱에서는 아무 값으로도 해석되지 않음 → 올바른 예제로 교체하고, 깨지는 케이스를 반례로 명시

> ⚠️ **정정**: 최초 리뷰 시점에 적었던 "미해결 0건" 은 **틀렸습니다.** 그때 스윕은 대상 경로를 손으로 나열해서(`docs/*.md` + 루트 README 류) `.claude/**`, `.agents/**`, `CHANGELOG.md`, `docs/VANILLA-PROMPT.md` 를 아예 스캔하지 않았습니다. 아래 "리뷰 반영" 항목에서 `git ls-files` 기준으로 다시 돌렸습니다.

### 2. IconButton 접근성 이름 (#434 반영)

- [x] `docs/COMPONENTS.md` IconButton props 표에 `aria-label` / `aria-labelledby` 행 추가 (**둘 중 하나 필수**)
- [x] `icon` 이 항상 `aria-hidden="true"` span 으로 감싸져 접근성 이름이 없으면 버튼에 이름이 전혀 없다는 점, `IconButtonProps` 가 `IconButtonWithAriaLabel | IconButtonWithAriaLabelledBy` union 이라 `<IconButton icon={<X />} />` 가 컴파일되지 않는다는 점을 주석으로 명시 (WCAG 2.1 SC 4.1.2)
- [x] 기존 `<IconButton>` 예제는 전부 이미 `aria-label` 을 넘기고 있어 수정 불필요 (확인함)

### 3. 측정값 재측정

#437 이후 develop 이 움직여서(a11y PR 이 테스트 추가, vanilla JS 변경) 제가 #437 에 넣은 수치가 이미 어긋나 있었습니다. 현재 develop 에서 다시 측정해 갱신했습니다.

- [x] `docs/VANILLA.md` — #437 이 `CLAUDE.md` 만 고치고 놓친 **VANILLA.md 자체 사본**의 번들 크기(27/21/20/9KB) → 실측 ~40/31/30/13KB
- [x] `CLAUDE.md` — Vanilla CSS 가 38KB → **40KB** 로 커져서 #437 이 넣은 값도 갱신
- [x] `docs/TESTING.md` + `CLAUDE.md` — 커버리지 재측정: stmts 90.01 → **90.02**, branch 85.59 → **85.69**, 테스트 수 779 → **788 passed** (a11y PR 이 IconButton / NavBar / Popover 테스트 추가). nav-bar · popover 행도 갱신

## 검증

- [x] `git diff --name-only origin/develop...HEAD` — `.md` 7개뿐, `src/` 무변경
- [x] `npx vitest run --project unit` — **55 test files / 788 passed · 9 skipped** (커밋 3회 모두 husky pre-commit 통과)
- [x] 토큰 스윕 3종(`$token`, `--bt-*`, `@include token.*`)을 `git ls-files '*.md' '*.mdx'` (**140개 파일**) 대상으로 재실행 → 미해결 0건
- [x] IconButton 문서는 머지된 develop 의 `src/ui/general/icon-button/index.tsx` 와 직접 대조 (union 타입명·`aria-hidden` 래핑 확인)
- [x] 번들 크기·커버리지는 추정이 아니라 `pnpm build` / `pnpm test:coverage` 실행 결과

## 전달할 추가 이슈

- `ui/display/icon` 커버리지 **0%**, `ui/forms/image-cropper` **57.04%** 로 문서 기준선(80%) 미달입니다. Icon 은 분기가 2개뿐이라 비용이 거의 없으니 우선 처리할 만합니다.
- `docs/VANILLA.md` 의 Button variant 클래스(`--primary/secondary/ghost/danger`)는 Vanilla 번들 기준이라 React `Button` 의 `filled/tonal/outline/text` 와 다릅니다. 의도된 차이인지, Vanilla 도 맞출지 확인이 필요합니다.


---

## 리뷰 반영 (6961bf4)

### 1. `docs/AGENT_GUIDE.md` 인라인 스타일 예제 자기모순 [Medium, comment 3718291032]

"✓ Correct" 예제가 `padding: 16` 하드코딩인데 바로 아래 문장은 "spacing 은 CSS 변수가 없으니 `style.scss` + `token.$spacing_16` 을 쓰라" 고 말하고 있었습니다. 이 PR 이 없애려는 바로 그 "헷갈리는 토큰 안내" 였습니다.

- [x] 우선순위를 명시적으로 재구성: **① `style.scss` + SCSS 토큰(권장)** → ② 런타임 계산값일 때만 인라인 → ③ 토큰 없는 리터럴(`padding: 16`)은 **최후 수단**임을 명시
- [x] `padding: 16` 을 "✓ Correct" 라벨에서 제거

### 2. 스윕이 `.claude/**` 를 통째로 빠뜨림 — "0건" 주장 정정

리뷰 지적대로 이전 스윕은 **대상 경로를 손으로 나열**해서 tracked markdown 전체를 덮지 못했습니다. `git ls-files '*.md' '*.mdx'` (140개) 기준으로 다시 돌렸고, mixin 참조 검사도 3번째 패스로 추가했습니다.

**`.claude/docs/design-system.md`** — AI 어시스턴트 가이드라 에이전트가 읽고 죽은 토큰을 실제 SCSS 에 그대로 써넣게 되는, 방금 고친 AGENT_GUIDE 와 동일한 실패 모드입니다.

| 위치 | 죽은 참조 | 수정 |
|------|-----------|------|
| `:614` | `token.$spacing_md` | `token.$spacing_16` |
| `:615` | `token.$color_primary` | `token.$color_text_heading` (+ `$color_bg_solid`) |
| `:617` | `token.$shadow_sm` | `token.$elevation_level1` |
| `:623` | `$spacing_xs/sm/md/lg/xl/2xl` (t-shirt 스케일 전체) | 실제 숫자 스케일 `$spacing_0`~`$spacing_48` |
| `:625` | `$color_primary` `$color_primary_hover` `$color_error` `$color_success` `$color_warning` `$color_info` `$color_text_primary` `$color_text_secondary` `$color_border` `$color_background` (**10개 전부 미정의**) | semantic 그룹(brand / text / bg / border / status / state)으로 교체 |
| `:629` | `$shadow_sm` `$shadow_md` `$shadow_lg` | `$elevation_level1`~`level5` |
| `:649` `:652` `:656` | `token.$spacing_lg` / `$spacing_sm` / `$spacing_md` | 숫자 스케일 |
| `:651` `:655` | `@include token.mobile` / `token.tablet` (**미정의 mixin**) | `compact` / `medium` / `expanded` / `large` + `from_*` 단축 |

- Radius / Typography / Motion 레퍼런스도 실제 정의 기준으로 보강
- Layout Mixins 블록(`flex_center` / `flex_between` / `flex_column`)은 **이미 정확**해서 손대지 않았습니다

**최종 스윕 결과 (3종 × 140파일): 미해결 참조 0건.** 남는 grep 히트는 (a) "이 토큰들은 존재하지 않는다" 는 설명 산문, (b) `$transition_*` / `--bt-color-*` glob 패턴, (c) `CLAUDE.md` 의 GraphQL `$threadId` 뿐입니다.

> 참고: `.agents/**` 와 `.claude/skills/**` 의 vercel-react-best-practices 문서(120여 개)도 스캔 대상에 포함했고, DS 토큰 참조는 0건이라 수정할 것이 없었습니다.
