### PR TITLE
config/pr-labels-automation

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,97 @@
+name: PR Auto Label
+
+# 브랜치 접두사(`label/domain`)를 PR 라벨로 매핑하고, 담당자가 비어 있으면 PR 작성자를 지정한다.
+# 레포의 모든 사람 PR 이 라벨/담당자 없이 열려 있던 문제를 자동화로 막는다.
+#
+# `pull_request` 가 아니라 `pull_request_target` 을 쓰는 이유:
+#  - fork PR 에서도 GITHUB_TOKEN 이 write 라 라벨/담당자 지정이 실제로 동작한다
+#    (`pull_request` 는 fork 일 때 토큰이 read-only 라 항상 실패한다)
+#  - 항상 base 브랜치의 워크플로가 실행된다 -> PR 브랜치에서 이 파일을 고쳐
+#    write 토큰 동작을 바꾸는 것을 막는다
+#  - checkout / 빌드가 전혀 없어 PR 코드를 실행하지 않는다 -> pull_request_target 의
+#    통상적인 보안 위험(신뢰되지 않은 코드 실행)에 해당하지 않는다
+#
+# 참고: `edited` 는 제목/본문/base 변경 시에도 발생한다. 매핑 라벨이 이미 있으면 아무것도
+#       하지 않으므로 재실행은 무해하다 (사람이 추가한 라벨은 절대 제거하지 않는다).
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+# 같은 PR 에 연속 편집이 들어오면 마지막 것만 실행한다.
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    # 최소 권한: PR 라벨/담당자 수정만 필요하다. checkout 이 없어 contents 도 불필요.
+    permissions:
+      pull-requests: write
+    steps:
+      # 서드파티 labeler 액션 대신 gh CLI 를 쓴다:
+      #  - release.yml 이 이미 `run:` + gh CLI 패턴을 쓴다 (스타일 일치)
+      #  - 핀·업그레이드할 액션 의존성이 0 개, checkout 도 불필요 (GH_REPO 로 레포 지정)
+      #  - 접두사 -> 라벨 매핑은 `case` 한 블록이면 끝난다
+      # 브랜치명은 신뢰할 수 없는 입력이므로 `${{ }}` 로 스크립트에 직접 보간하지 않고
+      # env 로 넘겨 따옴표로 감싸 쓴다 (셸 인젝션 방지).
+      - name: Apply branch-prefix label and assign author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: |
+          set -euo pipefail
+
+          # `label/domain` 의 첫 세그먼트. 슬래시가 없으면(예: `develop`) 이름 전체가 접두사.
+          PREFIX="$(printf '%s' "${HEAD_REF%%/*}" | tr '[:upper:]' '[:lower:]')"
+
+          # 커밋 라벨(CLAUDE.md `Commit Labels`) -> 레포 라벨 매핑.
+          case "$PREFIX" in
+            feat)                                              LABEL="Feature" ;;
+            fix|style|refactor|config|delete|note|ci|etc)      LABEL="Fix" ;;
+            bug)                                               LABEL="Bug" ;;
+            docs)                                              LABEL="Docs" ;;
+            release|deploy|develop|sync)                       LABEL="Deploy" ;;
+            *)                                                 LABEL="" ;;
+          esac
+
+          # --- 라벨 ---------------------------------------------------------
+          if [ -z "$LABEL" ]; then
+            echo "::notice::브랜치 접두사 '${PREFIX}' 에 매핑된 라벨이 없다 - 라벨 부여를 건너뛴다"
+          else
+            export LABEL
+            # 이미 붙어 있으면 건드리지 않는다. `--add-label` 은 추가만 하므로
+            # 사람이 별도로 붙인 라벨은 어떤 경우에도 제거되지 않는다.
+            HAS_LABEL="$(gh pr view "$PR_NUMBER" --json labels \
+              --jq '[.labels[].name] | index(env.LABEL) != null' || echo "false")"
+            if [ "$HAS_LABEL" = "true" ]; then
+              echo "'${LABEL}' 라벨이 이미 있다 - 건너뛴다"
+            elif gh pr edit "$PR_NUMBER" --add-label "$LABEL"; then
+              echo "'${LABEL}' 라벨을 부여했다 (접두사 '${PREFIX}')"
+            else
+              # 라벨이 레포에 없거나 권한/레이트리밋 문제 - PR 을 실패시키지 않는다.
+              echo "::warning::'${LABEL}' 라벨 부여 실패 (레포에 라벨이 없을 수 있다) - 무시하고 계속한다"
+            fi
+          fi
+
+          # --- 담당자 -------------------------------------------------------
+          # 봇(dependabot 등)은 assignee 가 될 수 없다. dependabot PR 은 `dependencies`
+          # 라벨을 이미 자동으로 받으므로 담당자 지정 대상에서 완전히 제외한다.
+          if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then
+            echo "::notice::봇 PR (${PR_AUTHOR}) - 담당자 지정을 건너뛴다"
+            exit 0
+          fi
+
+          ASSIGNEE_COUNT="$(gh pr view "$PR_NUMBER" --json assignees --jq '.assignees | length' || echo "0")"
+          if [ "$ASSIGNEE_COUNT" != "0" ]; then
+            echo "담당자가 이미 지정돼 있다 - 건너뛴다"
+          elif gh pr edit "$PR_NUMBER" --add-assignee "$PR_AUTHOR"; then
+            echo "담당자로 '${PR_AUTHOR}' 를 지정했다"
+          else
+            # 조직 외부 기여자 등 assignable 하지 않은 경우 - PR 을 실패시키지 않는다.
+            echo "::warning::'${PR_AUTHOR}' 담당자 지정 실패 - 무시하고 계속한다"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,7 +622,7 @@ EOF
 ```bash
 gh pr create --base develop --title "label/domain" \
   --label "Feature" --assignee @me --body "$(cat <<'EOF'
-## 작업 개요
+## 제목
 
 ## 작업한 내용
 - [x] 작업1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,9 +600,28 @@ EOF
 - **Base branch**: `develop` (NOT main!)
 - **PR title**: Same as branch name
 - **PR body**: Write in Korean
+- **Label**: 브랜치 접두사에 대응하는 라벨 1개 (아래 표)
+- **Assignee**: PR 작성자 본인 (`@me`)
+
+#### 브랜치 접두사 → PR 라벨 매핑
+
+| 브랜치 접두사 | 라벨 |
+|--------------|------|
+| `feat` | `Feature` |
+| `fix`, `style`, `refactor`, `config`, `delete`, `note`, `ci`, `etc` | `Fix` |
+| `bug` | `Bug` |
+| `docs` | `Docs` |
+| `release`, `deploy`, `develop`, `sync` | `Deploy` |
+
+> `.github/workflows/pr-labeler.yml` 이 PR open/reopen/edit 시 위 매핑을 **자동 적용**하고,
+> 담당자가 비어 있으면 작성자를 자동 지정한다. 아래 `--label` / `--assignee @me` 는
+> 워크플로가 안 돌거나(예: 워크플로 자체를 바꾸는 PR) 늦게 붙는 경우를 위한 이중 안전장치다.
+> 이미 붙은 라벨은 워크플로가 제거하지 않으니 수동 지정과 충돌하지 않는다.
+> 봇(dependabot 등) PR 은 assignee 가 될 수 없어 담당자 지정 대상에서 제외된다.
 
 ```bash
-gh pr create --base develop --title "label/domain" --body "$(cat <<'EOF'
+gh pr create --base develop --title "label/domain" \
+  --label "Feature" --assignee @me --body "$(cat <<'EOF'
 ## 작업 개요
 
 ## 작업한 내용
@@ -621,6 +640,7 @@ EOF
 ### Important Notes
 - Always create PRs targeting `develop` branch
 - Write PR body in Korean
+- 라벨/담당자를 항상 확인 - 워크플로가 자동으로 붙이지만 누락 시 수동 보정
 - Create issues first if needed and link them to PR
 - Requires team review before merging
 


### PR DESCRIPTION
## 작업 개요

레포의 사람 작성 PR 141건이 **전부 라벨·담당자 없이** 열려 있었다. 원인은 `CLAUDE.md` 의 "Create PR" 절이 `--base` / 제목 / 본문만 문서화하고 라벨·담당자를 전혀 언급하지 않았기 때문이다. 이슈는 조직 `.github` 레포의 fallback 템플릿이 각각 `labels:` 를 지정해 문제가 없지만, PR 템플릿은 마크다운이라 frontmatter 로 라벨을 실을 수 없다.

**브랜치 접두사 → PR 라벨 매핑 + PR 작성자 자동 담당자 지정** 을 워크플로로 자동화하고, 같은 규칙을 `CLAUDE.md` 에 명문화했다. 기존 PR 백필은 별도로 진행 중이며, 이 PR 은 앞으로 열리는 PR 에 규칙이 계속 적용되도록 하는 부분이다.

## 작업한 내용

- [x] `.github/workflows/pr-labeler.yml` 신규 추가 — PR open/reopen/edit 시 브랜치 접두사(`label/domain`)로 라벨 부여 + 담당자 비어 있으면 작성자 지정
- [x] 접두사 매핑 (레포에 이미 존재하는 라벨만 사용, `gh label list` 로 5개 전부 확인)

  | 브랜치 접두사 | 라벨 |
  |--------------|------|
  | `feat` | `Feature` |
  | `fix`, `style`, `refactor`, `config`, `delete`, `note`, `ci`, `etc` | `Fix` |
  | `bug` | `Bug` |
  | `docs` | `Docs` |
  | `release`, `deploy`, `develop`, `sync` | `Deploy` |

- [x] 서드파티 labeler 액션 대신 **`gh` CLI + `run:` 한 스텝** 으로 구현 — `release.yml` 이 이미 쓰는 패턴이라 스타일이 일치하고, 핀·업그레이드할 액션 의존성이 0개이며, `GH_REPO` 환경변수로 레포를 지정해 `actions/checkout` 조차 불필요하다. 매핑은 `case` 한 블록으로 끝난다.
- [x] `pull_request` 대신 **`pull_request_target`** 사용 — fork PR 에서도 `GITHUB_TOKEN` 이 write 라 실제로 동작하고(`pull_request` 는 fork 일 때 read-only 라 항상 실패), 항상 base 브랜치의 워크플로가 실행돼 PR 브랜치에서 이 파일을 고쳐 write 토큰 동작을 바꾸는 것을 막는다. checkout/빌드가 없어 PR 코드를 실행하지 않으므로 `pull_request_target` 의 통상적 보안 위험에는 해당하지 않는다.
- [x] 권한은 최소 스코프 — job-level `pull-requests: write` 하나뿐 (checkout 이 없어 `contents` 도 불필요)
- [x] **PR 을 실패시키지 않는 degrade** — 라벨이 레포에 없거나 담당자 지정이 안 되면 `::warning::` 만 남기고 계속 진행
- [x] **dependabot / 봇 PR 담당자 지정 제외** — `user.type == "Bot"` 이면 담당자 단계를 건너뛴다 (봇은 assignee 가 될 수 없고, dependabot 은 `dependencies` 라벨을 이미 자동으로 받는다)
- [x] **사람이 붙인 라벨은 절대 건드리지 않는다** — `--add-label` 은 추가 전용이고, 매핑 라벨이 이미 있으면 API 호출 자체를 건너뛴다. 라벨 제거 경로가 코드에 없다.
- [x] 브랜치명은 신뢰할 수 없는 입력이라 `${{ }}` 로 스크립트에 직접 보간하지 않고 `env:` 로 넘겨 따옴표로 감싸 사용 (셸 인젝션 방지)
- [x] `CLAUDE.md` "### 5. Create PR (if requested)" 절에 매핑 표 · 담당자 규칙 · `--label` / `--assignee @me` 를 포함한 `gh pr create` 예시 추가. 워크플로가 자동 적용하므로 수동 `--label` 은 이중 안전장치라는 점을 명시했다.
- [x] **PR 템플릿 첫 헤딩 불일치 해소** — 조직 공통 `Bigtablet/.github` → `.github/PULL_REQUEST_TEMPLATE.md` 는 `## 제목` 으로 시작하는데 `CLAUDE.md` 예시는 `## 작업 개요` 였다. 오너 결정에 따라 **조직 템플릿을 SSOT 로 삼아** `CLAUDE.md` 예시의 첫 헤딩을 `## 제목` 으로 맞췄다 (`5231afd`). 나머지 두 헤딩(`## 작업한 내용`, `## 전달할 추가 이슈`)은 원래 일치해 그대로 뒀다.

## 검증

- [x] 워크플로 YAML 파싱 — `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-labeler.yml'))"` 통과. 트리거 `pull_request_target [opened, reopened, edited]`, 권한 `{pull-requests: write}` 확인
- [x] `run:` 블록(51줄) `bash -n` 문법 검사 통과
- [x] 유닛 테스트 `npx vitest run --project unit` — 55 파일 / 788 통과 (9 skip). 헤딩 정렬 커밋 이후에도 재실행해 동일 결과 확인
- [x] **매핑 로직 단독 검증** — 워크플로 파일에서 실제 `PREFIX` 추출 라인과 `case` 블록을 그대로 뽑아 셸에서 실행 (재구현이 아니라 실제 배포될 코드를 실행):

```text
feat/sidebar             -> prefix=feat       label=Feature
fix/auth                 -> prefix=fix        label=Fix
style/button             -> prefix=style      label=Fix
refactor/tokens          -> prefix=refactor   label=Fix
config/pr-labels-automation -> prefix=config     label=Fix
delete/legacy-icons      -> prefix=delete     label=Fix
note/comments            -> prefix=note       label=Fix
ci/cache                 -> prefix=ci         label=Fix
etc/misc                 -> prefix=etc        label=Fix
bug/modal-focus          -> prefix=bug        label=Bug
docs/readme              -> prefix=docs       label=Docs
release/v3.8.0           -> prefix=release    label=Deploy
deploy/pages             -> prefix=deploy     label=Deploy
develop                  -> prefix=develop    label=Deploy
sync/figma-tokens        -> prefix=sync       label=Deploy
FEAT/Sidebar             -> prefix=feat       label=Feature
feat                     -> prefix=feat       label=Feature
main                     -> prefix=main       label=<none / skipped>
chore/lint               -> prefix=chore      label=<none / skipped>
dependabot/npm_and_yarn/vite-7.1.2 -> prefix=dependabot label=<none / skipped>
feat/oops$(whoami)`id`;rm -> prefix=feat       label=Feature
```

  - 매핑된 15개 접두사 전부 의도한 라벨로 떨어진다
  - 슬래시 없는 브랜치(`develop`, `feat`)도 이름 전체를 접두사로 잡는다 — `merge: release` PR(head = `develop`)이 `Deploy` 를 받는 경로
  - 대문자 브랜치(`FEAT/Sidebar`)는 소문자 정규화로 매칭된다
  - 미매핑 접두사(`main`, `chore`, `dependabot`)는 라벨 없이 조용히 건너뛴다 (에러 아님)
  - 마지막 케이스에서 `$(whoami)` / `` `id` `` / `;rm` 이 전개되지 않고 문자열로 남는다 — env 전달 + 따옴표 처리가 동작함을 확인

- [x] `--jq` 표현식 검증 (가짜 `gh pr view` 페이로드 대상):
  - 라벨 없음 → `false` / `Fix` 있음 → `true` / 사람이 붙인 `Feature` 만 있음 → `false`(= `Fix` 를 추가하되 `Feature` 는 그대로 둔다) / `Hotfix`+`Fix` → `true`(건너뜀)
  - 담당자 0명 → `0`, 1명 → `1`
  - `gh` 호출 자체가 실패하면 `|| echo "false"` 로 떨어져 추가를 시도하고, 그 시도도 실패하면 warning 만 남는다

> 워크플로는 `pull_request_target` 이라 base 브랜치(`develop`)에 머지되기 전까지는 돌지 않는다. 그래서 **이 PR 의 라벨(`Fix`)과 담당자는 수동으로 지정**했다. 실제 자동 동작은 머지 이후 첫 PR 에서 확인 가능하다.

## 전달할 추가 이슈

- 이 PR 은 앞으로 열리는 PR 만 커버한다. 기존 141건 백필은 별도 진행 중인 것으로 안다.
