### PR TITLE
fix/alert-scroll-lock-assertion

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,13 +8,12 @@ Globals.assign({ skipAnimation: true });
 
 // Modal/Drawer/Alert 는 document.body 에 스크롤락 카운터(dataset.openModals)와
 // overflow 를 공유한다(여러 오버레이 동시 오픈 조율용 - production 의도된 설계).
-// 이 전역이 테스트 간 누수되면 스크롤락 상태가 새어 flaky 해진다:
-// react-spring 퇴출(useSpringPresence) 의 unmount 가 skipAnimation 이라도 onRest 스케줄
-// 때문에 한 tick 늦게 실행될 수 있어, 앞 테스트 오버레이의 스크롤락 cleanup 이 테스트
-// 경계를 넘어 body 를 더럽히는 경우가 있다(coverage 계측 타이밍에서 재현).
+// 이 전역이 테스트 간 누수되면 오버레이가 originalOverflow 를 오염된 값으로 저장한다.
+// beforeEach 로 각 테스트 렌더 직전 초기화, afterEach 는 teardown 위생용.
 //
-// beforeEach 가 결정적 방어선: 각 테스트 렌더 직전 body 스크롤락 전역을 초기화해, 오버레이가
-// originalOverflow 를 항상 깨끗한 값으로 저장하도록 보장한다. afterEach 는 teardown 위생용.
+// 주의: 이건 테스트 간 격리용일 뿐, 한 테스트 안의 비동기 unmount 를 대신 처리하지 않는다.
+// 퇴출 spring 은 act 밖에서 setState 하므로 portal 제거 커밋과 useEffect cleanup flush 가
+// 한 tick 벌어진다 - 잠금 해제를 단언하려면 waitFor 안에서 함께 기다릴 것.
 function resetBodyScrollLock() {
 	document.body.style.overflow = "";
 	delete document.body.dataset.openModals;

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -270,11 +270,13 @@ describe("Alert", () => {
 		expect(document.body.dataset.openModals).toBe("1");
 
 		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
-		// 스크롤락 해제는 언마운트 cleanup 이라 alertdialog 가 사라진 틱과 같지 않을 수 있다.
-		// overflow 도 waitFor 안에서 기다려야 CI 부하에서 'hidden' 을 잡는 flake 가 안 난다.
+		// 퇴출 spring 은 act 밖에서 setState 하므로 portal 이 DOM 에서 빠진 커밋 시점과
+		// useEffect cleanup(스크롤락 해제) flush 시점이 한 tick 벌어진다. DOM 제거만 기다리면
+		// 부하가 걸린 러너에서 cleanup 전에 단언이 실행돼 flaky - 잠금 해제까지 함께 기다린다.
 		await waitFor(() => {
 			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
 			expect(document.body.style.overflow).toBe("");
+			expect(document.body.dataset.openModals).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
## 작업 개요

머지된 #441 이 잡은 Alert 스크롤락 flake 를 재현·계측해 원인을 정확히 특정하고, 단언 범위를 cleanup 전체로 넓힌다. #441 의 수정 방향은 맞았고 이 PR 은 그 위에 올리는 보강이다.

## 재현 · 계측

전체 유닛 스위트를 4개 동시 실행하면 4회 배치당 1회 꼴로 재현된다. 단언 시점의 body 상태를 찍어보면:

```
AssertionError: dataset={"originalOverflow":"","openModals":"1"}: expected 'hidden' to be ''
```

- `openModals` 가 아직 `1`, `originalOverflow` 는 깨끗함 → **앞 테스트에서 새어 나온 상태가 아니다**
- 퇴출 spring 은 `act` 밖에서 `setState` 한다 (RTL 이 async `waitFor` 동안 act 환경을 끈다). React 는 portal 제거를 즉시 커밋하지만 passive effect cleanup(스크롤락 해제)은 이후 scheduler task 에서 flush 한다
- `waitFor` 가 DOM 제거만 보고 통과 → 그 틈에서 단언이 실행됨. 부하가 걸린 러너에서 틈이 벌어져 flaky

## 작업한 내용

- [x] `dataset.openModals` 해제까지 같은 `waitFor` 안에서 단언 - 눈에 보이는 절반(overflow)만이 아니라 cleanup 전체를 기다린다
- [x] 주석에 act 경계를 명시 - "언마운트가 늦다" 가 아니라 "커밋과 effect flush 가 갈린다" 가 실제 원인
- [x] `src/test/setup.ts` 주석 정정 - `resetBodyScrollLock`(#392) 은 테스트 *간* 격리 장치이고 테스트 *안*의 경합은 못 막는다고 명시. 리셋 자체는 유지
- [x] 단언 완화 없음. Alert 구현(`index.tsx`) 무변경 - 카운터 로직은 정상
- [x] Modal/Drawer 동일 패턴 재확인 - 동기 `rerender`/`unmount` 라 같은 `act()` 에서 flush 됨. 영향 없음

## 검증

- 재현 조건(4개 동시 실행) 그대로 **전체 스위트 20회 → 실패 0회**
- pre-commit 전체 유닛: 55 files, 788 passed / 9 skipped

## 전달할 추가 이슈

- `npx biome check src/ui/feedback/alert/Alert.test.tsx` 가 `:228` 근처 포맷 diff 를 낸다. 이 PR 변경과 무관한 선재 항목(develop 기준으로도 동일)