### PR TITLE
fix/vanilla-license-banner

### DIFF
--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1,6 +1,9 @@
-/**
+/*!
  * Bigtablet Design System - Vanilla CSS
  * For use with plain HTML/CSS/JS, Thymeleaf, JSP, etc.
+ *
+ * @license Bigtablet Inc. Open Source License - see LICENSE at the repo root
+ *          (https://github.com/Bigtablet/.github/blob/main/BIGTABLET_LICENSE.md)
  */
 
 @use "../styles/token" as token;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -53,6 +53,10 @@ export default defineConfig([
 			// about the CommonJS `module` variable. Suppress this — the IIFE format handles
 			// the global export and the UMD check is irrelevant at runtime.
 			options.logOverride = { "commonjs-variable-in-esm": "silent" };
+			// min.js 는 files 에서 비minified bigtablet.js 를 제외해 실제로 배포되는 유일한 vanilla JS 다.
+			// esbuild 는 minify 시 legalComments 기본값이 "none" 이라 소스의 @license 배너를 떼버리는데,
+			// 그러면 배포물에 라이선스 표기가 하나도 남지 않는다. 원위치에 보존한다.
+			options.legalComments = "inline";
 		},
 	},
 ]);


### PR DESCRIPTION
## 작업 개요

라이선스를 조직 라이선스(Bigtablet Inc. Open Source License)로 통일했지만(#435), **실제 배포되는 Vanilla 번들에는 라이선스 표기가 하나도 남지 않던** 문제를 수정한다.

- `package.json` `files` 가 비minified `dist/vanilla/bigtablet.js` 를 제외 → 실제 배포되는 vanilla JS 는 `bigtablet.min.js` 뿐
- tsup 이 `minify: true` 로 빌드하며 esbuild 기본값 `legalComments: "none"` 이 `@license` 배너를 제거
- CSS 쪽은 반대 방향의 구멍 — 소스 배너에 라이선스 언급 자체가 없었고, 일반 `/* */` 주석이라 Sass 압축 시 소실

MIT 시절부터 있던 문제라 이번 변경의 회귀는 아니지만, 비상업 제한 라이선스를 선언한 이상 배포물 무표기는 방치할 수 없다.

## 작업한 내용

- [x] `tsup.config.ts` — vanilla JS 번들 `esbuildOptions` 에 `options.legalComments = "inline"` 추가 (사유 주석 동봉)
- [x] `src/vanilla/bigtablet.scss` — 배너를 `/*!` 로 바꾸고 `@license` 줄 추가 (Sass 압축에서 보존)

## 검증

- `dist/vanilla/bigtablet.min.js` 선두에 배너 보존 확인
- `dist/vanilla/bigtablet.min.css` · `bigtablet.css` 둘 다 배너 보존 확인
- `pnpm size` 전부 한도 내 — `min.js` 3.98 → **4.06 kB / 5 kB**, `index.js` 49.47 / 60 kB, `index.css` 12.17 / 130 kB
- stylelint exit 0 · tsc 0 errors · unit 788 passed / 9 skipped

## 전달할 추가 이슈

- React 번들(`dist/index.js`)과 그 CSS 에는 여전히 배너가 없다. 라이선스 전문은 `LICENSE` 파일로 tarball 에 포함되므로 최소 요건은 충족하나, CDN 등으로 파일만 떼가는 경우를 고려하면 동일하게 배너를 넣는 것도 검토할 만하다(이번 PR 스코프 밖).