### PR TITLE
fix/alert-scroll-lock-flake

### DIFF
--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -270,7 +270,11 @@ describe("Alert", () => {
 		expect(document.body.dataset.openModals).toBe("1");
 
 		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
-		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
-		expect(document.body.style.overflow).toBe("");
+		// 스크롤락 해제는 언마운트 cleanup 이라 alertdialog 가 사라진 틱과 같지 않을 수 있다.
+		// overflow 도 waitFor 안에서 기다려야 CI 부하에서 'hidden' 을 잡는 flake 가 안 난다.
+		await waitFor(() => {
+			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+			expect(document.body.style.overflow).toBe("");
+		});
 	});
 });


### PR DESCRIPTION
## 작업 개요

CI 에서 간헐적으로 터지던 Alert 스크롤락 테스트 flake 를 수정한다. PR #440 의 한 커밋에서 재현됐고(`expected 'hidden' to be ''`, `Alert.test.tsx:274`), 변경 내용과 무관한 선재 결함이다.

## 원인

테스트가 `alertdialog` 의 **DOM 제거만** `waitFor` 로 기다린 뒤 `document.body.style.overflow` 를 동기 단언했다. Alert 은 퇴장 애니메이션 후 언마운트되므로 스크롤락 해제(cleanup)가 제거와 같은 틱에 돌지 않을 수 있고, CI 부하에서 그 틈이 벌어지면 `'hidden'` 을 잡는다.

> 이전에 `src/test/setup.ts` 의 `resetBodyScrollLock`(#392)으로 고친 것과 **다른 결함**이다. 그건 테스트 *간* 전역 누수 방어였고, 이건 한 테스트 *안*의 경합이다. 그래서 그 수정으로 잡히지 않았다.

## 작업한 내용

- [x] `overflow` 단언을 dialog 제거와 같은 `waitFor` 블록 안으로 이동 + 사유 주석
- [x] 동일 패턴 전수 확인 — Drawer(`:275`, `:315`)·Modal 의 해제 단언은 **동기 `rerender` 직후**라 React 가 같은 `act()` 에서 cleanup 을 flush 함. 영향 없어 그대로 둠

## 검증

- Alert 스위트 **10회 연속 반복 실행 → 실패 0회**
- 원래 실패 조건이던 커버리지 모드 전체 실행: 55 files, **788 passed / 9 skipped**