### PR TITLE
feat/vanilla-react-parity

### DIFF
--- a/.claude/docs/design-system.md
+++ b/.claude/docs/design-system.md
@@ -704,8 +704,10 @@ For server templates (Thymeleaf, JSP, PHP, Django):
 
 ```html
 <!-- Button -->
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
-<button class="bt-button bt-button--md bt-button--secondary">Secondary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
+<button class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+<button class="bt-button bt-button--md bt-button--outline">Outline</button>
+<button class="bt-button bt-button--md bt-button--text">Text</button>
 <button class="bt-button bt-button--lg bt-button--danger">Danger</button>
 
 <!-- TextField -->
@@ -746,20 +748,35 @@ For server templates (Thymeleaf, JSP, PHP, Django):
   <p>Content</p>
 </div>
 
-<!-- Spinner -->
-<div class="bt-spinner bt-spinner--md"></div>
+<!-- Dropdown -->
+<div class="bt-dropdown" data-bt-dropdown>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">Select...</span>
+    <span class="bt-dropdown__icon">▼</span>
+  </button>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="1">Option 1</li>
+  </ul>
+</div>
+
+<!-- Spinner (크기는 --bt-spinner-size, 기본 24px) -->
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
 ```
+
+> Vanilla 클래스·JS 옵션 이름은 React API 와 1:1 로 맞춰져 있고 deprecated 별칭은 없다.
+> React 와 갈라져 있던 구 이름은 v3.8.0 에서 전부 제거됐다 - old → new 매핑은
+> `docs/MIGRATION.md` 의 "v3.8.0 (Vanilla 패키지 정리)" 섹션 참고.
 
 ### JavaScript API
 
 ```javascript
-// Select
-const select = Bigtablet.Select('#my-select', {
+// Dropdown
+const dropdown = Bigtablet.Dropdown('#my-dropdown', {
   options: [{ value: '1', label: 'One' }],
-  onChange: (value) => console.log(value)
+  onValueChange: (value) => console.log(value)
 });
-select.getValue();
-select.setValue('1');
+dropdown.getValue();
+dropdown.setValue('1');
 
 // Modal
 const modal = Bigtablet.Modal('#my-modal', {
@@ -772,7 +789,7 @@ modal.close();
 
 // Toggle
 const tg = Bigtablet.Toggle('#my-toggle', {
-  onChange: (checked) => console.log(checked)
+  onCheckedChange: (checked) => console.log(checked)
 });
 tg.toggle();
 tg.setChecked(true);
@@ -791,7 +808,7 @@ Bigtablet.Alert({
 const pagination = Bigtablet.Pagination('#my-pagination', {
   page: 1,
   totalPages: 10,
-  onChange: (page) => console.log(page)
+  onPageChange: (page) => console.log(page)
 });
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,7 +424,7 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 // Manual initialization
 const select = Bigtablet.Select('#my-select', {
   options: [{ value: '1', label: 'One' }],
-  onChange: (value, option) => console.log(value)
+  onValueChange: (value, option) => console.log(value)
 });
 select.getValue();
 select.setValue('1');
@@ -440,7 +440,7 @@ modal.open();
 modal.close();
 
 const sw = Bigtablet.Toggle('#my-toggle', {
-  onChange: (checked) => console.log(checked)
+  onCheckedChange: (checked) => console.log(checked)
 });
 sw.toggle();
 sw.setChecked(true);
@@ -448,7 +448,7 @@ sw.setChecked(true);
 const pagination = Bigtablet.Pagination('#my-pagination', {
   page: 1,
   totalPages: 10,
-  onChange: (page) => console.log(page)
+  onPageChange: (page) => console.log(page)
 });
 pagination.setPage(5);
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,32 +270,46 @@ dist/vanilla/
 
 ### Component Classes Reference
 
+클래스 이름은 대응하는 React 컴포넌트의 prop 값과 같게 맞춘다. 이름이 갈라진 구 클래스는
+deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크업/문서에는 canonical 이름만 쓴다.
+
 | Component | Base Class | Modifiers | States |
 |-----------|------------|-----------|--------|
-| Button | `.bt-button` | `--sm/md/lg`, `--primary/secondary/ghost/danger` | `:disabled` |
+| Button | `.bt-button` | `--sm/md/lg/xl`, `--filled/tonal/outline/text`, `--danger`(variant 와 직교), `--full-width` | `:disabled` |
 | TextField | `.bt-text-field` | `--full-width` | |
 | TextField Input | `.bt-text-field__input` | `--outline/filled`, `--sm/md/lg`, `--error/success` | `:disabled` |
 | Checkbox | `.bt-checkbox` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Radio | `.bt-radio` | `--sm/md/lg` | `:checked`, `:disabled` |
-| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` |
+| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` / `:disabled` |
 | Select | `.bt-select` | | |
 | Select Control | `.bt-select__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
 | Select List | `.bt-select__list` | `--up` (opens upward) | |
 | Select Option | `.bt-select__option` | | `.is-selected`, `.is-active`, `.is-disabled` |
 | Modal | `.bt-modal` | | `.is-open` |
-| Card | `.bt-card` | `--bordered`, `--elevation-1/2/3`, `--p-sm/md/lg` | |
+| Card | `.bt-card` | `--bordered`, `--shadow-none/sm/md/lg`, `--p-none/sm/md/lg` | |
 | Spinner | `.bt-spinner` | `--sm/md/lg/xl` | |
 | Pagination | `.bt-pagination` | | |
 | DatePicker | `.bt-date-picker` | `--full-width` | |
 | FileInput | `.bt-file-input` | | `.bt-file-input--disabled` |
 
+**Deprecated 별칭** (계속 동작 - v4.0.0 제거 예정):
+
+| 구 클래스 | 대체 |
+|---|---|
+| `.bt-button--primary` | `.bt-button--filled` |
+| `.bt-button--secondary` | `.bt-button--outline` |
+| `.bt-button--ghost` | `.bt-button--text` |
+| `.bt-card--elevation-1/2/3` | `.bt-card--shadow-sm/md/lg` |
+
 ### HTML Examples
 
 #### Button
 ```html
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
-<button class="bt-button bt-button--md bt-button--secondary">Secondary</button>
-<button class="bt-button bt-button--md bt-button--danger">Danger</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
+<button class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+<button class="bt-button bt-button--md bt-button--outline">Outline</button>
+<button class="bt-button bt-button--md bt-button--text">Text</button>
+<button class="bt-button bt-button--md bt-button--outline bt-button--danger">Delete</button>
 ```
 
 #### TextField
@@ -371,8 +385,8 @@ dist/vanilla/
     <div class="bt-modal__header">Title</div>
     <div class="bt-modal__body">Content</div>
     <div class="bt-modal__footer">
-      <button class="bt-button bt-button--md bt-button--secondary" data-modal-close>Cancel</button>
-      <button class="bt-button bt-button--md bt-button--primary" data-modal-close>Confirm</button>
+      <button class="bt-button bt-button--md bt-button--outline" data-modal-close>Cancel</button>
+      <button class="bt-button bt-button--md bt-button--filled" data-modal-close>Confirm</button>
     </div>
   </div>
 </div>
@@ -385,7 +399,7 @@ dist/vanilla/
   <p>Content</p>
 </div>
 
-<div class="bt-card bt-card--elevation-2 bt-card--p-lg">
+<div class="bt-card bt-card--shadow-md bt-card--p-lg">
   Elevation card
 </div>
 ```
@@ -486,7 +500,7 @@ All design tokens available as CSS variables:
           th:errors="*{name}"></span>
   </div>
 
-  <button type="submit" class="bt-button bt-button--md bt-button--primary">Submit</button>
+  <button type="submit" class="bt-button bt-button--md bt-button--filled">Submit</button>
 </form>
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,36 +270,28 @@ dist/vanilla/
 
 ### Component Classes Reference
 
-클래스 이름은 대응하는 React 컴포넌트의 prop 값과 같게 맞춘다. 이름이 갈라진 구 클래스는
-deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크업/문서에는 canonical 이름만 쓴다.
+클래스 이름·JS 옵션 이름은 대응하는 React 컴포넌트의 prop 값과 **같게 맞춘다**. deprecated 별칭은
+두지 않는다 - 이름이 갈라지면 별칭을 추가하는 대신 구 이름을 제거하고
+[docs/MIGRATION.md](./docs/MIGRATION.md) 에 old → new 표를 남긴다 (v3.8.0 에서 정리 완료).
 
 | Component | Base Class | Modifiers | States |
 |-----------|------------|-----------|--------|
-| Button | `.bt-button` | `--sm/md/lg/xl`, `--filled/tonal/outline/text`, `--danger`(variant 와 직교), `--full-width` | `:disabled` |
+| Button | `.bt-button` | `--sm/md/lg/xl`, `--filled/tonal/outline/text`, `--danger`(variant 와 직교), `--radius-none/xs/sm/md/lg/xl/full`(기본 full), `--full-width` | `:disabled` |
 | TextField | `.bt-text-field` | `--full-width` | |
 | TextField Input | `.bt-text-field__input` | `--outline/filled`, `--sm/md/lg`, `--error/success` | `:disabled` |
 | Checkbox | `.bt-checkbox` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Radio | `.bt-radio` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` / `:disabled` |
-| Select | `.bt-select` | | |
-| Select Control | `.bt-select__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
-| Select List | `.bt-select__list` | `--up` (opens upward) | |
-| Select Option | `.bt-select__option` | | `.is-selected`, `.is-active`, `.is-disabled` |
+| Dropdown | `.bt-dropdown` | | |
+| Dropdown Control | `.bt-dropdown__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
+| Dropdown List | `.bt-dropdown__list` | `--up` (opens upward) | |
+| Dropdown Option | `.bt-dropdown__option` | | `.is-selected`, `.is-active`, `.is-disabled` |
 | Modal | `.bt-modal` | | `.is-open` |
-| Card | `.bt-card` | `--bordered`, `--shadow-none/sm/md/lg`, `--p-none/sm/md/lg` | |
-| Spinner | `.bt-spinner` | `--sm/md/lg/xl` | |
+| Card | `.bt-card` | `--bordered`, `--shadow-none/sm/md/lg`(기본 sm), `--p-none/sm/md/lg`(기본 md), `--accent/glass/outlined`, `--interactive` | |
+| Spinner | `.bt-spinner` | 없음 - 크기는 `--bt-spinner-size` (기본 24px) | |
 | Pagination | `.bt-pagination` | | |
 | DatePicker | `.bt-date-picker` | `--full-width` | |
 | FileInput | `.bt-file-input` | | `.bt-file-input--disabled` |
-
-**Deprecated 별칭** (계속 동작 - v4.0.0 제거 예정):
-
-| 구 클래스 | 대체 |
-|---|---|
-| `.bt-button--primary` | `.bt-button--filled` |
-| `.bt-button--secondary` | `.bt-button--outline` |
-| `.bt-button--ghost` | `.bt-button--text` |
-| `.bt-card--elevation-1/2/3` | `.bt-card--shadow-sm/md/lg` |
 
 ### HTML Examples
 
@@ -357,18 +349,18 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 </button>
 ```
 
-#### Select
+#### Dropdown
 ```html
-<div class="bt-select" data-bt-select>
-  <label class="bt-select__label">Label</label>
-  <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-    <span class="bt-select__placeholder">Select...</span>
-    <span class="bt-select__icon">▼</span>
+<div class="bt-dropdown" data-bt-dropdown>
+  <label class="bt-dropdown__label">Label</label>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">Select...</span>
+    <span class="bt-dropdown__icon">▼</span>
   </button>
-  <ul class="bt-select__list">
-    <li class="bt-select__option" data-value="1">Option 1</li>
-    <li class="bt-select__option" data-value="2">Option 2</li>
-    <li class="bt-select__option is-disabled" data-value="3">Disabled</li>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="1">Option 1</li>
+    <li class="bt-dropdown__option" data-value="2">Option 2</li>
+    <li class="bt-dropdown__option is-disabled" data-value="3">Disabled</li>
   </ul>
 </div>
 ```
@@ -400,13 +392,20 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 </div>
 
 <div class="bt-card bt-card--shadow-md bt-card--p-lg">
-  Elevation card
+  Shadow card
+</div>
+
+<div class="bt-card bt-card--accent bt-card--interactive">
+  Accent + interactive card
 </div>
 ```
 
 #### Spinner
 ```html
-<div class="bt-spinner bt-spinner--md"></div>
+<!-- 기본 24px (React <Spinner /> 기본값) -->
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
+<!-- 임의 크기 -->
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
 ```
 
 #### Pagination
@@ -422,14 +421,14 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 // Auto-init: elements with data-bt-* are initialized on DOMContentLoaded
 
 // Manual initialization
-const select = Bigtablet.Select('#my-select', {
+const dropdown = Bigtablet.Dropdown('#my-dropdown', {
   options: [{ value: '1', label: 'One' }],
   onValueChange: (value, option) => console.log(value)
 });
-select.getValue();
-select.setValue('1');
-select.open();
-select.close();
+dropdown.getValue();
+dropdown.setValue('1');
+dropdown.open();
+dropdown.close();
 
 const modal = Bigtablet.Modal('#my-modal', {
   closeOnOverlay: true,
@@ -481,6 +480,7 @@ All design tokens available as CSS variables:
   --bt-spacing-lg: 1rem;
   --bt-radius-sm: 6px;
   --bt-radius-md: 8px;
+  --bt-radius-full: 9999px;
   --bt-elevation-1: 0 1px 1px -1px rgba(0,0,0,0.20), 0 3px 3px 0 rgba(0,0,0,0.12);
   --bt-transition-base: 0.2s ease-in-out;
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ dist/vanilla/
 | TextField Input | `.bt-text-field__input` | `--outline/filled`, `--sm/md/lg`, `--error/success` | `:disabled` |
 | Checkbox | `.bt-checkbox` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Radio | `.bt-radio` | `--sm/md/lg` | `:checked`, `:disabled` |
-| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` / `:disabled` |
+| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `:disabled` |
 | Dropdown | `.bt-dropdown` | | |
 | Dropdown Control | `.bt-dropdown__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
 | Dropdown List | `.bt-dropdown__list` | `--up` (opens upward) | |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For server-rendered apps (Thymeleaf, JSP, PHP, Django):
 <link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 <script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
 
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 ```
 
 →&nbsp;Full guide · [`docs/VANILLA.md`](./docs/VANILLA.md)

--- a/README_KR.md
+++ b/README_KR.md
@@ -153,7 +153,7 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 <link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 <script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
 
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 ```
 
 →&nbsp;자세히 · [`docs/VANILLA.md`](./docs/VANILLA.md)

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -465,16 +465,18 @@ For non-React contexts (Thymeleaf, JSP, PHP, Django):
 <link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 <script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
 
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 ```
 
 Class naming: `.bt-{component}` + `--{modifier}` + `.is-{state}` (BEM-like).
 
-Components available: Button, TextField, Checkbox, Radio, Toggle, Select, Modal, Card, Spinner, Pagination, DatePicker, FileInput.
+Components available: Button, TextField, Checkbox, Radio, Toggle, Dropdown, Modal, Card, Spinner, Pagination, DatePicker, FileInput.
+
+Class names and JS option names mirror the React API exactly - there are no deprecated aliases. See [MIGRATION.md](./MIGRATION.md#v380-vanilla-패키지-정리) for the v3.8.0 old → new map.
 
 JS API (auto-init on DOMContentLoaded, or manual):
 ```js
-const select = Bigtablet.Select("#my-select", { options, onChange });
+const dropdown = Bigtablet.Dropdown("#my-dropdown", { options, onValueChange });
 const modal = Bigtablet.Modal("#my-modal", { onOpen, onClose });
 Bigtablet.Alert({ title, message, showCancel: true, onConfirm });
 ```

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,7 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 ## 목차
 
 - [개요](#개요)
+- [v3.8.0 (Vanilla 패키지 정리)](#v380-vanilla-패키지-정리)
 - [v3.5.0](#v350)
 - [v3.3.0](#v330)
 - [v3.0.0](#v300)
@@ -21,8 +22,148 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 - `@deprecated` 로 표시된 prop 은 삭제되지 않고 계속 동작합니다. 실제 제거는 다음 major 릴리즈에서 이루어집니다.
 - deprecated prop 외에, **동작·타입 레벨 변경**(예: 렌더링 위치 변경, 타입 형태 변경)도 소비자에게 영향이 있으면 해당 버전 섹션에 함께 정리합니다 (v3.5.0 참고).
 - 변경 콜백(`onChange` 계열) 은 신규(canonical) prop 과 구(deprecated) prop 을 동시에 넘겨도 안전합니다. 컴포넌트 내부는 `canonical ?? deprecated` 순서로 우선 적용하므로, 신규 prop 을 넘기면 그 값만 호출되고 신규 prop 이 없을 때만 구 prop 이 fallback 으로 호출됩니다.
-- 이 문서는 `grep -rn "@deprecated" src/ui --include=index.tsx` 로 코드에 실제 존재하는 deprecated prop 전체를 기준으로 작성했습니다 (React 컴포넌트 공개 prop 기준 - Vanilla JS 패키지는 별도).
+- React 컴포넌트 섹션은 `grep -rn "@deprecated" src/ui --include=index.tsx` 로 코드에 실제 존재하는 deprecated prop 전체를 기준으로 작성했습니다.
+- **Vanilla JS 패키지(`/vanilla`)는 deprecated 유예 없이 한 번에 정리**했습니다. 클래스 이름은 컴파일러가 잡아주지 않으므로 [v3.8.0 섹션](#v380-vanilla-패키지-정리)의 old → new 표와 치환 스크립트를 그대로 사용하세요.
 - 버전은 semver 내림차순으로 정렬되어 있습니다.
+
+---
+
+## v3.8.0 (Vanilla 패키지 정리)
+
+> ⚠️ **Vanilla 패키지(`@bigtablet/design-system/vanilla`, `dist/vanilla/*`)의 파괴적 변경입니다.**
+> React export 는 영향이 없습니다.
+
+Vanilla 번들의 클래스·JS API 이름이 React 컴포넌트 API 와 갈라져 있어, 같은 디자인 시스템인데도 두 벌의 이름을 외워야 했습니다. v3.8.0 에서 **구 이름을 별칭으로 남기지 않고 전부 제거**하고 React 쪽 이름으로 통일했습니다. 처음부터 React API 를 보고 설계한 것처럼 보이게 하는 것이 목표라, deprecated 별칭은 두지 않았습니다.
+
+**타입 검사가 잡아주지 않습니다.** 구 클래스를 쓰면 에러 없이 스타일만 조용히 사라지므로, 아래 표와 치환 스크립트로 마크업 전체를 한 번에 훑으세요.
+
+### 1. Button - variant 이름
+
+React `<Button variant>` 값과 동일하게 맞췄습니다.
+
+| 구 클래스 (제거됨) | 대체 |
+|---|---|
+| `.bt-button--primary` | `.bt-button--filled` |
+| `.bt-button--secondary` | `.bt-button--outline` |
+| `.bt-button--ghost` | `.bt-button--text` |
+
+`.bt-button--danger` 는 그대로입니다. React 의 `danger` boolean 처럼 variant 와 **직교**하므로 `--outline --danger` 같이 조합해 쓸 수 있고, variant 없이 단독으로 쓰면 React `<Button danger />`(기본 variant `filled`)와 같은 red filled 입니다.
+
+### 2. Button - 기본 radius 와 filled 채움색 (클래스 이름은 그대로, 렌더링이 바뀜)
+
+| 항목 | 구 동작 | 신 동작 (React 와 동일) |
+|---|---|---|
+| 기본 `border-radius` | `--bt-radius-md` (8px) | `--bt-radius-full` (pill) |
+| `--filled` 배경 | `--bt-color-primary` (양 테마 검정 고정) | `--bt-color-accent` (light 검정 / dark 흰색 자동 반전) |
+
+- **각진 버튼을 유지하려면** 새로 추가된 `.bt-button--radius-md` 를 명시하세요 (React `radius` prop 과 같은 `none/xs/sm/md/lg/xl/full` 스케일 전체 제공).
+- filled 색 변경은 **다크 테마에서만** 눈에 띕니다. 구 동작은 다크에서도 검정 채움이라 페이지 배경에 묻혔습니다. 양 테마 고정색이 꼭 필요하면 `--bt-color-primary` 를 직접 적용하세요.
+
+### 3. Card - elevation → shadow, 기본값 도입
+
+| 구 클래스 (제거됨) | 대체 |
+|---|---|
+| `.bt-card--elevation-1` | `.bt-card--shadow-sm` |
+| `.bt-card--elevation-2` | `.bt-card--shadow-md` |
+| `.bt-card--elevation-3` | `.bt-card--shadow-lg` |
+
+`.bt-card` 의 **기본값도 React `<Card>` 와 같아졌습니다** - shadow 클래스를 안 붙이면 `shadow=sm`, padding 클래스를 안 붙이면 `padding=md` 가 적용됩니다 (구 Vanilla 는 둘 다 없음). 그림자·여백이 없는 맨 카드가 필요하면 `.bt-card--shadow-none .bt-card--p-none` 을 명시하세요.
+
+React 의 `variant`(`accent` / `glass` / `outlined`)와 `interactive` 도 새로 추가됐습니다 (`.bt-card--accent` / `--glass` / `--outlined` / `--interactive`) - 추가라 마이그레이션은 불필요합니다.
+
+### 4. Select → Dropdown 전면 개명
+
+React 컴포넌트 이름이 `Dropdown` 이므로 블록 이름·data 속성·JS 팩토리를 모두 맞췄습니다. **CSS 만의 변경이 아니라 JS 런타임까지 걸쳐 있습니다.**
+
+| 구 이름 (제거됨) | 대체 |
+|---|---|
+| `.bt-select` | `.bt-dropdown` |
+| `.bt-select__label` | `.bt-dropdown__label` |
+| `.bt-select__control` | `.bt-dropdown__control` |
+| `.bt-select__control--outline` / `--filled` | `.bt-dropdown__control--outline` / `--filled` |
+| `.bt-select__control--sm` / `--md` / `--lg` | `.bt-dropdown__control--sm` / `--md` / `--lg` |
+| `.bt-select__value` | `.bt-dropdown__value` |
+| `.bt-select__placeholder` | `.bt-dropdown__placeholder` |
+| `.bt-select__icon` | `.bt-dropdown__icon` |
+| `.bt-select__list` | `.bt-dropdown__list` |
+| `.bt-select__list--up` | `.bt-dropdown__list--up` |
+| `.bt-select__option` | `.bt-dropdown__option` |
+| `data-bt-select` (자동 초기화 속성) | `data-bt-dropdown` |
+| `Bigtablet.Select(el, options)` | `Bigtablet.Dropdown(el, options)` |
+| `el._btSelect` (자동 초기화 인스턴스) | `el._btDropdown` |
+
+`.is-open` / `.is-selected` / `.is-active` / `.is-disabled` 상태 클래스와 인스턴스 API(`getValue` / `setValue` / `open` / `close` / `toggle` / `setDisabled` / `destroy`)는 그대로입니다.
+
+> **남은 격차**: React `Dropdown` 의 `multiple`(다중 선택)·`searchable`(검색 필터)은 Vanilla 에 아직 없습니다. 이름만 맞췄을 뿐 기능까지 동등하지는 않으니, 두 기능이 필요하면 React 쪽을 쓰세요.
+
+### 5. Spinner - size enum → px 커스텀 프로퍼티
+
+React `<Spinner size>` 는 enum 이 아니라 px 숫자(기본 24)를 받습니다. Vanilla 도 자유 스케일로 맞췄습니다.
+
+| 구 클래스 (제거됨) | 대체 |
+|---|---|
+| `.bt-spinner--sm` | `style="--bt-spinner-size: 16px"` |
+| `.bt-spinner--md` | (기본값 24px - 아무것도 안 붙이면 됨) |
+| `.bt-spinner--lg` | `style="--bt-spinner-size: 32px"` |
+| `.bt-spinner--xl` | `style="--bt-spinner-size: 48px"` |
+
+React `<Spinner>` 가 자동으로 붙이는 `role="status"` + `aria-label` 은 Vanilla 에선 마크업에서 직접 지정해야 합니다.
+
+### 6. JS 변경 콜백 - `onChange` 제거
+
+v3.3.0 에서 React 가 `on*Change` 패밀리로 통일된 것에 맞춰 Vanilla 도 canonical 이름만 남겼습니다. `onChange` 를 계속 넘기면 **조용히 무시**됩니다(에러 없음).
+
+| 팩토리 | 구 옵션 (제거됨) | 대체 |
+|---|---|---|
+| `Bigtablet.Dropdown` | `onChange(value, option)` | `onValueChange(value, option)` |
+| `Bigtablet.Toggle` | `onChange(checked)` | `onCheckedChange(checked)` |
+| `Bigtablet.Pagination` | `onChange(page)` | `onPageChange(page)` |
+
+### 7. Alert - 오버레이·Escape 닫힘이 `onCancel` 을 경유
+
+구 동작에서는 오버레이 클릭이나 Escape 로 닫으면 `onCancel` 이 호출되지 않아, 취소 정리 로직(롤백 등)이 조용히 우회됐습니다. React `Alert`(`dismiss = onCancel ?? onClose`)와 동일하게 두 경로 모두 `onCancel` 을 먼저 호출한 뒤 닫습니다 (WAI-ARIA APG alertdialog).
+
+- **영향**: `onCancel` 안에서 "취소 버튼을 눌렀다"고 가정하고 로그를 남기거나 카운트를 올리던 코드는 이제 오버레이/Escape 에서도 실행됩니다.
+- 오버레이 닫힘 자체를 막고 싶으면 `closeOnOverlay: false` 를 쓰세요.
+
+또한 `Bigtablet.Alert` 가 생성하는 확인/취소 버튼의 클래스가 `bt-button--primary` / `bt-button--secondary` → `bt-button--filled` / `bt-button--outline` 로 바뀝니다. 생성된 마크업의 클래스를 셀렉터로 잡아 스타일을 덮어쓰던 CSS 가 있다면 함께 수정하세요.
+
+### 치환 스크립트
+
+기계적으로 바꿀 수 있는 항목만 모았습니다. **순서대로** 실행하세요 (`bt-select` → `bt-dropdown` 을 먼저 돌려야 다른 규칙과 겹치지 않습니다).
+
+```bash
+# 대상 디렉터리로 이동 후 실행. 확장자는 프로젝트에 맞게 조정하세요.
+# macOS(BSD sed)는 -i '' , GNU sed 는 -i 를 사용합니다.
+FILES=$(grep -rl -E 'bt-select|bt-button--(primary|secondary|ghost)|bt-card--elevation|bt-spinner--|Bigtablet\.Select|_btSelect' \
+  --include='*.html' --include='*.jsp' --include='*.php' --include='*.js' --include='*.css' --include='*.scss' .)
+
+# 1) Select → Dropdown (클래스 / data 속성 / JS 팩토리 / 인스턴스 프로퍼티)
+sed -i '' -e 's/bt-select/bt-dropdown/g' \
+          -e 's/Bigtablet\.Select/Bigtablet.Dropdown/g' \
+          -e 's/_btSelect/_btDropdown/g' $FILES
+
+# 2) Button variant
+sed -i '' -e 's/bt-button--primary/bt-button--filled/g' \
+          -e 's/bt-button--secondary/bt-button--outline/g' \
+          -e 's/bt-button--ghost/bt-button--text/g' $FILES
+
+# 3) Card elevation → shadow
+sed -i '' -e 's/bt-card--elevation-1/bt-card--shadow-sm/g' \
+          -e 's/bt-card--elevation-2/bt-card--shadow-md/g' \
+          -e 's/bt-card--elevation-3/bt-card--shadow-lg/g' $FILES
+
+# 4) 확인 - 남은 구 이름이 없어야 합니다
+grep -rn -E 'bt-select|bt-button--(primary|secondary|ghost)|bt-card--elevation|bt-spinner--|Bigtablet\.Select|_btSelect|data-bt-select' . || echo "clean"
+```
+
+기계적으로 치환할 수 없어 **손으로 확인해야 하는 항목**:
+
+- `.bt-spinner--*` → `--bt-spinner-size` 인라인 스타일 (클래스 삭제 + `style` 추가라 1:1 치환 불가)
+- JS 옵션의 `onChange:` → `onValueChange:` / `onCheckedChange:` / `onPageChange:` (같은 이름이 다른 팩토리에서 다른 이름으로 바뀌므로 호출부별 판단 필요)
+- 각진 버튼을 유지할지(`.bt-button--radius-md` 추가) 아니면 pill 기본값을 받아들일지
+- 그림자·여백 없는 `.bt-card` 를 유지할지(`--shadow-none --p-none` 추가) 아니면 React 기본값을 받아들일지
+- `onCancel` 이 오버레이/Escape 에서도 불리게 된 것에 대한 영향
 
 ---
 

--- a/docs/VANILLA-PROMPT.md
+++ b/docs/VANILLA-PROMPT.md
@@ -21,15 +21,15 @@ JS: https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js
 - .is-{state} (상태)
 
 사용 가능한 컴포넌트:
-- Button: .bt-button --sm/md/lg --primary/secondary/ghost/danger
+- Button: .bt-button --sm/md/lg/xl --filled/tonal/outline/text (+ --danger 조합, --radius-* 기본 full)
 - TextField: .bt-text-field, .bt-text-field__input --outline/filled --sm/md/lg --error/success
 - Checkbox: .bt-checkbox --sm/md/lg
 - Radio: .bt-radio --sm/md/lg
 - Toggle: .bt-toggle --sm/md --on --disabled
-- Select: .bt-select, .bt-select__control --outline/filled --sm/md/lg
+- Dropdown: .bt-dropdown, .bt-dropdown__control --outline/filled --sm/md/lg
 - Modal: .bt-modal .is-open
-- Card: .bt-card --bordered --shadow-sm/md/lg --p-sm/md/lg
-- Spinner: .bt-spinner --sm/md/lg/xl
+- Card: .bt-card --bordered --shadow-none/sm/md/lg(기본 sm) --p-none/sm/md/lg(기본 md) --accent/glass/outlined --interactive
+- Spinner: .bt-spinner (크기는 --bt-spinner-size 커스텀 프로퍼티, 기본 24px)
 - Pagination: .bt-pagination
 - DatePicker: .bt-date-picker --full-width
 - FileInput: .bt-file-input --disabled
@@ -155,7 +155,7 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
 
 ### Button
 ```html
-<button class="bt-button bt-button--md bt-button--primary">버튼</button>
+<button class="bt-button bt-button--md bt-button--filled">버튼</button>
 ```
 
 ### TextField
@@ -194,15 +194,15 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
 </button>
 ```
 
-### Select
+### Dropdown
 ```html
-<div class="bt-select" data-bt-select>
-  <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-    <span class="bt-select__placeholder">선택...</span>
-    <span class="bt-select__icon">▼</span>
+<div class="bt-dropdown" data-bt-dropdown>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">선택...</span>
+    <span class="bt-dropdown__icon">▼</span>
   </button>
-  <ul class="bt-select__list">
-    <li class="bt-select__option" data-value="1">옵션 1</li>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="1">옵션 1</li>
   </ul>
 </div>
 ```
@@ -215,8 +215,8 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
     <div class="bt-modal__header">제목</div>
     <div class="bt-modal__body">내용</div>
     <div class="bt-modal__footer">
-      <button class="bt-button bt-button--md bt-button--secondary" data-modal-close>취소</button>
-      <button class="bt-button bt-button--md bt-button--primary" data-modal-close>확인</button>
+      <button class="bt-button bt-button--md bt-button--outline" data-modal-close>취소</button>
+      <button class="bt-button bt-button--md bt-button--filled" data-modal-close>확인</button>
     </div>
   </div>
 </div>
@@ -232,7 +232,8 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
 
 ### Spinner
 ```html
-<div class="bt-spinner bt-spinner--md"></div>
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
 ```
 
 ### Pagination

--- a/docs/VANILLA-PROMPT.md
+++ b/docs/VANILLA-PROMPT.md
@@ -25,7 +25,7 @@ JS: https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js
 - TextField: .bt-text-field, .bt-text-field__input --outline/filled --sm/md/lg --error/success
 - Checkbox: .bt-checkbox --sm/md/lg
 - Radio: .bt-radio --sm/md/lg
-- Toggle: .bt-toggle --sm/md --on --disabled
+- Toggle: .bt-toggle --sm/md --on (비활성화는 native disabled 속성)
 - Dropdown: .bt-dropdown, .bt-dropdown__control --outline/filled --sm/md/lg
 - Modal: .bt-modal .is-open
 - Card: .bt-card --bordered --shadow-none/sm/md/lg(기본 sm) --p-none/sm/md/lg(기본 md) --accent/glass/outlined --interactive

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -302,7 +302,7 @@ npm install @bigtablet/design-system
   const toggleEl = document.getElementById('my-toggle');
   const myToggle = Bigtablet.Toggle(toggleEl, {
     defaultChecked: false,
-    onChange: (checked) => {
+    onCheckedChange: (checked) => {
       console.log('Toggle:', checked);
     }
   });
@@ -401,7 +401,7 @@ npm install @bigtablet/design-system
       { value: 'banana', label: '바나나' },
       { value: 'mango', label: '망고', disabled: true },
     ],
-    onChange: (value, option) => {
+    onValueChange: (value, option) => {
       console.log('Selected:', value, option);
     }
   });
@@ -586,7 +586,7 @@ Alert는 JavaScript로만 사용합니다.
   const pagination = Bigtablet.Pagination(paginationEl, {
     page: 1,
     totalPages: 20,
-    onChange: (page) => {
+    onPageChange: (page) => {
       console.log('Page:', page);
       // 데이터 로드 등
     }
@@ -778,6 +778,17 @@ document.addEventListener('DOMContentLoaded', function() {
 // 전체 재초기화
 Bigtablet.init();
 ```
+
+### 콜백 이름 (React 와 동일)
+
+값 변경 콜백은 React 컴포넌트와 같은 이름을 사용합니다. 구 `onChange` 도 계속 동작하지만
+**deprecated** 이며 v4.0.0 에서 제거됩니다. 둘 다 주면 canonical 쪽만 호출됩니다.
+
+| 컴포넌트 | canonical | deprecated |
+|---|---|---|
+| `Bigtablet.Select` | `onValueChange(value, option)` | `onChange` |
+| `Bigtablet.Toggle` | `onCheckedChange(checked)` | `onChange` |
+| `Bigtablet.Pagination` | `onPageChange(page)` | `onChange` |
 
 ### 유틸리티
 

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -280,11 +280,8 @@ npm install @bigtablet/design-system
 <button type="button" class="bt-toggle bt-toggle--sm" data-bt-toggle>...</button>  <!-- 기본값 -->
 <button type="button" class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
 
-<!-- 비활성화 - native disabled 또는 --disabled 클래스 -->
+<!-- 비활성화 - React Toggle 과 동일하게 native disabled 속성을 쓴다 -->
 <button type="button" class="bt-toggle" data-bt-toggle disabled>
-  <span class="bt-toggle__thumb"></span>
-</button>
-<button type="button" class="bt-toggle bt-toggle--disabled" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 ```
@@ -397,8 +394,11 @@ React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
 
 ```html
 <script>
-  const dropdownEl = document.querySelector('[data-bt-dropdown]');
-  const myDropdown = Bigtablet.Dropdown(dropdownEl, {
+  // 옵션을 직접 넘겨 수동 초기화할 때는 `data-bt-dropdown` 을 붙이지 않는다.
+  // 그 속성이 있으면 DOMContentLoaded 에 자동 초기화되어 인스턴스가 두 개 생기고
+  // (각각 리스너·상태를 갖는다) 클릭 처리와 상태 동기화가 어긋난다.
+  // 자동 초기화된 요소를 다루려면 새로 만들지 말고 `el._btDropdown` 을 재사용할 것.
+  const myDropdown = Bigtablet.Dropdown('#fruit-dropdown', {
     placeholder: '선택하세요',
     options: [
       { value: 'apple', label: '사과' },
@@ -606,8 +606,9 @@ React `<Spinner size>` 가 px 숫자를 그대로 받는 것과 맞춰, 크기�
 
 ```html
 <script>
-  const paginationEl = document.querySelector('[data-bt-pagination]');
-  const pagination = Bigtablet.Pagination(paginationEl, {
+  // Dropdown 과 마찬가지로, 수동 초기화 대상에는 `data-bt-pagination` 을 붙이지 않는다
+  // (붙이면 자동 초기화와 인스턴스가 겹친다).
+  const pagination = Bigtablet.Pagination('#article-pagination', {
     page: 1,
     totalPages: 20,
     onPageChange: (page) => {

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -85,7 +85,7 @@ npm install @bigtablet/design-system
   <div style="padding: 2rem;">
     <h1>Hello Bigtablet</h1>
 
-    <button class="bt-button bt-button--md bt-button--primary">
+    <button class="bt-button bt-button--md bt-button--filled">
       버튼
     </button>
 
@@ -111,31 +111,47 @@ npm install @bigtablet/design-system
 
 ```html
 <!-- 기본 -->
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 
-<!-- Variants -->
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
-<button class="bt-button bt-button--md bt-button--secondary">Secondary</button>
-<button class="bt-button bt-button--md bt-button--ghost">Ghost</button>
-<button class="bt-button bt-button--md bt-button--danger">Danger</button>
+<!-- Variants (React <Button variant> 와 동일) -->
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
+<button class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+<button class="bt-button bt-button--md bt-button--outline">Outline</button>
+<button class="bt-button bt-button--md bt-button--text">Text</button>
+
+<!-- danger 는 variant 와 직교하는 modifier (React <Button danger /> 와 동일) -->
+<button class="bt-button bt-button--md bt-button--filled bt-button--danger">Delete</button>
+<button class="bt-button bt-button--md bt-button--outline bt-button--danger">Delete</button>
+<button class="bt-button bt-button--md bt-button--danger">Delete</button> <!-- variant 생략 시 filled -->
 
 <!-- Sizes -->
-<button class="bt-button bt-button--sm bt-button--primary">Small</button>
-<button class="bt-button bt-button--md bt-button--primary">Medium</button>
-<button class="bt-button bt-button--lg bt-button--primary">Large</button>
+<button class="bt-button bt-button--sm bt-button--filled">Small</button>
+<button class="bt-button bt-button--md bt-button--filled">Medium</button>
+<button class="bt-button bt-button--lg bt-button--filled">Large</button>
+<button class="bt-button bt-button--xl bt-button--filled">XLarge</button>
 
 <!-- 전체 너비 -->
-<button class="bt-button bt-button--md bt-button--primary bt-button--full-width">전체 너비</button>
+<button class="bt-button bt-button--md bt-button--filled bt-button--full-width">전체 너비</button>
 
 <!-- 비활성화 -->
-<button class="bt-button bt-button--md bt-button--primary" disabled>Disabled</button>
+<button class="bt-button bt-button--md bt-button--filled" disabled>Disabled</button>
 ```
 
 **클래스 조합:**
 - `.bt-button` (필수)
-- `.bt-button--{size}`: `sm`, `md`, `lg`
-- `.bt-button--{variant}`: `primary`, `secondary`, `ghost`, `danger`
+- `.bt-button--{size}`: `sm`, `md`, `lg`, `xl`
+- `.bt-button--{variant}`: `filled`, `tonal`, `outline`, `text`
+- `.bt-button--danger` (선택) - variant 와 함께 조합
 - `.bt-button--full-width` (선택)
+
+> **Deprecated 별칭** - 구 variant 이름은 계속 동작하지만 **v4.0.0 에서 제거**됩니다.
+> 새 마크업에는 오른쪽 이름을 사용하세요.
+>
+> | 구 이름 (deprecated) | 대체 |
+> |---|---|
+> | `.bt-button--primary` | `.bt-button--filled` |
+> | `.bt-button--secondary` | `.bt-button--outline` |
+> | `.bt-button--ghost` | `.bt-button--text` |
 
 ---
 
@@ -259,11 +275,14 @@ npm install @bigtablet/design-system
   <span class="bt-toggle__thumb"></span>
 </button>
 
-<!-- Sizes -->
-<button type="button" class="bt-toggle" data-bt-toggle>...</button>  <!-- 기본 sm -->
+<!-- Sizes (React ToggleSize 와 동일) -->
+<button type="button" class="bt-toggle bt-toggle--sm" data-bt-toggle>...</button>  <!-- 기본값 -->
 <button type="button" class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
 
-<!-- 비활성화 -->
+<!-- 비활성화 - native disabled 또는 --disabled 클래스 -->
+<button type="button" class="bt-toggle" data-bt-toggle disabled>
+  <span class="bt-toggle__thumb"></span>
+</button>
 <button type="button" class="bt-toggle bt-toggle--disabled" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
@@ -402,7 +421,7 @@ npm install @bigtablet/design-system
 
 ```html
 <!-- 트리거 버튼 -->
-<button class="bt-button bt-button--md bt-button--primary" data-bt-modal-open="my-modal">
+<button class="bt-button bt-button--md bt-button--filled" data-bt-modal-open="my-modal">
   모달 열기
 </button>
 
@@ -418,8 +437,8 @@ npm install @bigtablet/design-system
       <p>여러 줄의 콘텐츠도 가능합니다.</p>
     </div>
     <div class="bt-modal__footer">
-      <button class="bt-button bt-button--md bt-button--secondary" data-modal-close>취소</button>
-      <button class="bt-button bt-button--md bt-button--primary" data-modal-close>확인</button>
+      <button class="bt-button bt-button--md bt-button--outline" data-modal-close>취소</button>
+      <button class="bt-button bt-button--md bt-button--filled" data-modal-close>확인</button>
     </div>
   </div>
 </div>
@@ -452,7 +471,7 @@ npm install @bigtablet/design-system
 Alert는 JavaScript로만 사용합니다.
 
 ```html
-<button class="bt-button bt-button--md bt-button--primary" onclick="showAlert()">
+<button class="bt-button bt-button--md bt-button--filled" onclick="showAlert()">
   알림 표시
 </button>
 
@@ -497,7 +516,9 @@ Alert는 JavaScript로만 사용합니다.
 | `confirmText` | `string` | `'확인'` | 확인 버튼 텍스트 |
 | `cancelText` | `string` | `'취소'` | 취소 버튼 텍스트 |
 | `showCancel` | `boolean` | `false` | 취소 버튼 표시 |
+| `destructive` | `boolean` | `false` | 확인 버튼을 danger(빨강)로 강조 (React `AlertOptions.destructive` 와 동일) |
 | `actionsAlign` | `string` | `'right'` | 버튼 정렬 |
+| `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭으로 닫기 허용 (React `AlertOptions.closeOnOverlay` 와 동일) |
 | `onConfirm` | `function` | - | 확인 콜백 |
 | `onCancel` | `function` | - | 취소 콜백 |
 
@@ -512,16 +533,29 @@ Alert는 JavaScript로만 사용합니다.
   <p>카드 내용입니다.</p>
 </div>
 
-<!-- Shadow -->
+<!-- Shadow (React Card shadow prop 과 동일) -->
+<div class="bt-card bt-card--shadow-none bt-card--p-md">내용</div>
 <div class="bt-card bt-card--shadow-sm bt-card--p-md">내용</div>
 <div class="bt-card bt-card--shadow-md bt-card--p-md">내용</div>
 <div class="bt-card bt-card--shadow-lg bt-card--p-md">내용</div>
 
-<!-- Padding -->
+<!-- Padding (React Card padding prop 과 동일) -->
+<div class="bt-card bt-card--bordered bt-card--p-none">No padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-sm">Small padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-md">Medium padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-lg">Large padding</div>
 ```
+
+> **Deprecated 별칭** - **v4.0.0 에서 제거** 예정.
+>
+> | 구 이름 (deprecated) | 대체 |
+> |---|---|
+> | `.bt-card--elevation-1` | `.bt-card--shadow-sm` |
+> | `.bt-card--elevation-2` | `.bt-card--shadow-md` |
+> | `.bt-card--elevation-3` | `.bt-card--shadow-lg` |
+>
+> React `Card` 는 `shadow` 기본값이 `sm` 이지만, Vanilla `.bt-card` 는 기존 동작대로
+> shadow 클래스를 붙이지 않으면 그림자가 없습니다.
 
 ---
 
@@ -640,6 +674,7 @@ Alert는 JavaScript로만 사용합니다.
   /* Colors */
   --bt-color-primary: #000000;
   --bt-color-primary-hover: #333333;
+  --bt-color-primary-container: rgba(0, 0, 0, 0.05);  /* .bt-button--tonal 채움색 */
   --bt-color-background: #ffffff;
   --bt-color-background-secondary: #fafafa;
   --bt-color-text-primary: #1a1a1a;
@@ -797,7 +832,7 @@ cleanup();  // 리스너 제거
     </div>
 
     <!-- Button -->
-    <button type="submit" class="bt-button bt-button--md bt-button--primary">
+    <button type="submit" class="bt-button bt-button--md bt-button--filled">
       제출
     </button>
   </form>

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -15,7 +15,7 @@ React 없이 순수 HTML/CSS/JS 환경에서 사용하는 가이드입니다.
   - [Checkbox](#checkbox)
   - [Radio](#radio)
   - [Toggle](#toggle)
-  - [Select](#select)
+  - [Dropdown](#dropdown)
   - [Modal](#modal)
   - [Alert](#alert)
   - [Card](#card)
@@ -142,16 +142,17 @@ npm install @bigtablet/design-system
 - `.bt-button--{size}`: `sm`, `md`, `lg`, `xl`
 - `.bt-button--{variant}`: `filled`, `tonal`, `outline`, `text`
 - `.bt-button--danger` (선택) - variant 와 함께 조합
+- `.bt-button--radius-{none|xs|sm|md|lg|xl|full}` (선택) - React `radius` prop 과 동일. 기본값은 `full`(pill)
 - `.bt-button--full-width` (선택)
 
-> **Deprecated 별칭** - 구 variant 이름은 계속 동작하지만 **v4.0.0 에서 제거**됩니다.
-> 새 마크업에는 오른쪽 이름을 사용하세요.
->
-> | 구 이름 (deprecated) | 대체 |
-> |---|---|
-> | `.bt-button--primary` | `.bt-button--filled` |
-> | `.bt-button--secondary` | `.bt-button--outline` |
-> | `.bt-button--ghost` | `.bt-button--text` |
+```html
+<!-- radius 는 기본이 pill - 사각형에 가깝게 하려면 modifier 로 -->
+<button class="bt-button bt-button--md bt-button--filled bt-button--radius-md">Radius md</button>
+```
+
+> `--filled` 는 React `variant="filled"` 와 동일하게 accent 색을 씁니다 - 라이트에선 검정,
+> 다크에선 흰색으로 자동 반전되어 다크 테마에서 버튼이 배경에 묻히지 않습니다.
+> 양 테마 고정색이 필요하면 `--bt-color-primary` 를 직접 적용하세요.
 
 ---
 
@@ -341,25 +342,28 @@ npm install @bigtablet/design-system
 
 ---
 
-### Select
+### Dropdown
+
+React `<Dropdown>` 의 Vanilla 대응입니다. 단일 선택 전용이며,
+React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
 
 ```html
-<div class="bt-select" data-bt-select style="width: 300px;">
-  <label class="bt-select__label">과일 선택</label>
-  <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-    <span class="bt-select__placeholder">선택하세요...</span>
-    <span class="bt-select__icon">
+<div class="bt-dropdown" data-bt-dropdown style="width: 300px;">
+  <label class="bt-dropdown__label">과일 선택</label>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">선택하세요...</span>
+    <span class="bt-dropdown__icon">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M6 9l6 6 6-6"/>
       </svg>
     </span>
   </button>
-  <ul class="bt-select__list">
-    <li class="bt-select__option" data-value="apple">사과</li>
-    <li class="bt-select__option" data-value="banana">바나나</li>
-    <li class="bt-select__option" data-value="cherry">체리</li>
-    <li class="bt-select__option is-disabled" data-value="mango">망고 (품절)</li>
-    <li class="bt-select__option" data-value="orange">오렌지</li>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="apple">사과</li>
+    <li class="bt-dropdown__option" data-value="banana">바나나</li>
+    <li class="bt-dropdown__option" data-value="cherry">체리</li>
+    <li class="bt-dropdown__option is-disabled" data-value="mango">망고 (품절)</li>
+    <li class="bt-dropdown__option" data-value="orange">오렌지</li>
   </ul>
 </div>
 ```
@@ -370,31 +374,31 @@ npm install @bigtablet/design-system
 **폼 제출 참여 (Thymeleaf/JSP):**
 
 `data-name` 을 지정하면 hidden input 이 생성되어 선택 값이 폼 POST 에 포함됩니다.
-서버 템플릿이 `.bt-select` 안에 hidden input 을 미리 렌더링해 두면 (예: `th:field`)
+서버 템플릿이 `.bt-dropdown` 안에 hidden input 을 미리 렌더링해 두면 (예: `th:field`)
 그 input 의 name/초기값을 그대로 이어받아 표시·동기화합니다.
 
 ```html
-<div class="bt-select" data-bt-select data-name="fruit">
+<div class="bt-dropdown" data-bt-dropdown data-name="fruit">
   <!-- 또는 서버 바인딩: <input type="hidden" th:field="*{fruit}"> -->
   ...
 </div>
 ```
 
 **Variants:**
-- `.bt-select__control--outline` (기본)
-- `.bt-select__control--filled`
+- `.bt-dropdown__control--outline` (기본) - React `Dropdown` 과 동등한 스타일
+- `.bt-dropdown__control--filled` - Vanilla 전용 (React `Dropdown` 에는 대응 prop 없음)
 
 **Sizes:**
-- `.bt-select__control--sm`
-- `.bt-select__control--md`
-- `.bt-select__control--lg`
+- `.bt-dropdown__control--sm`
+- `.bt-dropdown__control--md`
+- `.bt-dropdown__control--lg`
 
 **JavaScript 연동:**
 
 ```html
 <script>
-  const selectEl = document.querySelector('[data-bt-select]');
-  const mySelect = Bigtablet.Select(selectEl, {
+  const dropdownEl = document.querySelector('[data-bt-dropdown]');
+  const myDropdown = Bigtablet.Dropdown(dropdownEl, {
     placeholder: '선택하세요',
     options: [
       { value: 'apple', label: '사과' },
@@ -407,11 +411,11 @@ npm install @bigtablet/design-system
   });
 
   // API
-  mySelect.getValue();       // 현재 값
-  mySelect.setValue('apple'); // 값 설정
-  mySelect.open();           // 드롭다운 열기
-  mySelect.close();          // 드롭다운 닫기
-  mySelect.setDisabled(true); // 비활성화
+  myDropdown.getValue();       // 현재 값
+  myDropdown.setValue('apple'); // 값 설정
+  myDropdown.open();           // 드롭다운 열기
+  myDropdown.close();          // 드롭다운 닫기
+  myDropdown.setDisabled(true); // 비활성화
 </script>
 ```
 
@@ -544,29 +548,49 @@ Alert는 JavaScript로만 사용합니다.
 <div class="bt-card bt-card--bordered bt-card--p-sm">Small padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-md">Medium padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-lg">Large padding</div>
+
+<!-- Variant (React Card variant prop 과 동일) -->
+<div class="bt-card bt-card--accent bt-card--p-md">Accent</div>
+<div class="bt-card bt-card--outlined bt-card--p-md">Outlined (shadow 무시)</div>
+<div class="bt-card bt-card--glass bt-card--p-md">Glass (컬러/이미지 배경 위에서)</div>
+
+<!-- interactive - hover 시 살짝 떠오름 (React interactive prop) -->
+<div class="bt-card bt-card--interactive bt-card--p-md">클릭 가능한 카드</div>
 ```
 
-> **Deprecated 별칭** - **v4.0.0 에서 제거** 예정.
->
-> | 구 이름 (deprecated) | 대체 |
-> |---|---|
-> | `.bt-card--elevation-1` | `.bt-card--shadow-sm` |
-> | `.bt-card--elevation-2` | `.bt-card--shadow-md` |
-> | `.bt-card--elevation-3` | `.bt-card--shadow-lg` |
->
-> React `Card` 는 `shadow` 기본값이 `sm` 이지만, Vanilla `.bt-card` 는 기존 동작대로
-> shadow 클래스를 붙이지 않으면 그림자가 없습니다.
+**클래스 조합:**
+- `.bt-card` (필수) - 기본값은 React 와 동일하게 `shadow=sm` / `padding=md`
+- `.bt-card--shadow-{none|sm|md|lg}` (선택)
+- `.bt-card--p-{none|sm|md|lg}` (선택)
+- `.bt-card--bordered` (선택)
+- `.bt-card--{accent|outlined|glass}` (선택) - variant. 미지정 시 `default`
+- `.bt-card--interactive` (선택)
+
+> `.bt-card` 는 클래스를 하나도 더 붙이지 않아도 React `<Card>` 기본값과 같은
+> 그림자(sm)·여백(md)을 갖습니다. 없애려면 `--shadow-none` / `--p-none` 을 명시하세요.
 
 ---
 
 ### Spinner
 
+React `<Spinner size>` 가 px 숫자를 그대로 받는 것과 맞춰, 크기는 size enum 클래스가 아니라
+`--bt-spinner-size` CSS 커스텀 프로퍼티로 지정합니다. 기본값은 React 와 같은 **24px** 입니다.
+
 ```html
-<div class="bt-spinner bt-spinner--sm"></div>  <!-- 16px -->
-<div class="bt-spinner bt-spinner--md"></div>  <!-- 24px -->
-<div class="bt-spinner bt-spinner--lg"></div>  <!-- 32px -->
-<div class="bt-spinner bt-spinner--xl"></div>  <!-- 48px -->
+<!-- 기본 24px -->
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
+
+<!-- 임의 크기 -->
+<span class="bt-spinner" style="--bt-spinner-size: 16px" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 48px" role="status" aria-label="Loading"></span>
 ```
+
+> `role="status"` + `aria-label` 을 직접 붙이세요 - React `<Spinner>` 는 이 둘을 자동으로
+> 렌더링하지만 Vanilla 는 CSS 만 제공하므로 마크업에서 지정해야 스크린리더에 로딩 상태가 전달됩니다.
+>
+> 회전 모양은 React 와 다릅니다 - React 는 12개 bar 가 페이드하는 iOS 스타일이고
+> Vanilla 는 단일 border spinner 입니다 (CSS 만으로 동일 렌더 불가 - 의도된 차이).
 
 ---
 
@@ -701,10 +725,14 @@ Alert는 JavaScript로만 사용합니다.
   --bt-font-size-md: 1rem;
   --bt-font-size-lg: 1.125rem;
 
-  /* Radius */
+  /* Radius (React `radius` prop 스케일과 동일) */
+  --bt-radius-none: 0px;
+  --bt-radius-xs: 4px;
   --bt-radius-sm: 6px;
   --bt-radius-md: 8px;
   --bt-radius-lg: 12px;
+  --bt-radius-xl: 16px;
+  --bt-radius-full: 9999px;
 
   /* Elevation (구 --bt-shadow-* 는 존재하지 않음) */
   --bt-elevation-1: var(--bt-elevation-level1);
@@ -748,7 +776,7 @@ Alert는 JavaScript로만 사용합니다.
 `data-bt-*` 속성이 있는 요소는 페이지 로드 시 자동으로 초기화됩니다.
 
 ```html
-<div data-bt-select>...</div>     <!-- Select 자동 초기화 -->
+<div data-bt-dropdown>...</div>   <!-- Dropdown 자동 초기화 -->
 <div data-bt-modal>...</div>      <!-- Modal 자동 초기화 -->
 <button data-bt-toggle>...</button> <!-- Toggle 자동 초기화 -->
 <nav data-bt-pagination>...</nav> <!-- Pagination 자동 초기화 -->
@@ -759,8 +787,8 @@ Alert는 JavaScript로만 사용합니다.
 ```javascript
 // 페이지 로드 후 수동 초기화
 document.addEventListener('DOMContentLoaded', function() {
-  // Select
-  const select = Bigtablet.Select('#my-select', options);
+  // Dropdown
+  const dropdown = Bigtablet.Dropdown('#my-dropdown', options);
 
   // Modal
   const modal = Bigtablet.Modal('#my-modal', options);
@@ -781,14 +809,14 @@ Bigtablet.init();
 
 ### 콜백 이름 (React 와 동일)
 
-값 변경 콜백은 React 컴포넌트와 같은 이름을 사용합니다. 구 `onChange` 도 계속 동작하지만
-**deprecated** 이며 v4.0.0 에서 제거됩니다. 둘 다 주면 canonical 쪽만 호출됩니다.
+값 변경 콜백은 React 컴포넌트와 같은 이름을 사용합니다. 구 `onChange` 는 **더 이상 호출되지
+않습니다** (v3.8.0 제거 - [마이그레이션 가이드](./MIGRATION.md#v380-vanilla-패키지-정리) 참고).
 
-| 컴포넌트 | canonical | deprecated |
-|---|---|---|
-| `Bigtablet.Select` | `onValueChange(value, option)` | `onChange` |
-| `Bigtablet.Toggle` | `onCheckedChange(checked)` | `onChange` |
-| `Bigtablet.Pagination` | `onPageChange(page)` | `onChange` |
+| 컴포넌트 | 콜백 |
+|---|---|
+| `Bigtablet.Dropdown` | `onValueChange(value, option)` |
+| `Bigtablet.Toggle` | `onCheckedChange(checked)` |
+| `Bigtablet.Pagination` | `onPageChange(page)` |
 
 ### 유틸리티
 

--- a/src/stories/getting-started/installation.stories.tsx
+++ b/src/stories/getting-started/installation.stories.tsx
@@ -101,7 +101,7 @@ export const Vanilla: Story = {
 						description="BEM-like 클래스 네이밍. data-bt-* 속성으로 컴포넌트 식별."
 						lang="html"
 						code={`<!-- 버튼 -->
-<button class="bt-button bt-button--md bt-button--primary">
+<button class="bt-button bt-button--md bt-button--filled">
   저장
 </button>
 
@@ -119,13 +119,13 @@ export const Vanilla: Story = {
 						description="data-bt-* 속성 가진 요소는 DOMContentLoaded 에 자동 동작. 수동 init 도 가능."
 						lang="html"
 						code={`<!-- 자동 -->
-<div class="bt-select" data-bt-select>...</div>
+<div class="bt-dropdown" data-bt-dropdown>...</div>
 <div class="bt-modal" data-bt-modal>...</div>
 
 <!-- 수동 -->
 <script>
-  const select = Bigtablet.Select('#my-select', {
-    onChange: (value) => console.log(value)
+  const dropdown = Bigtablet.Dropdown('#my-dropdown', {
+    onValueChange: (value) => console.log(value)
   });
 </script>`}
 					/>

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -834,7 +834,8 @@
 		}
 
 		function toggle() {
-			if (!config.disabled && !toggleEl.classList.contains("bt-toggle--disabled")) {
+			// React Toggle 과 동일하게 native `disabled` 만 본다 (구 --disabled 클래스는 v3.8.0 에서 제거).
+			if (!config.disabled && !toggleEl.disabled) {
 				setChecked(!state.checked);
 			}
 		}
@@ -860,7 +861,7 @@
 			toggle,
 			setDisabled: (disabled) => {
 				config.disabled = disabled;
-				toggleEl.classList.toggle("bt-toggle--disabled", disabled);
+				toggleEl.disabled = disabled;
 			},
 			destroy: () => cleanup(),
 		};

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -116,6 +116,8 @@
 		const config = {
 			placeholder: "Select...",
 			disabled: false,
+			// React Dropdown 과 동일하게 onValueChange 가 canonical, onChange 는 @deprecated 별칭.
+			onValueChange: null,
 			onChange: null,
 			...options,
 		};
@@ -229,8 +231,9 @@
 				el.setAttribute("aria-selected", selected ? "true" : "false");
 			});
 
-			if (config.onChange) {
-				config.onChange(newValue, option);
+			const emit = config.onValueChange ?? config.onChange;
+			if (emit) {
+				emit(newValue, option);
 			}
 		}
 
@@ -766,6 +769,8 @@
 		const config = {
 			defaultChecked: false,
 			disabled: false,
+			// React Toggle 과 동일하게 onCheckedChange 가 canonical, onChange 는 @deprecated 별칭.
+			onCheckedChange: null,
 			onChange: null,
 			...options,
 		};
@@ -815,8 +820,9 @@
 				hiddenInput.value = checked ? "true" : "false";
 			}
 
-			if (config.onChange) {
-				config.onChange(checked);
+			const emit = config.onCheckedChange ?? config.onChange;
+			if (emit) {
+				emit(checked);
 			}
 		}
 
@@ -870,6 +876,8 @@
 			page: 1,
 			totalPages: 1,
 			sibling: 2,
+			// React Pagination 과 동일하게 onPageChange 가 canonical, onChange 는 @deprecated 별칭.
+			onPageChange: null,
 			onChange: null,
 			...options,
 		};
@@ -971,8 +979,9 @@
 			config.page = page;
 			render();
 
-			if (config.onChange) {
-				config.onChange(page);
+			const emit = config.onPageChange ?? config.onChange;
+			if (emit) {
+				emit(page);
 			}
 		}
 

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -101,24 +101,25 @@
 	}
 
 	/* ========================================
-     Select Component
+     Dropdown Component
      ======================================== */
 
 	/**
-	 * Initialize Select component
-	 * @param {HTMLElement|string} element - Select wrapper element or selector
+	 * Initialize Dropdown component (React `<Dropdown>` 의 Vanilla 대응)
+	 *
+	 * React 의 `multiple` / `searchable` 은 아직 지원하지 않는다 - 단일 선택 전용.
+	 * @param {HTMLElement|string} element - Dropdown wrapper element or selector
 	 * @param {Object} options - Configuration options
 	 */
-	function Select(element, options = {}) {
+	function Dropdown(element, options = {}) {
 		const wrapper = typeof element === "string" ? $(element) : element;
 		if (!wrapper) return null;
 
 		const config = {
 			placeholder: "Select...",
 			disabled: false,
-			// React Dropdown 과 동일하게 onValueChange 가 canonical, onChange 는 @deprecated 별칭.
+			// React Dropdown 과 동일한 값 변경 콜백.
 			onValueChange: null,
-			onChange: null,
 			...options,
 		};
 
@@ -130,14 +131,16 @@
 		};
 
 		// Create DOM structure
-		const controlId = wrapper.id || generateId("select");
+		const controlId = wrapper.id || generateId("dropdown");
 		const _listId = `${controlId}_listbox`;
 
-		const control = wrapper.querySelector(".bt-select__control");
-		const list = wrapper.querySelector(".bt-select__list");
+		const control = wrapper.querySelector(".bt-dropdown__control");
+		const list = wrapper.querySelector(".bt-dropdown__list");
 
 		if (!control || !list) {
-			console.warn("Select: Missing required elements (.bt-select__control, .bt-select__list)");
+			console.warn(
+				"Dropdown: Missing required elements (.bt-dropdown__control, .bt-dropdown__list)",
+			);
 			return null;
 		}
 
@@ -146,7 +149,7 @@
 		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
 		// data-options 는 잘못된 JSON(작은따옴표 등)이면 스크립트 전체가 크래시하므로 방어적 파싱.
 		const parseDomOptions = () =>
-			$$(".bt-select__option", list).map((el) => ({
+			$$(".bt-dropdown__option", list).map((el) => ({
 				value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
 				label: el.textContent.trim(),
 				disabled: el.classList.contains("is-disabled"),
@@ -159,9 +162,9 @@
 			try {
 				const parsed = JSON.parse(wrapper.dataset.options);
 				if (Array.isArray(parsed)) optionsData = parsed;
-				else console.warn("Select: data-options is not a JSON array");
+				else console.warn("Dropdown: data-options is not a JSON array");
 			} catch (e) {
-				console.warn("Select: invalid JSON in data-options", e);
+				console.warn("Dropdown: invalid JSON in data-options", e);
 			}
 		}
 		if (optionsData === undefined) {
@@ -179,7 +182,7 @@
 		control.setAttribute("aria-haspopup", "listbox");
 		control.setAttribute("aria-expanded", "false");
 		control.setAttribute("aria-controls", list.id);
-		$$(".bt-select__option", list).forEach((el, i) => {
+		$$(".bt-dropdown__option", list).forEach((el, i) => {
 			el.id = el.id || `${controlId}_option_${i}`;
 			el.setAttribute("role", "option");
 			el.setAttribute("aria-selected", "false");
@@ -210,30 +213,29 @@
 				hiddenInput.value = newValue == null ? "" : newValue;
 			}
 
-			const valueEl = control.querySelector(".bt-select__value, .bt-select__placeholder");
+			const valueEl = control.querySelector(".bt-dropdown__value, .bt-dropdown__placeholder");
 			if (valueEl) {
 				if (option) {
 					valueEl.textContent = option.label;
-					valueEl.classList.remove("bt-select__placeholder");
-					valueEl.classList.add("bt-select__value");
+					valueEl.classList.remove("bt-dropdown__placeholder");
+					valueEl.classList.add("bt-dropdown__value");
 				} else {
 					valueEl.textContent = config.placeholder;
-					valueEl.classList.remove("bt-select__value");
-					valueEl.classList.add("bt-select__placeholder");
+					valueEl.classList.remove("bt-dropdown__value");
+					valueEl.classList.add("bt-dropdown__placeholder");
 				}
 			}
 
 			// Update selected state in list
-			$$(".bt-select__option", list).forEach((el, i) => {
+			$$(".bt-dropdown__option", list).forEach((el, i) => {
 				// String 비교(#374: 숫자 value vs 문자열 hidden 초기값) + aria-selected(#379: AT 노출)
 				const selected = String(state.options[i]?.value) === String(newValue);
 				el.classList.toggle("is-selected", selected);
 				el.setAttribute("aria-selected", selected ? "true" : "false");
 			});
 
-			const emit = config.onValueChange ?? config.onChange;
-			if (emit) {
-				emit(newValue, option);
+			if (config.onValueChange) {
+				config.onValueChange(newValue, option);
 			}
 		}
 
@@ -252,9 +254,9 @@
 			const spaceAbove = rect.top;
 
 			if (spaceBelow < listHeight && spaceAbove > spaceBelow) {
-				list.classList.add("bt-select__list--up");
+				list.classList.add("bt-dropdown__list--up");
 			} else {
-				list.classList.remove("bt-select__list--up");
+				list.classList.remove("bt-dropdown__list--up");
 			}
 
 			// Set active index
@@ -263,7 +265,7 @@
 			updateActiveOption();
 
 			// Rotate icon
-			const icon = control.querySelector(".bt-select__icon");
+			const icon = control.querySelector(".bt-dropdown__icon");
 			if (icon) icon.classList.add("is-open");
 		}
 
@@ -274,7 +276,7 @@
 			control.removeAttribute("aria-activedescendant");
 			list.style.display = "none";
 
-			const icon = control.querySelector(".bt-select__icon");
+			const icon = control.querySelector(".bt-dropdown__icon");
 			if (icon) icon.classList.remove("is-open");
 		}
 
@@ -288,7 +290,7 @@
 
 		function updateActiveOption() {
 			let activeId = null;
-			$$(".bt-select__option", list).forEach((el, i) => {
+			$$(".bt-dropdown__option", list).forEach((el, i) => {
 				const active = i === state.activeIndex;
 				el.classList.toggle("is-active", active);
 				if (active) activeId = el.id;
@@ -416,7 +418,7 @@
 			on(document, "mousedown", onDocumentClick),
 		];
 
-		$$(".bt-select__option", list).forEach((el, i) => {
+		$$(".bt-dropdown__option", list).forEach((el, i) => {
 			cleanups.push(on(el, "click", onOptionClick(i)));
 			cleanups.push(on(el, "mouseenter", onOptionMouseEnter(i)));
 		});
@@ -601,10 +603,8 @@
      ======================================== */
 
 	// React Alert 와 동일한 버튼 variant (confirm=filled / cancel=outline).
-	// canonical 이름과 함께 구 이름(--primary / --secondary)도 붙여 둔다 - 생성된 마크업의
-	// 클래스를 기준으로 스타일을 덮어쓰던 소비자 CSS 가 깨지지 않도록. 구 이름은 v4.0.0 에서 제거.
-	const CONFIRM_BUTTON_VARIANT = "bt-button--filled bt-button--primary";
-	const CANCEL_BUTTON_VARIANT = "bt-button--outline bt-button--secondary";
+	const CONFIRM_BUTTON_VARIANT = "bt-button--filled";
+	const CANCEL_BUTTON_VARIANT = "bt-button--outline";
 
 	/**
 	 * Show Alert dialog
@@ -697,6 +697,15 @@
 			}, 200);
 		}
 
+		// 오버레이 클릭 / Escape 는 "취소"와 동등한 동작이어야 한다 (WAI-ARIA APG alertdialog).
+		// React Alert 의 `dismiss = onCancel ?? onClose` 와 동일하게 onCancel 경로로 보내
+		// 소비자의 취소 정리 로직(롤백 등)이 조용히 우회되지 않게 한다.
+		function dismiss() {
+			if (!isOpen) return;
+			if (config.onCancel) config.onCancel();
+			close();
+		}
+
 		// Event handlers
 		const confirmBtn = overlay.querySelector("[data-alert-confirm]");
 		const cancelBtn = overlay.querySelector("[data-alert-cancel]");
@@ -718,14 +727,14 @@
 		// Close on overlay click (React Alert 와 동일하게 closeOnOverlay 로 끌 수 있다)
 		overlay.addEventListener("click", (e) => {
 			if (config.closeOnOverlay && e.target === overlay) {
-				close();
+				dismiss();
 			}
 		});
 
 		// Close on Escape + Tab 포커스 트랩 (WAI-ARIA APG Dialog) - Modal 과 동일 패턴
 		function onKeyDown(e) {
 			if (e.key === "Escape") {
-				close();
+				dismiss();
 				return;
 			}
 			if (e.key === "Tab" && alertPanel) {
@@ -769,9 +778,8 @@
 		const config = {
 			defaultChecked: false,
 			disabled: false,
-			// React Toggle 과 동일하게 onCheckedChange 가 canonical, onChange 는 @deprecated 별칭.
+			// React Toggle 과 동일한 체크 변경 콜백.
 			onCheckedChange: null,
-			onChange: null,
 			...options,
 		};
 
@@ -820,9 +828,8 @@
 				hiddenInput.value = checked ? "true" : "false";
 			}
 
-			const emit = config.onCheckedChange ?? config.onChange;
-			if (emit) {
-				emit(checked);
+			if (config.onCheckedChange) {
+				config.onCheckedChange(checked);
 			}
 		}
 
@@ -876,9 +883,8 @@
 			page: 1,
 			totalPages: 1,
 			sibling: 2,
-			// React Pagination 과 동일하게 onPageChange 가 canonical, onChange 는 @deprecated 별칭.
+			// React Pagination 과 동일한 페이지 변경 콜백.
 			onPageChange: null,
-			onChange: null,
 			...options,
 		};
 
@@ -979,9 +985,8 @@
 			config.page = page;
 			render();
 
-			const emit = config.onPageChange ?? config.onChange;
-			if (emit) {
-				emit(page);
+			if (config.onPageChange) {
+				config.onPageChange(page);
 			}
 		}
 
@@ -1012,10 +1017,10 @@
 	 * Auto-initialize all components with data-bt attribute
 	 */
 	function init() {
-		// Select
-		$$("[data-bt-select]").forEach((el) => {
-			if (!el._btSelect) {
-				el._btSelect = Select(el);
+		// Dropdown
+		$$("[data-bt-dropdown]").forEach((el) => {
+			if (!el._btDropdown) {
+				el._btDropdown = Dropdown(el);
 			}
 		});
 
@@ -1069,7 +1074,7 @@
 
 	return {
 		// Components
-		Select,
+		Dropdown,
 		Modal,
 		Alert,
 		Toggle,

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -597,6 +597,12 @@
      Alert Component
      ======================================== */
 
+	// React Alert 와 동일한 버튼 variant (confirm=filled / cancel=outline).
+	// canonical 이름과 함께 구 이름(--primary / --secondary)도 붙여 둔다 - 생성된 마크업의
+	// 클래스를 기준으로 스타일을 덮어쓰던 소비자 CSS 가 깨지지 않도록. 구 이름은 v4.0.0 에서 제거.
+	const CONFIRM_BUTTON_VARIANT = "bt-button--filled bt-button--primary";
+	const CANCEL_BUTTON_VARIANT = "bt-button--outline bt-button--secondary";
+
 	/**
 	 * Show Alert dialog
 	 * @param {Object} options - Alert configuration
@@ -609,7 +615,11 @@
 			confirmText: "확인",
 			cancelText: "취소",
 			showCancel: false,
+			// React AlertOptions.destructive 와 동일 - true 면 확인 버튼이 danger(빨강)로 강조된다.
+			destructive: false,
 			actionsAlign: "right", // left, center, right
+			// React AlertOptions.closeOnOverlay 와 동일 - false 면 오버레이 클릭으로 닫히지 않는다.
+			closeOnOverlay: true,
 			onConfirm: null,
 			onCancel: null,
 			...options,
@@ -632,10 +642,12 @@
 				}">
           ${
 						config.showCancel
-							? `<button class="bt-button bt-button--md bt-button--secondary" data-alert-cancel>${escapeHtml(config.cancelText)}</button>`
+							? `<button class="bt-button bt-button--md ${CANCEL_BUTTON_VARIANT}" data-alert-cancel>${escapeHtml(config.cancelText)}</button>`
 							: ""
 					}
-          <button class="bt-button bt-button--md bt-button--primary" data-alert-confirm>${escapeHtml(config.confirmText)}</button>
+          <button class="bt-button bt-button--md ${CONFIRM_BUTTON_VARIANT}${
+						config.destructive ? " bt-button--danger" : ""
+					}" data-alert-confirm>${escapeHtml(config.confirmText)}</button>
         </div>
       </div>
     `;
@@ -700,9 +712,9 @@
 			});
 		}
 
-		// Close on overlay click
+		// Close on overlay click (React Alert 와 동일하게 closeOnOverlay 로 끌 수 있다)
 		overlay.addEventListener("click", (e) => {
-			if (e.target === overlay) {
+			if (config.closeOnOverlay && e.target === overlay) {
 				close();
 			}
 		});

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -25,6 +25,9 @@
   /* Colors - Accent (light=검정/dark=흰 자동 반전 - indicator/checked/focus 강조) */
   --bt-color-accent: #{token.$color_accent_default};
 
+  /* Colors - Primary container (React Button variant="tonal" 의 채움색) */
+  --bt-color-primary-container: #{token.$color_brand_primary_container};
+
   /* Colors - Background */
   --bt-color-background: #{token.$color_bg_solid};
   --bt-color-background-dim: #{token.$color_bg_solid_dim};
@@ -130,7 +133,15 @@
 
 /* ========================================
    Button
-   ======================================== */
+   ========================================
+   variant 이름은 React `<Button variant>` 와 동일한 filled / tonal / outline / text 가 정식이다.
+   구 이름은 @deprecated 별칭으로 계속 동작하며 v4.0.0 에서 제거 예정:
+     --primary   → --filled
+     --secondary → --outline
+     --ghost     → --text
+   danger 는 React 의 `danger` boolean 처럼 variant 와 직교(orthogonal)한 modifier 다.
+   `--danger` 단독은 기존과 동일하게 red filled 로 렌더링되고, variant 클래스와 함께 쓰면
+   해당 variant 의 red 표현(outline=빨간 테두리, tonal=빨간 wash, text=빨간 텍스트)이 된다. */
 .bt-button {
   display: inline-flex;
   align-items: center;
@@ -151,7 +162,7 @@
     opacity: 0.6;
   }
 
-  /* Sizes */
+  /* Sizes - React ButtonSize(sm/md/lg/xl) 와 동일 */
   &--sm {
     padding: var(--bt-spacing-sm) var(--bt-spacing-lg);
     font-size: var(--bt-font-size-sm);
@@ -167,7 +178,14 @@
     font-size: var(--bt-font-size-md);
   }
 
+  &--xl {
+    padding: var(--bt-spacing-xl) var(--bt-spacing-3xl);
+    font-size: var(--bt-font-size-lg);
+  }
+
   /* Variants */
+  /* --primary 는 @deprecated 별칭 (→ --filled, v4.0.0 제거 예정) */
+  &--filled,
   &--primary {
     background: var(--bt-color-primary);
     color: var(--bt-color-background);
@@ -181,6 +199,22 @@
     }
   }
 
+  /* React Button variant="tonal" - 구 Vanilla 에는 없던 variant */
+  &--tonal {
+    background: var(--bt-color-primary-container);
+    color: var(--bt-color-text-primary);
+
+    &:hover:not(:disabled) {
+      background: var(--bt-color-pressed);
+    }
+
+    &:active:not(:disabled) {
+      transform: scale(0.98);
+    }
+  }
+
+  /* --secondary 는 @deprecated 별칭 (→ --outline, v4.0.0 제거 예정) */
+  &--outline,
   &--secondary {
     background: transparent;
     border: 1px solid var(--bt-color-border);
@@ -195,6 +229,8 @@
     }
   }
 
+  /* --ghost 는 @deprecated 별칭 (→ --text, v4.0.0 제거 예정) */
+  &--text,
   &--ghost {
     background: transparent;
     color: var(--bt-color-text-primary);
@@ -208,6 +244,7 @@
     }
   }
 
+  /* --danger 단독 = React `<Button variant="filled" danger />` (하위 호환 유지) */
   &--danger {
     background: var(--bt-color-error);
     color: var(--bt-color-background);
@@ -223,6 +260,38 @@
 
   &--full-width {
     width: 100%;
+  }
+}
+
+/* danger × variant - React 의 `variant` + `danger` 조합과 동일한 렌더링.
+   클래스 2개라 단독 `--danger`(클래스 1개)보다 우선순위가 높다. */
+.bt-button--danger.bt-button--outline,
+.bt-button--danger.bt-button--secondary {
+  background: transparent;
+  border-color: var(--bt-color-error);
+  color: var(--bt-color-error);
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--bt-color-error) 8%, transparent);
+  }
+}
+
+.bt-button--danger.bt-button--tonal {
+  background: color-mix(in srgb, var(--bt-color-error) 12%, transparent);
+  color: var(--bt-color-error);
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--bt-color-error) 18%, transparent);
+  }
+}
+
+.bt-button--danger.bt-button--text,
+.bt-button--danger.bt-button--ghost {
+  background: transparent;
+  color: var(--bt-color-error);
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--bt-color-error) 8%, transparent);
   }
 }
 
@@ -275,7 +344,8 @@
       opacity: 0.7;
     }
 
-    /* Variants */
+    /* Variants - React TextField 에는 variant prop 이 없고 outline 스타일만 있다.
+       --outline 이 React 와 동등한 기본값이고, --filled 는 Vanilla 전용이다. */
     &--outline {
       border: 1px solid var(--bt-color-border);
 
@@ -586,7 +656,13 @@
     }
   }
 
-  /* Sizes */
+  /* Sizes - React ToggleSize(sm/md) 와 동일. sm 은 기본값이라 클래스 없이도 같게 렌더링되지만,
+     React 의 `size="sm"` 를 그대로 옮겨 적을 수 있도록 명시적 클래스를 제공한다. */
+  &--sm {
+    width: 40px;
+    height: 24px;
+  }
+
   &--md {
     width: 48px;
     height: 28px;
@@ -603,7 +679,10 @@
     }
   }
 
-  &--disabled {
+  /* React Toggle 은 native `disabled` 를 쓰는 <button> 이라 :disabled 도 함께 받는다.
+     (--disabled 는 JS 가 토글하는 기존 클래스 - 계속 지원) */
+  &--disabled,
+  &:disabled {
     cursor: not-allowed;
     background: var(--bt-color-border-light);
 
@@ -657,7 +736,8 @@
       color: var(--bt-color-text-tertiary);
     }
 
-    /* Variants */
+    /* Variants - React Dropdown 은 variant prop 을 @deprecated 처리하고 outline 만 쓴다.
+       --outline 이 React 와 동등한 기본값이고, --filled 는 Vanilla 전용이다. */
     &--outline {
       border: 1px solid var(--bt-color-border);
 
@@ -945,10 +1025,21 @@
     border: 1px solid var(--bt-color-border);
   }
 
+  /* Shadow - React Card `shadow` prop(none/sm/md/lg) 과 이름·토큰이 동일한 쪽이 정식.
+     --elevation-1/2/3 은 @deprecated 별칭 (v4.0.0 제거 예정). */
+  &--shadow-none { box-shadow: none; }
+
+  &--shadow-sm,
   &--elevation-1 { box-shadow: var(--bt-elevation-1); }
+
+  &--shadow-md,
   &--elevation-2 { box-shadow: var(--bt-elevation-2); }
+
+  &--shadow-lg,
   &--elevation-3 { box-shadow: var(--bt-elevation-3); }
 
+  /* Padding - React Card `padding` prop(none/sm/md/lg) 과 동일 */
+  &--p-none { padding: 0; }
   &--p-sm { padding: var(--bt-spacing-sm); }
   &--p-md { padding: var(--bt-spacing-lg); }
   &--p-lg { padding: var(--bt-spacing-2xl); }

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -18,11 +18,11 @@
    CSS Custom Properties (Design Tokens)
    ======================================== */
 :root {
-  /* Colors - Brand (양 테마 검정/흰 고정 - Button --primary 등 의도된 다크 fill) */
+  /* Colors - Brand (양 테마 검정/흰 고정 - 의도적으로 반전되지 않아야 하는 표면용) */
   --bt-color-primary: #{token.$color_brand_primary};
   --bt-color-on-primary: #{token.$color_brand_on_primary};
 
-  /* Colors - Accent (light=검정/dark=흰 자동 반전 - indicator/checked/focus 강조) */
+  /* Colors - Accent (light=검정/dark=흰 자동 반전 - Button --filled / indicator / checked / focus) */
   --bt-color-accent: #{token.$color_accent_default};
 
   /* Colors - Primary container (React Button variant="tonal" 의 채움색) */
@@ -108,10 +108,13 @@
   --bt-font-size-xl:   var(--bt-font-size-20);
   --bt-line-height-normal: 1.5;
 
-  /* Radius */
+  /* Radius - React `radius` prop 스케일과 동일 */
+  --bt-radius-none: #{token.$radius_none};
+  --bt-radius-xs: #{token.$radius_xs};
   --bt-radius-sm: #{token.$radius_sm};
   --bt-radius-md: #{token.$radius_md};
   --bt-radius-lg: #{token.$radius_lg};
+  --bt-radius-xl: #{token.$radius_xl};
   --bt-radius-full: #{token.$radius_full};
 
   /* Elevation */
@@ -134,20 +137,18 @@
 /* ========================================
    Button
    ========================================
-   variant 이름은 React `<Button variant>` 와 동일한 filled / tonal / outline / text 가 정식이다.
-   구 이름은 @deprecated 별칭으로 계속 동작하며 v4.0.0 에서 제거 예정:
-     --primary   → --filled
-     --secondary → --outline
-     --ghost     → --text
+   variant 는 React `<Button variant>` 와 동일한 filled / tonal / outline / text 4종.
    danger 는 React 의 `danger` boolean 처럼 variant 와 직교(orthogonal)한 modifier 다.
-   `--danger` 단독은 기존과 동일하게 red filled 로 렌더링되고, variant 클래스와 함께 쓰면
-   해당 variant 의 red 표현(outline=빨간 테두리, tonal=빨간 wash, text=빨간 텍스트)이 된다. */
+   `--danger` 단독은 React `<Button danger />`(variant 기본값 filled)와 같이 red filled 이고,
+   variant 클래스와 함께 쓰면 해당 variant 의 red 표현(outline=빨간 테두리, tonal=빨간 wash,
+   text=빨간 텍스트)이 된다.
+   기본 radius 는 React `radius` 기본값과 동일한 full(pill) - `--radius-*` 로 덮어쓴다. */
 .bt-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--bt-spacing-sm);
-  border-radius: var(--bt-radius-md);
+  border-radius: var(--bt-radius-full);
   border: none;
   cursor: pointer;
   font-family: var(--bt-font-family);
@@ -184,14 +185,15 @@
   }
 
   /* Variants */
-  /* --primary 는 @deprecated 별칭 (→ --filled, v4.0.0 제거 예정) */
-  &--filled,
-  &--primary {
-    background: var(--bt-color-primary);
-    color: var(--bt-color-background);
+  /* React `variant="filled"` 와 동일하게 accent 계열을 쓴다 - light 는 검정(brand 와 같은 값),
+     dark 는 흰색으로 자동 반전되어 다크 테마에서 채움이 페이지 배경에 묻히지 않는다.
+     (구 Vanilla 는 양 테마 고정인 --bt-color-primary 를 써서 다크에서 React 와 갈라졌다.) */
+  &--filled {
+    background: var(--bt-color-accent);
+    color: var(--bt-color-accent-on-surface);
 
     &:hover:not(:disabled) {
-      background: var(--bt-color-primary-hover);
+      background: color-mix(in srgb, var(--bt-color-accent) 88%, var(--bt-color-accent-on-surface));
     }
 
     &:active:not(:disabled) {
@@ -199,7 +201,7 @@
     }
   }
 
-  /* React Button variant="tonal" - 구 Vanilla 에는 없던 variant */
+  /* React Button variant="tonal" */
   &--tonal {
     background: var(--bt-color-primary-container);
     color: var(--bt-color-text-primary);
@@ -213,9 +215,7 @@
     }
   }
 
-  /* --secondary 는 @deprecated 별칭 (→ --outline, v4.0.0 제거 예정) */
-  &--outline,
-  &--secondary {
+  &--outline {
     background: transparent;
     border: 1px solid var(--bt-color-border);
     color: var(--bt-color-text-primary);
@@ -229,9 +229,7 @@
     }
   }
 
-  /* --ghost 는 @deprecated 별칭 (→ --text, v4.0.0 제거 예정) */
-  &--text,
-  &--ghost {
+  &--text {
     background: transparent;
     color: var(--bt-color-text-primary);
 
@@ -244,19 +242,28 @@
     }
   }
 
-  /* --danger 단독 = React `<Button variant="filled" danger />` (하위 호환 유지) */
+  /* --danger 단독 = React `<Button danger />` (variant 기본값 filled) */
   &--danger {
     background: var(--bt-color-error);
-    color: var(--bt-color-background);
+    color: var(--bt-color-on-primary);
 
     &:hover:not(:disabled) {
-      background: color-mix(in srgb, var(--bt-color-error) 92%, #000);
+      background: color-mix(in srgb, var(--bt-color-error) 88%, #000);
     }
 
     &:active:not(:disabled) {
       transform: scale(0.98);
     }
   }
+
+  /* Radius overrides - React `radius` prop 과 동일 (기본값 full) */
+  &--radius-none { border-radius: var(--bt-radius-none); }
+  &--radius-xs   { border-radius: var(--bt-radius-xs); }
+  &--radius-sm   { border-radius: var(--bt-radius-sm); }
+  &--radius-md   { border-radius: var(--bt-radius-md); }
+  &--radius-lg   { border-radius: var(--bt-radius-lg); }
+  &--radius-xl   { border-radius: var(--bt-radius-xl); }
+  &--radius-full { border-radius: var(--bt-radius-full); }
 
   &--full-width {
     width: 100%;
@@ -265,8 +272,7 @@
 
 /* danger × variant - React 의 `variant` + `danger` 조합과 동일한 렌더링.
    클래스 2개라 단독 `--danger`(클래스 1개)보다 우선순위가 높다. */
-.bt-button--danger.bt-button--outline,
-.bt-button--danger.bt-button--secondary {
+.bt-button--danger.bt-button--outline {
   background: transparent;
   border-color: var(--bt-color-error);
   color: var(--bt-color-error);
@@ -285,8 +291,7 @@
   }
 }
 
-.bt-button--danger.bt-button--text,
-.bt-button--danger.bt-button--ghost {
+.bt-button--danger.bt-button--text {
   background: transparent;
   color: var(--bt-color-error);
 
@@ -693,9 +698,11 @@
 }
 
 /* ========================================
-   Select
-   ======================================== */
-.bt-select {
+   Dropdown
+   ========================================
+   React `<Dropdown>` 과 같은 블록 이름을 쓴다 (구 Vanilla 이름은 Select 였다).
+   React 의 `multiple` / `searchable` 은 Vanilla 에 아직 없다 - 단일 선택 전용. */
+.bt-dropdown {
   position: relative;
   display: inline-flex;
   flex-direction: column;
@@ -1016,33 +1023,82 @@
 
 /* ========================================
    Card
-   ======================================== */
+   ========================================
+   React `<Card>` 는 shadow / padding / bordered(조합형)와 variant(enum)를 모두 노출한다.
+   Vanilla 도 같은 모델을 그대로 따른다 - shadow·padding·bordered 는 서로 직교하는 modifier 고,
+   variant(accent / glass / outlined)는 그 위에 얹는 표면 스타일이다(기본 = default).
+   기본값도 React 와 동일하게 shadow=sm / padding=md - 끄려면 --shadow-none / --p-none. */
 .bt-card {
   background: var(--bt-color-background);
   border-radius: var(--bt-radius-lg);
+  box-shadow: var(--bt-elevation-1);
+  padding: var(--bt-spacing-lg);
+  transition: transform var(--bt-transition-base),
+              box-shadow var(--bt-transition-base);
 
   &--bordered {
     border: 1px solid var(--bt-color-border);
   }
 
-  /* Shadow - React Card `shadow` prop(none/sm/md/lg) 과 이름·토큰이 동일한 쪽이 정식.
-     --elevation-1/2/3 은 @deprecated 별칭 (v4.0.0 제거 예정). */
+  /* Shadow - React Card `shadow` prop(none/sm/md/lg) 과 동일 (기본값 sm) */
   &--shadow-none { box-shadow: none; }
+  &--shadow-sm { box-shadow: var(--bt-elevation-1); }
+  &--shadow-md { box-shadow: var(--bt-elevation-2); }
+  &--shadow-lg { box-shadow: var(--bt-elevation-3); }
 
-  &--shadow-sm,
-  &--elevation-1 { box-shadow: var(--bt-elevation-1); }
-
-  &--shadow-md,
-  &--elevation-2 { box-shadow: var(--bt-elevation-2); }
-
-  &--shadow-lg,
-  &--elevation-3 { box-shadow: var(--bt-elevation-3); }
-
-  /* Padding - React Card `padding` prop(none/sm/md/lg) 과 동일 */
+  /* Padding - React Card `padding` prop(none/sm/md/lg) 과 동일 (기본값 md) */
   &--p-none { padding: 0; }
   &--p-sm { padding: var(--bt-spacing-sm); }
   &--p-md { padding: var(--bt-spacing-lg); }
   &--p-lg { padding: var(--bt-spacing-2xl); }
+
+  /* Variant: accent - 반전 배경 + 대비 텍스트 (React card_variant_accent) */
+  &--accent {
+    background: var(--bt-color-accent);
+    color: var(--bt-color-accent-on-surface);
+
+    .bt-card__title {
+      color: var(--bt-color-accent-on-surface);
+    }
+  }
+
+  /* Variant: outlined - 투명 배경 + 테두리만, shadow 무시 (React card_variant_outlined) */
+  &--outlined {
+    background: transparent;
+    border: 1px solid var(--bt-color-border);
+    box-shadow: none;
+  }
+
+  /* Variant: glass - 반투명 frosted + backdrop blur (React card_variant_glass).
+     컬러/이미지 배경 위에서 쓴다. 흰 텍스트로 가독성 확보. */
+  &--glass {
+    @include token.glass_dark;
+    color: var(--bt-color-on-primary);
+
+    .bt-card__title {
+      color: var(--bt-color-on-primary);
+    }
+
+    /* 다크 표면 위에서는 밝은 frosted 로 뒤집는다 (React 와 동일) */
+    [data-theme="dark"] & {
+      @include token.glass_card;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme]) & {
+        @include token.glass_card;
+      }
+    }
+  }
+
+  /* React `interactive` prop - hover 시 살짝 떠오른다 */
+  &--interactive {
+    cursor: pointer;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--bt-elevation-2);
+    }
+  }
 
   &__title {
     font-size: var(--bt-font-size-xl);
@@ -1060,18 +1116,18 @@
   to { transform: rotate(360deg); }
 }
 
+/* React `<Spinner size>` 는 px 숫자를 그대로 받는 자유 스케일이라(기본 24) Vanilla 도
+   size enum 대신 --bt-spinner-size 커스텀 프로퍼티로 임의 px 을 받는다.
+   예) <span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span> */
 .bt-spinner {
   display: inline-block;
   box-sizing: border-box;
+  width: var(--bt-spinner-size, 24px);
+  height: var(--bt-spinner-size, 24px);
   border-radius: 50%;
   border: 2px solid var(--bt-color-border);
   border-top-color: var(--bt-color-accent);
   animation: bt-spinner-spin 0.8s linear infinite;
-
-  &--sm { width: 16px; height: 16px; }
-  &--md { width: 24px; height: 24px; }
-  &--lg { width: 32px; height: 32px; }
-  &--xl { width: 48px; height: 48px; }
 }
 
 /* ========================================
@@ -1313,7 +1369,7 @@
    Reduced Motion (WCAG 2.1 SC 2.3.3)
    ======================================== */
 /* 이 번들은 컴포넌트별 파일이 아닌 단일 플랫 스타일시트라 마지막에 한 블록으로 모아 처리한다.
-   Button / TextField / Checkbox / Radio / Toggle / Select / Modal / Pagination /
+   Button / TextField / Checkbox / Radio / Toggle / Dropdown / Card / Modal / Pagination /
    DatePicker / FileInput 의 transition 은 전부 --bt-transition-* 를 경유하므로,
    선택자를 나열하는 대신 토큰 자체를 0s 로 눌러 일괄 무효화한다.
    (이후 추가되는 규칙과, 같은 var 를 쓰는 소비자 커스텀 스타일까지 자동으로 커버된다.) */
@@ -1330,6 +1386,12 @@
   .bt-alert__overlay,
   .bt-alert__modal {
     animation: none;
+  }
+
+  /* Card --interactive 의 hover lift 는 transform 이라 토큰 무효화만으로는 안 사라진다
+     (transition 만 사라지고 이동은 즉시 일어남) - React Card 와 동일하게 아예 끈다. */
+  .bt-card--interactive:hover {
+    transform: none;
   }
 
   /* Spinner 는 끄지 않는다 - 회전 자체가 "로딩 중"이라는 상태 정보라

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -202,15 +202,19 @@
   }
 
   /* React Button variant="tonal" */
+  /* state 토큰(--bt-color-hover/pressed)은 반투명 alpha 라 background 를 교체하면 컨테이너 색이
+     사라진다. React 는 ::before 오버레이로 겹치는데 여기엔 그 레이어가 없으므로,
+     background-image 로 같은 알파를 컨테이너 위에 덧칠해 동일한 결과를 낸다. */
   &--tonal {
     background: var(--bt-color-primary-container);
     color: var(--bt-color-text-primary);
 
     &:hover:not(:disabled) {
-      background: var(--bt-color-pressed);
+      background-image: linear-gradient(var(--bt-color-hover), var(--bt-color-hover));
     }
 
     &:active:not(:disabled) {
+      background-image: linear-gradient(var(--bt-color-pressed), var(--bt-color-pressed));
       transform: scale(0.98);
     }
   }
@@ -684,9 +688,8 @@
     }
   }
 
-  /* React Toggle 은 native `disabled` 를 쓰는 <button> 이라 :disabled 도 함께 받는다.
-     (--disabled 는 JS 가 토글하는 기존 클래스 - 계속 지원) */
-  &--disabled,
+  /* React Toggle 과 동일하게 native `disabled` 속성만 지원한다.
+     (구 `--disabled` 클래스는 v3.8.0 에서 제거 - docs/MIGRATION.md 참고) */
   &:disabled {
     cursor: not-allowed;
     background: var(--bt-color-border-light);

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -94,24 +94,36 @@
     <div class="section">
       <h2>Button</h2>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary">Primary</button>
-        <button type="button" class="bt-button bt-button--md bt-button--secondary">Secondary</button>
-        <button type="button" class="bt-button bt-button--md bt-button--ghost">Ghost</button>
-        <button type="button" class="bt-button bt-button--md bt-button--danger">Danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled">Filled</button>
+        <button type="button" class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+        <button type="button" class="bt-button bt-button--md bt-button--outline">Outline</button>
+        <button type="button" class="bt-button bt-button--md bt-button--text">Text</button>
       </div>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--sm bt-button--primary">Small</button>
-        <button type="button" class="bt-button bt-button--md bt-button--primary">Medium</button>
-        <button type="button" class="bt-button bt-button--lg bt-button--primary">Large</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled bt-button--danger">Filled danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--tonal bt-button--danger">Tonal danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--outline bt-button--danger">Outline danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--text bt-button--danger">Text danger</button>
       </div>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary" disabled>Disabled</button>
+        <button type="button" class="bt-button bt-button--sm bt-button--filled">Small</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled">Medium</button>
+        <button type="button" class="bt-button bt-button--lg bt-button--filled">Large</button>
+        <button type="button" class="bt-button bt-button--xl bt-button--filled">XLarge</button>
+      </div>
+      <div class="demo-row">
+        <button type="button" class="bt-button bt-button--md bt-button--filled" disabled>Disabled</button>
       </div>
 
-      <pre><code>&lt;button class="bt-button bt-button--md bt-button--primary"&gt;Primary&lt;/button&gt;
-&lt;button class="bt-button bt-button--md bt-button--secondary"&gt;Secondary&lt;/button&gt;
-&lt;button class="bt-button bt-button--md bt-button--ghost"&gt;Ghost&lt;/button&gt;
-&lt;button class="bt-button bt-button--md bt-button--danger"&gt;Danger&lt;/button&gt;</code></pre>
+      <pre><code>&lt;button class="bt-button bt-button--md bt-button--filled"&gt;Filled&lt;/button&gt;
+&lt;button class="bt-button bt-button--md bt-button--tonal"&gt;Tonal&lt;/button&gt;
+&lt;button class="bt-button bt-button--md bt-button--outline"&gt;Outline&lt;/button&gt;
+&lt;button class="bt-button bt-button--md bt-button--text"&gt;Text&lt;/button&gt;
+
+&lt;!-- danger 는 variant 와 직교 --&gt;
+&lt;button class="bt-button bt-button--md bt-button--outline bt-button--danger"&gt;Delete&lt;/button&gt;
+
+&lt;!-- 구 이름(--primary / --secondary / --ghost)도 계속 동작하지만 deprecated 입니다 --&gt;</code></pre>
     </div>
 
     <!-- TextField -->
@@ -288,7 +300,7 @@
           <div class="bt-card__title">Card Title</div>
           <p>This is a card component with bordered style and medium padding.</p>
         </div>
-        <div class="bt-card bt-card--elevation-2 bt-card--p-md" style="width: 300px;">
+        <div class="bt-card bt-card--shadow-md bt-card--p-md" style="width: 300px;">
           <div class="bt-card__title">Shadow Card</div>
           <p>This card uses shadow instead of border.</p>
         </div>
@@ -338,7 +350,7 @@ const pagination = Bigtablet.Pagination('#my-pagination', {
     <div class="section">
       <h2>Modal</h2>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary" data-bt-modal-open="demo-modal">
+        <button type="button" class="bt-button bt-button--md bt-button--filled" data-bt-modal-open="demo-modal">
           Open Modal
         </button>
       </div>
@@ -350,8 +362,8 @@ const pagination = Bigtablet.Pagination('#my-pagination', {
             <p>This is the modal content. You can put any HTML here.</p>
           </div>
           <div class="bt-modal__footer">
-            <button type="button" class="bt-button bt-button--md bt-button--secondary" data-modal-close>Cancel</button>
-            <button type="button" class="bt-button bt-button--md bt-button--primary" data-modal-close>Confirm</button>
+            <button type="button" class="bt-button bt-button--md bt-button--outline" data-modal-close>Cancel</button>
+            <button type="button" class="bt-button bt-button--md bt-button--filled" data-modal-close>Confirm</button>
           </div>
         </div>
       </div>
@@ -373,8 +385,8 @@ const pagination = Bigtablet.Pagination('#my-pagination', {
     <div class="section">
       <h2>Alert (JavaScript)</h2>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary" onclick="showInfoAlert()">Info Alert</button>
-        <button type="button" class="bt-button bt-button--md bt-button--secondary" onclick="showConfirmAlert()">Confirm Alert</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled" onclick="showInfoAlert()">Info Alert</button>
+        <button type="button" class="bt-button bt-button--md bt-button--outline" onclick="showConfirmAlert()">Confirm Alert</button>
         <button type="button" class="bt-button bt-button--md bt-button--danger" onclick="showErrorAlert()">Error Alert</button>
       </div>
 

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -255,39 +255,39 @@
 &lt;/button&gt;</code></pre>
     </div>
 
-    <!-- Select -->
+    <!-- Dropdown -->
     <div class="section">
-      <h2>Select</h2>
+      <h2>Dropdown</h2>
       <div class="demo-row">
-        <div class="bt-select" data-bt-select style="width: 300px;">
-          <label class="bt-select__label">Select Option</label>
-          <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-            <span class="bt-select__placeholder">Select...</span>
-            <span class="bt-select__icon">
+        <div class="bt-dropdown" data-bt-dropdown style="width: 300px;">
+          <label class="bt-dropdown__label">Select Option</label>
+          <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+            <span class="bt-dropdown__placeholder">Select...</span>
+            <span class="bt-dropdown__icon">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M6 9l6 6 6-6"/>
               </svg>
             </span>
           </button>
-          <ul class="bt-select__list" style="display: none;">
-            <li class="bt-select__option" data-value="apple">Apple</li>
-            <li class="bt-select__option" data-value="banana">Banana</li>
-            <li class="bt-select__option" data-value="cherry">Cherry</li>
-            <li class="bt-select__option is-disabled" data-value="disabled">Disabled Option</li>
-            <li class="bt-select__option" data-value="elderberry">Elderberry</li>
+          <ul class="bt-dropdown__list" style="display: none;">
+            <li class="bt-dropdown__option" data-value="apple">Apple</li>
+            <li class="bt-dropdown__option" data-value="banana">Banana</li>
+            <li class="bt-dropdown__option" data-value="cherry">Cherry</li>
+            <li class="bt-dropdown__option is-disabled" data-value="disabled">Disabled Option</li>
+            <li class="bt-dropdown__option" data-value="elderberry">Elderberry</li>
           </ul>
         </div>
       </div>
 
-      <pre><code>&lt;div class="bt-select" data-bt-select&gt;
-  &lt;label class="bt-select__label"&gt;Select Option&lt;/label&gt;
-  &lt;button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md"&gt;
-    &lt;span class="bt-select__placeholder"&gt;Select...&lt;/span&gt;
-    &lt;span class="bt-select__icon"&gt;▼&lt;/span&gt;
+      <pre><code>&lt;div class="bt-dropdown" data-bt-dropdown&gt;
+  &lt;label class="bt-dropdown__label"&gt;Select Option&lt;/label&gt;
+  &lt;button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md"&gt;
+    &lt;span class="bt-dropdown__placeholder"&gt;Select...&lt;/span&gt;
+    &lt;span class="bt-dropdown__icon"&gt;▼&lt;/span&gt;
   &lt;/button&gt;
-  &lt;ul class="bt-select__list"&gt;
-    &lt;li class="bt-select__option" data-value="apple"&gt;Apple&lt;/li&gt;
-    &lt;li class="bt-select__option" data-value="banana"&gt;Banana&lt;/li&gt;
+  &lt;ul class="bt-dropdown__list"&gt;
+    &lt;li class="bt-dropdown__option" data-value="apple"&gt;Apple&lt;/li&gt;
+    &lt;li class="bt-dropdown__option" data-value="banana"&gt;Banana&lt;/li&gt;
   &lt;/ul&gt;
 &lt;/div&gt;</code></pre>
     </div>
@@ -316,13 +316,17 @@
     <div class="section">
       <h2>Spinner</h2>
       <div class="demo-row">
-        <div class="bt-spinner bt-spinner--sm"></div>
-        <div class="bt-spinner bt-spinner--md"></div>
-        <div class="bt-spinner bt-spinner--lg"></div>
-        <div class="bt-spinner bt-spinner--xl"></div>
+        <div class="bt-spinner" style="--bt-spinner-size: 16px" role="status" aria-label="Loading"></div>
+        <div class="bt-spinner" role="status" aria-label="Loading"></div>
+        <div class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></div>
+        <div class="bt-spinner" style="--bt-spinner-size: 48px" role="status" aria-label="Loading"></div>
       </div>
 
-      <pre><code>&lt;div class="bt-spinner bt-spinner--md"&gt;&lt;/div&gt;</code></pre>
+      <pre><code>&lt;!-- 기본 24px (React &lt;Spinner /&gt; 기본값) --&gt;
+&lt;span class="bt-spinner" role="status" aria-label="Loading"&gt;&lt;/span&gt;
+
+&lt;!-- 임의 크기 --&gt;
+&lt;span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"&gt;&lt;/span&gt;</code></pre>
     </div>
 
     <!-- Pagination -->
@@ -520,12 +524,12 @@ Bigtablet.Alert({
       });
     }
 
-    // Select example with options
+    // Dropdown example with options
     document.addEventListener('DOMContentLoaded', () => {
-      const selectEl = document.querySelector('[data-bt-select]');
-      if (selectEl?._btSelect) {
+      const dropdownEl = document.querySelector('[data-bt-dropdown]');
+      if (dropdownEl?._btDropdown) {
         // Already initialized by auto-init
-      } else if (selectEl) {
+      } else if (dropdownEl) {
         const options = [
           { value: 'apple', label: 'Apple' },
           { value: 'banana', label: 'Banana' },
@@ -534,10 +538,10 @@ Bigtablet.Alert({
           { value: 'elderberry', label: 'Elderberry' }
         ];
 
-        Bigtablet.Select(selectEl, {
+        Bigtablet.Dropdown(dropdownEl, {
           options,
           placeholder: 'Select a fruit...',
-          onChange: (value, option) => {
+          onValueChange: (value, option) => {
             console.log('Selected:', value, option);
           }
         });
@@ -546,7 +550,7 @@ Bigtablet.Alert({
       // Pagination change handler
       const paginationEl = document.querySelector('[data-bt-pagination]');
       if (paginationEl?._btPagination) {
-        // You can set onChange after init if needed
+        // You can set onPageChange after init if needed
       }
     });
   </script>

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -123,7 +123,7 @@
 &lt;!-- danger 는 variant 와 직교 --&gt;
 &lt;button class="bt-button bt-button--md bt-button--outline bt-button--danger"&gt;Delete&lt;/button&gt;
 
-&lt;!-- 구 이름(--primary / --secondary / --ghost)도 계속 동작하지만 deprecated 입니다 --&gt;</code></pre>
+&lt;!-- 구 이름(--primary / --secondary / --ghost)은 v3.8.0 에서 제거되었습니다. docs/MIGRATION.md 참고 --&gt;</code></pre>
     </div>
 
     <!-- TextField -->


### PR DESCRIPTION
## 작업 개요

Vanilla 번들(`@bigtablet/design-system/vanilla`)의 클래스·JS API 이름이 React 컴포넌트 API 와 갈라져 있어 같은 디자인 시스템인데 두 벌의 이름을 외워야 했습니다. 이번 PR 에서 **React 쪽 이름으로 통일하고, 구 이름은 별칭으로 남기지 않고 전부 제거**했습니다.

초기 커밋에서는 구 클래스를 `@deprecated` 별칭으로 유지하는 방향(`.bt-button--filled, .bt-button--primary { … }`)이었으나, **clean break 로 방침을 변경**했습니다. 별칭이 남아 있으면 "정식 이름이 두 개"인 상태가 굳어지고 새 마크업에서도 계속 구 이름이 복사됩니다. 처음부터 현재 React API 를 보고 설계한 것처럼 보이는 게 목표라 별칭을 전부 걷어냈습니다.

React export 는 이 PR 에서 변경되지 않습니다.

## 작업한 내용

### 1. 별칭 제거 (clean break)

- [x] Button `--primary` / `--secondary` / `--ghost` 삭제 → `--filled` / `--outline` / `--text` 만 남김
- [x] Card `--elevation-1/2/3` 삭제 → `--shadow-none/sm/md/lg` 만 남김
- [x] JS 콜백의 `onChange` fallback 삭제 → `onValueChange` / `onCheckedChange` / `onPageChange` 만 읽음
- [x] `Bigtablet.Alert` 가 생성하는 버튼 마크업에서 구 클래스 병기 제거 (`bt-button--filled bt-button--primary` → `bt-button--filled`)
- [x] 문서의 "Deprecated 별칭" 표 전부 삭제

`--danger` 는 React 의 `danger` boolean 처럼 variant 와 **직교**하므로 유지했고, 새로 추가한 `--xl` 사이즈도 유지했습니다.

### 2. 미결로 남겼던 항목 정리 (React 소스 재확인 후 판단)

- [x] **Card - variant** : 확인해 보니 React `Card` 는 `bordered` + `shadow` + `padding` **조합형 모델과 `variant` enum 을 둘 다** 노출합니다(`src/ui/display/card/index.tsx`). 조합형을 enum 으로 치환하는 게 아니라, 기존 modifier 를 그대로 두고 `--accent` / `--glass` / `--outlined` / `--interactive` 를 **추가**하는 것이 실제 parity 였습니다. 기본값도 React 와 동일하게 `shadow=sm` / `padding=md` 로 맞췄습니다.
- [x] **`.bt-select` → `.bt-dropdown`** : CSS 클래스뿐 아니라 런타임까지 함께 개명했습니다 — `data-bt-select` → `data-bt-dropdown`, `Bigtablet.Select` → `Bigtablet.Dropdown`, 자동 초기화 인스턴스 `el._btSelect` → `el._btDropdown`, 내부 `console.warn` 메시지·`generateId` prefix 까지. React `Dropdown` 의 `multiple` / `searchable` 은 **구현하지 않았고**, 흉내내지 않은 채 격차로 명시했습니다.
- [x] **Button `radius` 기본값** : React 기본값은 `radius_full`(pill), Vanilla 는 `--bt-radius-md` 였습니다. `full` 로 맞추고 React `radius` prop 과 같은 `--radius-none/xs/sm/md/lg/xl/full` 스케일을 escape hatch 로 추가했습니다.
- [x] **Button 다크 테마 채움 divergence** : React `variant="filled"` 는 `$color_accent_default`(light 검정 / dark 흰색 자동 반전)를 쓰는데 Vanilla 는 양 테마 고정인 `--bt-color-primary` 를 써서 다크에서 검정 버튼이 배경에 묻혔습니다. accent 토큰으로 교체했습니다.
- [x] **Spinner size enum vs number** : React `<Spinner size>` 는 enum 이 아니라 px 숫자(기본 24)를 받습니다. size enum 클래스를 없애고 `--bt-spinner-size` 커스텀 프로퍼티(기본 24px)로 임의 px 을 받도록 바꿨습니다.
- [x] **Alert 오버레이/Escape 닫힘** : 구 동작은 `close()` 만 불러 `onCancel` 이 우회됐습니다. React 의 `dismiss = onCancel ?? onClose` 와 동일하게 두 경로 모두 `onCancel` 을 먼저 호출하도록 고쳤습니다 (WAI-ARIA APG alertdialog).

**남은 격차 (이번 PR 범위 밖 — 제품 판단 필요)**

- Dropdown `multiple` / `searchable` : Vanilla 미구현. 이름만 맞췄을 뿐 기능 동등이 아님을 문서에 명시했습니다.
- Spinner 렌더 방식 : React 는 12개 bar 가 페이드하는 iOS 스타일, Vanilla 는 단일 border spinner 입니다. CSS 만으로 동일 렌더가 불가해 의도된 차이로 남기고 문서화했습니다.
- Card `heading` / `footer` / `footerAlign` 컴포지션 : Vanilla 에는 `__title` 만 있습니다.

### 3. 마이그레이션 가이드 (필수 — 안전망)

- [x] `docs/MIGRATION.md` 에 **v3.8.0 (Vanilla 패키지 정리)** 섹션 추가. 제거된 클래스 / 개명된 속성 / 개명된 JS 팩토리 / 개명된 콜백 전부의 old → new 표, 복사해 쓰는 `sed` 치환 스크립트, 기계 치환이 불가해 손으로 봐야 하는 항목 목록 포함.

클래스 이름은 컴파일러가 잡아주지 않고 **구 이름을 쓰면 에러 없이 스타일만 조용히 사라지므로**, 이 표가 유일한 안전망입니다.

### 4. 구 이름 참조처 전면 갱신

- [x] `src/vanilla/examples/index.html`
- [x] `docs/VANILLA.md`, `docs/VANILLA-PROMPT.md`, `docs/AGENT_GUIDE.md`
- [x] `CLAUDE.md` "Component Classes Reference" 표 (별칭 표 삭제 + 새 기본값 반영)
- [x] `.claude/docs/design-system.md`, `README.md`, `README_KR.md`
- [x] `src/stories/getting-started/installation.stories.tsx`

## 검증

| 항목 | 결과 |
|---|---|
| `pnpm build` | 통과 |
| 빌드 산출물에서 **제거된 이름** grep (`bigtablet.css` / `.min.css` / `.js` / `.min.js`) | **0건** |
| 빌드 산출물에서 **canonical 이름** grep | 전부 존재 (`--filled/tonal/outline/text/danger/xl`, `--radius-*`, `--shadow-none/sm/md/lg`, `--accent/glass/outlined/interactive`, `bt-dropdown__*`, `--bt-spinner-size`, `onValueChange/onCheckedChange/onPageChange`) |
| `npx stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss' 'src/vanilla/*.scss'` | 통과 |
| `npx tsc --noEmit -p tsconfig.json` | 통과 |
| `npx vitest run --project unit` | 788 passed / 9 skipped |
| `pnpm size` | `bigtablet.min.js` 4.14 kB (limit 5 kB), `index.js` 49.47 kB (limit 60 kB), `index.css` 12.17 kB (limit 130 kB) |
| jsdom 스모크 테스트 (빌드된 `bigtablet.js` 대상) | 통과 |
| repo 전체 `git grep` 제거 식별자 | 마이그레이션 가이드 외 **0건** |

jsdom 스모크 테스트가 확인한 것:

- `Bigtablet.Dropdown` 존재 / `Bigtablet.Select` 부재
- `data-bt-dropdown` 자동 초기화 → `el._btDropdown` (`el._btSelect` 부재)
- Dropdown `onValueChange(value, option)` 호출 · 구 `onChange` **미호출**, combobox ARIA(`role`/`aria-expanded`) 유지, 옵션 클릭 선택
- Toggle `onCheckedChange` 호출 · 구 `onChange` 미호출
- Pagination `onPageChange` 호출 · 구 `onChange` 미호출
- Alert 버튼이 `--filled` / `--outline` 이고 구 별칭 없음, `destructive` → `--danger`
- Alert **Escape** 및 **오버레이 클릭** 이 `onCancel` 을 경유, `closeOnOverlay: false` 면 무시

## 주의

> ⚠️ **Vanilla 표면(`@bigtablet/design-system/vanilla`, `dist/vanilla/*`)의 파괴적 변경입니다.**
> React export 는 영향 없습니다.

**릴리즈 목표는 `3.8.0` (minor)** 입니다. 통상 이런 제거는 major 대상이지만, 현재 Vanilla 번들의 소비자는 사내 Thymeleaf 앱 한 곳뿐이고 그마저 임시 디자인 레퍼런스 용도라 실제 integration 이 없습니다. major bump 는 `^3.x` 에 고정된 소비자를 보호하는 신호인데, 보호할 대상이 없어 신호할 것이 없는 bump 가 됩니다.

대신 **CHANGELOG 항목에서 파괴적 변경임을 명시적으로 적어야** 합니다. 버전 번호가 이 변경을 알려주지 않으므로, 나중에 이 커밋을 되짚는 사람에게 CHANGELOG 가 유일한 단서입니다.

**제거된 식별자 전체** (전부 즉시 동작 중단 — 에러 없이 스타일/콜백만 조용히 사라짐):

| 분류 | 제거됨 | 대체 |
|---|---|---|
| Button variant | `.bt-button--primary` | `.bt-button--filled` |
| Button variant | `.bt-button--secondary` | `.bt-button--outline` |
| Button variant | `.bt-button--ghost` | `.bt-button--text` |
| Card shadow | `.bt-card--elevation-1` | `.bt-card--shadow-sm` |
| Card shadow | `.bt-card--elevation-2` | `.bt-card--shadow-md` |
| Card shadow | `.bt-card--elevation-3` | `.bt-card--shadow-lg` |
| Dropdown 블록 | `.bt-select`, `.bt-select__label/__control/__value/__placeholder/__icon/__list/__option` (+ `--outline` `--filled` `--sm` `--md` `--lg` `--up` 변형) | `.bt-dropdown…` 동일 구조 |
| Dropdown 속성 | `data-bt-select` | `data-bt-dropdown` |
| Dropdown 팩토리 | `Bigtablet.Select(el, options)` | `Bigtablet.Dropdown(el, options)` |
| Dropdown 인스턴스 | `el._btSelect` | `el._btDropdown` |
| Spinner size | `.bt-spinner--sm/md/lg/xl` | `style="--bt-spinner-size: 16px/24px/32px/48px"` (md=기본값) |
| JS 콜백 | `Bigtablet.Dropdown({ onChange })` | `onValueChange` |
| JS 콜백 | `Bigtablet.Toggle({ onChange })` | `onCheckedChange` |
| JS 콜백 | `Bigtablet.Pagination({ onChange })` | `onPageChange` |

**클래스 이름은 그대로인데 렌더링/동작이 바뀐 항목** (grep 으로 안 잡히니 특히 주의):

- `.bt-button` 기본 `border-radius`: md(8px) → **full(pill)**. 각진 버튼 유지하려면 `.bt-button--radius-md` 명시
- `.bt-button--filled` 배경: 양 테마 고정 검정 → **accent(다크에서 흰색으로 반전)**
- `.bt-card` 기본값: 그림자·여백 없음 → **shadow=sm / padding=md**. 맨 카드는 `--shadow-none --p-none` 명시
- `Bigtablet.Alert` 의 오버레이 클릭·Escape 가 이제 **`onCancel` 을 호출**. `onCancel` 안에서 "취소 버튼을 눌렀다"고 가정하던 코드는 영향 받음

→ 전체 매핑과 `sed` 치환 스크립트: **[docs/MIGRATION.md - v3.8.0 (Vanilla 패키지 정리)](https://github.com/Bigtablet/bigtablet-design-system/blob/feat/vanilla-react-parity/docs/MIGRATION.md#v380-vanilla-패키지-정리)**

## 전달할 추가 이슈

- Vanilla Dropdown 에 `multiple` / `searchable` 구현 여부 — 서버 템플릿 환경에서 수요가 있는지 확인 필요
- Vanilla Spinner 를 React 와 같은 12-bar 렌더로 맞출지 (마크업에 12개 자식 span 이 필요 — 디자인 결정)
- Vanilla Card 에 `heading` / `footer` / `footerAlign` 컴포지션 추가 여부
- `.bt-text-field__input--filled` / `.bt-dropdown__control--filled` 는 React 에 대응 prop 이 없는 Vanilla 전용 스타일입니다. 유지 중이지만 정리 대상인지 판단 필요
