### PR TITLE
fix/token-discipline-rgba

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,10 @@
     "color-named": ["never", {
       "severity": "error",
       "message": "named color (white, black, red 등) 금지 — DS 토큰 사용."
+    }],
+    "function-disallowed-list": [["rgb", "rgba", "hsl", "hsla"], {
+      "severity": "error",
+      "message": "DS 컴포넌트 SCSS 에 raw rgb()/rgba()/hsl()/hsla() 금지 — alpha 컬러도 token (token.$color_text_on_dark_* / $color_scrim_* 등) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
     }]
   },
   "overrides": [
@@ -15,14 +19,16 @@
       "files": ["src/styles/**/*.scss"],
       "rules": {
         "color-no-hex": null,
-        "color-named": null
+        "color-named": null,
+        "function-disallowed-list": null
       }
     },
     {
       "files": ["src/vanilla/**/*.scss"],
       "rules": {
         "color-no-hex": null,
-        "color-named": null
+        "color-named": null,
+        "function-disallowed-list": null
       }
     }
   ]

--- a/src/styles/colors/_index.scss
+++ b/src/styles/colors/_index.scss
@@ -163,3 +163,33 @@ $color_accent_light:          var(--bt-color-accent-light);
 $color_accent_default:        var(--bt-color-accent-default);
 $color_accent_strong:         var(--bt-color-accent-strong);
 $color_accent_on_surface:     var(--bt-color-accent-on-surface);
+
+// ── Fixed-surface semantics (raw alpha, theme 무관) ────────────────────
+// hero scrim / media-card overlay / accent·transparent nav bar 처럼 표면 명암이
+// 테마와 무관하게 고정된 자리의 콘텐츠용 어휘.
+// `$color_state_*_on_dark` 와 이름 규칙(`_on_dark`)은 공유하지만 구조는 다르다:
+// state 계열은 [data-theme="dark"] 에서 black alpha 로 뒤집히는 반면, 여기 값들은
+// 배경이 항상 어둡거나(밝거나) 하므로 뒤집히면 안 된다. 그래서 var() 가 아닌
+// raw alpha 로 두고 SCSS 컴파일 시점에 그대로 박힌다.
+
+// Text on a permanently dark surface (강조 → 캡션 순 램프)
+$color_text_on_dark_strong:   rgba(255, 255, 255, 0.9);   // 인터랙티브 라벨 (text button)
+$color_text_on_dark_body:     rgba(255, 255, 255, 0.85);  // 본문 / 설명문
+$color_text_on_dark_label:    rgba(255, 255, 255, 0.75);  // eyebrow / 오버레이 라벨
+$color_text_on_dark_muted:    rgba(255, 255, 255, 0.7);   // 비활성 nav link / 보조 라벨
+$color_text_on_dark_caption:  rgba(255, 255, 255, 0.6);   // meta / 캡션
+
+// Text on a permanently light surface (light scrim 위 forced dark text)
+$color_text_on_light_body:    rgba(0, 0, 0, 0.85);
+$color_text_on_light_muted:   rgba(0, 0, 0, 0.6);
+
+// Border on a permanently dark surface (outline button 등 hairline)
+$color_border_on_dark:        rgba(255, 255, 255, 0.55);
+
+// Scrim - 이미지 위 텍스트 가독성 확보용 gradient stop (clear → heavy 세기 램프)
+$color_scrim_dark_clear:      rgba(0, 0, 0, 0);
+$color_scrim_dark_soft:       rgba(0, 0, 0, 0.1);
+$color_scrim_dark_strong:     rgba(0, 0, 0, 0.55);
+$color_scrim_dark_heavy:      rgba(0, 0, 0, 0.85);
+$color_scrim_light_soft:      rgba(255, 255, 255, 0.1);
+$color_scrim_light_strong:    rgba(255, 255, 255, 0.7);

--- a/src/styles/motion/_index.scss
+++ b/src/styles/motion/_index.scss
@@ -53,4 +53,4 @@ $transition_lift: transform 0.25s $ease_out_expo, box-shadow 0.25s $ease_out_exp
 // ($skeleton_animation_duration / _timing 과 같은 역할의 컴포넌트 스코프 토큰)
 $duration_loading_spinner:  1.2s;    // Spinner spoke fade 1 cycle
 $duration_loading_bar:      1.5s;    // TopLoading indeterminate sweep 1 cycle
-$duration_progress_default: 3000ms;  // Toast progress bar 기본값 (--toast-duration fallback)
+$duration_progress_default: 3s;      // Toast progress bar 기본값 (--toast-duration fallback)

--- a/src/styles/motion/_index.scss
+++ b/src/styles/motion/_index.scss
@@ -8,6 +8,12 @@ $transition_fast: $duration_fast ease-in-out;   // hover, icon
 $transition_base: $duration_base ease-in-out;   // 메뉴 열림
 $transition_slow: $duration_slow ease-in-out;   // 레이아웃 변화
 
+// Keyword easing - animation shorthand 에서 duration 과 조합할 때.
+// ($transition_* composite 는 easing 이 이미 들어있어 animation 에 쓰면 중복된다)
+// `//` 주석 사용 - `/* */` 는 vanilla CSS 번들에 그대로 실려 나간다.
+$easing_linear:   linear;
+$easing_standard: ease-in-out;
+
 /* Easing Curves */
 $ease_out_expo: cubic-bezier(0.16, 1, 0.3, 1);
 $ease_out_quart: cubic-bezier(0.25, 1, 0.5, 1);
@@ -41,3 +47,10 @@ $transition_dramatic: 0.6s $ease_out_quart;
 
 /* Hover Lift */
 $transition_lift: transform 0.25s $ease_out_expo, box-shadow 0.25s $ease_out_expo;
+
+// Loading & progress indicators
+// 무한 반복(`infinite`) 이 허용되는 유일한 자리 - loading affordance 전용.
+// ($skeleton_animation_duration / _timing 과 같은 역할의 컴포넌트 스코프 토큰)
+$duration_loading_spinner:  1.2s;    // Spinner spoke fade 1 cycle
+$duration_loading_bar:      1.5s;    // TopLoading indeterminate sweep 1 cycle
+$duration_progress_default: 3000ms;  // Toast progress bar 기본값 (--toast-duration fallback)

--- a/src/styles/tokens.json
+++ b/src/styles/tokens.json
@@ -35,6 +35,41 @@
 				"disabled": {
 					"$value": "{base.color.alpha-black-38}",
 					"$type": "color"
+				},
+				"on-dark-strong": {
+					"$value": "rgba(255, 255, 255, 0.9)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 인터랙티브 라벨 - theme 무관 고정 alpha"
+				},
+				"on-dark-body": {
+					"$value": "rgba(255, 255, 255, 0.85)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 본문/설명문"
+				},
+				"on-dark-label": {
+					"$value": "rgba(255, 255, 255, 0.75)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 eyebrow/오버레이 라벨"
+				},
+				"on-dark-muted": {
+					"$value": "rgba(255, 255, 255, 0.7)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 비활성 nav link/보조 라벨"
+				},
+				"on-dark-caption": {
+					"$value": "rgba(255, 255, 255, 0.6)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 meta/캡션"
+				},
+				"on-light-body": {
+					"$value": "rgba(0, 0, 0, 0.85)",
+					"$type": "color",
+					"$description": "항상 밝은 표면(light scrim) 위 본문 - theme 무관 고정 alpha"
+				},
+				"on-light-muted": {
+					"$value": "rgba(0, 0, 0, 0.6)",
+					"$type": "color",
+					"$description": "항상 밝은 표면(light scrim) 위 보조 라벨"
 				}
 			},
 			"bg": {
@@ -101,6 +136,43 @@
 				"disabled": {
 					"$value": "{base.color.neutral-100}",
 					"$type": "color"
+				},
+				"on-dark": {
+					"$value": "rgba(255, 255, 255, 0.55)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 hairline border (outline button 등) - theme 무관 고정 alpha"
+				}
+			},
+			"scrim": {
+				"dark-clear": {
+					"$value": "rgba(0, 0, 0, 0)",
+					"$type": "color",
+					"$description": "이미지 위 scrim gradient 시작 - 완전 투명"
+				},
+				"dark-soft": {
+					"$value": "rgba(0, 0, 0, 0.1)",
+					"$type": "color",
+					"$description": "이미지 위 dark scrim - 약한 tint"
+				},
+				"dark-strong": {
+					"$value": "rgba(0, 0, 0, 0.55)",
+					"$type": "color",
+					"$description": "이미지 위 dark scrim - hero 하단 마감"
+				},
+				"dark-heavy": {
+					"$value": "rgba(0, 0, 0, 0.85)",
+					"$type": "color",
+					"$description": "이미지 위 dark scrim - 텍스트가 직접 얹히는 media overlay 하단"
+				},
+				"light-soft": {
+					"$value": "rgba(255, 255, 255, 0.1)",
+					"$type": "color",
+					"$description": "이미지 위 light scrim - 약한 tint"
+				},
+				"light-strong": {
+					"$value": "rgba(255, 255, 255, 0.7)",
+					"$type": "color",
+					"$description": "이미지 위 light scrim - hero 하단 마감"
 				}
 			},
 			"status": {

--- a/src/ui/display/hero/style.scss
+++ b/src/ui/display/hero/style.scss
@@ -34,24 +34,24 @@
   &_overlay_dark .hero_overlay {
     background: linear-gradient(
       180deg,
-      rgba(0, 0, 0, 0.1) 0%,
-      rgba(0, 0, 0, 0.55) 100%
+      token.$color_scrim_dark_soft 0%,
+      token.$color_scrim_dark_strong 100%
     );
   }
 
   &_overlay_light .hero_overlay {
     background: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.1) 0%,
-      rgba(255, 255, 255, 0.7) 100%
+      token.$color_scrim_light_soft 0%,
+      token.$color_scrim_light_strong 100%
     );
   }
 
   // Light overlay 는 항상 흰색계 표면 - 텍스트는 theme 무관 forced dark.
   &_overlay_light.hero_text_default {
-    .hero_eyebrow  { color: rgba(0, 0, 0, 0.6); }
+    .hero_eyebrow  { color: token.$color_text_on_light_muted; }
     .hero_title    { color: token.$color_brand_primary; }
-    .hero_subtitle { color: rgba(0, 0, 0, 0.85); }
+    .hero_subtitle { color: token.$color_text_on_light_body; }
   }
 
   // ── Content area ──────────────────────────────────────────────────────
@@ -89,14 +89,14 @@
   }
 
   &_text_inverse {
-    .hero_eyebrow  { color: rgba(255, 255, 255, 0.7); }
+    .hero_eyebrow  { color: token.$color_text_on_dark_muted; }
     .hero_title    { color: token.$color_brand_on_primary; }
-    .hero_subtitle { color: rgba(255, 255, 255, 0.85); }
+    .hero_subtitle { color: token.$color_text_on_dark_body; }
 
     // 어두운 배경 위 버튼 - outline/text 를 흰색 계열로 강제
     .hero_actions {
       .button_variant_outline {
-        border-color: rgba(255, 255, 255, 0.55);
+        border-color: token.$color_border_on_dark;
         color: token.$color_brand_on_primary;
 
         &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
@@ -105,7 +105,7 @@
       }
 
       .button_variant_text {
-        color: rgba(255, 255, 255, 0.9);
+        color: token.$color_text_on_dark_strong;
 
         &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
         &:focus-visible:not(:disabled)::before { background: token.$color_state_focus_on_dark; }

--- a/src/ui/display/media-card/style.scss
+++ b/src/ui/display/media-card/style.scss
@@ -134,8 +134,8 @@
       inset: 0;
       background: linear-gradient(
         180deg,
-        rgba(0, 0, 0, 0) 30%,
-        rgba(0, 0, 0, 0.85) 100%
+        token.$color_scrim_dark_clear 30%,
+        token.$color_scrim_dark_heavy 100%
       );
       pointer-events: none;
       z-index: 1;
@@ -150,13 +150,13 @@
       justify-content: flex-end;
     }
 
-    .media_card_eyebrow  { color: rgba(255, 255, 255, 0.75); }
+    .media_card_eyebrow  { color: token.$color_text_on_dark_label; }
     .media_card_heading  { color: token.$color_brand_on_primary; }
     .media_card_content  {
-      color: rgba(255, 255, 255, 0.85);
+      color: token.$color_text_on_dark_body;
       flex: 0 0 auto; // overlay에선 늘어나지 않음 - 텍스트 블록이 하단에 모이도록
     }
-    .media_card_meta     { color: rgba(255, 255, 255, 0.6); }
+    .media_card_meta     { color: token.$color_text_on_dark_caption; }
   }
 }
 

--- a/src/ui/feedback/spinner/style.scss
+++ b/src/ui/feedback/spinner/style.scss
@@ -21,13 +21,14 @@
     border-radius: 5px;
     background: currentColor;
     transform-origin: 250% 50%; // bar 의 우측 (= 컨테이너 정중앙) 기준 회전
-    animation: spinner_fade 1.2s linear infinite;
+    animation: spinner_fade token.$duration_loading_spinner token.$easing_linear infinite;
   }
 
+  // 12개 bar 를 한 사이클에 균등 분산 - 음수 delay 로 시작부터 서로 다른 위상.
   @for $i from 0 through 11 {
     &_bar:nth-child(#{$i + 1}) {
       transform: rotate(#{$i * 30}deg);
-      animation-delay: #{-1.2 + $i * 0.1}s;
+      animation-delay: (-1 * token.$duration_loading_spinner) + ($i * 0.1s);
     }
   }
 }

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -147,7 +147,7 @@
   left: 0;
   height: token.$spacing_3;
   border-radius: 0 0 0 token.$radius_lg;
-  animation: toast_progress var(--toast-duration, 3000ms) linear forwards;
+  animation: toast_progress var(--toast-duration, #{token.$duration_progress_default}) token.$easing_linear forwards;
 
   &_success { background: token.$color_status_success; }
   &_error   { background: token.$color_status_error; }

--- a/src/ui/feedback/top-loading/style.scss
+++ b/src/ui/feedback/top-loading/style.scss
@@ -18,7 +18,7 @@
 
   &_indeterminate {
     width: 30%;
-    animation: top_loading_indeterminate 1.5s ease-in-out infinite;
+    animation: top_loading_indeterminate token.$duration_loading_bar token.$easing_standard infinite;
   }
 }
 

--- a/src/ui/navigation/nav-bar/style.scss
+++ b/src/ui/navigation/nav-bar/style.scss
@@ -243,7 +243,7 @@
     color: token.$color_brand_on_primary;
 
     .nav_bar_link {
-      color: rgba(255, 255, 255, 0.7);
+      color: token.$color_text_on_dark_muted;
 
       &:hover:not(.nav_bar_link_active) {
         color: token.$color_brand_on_primary;
@@ -261,7 +261,7 @@
 
     // dark accent bg 위 button - outline/text variant 강제 흰 텍스트 + 흰 border
     .button_variant_outline {
-      border-color: rgba(255, 255, 255, 0.55);
+      border-color: token.$color_border_on_dark;
       color: token.$color_brand_on_primary;
 
       &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
@@ -270,7 +270,7 @@
     }
 
     .button_variant_text {
-      color: rgba(255, 255, 255, 0.9);
+      color: token.$color_text_on_dark_strong;
 
       &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
       &:focus-visible:not(:disabled)::before { background: token.$color_state_focus_on_dark; }
@@ -282,7 +282,7 @@
 
   &_variant_transparent {
     .nav_bar_link {
-      color: rgba(255, 255, 255, 0.7);
+      color: token.$color_text_on_dark_muted;
 
       &:hover:not(.nav_bar_link_active) {
         color: token.$color_brand_on_primary;


### PR DESCRIPTION
## 작업 개요

`stylelint` 의 `color-no-hex` 는 hex 만 잡고 `rgba()` 리터럴은 통과시킨다. 그 틈으로 컴포넌트 SCSS 에 하드코딩 컬러 19곳이 들어와 있었고, 세 곳 모두 **바로 옆 줄은 이미 토큰을 쓰고 있어서** 의도된 예외가 아니라 누락으로 확인됐다. 같은 맥락에서 로딩 인디케이터 3개의 애니메이션 duration/easing 도 하드코딩 상태였다.

일관성/테마 리팩터링이며 **색상 값 자체는 하나도 바꾸지 않았다.** 대비(contrast)는 현재 문제가 없어(예: nav link `rgba(255,255,255,0.7)` on `#121212` ≈ 9.4:1) 손대지 않았다.

토큰은 1:1 rename 이 아니라 **재사용 가능한 어휘**로 설계했다 - 14개 토큰이 19개 사용처를 덮고, 그중 4개는 2~3회 재사용된다.

## 작업한 내용

### Part 1 - rgba 리터럴 → fixed-surface 컬러 토큰

`src/styles/colors/_index.scss` 에 신규 어휘 추가. 이름 규칙(`_on_dark`)은 기존 `$color_state_*_on_dark` 를 따르되, **구조는 raw alpha 로 다르게** 갔다: state 계열은 `[data-theme="dark"]` 에서 black alpha 로 뒤집히는데, 여기 값들은 hero scrim / media overlay / accent nav 처럼 **배경 명암이 테마와 무관하게 고정된** 자리라 뒤집히면 안 된다.

- [x] on-dark 텍스트 램프 (강조 → 캡션)
  - `$color_text_on_dark_strong` `rgba(255,255,255,0.9)` - 인터랙티브 라벨 (text button)
  - `$color_text_on_dark_body` `rgba(255,255,255,0.85)` - 본문/설명문
  - `$color_text_on_dark_label` `rgba(255,255,255,0.75)` - eyebrow/오버레이 라벨
  - `$color_text_on_dark_muted` `rgba(255,255,255,0.7)` - 비활성 nav link/보조 라벨
  - `$color_text_on_dark_caption` `rgba(255,255,255,0.6)` - meta/캡션
- [x] on-light 텍스트 (light scrim 위 forced dark text)
  - `$color_text_on_light_body` `rgba(0,0,0,0.85)` / `$color_text_on_light_muted` `rgba(0,0,0,0.6)`
- [x] on-dark hairline border
  - `$color_border_on_dark` `rgba(255,255,255,0.55)`
- [x] scrim gradient stop 램프 (clear → heavy)
  - `$color_scrim_dark_clear` `rgba(0,0,0,0)` / `$color_scrim_dark_soft` `rgba(0,0,0,0.1)` / `$color_scrim_dark_strong` `rgba(0,0,0,0.55)` / `$color_scrim_dark_heavy` `rgba(0,0,0,0.85)`
  - `$color_scrim_light_soft` `rgba(255,255,255,0.1)` / `$color_scrim_light_strong` `rgba(255,255,255,0.7)`
- [x] `src/styles/tokens.json` 에 동일 이름 미러링 (`semantic.color.text.on-dark-*` / `on-light-*`, `semantic.color.border.on-dark`, 신규 `semantic.color.scrim` 그룹)
- [x] `src/ui/display/hero/style.scss` - 10곳 치환 (dark/light overlay gradient 4, light overlay 텍스트 2, inverse 텍스트 2, outline border 1, text button 1)
- [x] `src/ui/display/media-card/style.scss` - 5곳 치환 (overlay gradient 2, eyebrow/content/meta 3)
- [x] `src/ui/navigation/nav-bar/style.scss` - 4곳 치환 (accent·transparent variant nav link 2, outline border 1, text button 1)
- [x] `src/ui` 전체에 남은 `rgba()` 리터럴 0건 확인

### Part 2 - 로딩 애니메이션 duration/easing 토큰화

`$skeleton_animation_duration` / `$skeleton_animation_timing` 선례를 따라 `src/styles/motion/_index.scss` 에 추가. 새 도메인 폴더 대신 motion 에 둔 이유는 skeleton 처럼 standalone import 가 필요한 값이 아니고, 이미 duration/easing 이 모여 있는 도메인이라서다.

- [x] `$easing_linear` (`linear`) / `$easing_standard` (`ease-in-out`) - `animation` shorthand 전용 keyword easing. `$transition_*` composite 는 easing 을 이미 포함해서 `animation` 에 쓰면 중복된다.
- [x] `$duration_loading_spinner` `1.2s` / `$duration_loading_bar` `1.5s` / `$duration_progress_default` `3s`
- [x] `src/ui/feedback/spinner/style.scss:24` - `1.2s linear infinite` → 토큰. 추가로 bar 별 `animation-delay` 가 리터럴 `-1.2` 를 반복하고 있어 같은 토큰에서 파생하도록 바꿨다 (사이클과 위상 오프셋이 따로 놀 수 없게).
- [x] `src/ui/feedback/top-loading/style.scss:21` - `1.5s ease-in-out infinite` → 토큰
- [x] `src/ui/feedback/toast/style.scss:150` - `var(--toast-duration, 3000ms) linear` → 토큰
- [x] toast 의 reduced-motion 블록(`:167-176`)은 **의도적으로 그대로 뒀다.** `animation-name` 만 정적 keyframe 으로 바꿔 `onAnimationEnd` 가 계속 발화하는 구조라 현재가 맞다.
- [x] motion 신규 그룹 주석은 `/* */` 가 아닌 `//` 사용 - vanilla Sass 빌드가 loud comment 를 `dist/vanilla/bigtablet.css` 에 그대로 실어 보내서, 처음엔 실제로 주석이 번들에 새어 나갔다.

`infinite` 는 세 곳 모두 유지했다 (CLAUDE.md 가 loading affordance 에 한해 허용).

### Part 3 - 재발 방지 stylelint 룰

`src/ui` 가 0건이 된 지금이 룰을 켤 수 있는 유일한 타이밍이라 같은 PR 에 넣었다. 이것 없이 머지하면 다음 `rgba()` 가 그대로 다시 들어온다.

- [x] `.stylelintrc.json` 에 `function-disallowed-list` 추가 - `["rgb", "rgba", "hsl", "hsla"]`
  ```json
  "function-disallowed-list": [["rgb", "rgba", "hsl", "hsla"], {
    "severity": "error",
    "message": "DS 컴포넌트 SCSS 에 raw rgb()/rgba()/hsl()/hsla() 금지 — alpha 컬러도 token (token.$color_text_on_dark_* / $color_scrim_* 등) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
  }]
  ```
- [x] 기존 `color-no-hex` / `color-named` 와 동일한 형태 유지 - `severity: error` + 토큰을 가리키는 한글 메시지
- [x] 동일한 `src/styles/**` + `src/vanilla/**` exemption 적용 - 토큰 정의(이번에 추가한 raw alpha 포함)와 vanilla 번들의 CSS custom property 는 raw alpha 가 정당하다

룰 선정 근거: `color-function-notation` 은 표기법(legacy/modern)만 강제하지 리터럴 자체를 막지 못하고, `declaration-property-value-disallowed-list` 는 속성별 나열이 필요해 `box-shadow` 같은 shorthand 를 놓치기 쉽다. `function-disallowed-list` 가 "함수 호출 자체를 금지" 라는 의도를 가장 정확히 표현한다.

## 검증

전부 통과:

- `npx stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss'` - 통과
- `npx tsc --noEmit -p tsconfig.json` - 통과
- `npx vitest run --project unit` - 788 passed / 9 skipped (55 files)
- `pnpm build` - 성공

리뷰 반영 커밋 이후 위 4개를 모두 다시 돌렸고 전부 통과했다.

### 렌더링 결과 무변경 증명

각 토큰 값이 자신이 대체한 리터럴과 정확히 같으므로 컴파일 결과가 바뀌지 않아야 한다. 이를 **빌드 산출물 바이트 비교**로 확인했다.

1. 변경 전 `origin/develop`(`cbd5a60`) 에서 `pnpm build` → `dist/index.css`, `dist/vanilla/bigtablet.css` 스냅샷 보관
2. 이 브랜치에서 `pnpm build` → 동일 파일 재생성
3. `diff` + `shasum -a 256` 비교

**`dist/vanilla/bigtablet.css` 는 완전한 byte-identical** (해시 `838dc447…` 그대로).

**`dist/index.css` 는 딱 한 줄 다르다.** 리뷰 반영(`$duration_progress_default` 를 `3000ms` → `3s`, 로딩 토큰 그룹 단위 통일)으로 생긴 텍스트 차이다:

```diff
  3567c3567
- animation: toast_progress var(--toast-duration, 3000ms) linear forwards;
+ animation: toast_progress var(--toast-duration, 3s) linear forwards;
```

`diff` 출력 전체가 위 한 줄이며 그 외 차이는 없다. `3s` 와 `3000ms` 는 동일한 CSS `<time>` 이라 computed style·렌더링은 그대로고, 이 fallback 을 파싱하는 코드도 없다 — Toast 는 React 에서 `--toast-duration` 을 `${item.duration}ms` 로 항상 인라인 지정하므로 fallback 은 인라인 값이 없을 때만 쓰인다.

> 정확성을 위해 덧붙이면: 토큰 치환 커밋 2개(Part 1·2)까지는 `dist/index.css` 도 해시 `187f820d…` 로 완전 일치했다. 위 한 줄 차이는 그 이후 리뷰 반영 커밋에서 **의도적으로** 생긴 것이라, "전 구간 byte-identical" 이라는 초기 서술은 현재 기준으로는 정확하지 않아 이렇게 정정한다.

컴파일된 선언 직접 확인 (`dist/index.css`):

```css
animation: spinner_fade 1.2s linear infinite;
.spinner_bar:nth-child(1) { animation-delay: -1.2s; }   /* … -1.1s, -1s, -0.9s … 12개 그대로 */
animation: top_loading_indeterminate 1.5s ease-in-out infinite;
animation: toast_progress var(--toast-duration, 3s) linear forwards;
```

> 참고: 최초 검증은 rebase 이전 base 에서 했고, `origin/develop` 이 16 커밋 앞서 있어 rebase 후 **새 base 기준으로 baseline 을 다시 만들어 재검증**했다. 위 해시는 재검증 결과다.

### stylelint 룰이 실제로 잡는지 확인

**동작을 보지 않은 룰은 넣지 않았다.** 임시 probe 규칙을 `src/ui` SCSS 에 넣고 실패를 눈으로 확인한 뒤 제거했다.

```scss
/* 임시 probe - 확인 후 제거함 */
.stylelint_probe_delete_me {
  color: rgba(0, 0, 0, 0.5);
  background: rgb(1, 2, 3);
  border-color: hsl(200, 50%, 50%);
  outline-color: hsla(200, 50%, 50%, 0.4);
  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);  /* shorthand 안에 중첩된 케이스 */
}
```

결과: **5 errors, exit code 2** - 네 함수 전부와, `box-shadow` shorthand 안에 중첩된 `rgba` 까지 잡혔다 (중첩 케이스가 실질적으로 중요한 부분).

exemption 도 vacuous 하지 않게 확인했다 - `src/styles/**` 에는 `rgba` 가 28개, `src/vanilla/**` 에는 2개 실제로 들어있는데 둘 다 통과한다:

```
$ npx stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss'  → exit 0
$ npx stylelint 'src/vanilla/**/*.scss'                    → exit 0
```

probe 제거 후 위 두 커맨드 모두 clean 이며, 커밋된 상태가 검증된 그 상태다.

## 전달할 추가 이슈

- hero eyebrow 는 `0.7`, media-card eyebrow 는 `0.75` 로 **같은 역할인데 값이 다르다.** 이번엔 렌더링 무변경 원칙 때문에 `_muted` / `_label` 두 단계로 나눠 뒀는데, 디자인 확인 후 한 값으로 합치면 램프가 4단계로 줄어든다.
- `src/styles/colors/index.ts`(TS 미러) 에는 이번 토큰을 반영하지 않았다. 해당 파일은 이미 `alphaWhite38`, status container/on-surface 계열 등이 빠진 부분 미러라 별도로 싱크 맞추는 게 맞아 보인다.
