### PR TITLE
merge: release v3.8.0

### DIFF
--- a/.claude/docs/design-system.md
+++ b/.claude/docs/design-system.md
@@ -611,22 +611,35 @@ const items = [
 @use "@bigtablet/design-system/scss/token" as token;
 
 .my-class {
-  padding: token.$spacing_md;       // 0.75rem
-  color: token.$color_primary;      // #000000
-  border-radius: token.$radius_md;  // 8px
-  box-shadow: token.$shadow_sm;
+  padding: token.$spacing_16;            // 16px
+  color: token.$color_text_heading;
+  background: token.$color_bg_solid;
+  border-radius: token.$radius_md;       // 8px
+  box-shadow: token.$elevation_level1;
 }
 ```
 
 ### Token Reference
 
-**Spacing:** `$spacing_xs` (4px), `$spacing_sm` (8px), `$spacing_md` (12px), `$spacing_lg` (16px), `$spacing_xl` (20px), `$spacing_2xl` (24px)
+토큰 이름은 **숫자 스케일 + semantic** 이다. `xs/sm/md/lg` 같은 t-shirt spacing, `$color_primary` 같은 원시 색상, `$shadow_*` 는 **존재하지 않는다**.
 
-**Colors:** `$color_primary`, `$color_primary_hover`, `$color_error`, `$color_success`, `$color_warning`, `$color_info`, `$color_text_primary`, `$color_text_secondary`, `$color_border`, `$color_background`
+**Spacing** (숫자 = px): `$spacing_0` `$spacing_1` `$spacing_2` `$spacing_3` `$spacing_4` `$spacing_6` `$spacing_8` `$spacing_12` `$spacing_16` `$spacing_20` `$spacing_24` `$spacing_32` `$spacing_40` `$spacing_48`
 
-**Radius:** `$radius_sm` (6px), `$radius_md` (8px), `$radius_lg` (12px)
+**Colors** (semantic, `var(--bt-*)` 참조라 다크 모드 자동 대응):
+- brand: `$color_brand_primary`, `$color_brand_on_primary`, `$color_brand_primary_container`
+- text: `$color_text_heading`, `$color_text_body`, `$color_text_caption`, `$color_text_brand`, `$color_text_inverse`, `$color_text_disabled`
+- bg: `$color_bg_solid`, `$color_bg_solid_dim`, `$color_bg_additive`, `$color_bg_disabled`, `$color_bg_overlay`, `$color_bg_inverse_surface`
+- border: `$color_border_default`, `$color_border_hover`, `$color_border_subtle`, `$color_border_focus`, `$color_border_disabled`
+- status: `$color_status_error` / `_success` / `_warning` / `_info` (+ `_on_default`, `_container`, `_on_container`, `_on_surface` 변형)
+- state: `$color_state_hover_on_light` / `_pressed_on_light` / `_focus_on_light` (+ `_on_dark` 변형)
 
-**Shadows:** `$shadow_sm`, `$shadow_md`, `$shadow_lg`
+**Radius:** `$radius_none` (0), `$radius_xs` (4px), `$radius_sm` (6px), `$radius_md` (8px), `$radius_lg` (12px), `$radius_xl` (16px), `$radius_full` (9999px)
+
+**Elevation** (구 `$shadow_*` 아님): `$elevation_level1` ~ `$elevation_level5`
+
+**Typography** (숫자 = px): `$font_size_12` ~ `$font_size_48`, `$font_weight_regular` / `_medium` / `_semi_bold` / `_bold`
+
+**Motion:** `$duration_fast|base|slow`, `$transition_fast|base|slow`, `$easing_enter`, `$easing_exit`, `$transition_enter_*` / `$transition_exit_*` (composite - easing 포함되어 있으니 easing 을 또 붙이지 말 것)
 
 ### Layout Mixins
 
@@ -646,17 +659,25 @@ const items = [
 @use "@bigtablet/design-system/scss/token" as token;
 
 .component {
-  padding: token.$spacing_lg;
+  padding: token.$spacing_24;
 
-  @include token.mobile {
-    padding: token.$spacing_sm;
+  // 구간 지정 (compact 0~599 / medium 600~839 / expanded 840~1199 / large 1200~)
+  @include token.compact {
+    padding: token.$spacing_12;
   }
 
-  @include token.tablet {
-    padding: token.$spacing_md;
+  @include token.medium {
+    padding: token.$spacing_16;
+  }
+
+  // min-width 단축 mixin - from_medium / from_expanded / from_large
+  @include token.from_large {
+    padding: token.$spacing_32;
   }
 }
 ```
+
+> `token.mobile` / `token.tablet` 같은 mixin 은 없다. 구간은 `compact` / `medium` / `expanded` / `large`, min-width 단축은 `from_medium` / `from_expanded` / `from_large` 를 쓴다.
 
 ---
 

--- a/.claude/docs/design-system.md
+++ b/.claude/docs/design-system.md
@@ -704,8 +704,10 @@ For server templates (Thymeleaf, JSP, PHP, Django):
 
 ```html
 <!-- Button -->
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
-<button class="bt-button bt-button--md bt-button--secondary">Secondary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
+<button class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+<button class="bt-button bt-button--md bt-button--outline">Outline</button>
+<button class="bt-button bt-button--md bt-button--text">Text</button>
 <button class="bt-button bt-button--lg bt-button--danger">Danger</button>
 
 <!-- TextField -->
@@ -746,20 +748,35 @@ For server templates (Thymeleaf, JSP, PHP, Django):
   <p>Content</p>
 </div>
 
-<!-- Spinner -->
-<div class="bt-spinner bt-spinner--md"></div>
+<!-- Dropdown -->
+<div class="bt-dropdown" data-bt-dropdown>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">Select...</span>
+    <span class="bt-dropdown__icon">▼</span>
+  </button>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="1">Option 1</li>
+  </ul>
+</div>
+
+<!-- Spinner (크기는 --bt-spinner-size, 기본 24px) -->
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
 ```
+
+> Vanilla 클래스·JS 옵션 이름은 React API 와 1:1 로 맞춰져 있고 deprecated 별칭은 없다.
+> React 와 갈라져 있던 구 이름은 v3.8.0 에서 전부 제거됐다 - old → new 매핑은
+> `docs/MIGRATION.md` 의 "v3.8.0 (Vanilla 패키지 정리)" 섹션 참고.
 
 ### JavaScript API
 
 ```javascript
-// Select
-const select = Bigtablet.Select('#my-select', {
+// Dropdown
+const dropdown = Bigtablet.Dropdown('#my-dropdown', {
   options: [{ value: '1', label: 'One' }],
-  onChange: (value) => console.log(value)
+  onValueChange: (value) => console.log(value)
 });
-select.getValue();
-select.setValue('1');
+dropdown.getValue();
+dropdown.setValue('1');
 
 // Modal
 const modal = Bigtablet.Modal('#my-modal', {
@@ -772,7 +789,7 @@ modal.close();
 
 // Toggle
 const tg = Bigtablet.Toggle('#my-toggle', {
-  onChange: (checked) => console.log(checked)
+  onCheckedChange: (checked) => console.log(checked)
 });
 tg.toggle();
 tg.setChecked(true);
@@ -791,7 +808,7 @@ Bigtablet.Alert({
 const pagination = Bigtablet.Pagination('#my-pagination', {
   page: 1,
   totalPages: 10,
-  onChange: (page) => console.log(page)
+  onPageChange: (page) => console.log(page)
 });
 ```
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,97 @@
+name: PR Auto Label
+
+# 브랜치 접두사(`label/domain`)를 PR 라벨로 매핑하고, 담당자가 비어 있으면 PR 작성자를 지정한다.
+# 레포의 모든 사람 PR 이 라벨/담당자 없이 열려 있던 문제를 자동화로 막는다.
+#
+# `pull_request` 가 아니라 `pull_request_target` 을 쓰는 이유:
+#  - fork PR 에서도 GITHUB_TOKEN 이 write 라 라벨/담당자 지정이 실제로 동작한다
+#    (`pull_request` 는 fork 일 때 토큰이 read-only 라 항상 실패한다)
+#  - 항상 base 브랜치의 워크플로가 실행된다 -> PR 브랜치에서 이 파일을 고쳐
+#    write 토큰 동작을 바꾸는 것을 막는다
+#  - checkout / 빌드가 전혀 없어 PR 코드를 실행하지 않는다 -> pull_request_target 의
+#    통상적인 보안 위험(신뢰되지 않은 코드 실행)에 해당하지 않는다
+#
+# 참고: `edited` 는 제목/본문/base 변경 시에도 발생한다. 매핑 라벨이 이미 있으면 아무것도
+#       하지 않으므로 재실행은 무해하다 (사람이 추가한 라벨은 절대 제거하지 않는다).
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+# 같은 PR 에 연속 편집이 들어오면 마지막 것만 실행한다.
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    # 최소 권한: PR 라벨/담당자 수정만 필요하다. checkout 이 없어 contents 도 불필요.
+    permissions:
+      pull-requests: write
+    steps:
+      # 서드파티 labeler 액션 대신 gh CLI 를 쓴다:
+      #  - release.yml 이 이미 `run:` + gh CLI 패턴을 쓴다 (스타일 일치)
+      #  - 핀·업그레이드할 액션 의존성이 0 개, checkout 도 불필요 (GH_REPO 로 레포 지정)
+      #  - 접두사 -> 라벨 매핑은 `case` 한 블록이면 끝난다
+      # 브랜치명은 신뢰할 수 없는 입력이므로 `${{ }}` 로 스크립트에 직접 보간하지 않고
+      # env 로 넘겨 따옴표로 감싸 쓴다 (셸 인젝션 방지).
+      - name: Apply branch-prefix label and assign author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: |
+          set -euo pipefail
+
+          # `label/domain` 의 첫 세그먼트. 슬래시가 없으면(예: `develop`) 이름 전체가 접두사.
+          PREFIX="$(printf '%s' "${HEAD_REF%%/*}" | tr '[:upper:]' '[:lower:]')"
+
+          # 커밋 라벨(CLAUDE.md `Commit Labels`) -> 레포 라벨 매핑.
+          case "$PREFIX" in
+            feat)                                              LABEL="Feature" ;;
+            fix|style|refactor|config|delete|note|ci|etc)      LABEL="Fix" ;;
+            bug)                                               LABEL="Bug" ;;
+            docs)                                              LABEL="Docs" ;;
+            release|deploy|develop|sync)                       LABEL="Deploy" ;;
+            *)                                                 LABEL="" ;;
+          esac
+
+          # --- 라벨 ---------------------------------------------------------
+          if [ -z "$LABEL" ]; then
+            echo "::notice::브랜치 접두사 '${PREFIX}' 에 매핑된 라벨이 없다 - 라벨 부여를 건너뛴다"
+          else
+            export LABEL
+            # 이미 붙어 있으면 건드리지 않는다. `--add-label` 은 추가만 하므로
+            # 사람이 별도로 붙인 라벨은 어떤 경우에도 제거되지 않는다.
+            HAS_LABEL="$(gh pr view "$PR_NUMBER" --json labels \
+              --jq '[.labels[].name] | index(env.LABEL) != null' || echo "false")"
+            if [ "$HAS_LABEL" = "true" ]; then
+              echo "'${LABEL}' 라벨이 이미 있다 - 건너뛴다"
+            elif gh pr edit "$PR_NUMBER" --add-label "$LABEL"; then
+              echo "'${LABEL}' 라벨을 부여했다 (접두사 '${PREFIX}')"
+            else
+              # 라벨이 레포에 없거나 권한/레이트리밋 문제 - PR 을 실패시키지 않는다.
+              echo "::warning::'${LABEL}' 라벨 부여 실패 (레포에 라벨이 없을 수 있다) - 무시하고 계속한다"
+            fi
+          fi
+
+          # --- 담당자 -------------------------------------------------------
+          # 봇(dependabot 등)은 assignee 가 될 수 없다. dependabot PR 은 `dependencies`
+          # 라벨을 이미 자동으로 받으므로 담당자 지정 대상에서 완전히 제외한다.
+          if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then
+            echo "::notice::봇 PR (${PR_AUTHOR}) - 담당자 지정을 건너뛴다"
+            exit 0
+          fi
+
+          ASSIGNEE_COUNT="$(gh pr view "$PR_NUMBER" --json assignees --jq '.assignees | length' || echo "0")"
+          if [ "$ASSIGNEE_COUNT" != "0" ]; then
+            echo "담당자가 이미 지정돼 있다 - 건너뛴다"
+          elif gh pr edit "$PR_NUMBER" --add-assignee "$PR_AUTHOR"; then
+            echo "담당자로 '${PR_AUTHOR}' 를 지정했다"
+          else
+            # 조직 외부 기여자 등 assignable 하지 않은 경우 - PR 을 실패시키지 않는다.
+            echo "::warning::'${PR_AUTHOR}' 담당자 지정 실패 - 무시하고 계속한다"
+          fi

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,9 +9,9 @@
       "severity": "error",
       "message": "named color (white, black, red 등) 금지 — DS 토큰 사용."
     }],
-    "function-disallowed-list": [["rgb", "rgba", "hsl", "hsla"], {
+    "function-disallowed-list": [["rgb", "rgba", "hsl", "hsla", "hwb", "lab", "lch", "oklab", "oklch", "color"], {
       "severity": "error",
-      "message": "DS 컴포넌트 SCSS 에 raw rgb()/rgba()/hsl()/hsla() 금지 — alpha 컬러도 token (token.$color_text_on_dark_* / $color_scrim_* 등) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
+      "message": "DS 컴포넌트 SCSS 에 raw 컬러 함수(rgb/rgba/hsl/hsla/hwb/lab/lch/oklab/oklch/color) 금지 — alpha 컬러도 token (token.$color_text_on_dark_* / $color_scrim_* 등) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
     }]
   },
   "overrides": [

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,10 @@
     "color-named": ["never", {
       "severity": "error",
       "message": "named color (white, black, red 등) 금지 — DS 토큰 사용."
+    }],
+    "function-disallowed-list": [["rgb", "rgba", "hsl", "hsla"], {
+      "severity": "error",
+      "message": "DS 컴포넌트 SCSS 에 raw rgb()/rgba()/hsl()/hsla() 금지 — alpha 컬러도 token (token.$color_text_on_dark_* / $color_scrim_* 등) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
     }]
   },
   "overrides": [
@@ -15,14 +19,16 @@
       "files": ["src/styles/**/*.scss"],
       "rules": {
         "color-no-hex": null,
-        "color-named": null
+        "color-named": null,
+        "function-disallowed-list": null
       }
     },
     {
       "files": ["src/vanilla/**/*.scss"],
       "rules": {
         "color-no-hex": null,
-        "color-named": null
+        "color-named": null,
+        "function-disallowed-list": null
       }
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.8.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.8.0) - 2026-08-05
+
+- Tooltip·Popover 뷰포트 충돌 회피 + 진입/퇴출 애니메이션 - `body` 포탈 + `position: fixed` 로 조상의 `overflow`/`transform` 을 벗어나 잘리지 않게 하고, flip→shift→shrink 로 화면 안에 맞추도록 재배치. Tooltip 은 언마운트 전에 퇴출 애니메이션을 재생 (#429, #431). **(주의: 오버레이가 `body` 로 포탈됨 - z-index/스타일 상속을 부모 트리 기준으로 가정하던 코드는 확인 필요)**
+- IconButton 접근 이름 필수화 - `aria-label` 또는 `aria-labelledby` 중 하나를 반드시 받도록 판별 유니온 타입으로 강제. **(주의: 접근 이름 없이 쓰던 호출부는 타입 에러 - 하나를 추가해야 함)**
+- 접근성 accessible name 보강 - NavBar 로케일 트리거·IconButton·Popover dialog 에 접근 이름 부여
+- 공개 컴포넌트 타입 16종 barrel re-export - `import type { ButtonProps } from "@bigtablet/design-system"` 형태로 직접 임포트 가능
+- Vanilla 번들 React API 정합 - 클래스명·JS 콜백을 React 쪽 canonical 이름으로 통일하고 레거시 alias 제거. **(주의: 구 Vanilla 클래스명/콜백명 제거 - `docs/MIGRATION.md` 의 v3.8.0 가이드 참고)**
+- 라이선스 통일 - MIT → Bigtablet Inc. Open Source License. **(주의: 배포 패키지 라이선스 변경)**
+- reduced-motion 준수 확대 - 컴포넌트 SCSS·Vanilla 번들·layout hover mixin 에 `prefers-reduced-motion` 가드 추가 (WCAG 2.1 SC 2.3.3)
+- (개발) 토큰 규율·문서 정비 - stylelint 로 컴포넌트 SCSS 의 raw `rgb/rgba/hsl/hsla` 차단, 죽은 토큰 정리, PR 라벨 자동화 워크플로우 추가, 컴포넌트/아키텍처 문서 실 API 와 동기화
+
 ## [3.7.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.7.0) - 2026-08-05
 
 - ImageCropper 문구 다국어 대응 - 조작 안내·줌 버튼/슬라이더 접근성 레이블·이동 여유 안내를 `hint`/`zoomOutLabel`/`zoomLabel`/`zoomInLabel`/`noPanHint` prop 으로 개방(각 기본값 동일 → 기존 호출부 무영향). 다국어 앱에서 스크린리더에 한국어가 고정 낭독되던 문제 해소

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ return <animated.div style={style}>...</animated.div>;
 
 - **Test Runner**: Vitest (multi-project: `unit` + `storybook`)
 - **a11y Testing**: axe-core via `@storybook/addon-a11y` + Playwright (headless Chromium)
-- **Coverage**: 90% (stmts 90.01 / branch 85.59 / funcs 90.07 / lines 91.97 - 자세한 표는 [docs/TESTING.md](./docs/TESTING.md#커버리지))
+- **Coverage**: 90% (stmts 90.02 / branch 85.69 / funcs 90.07 / lines 91.97 - 자세한 표는 [docs/TESTING.md](./docs/TESTING.md#커버리지))
 - **Commands**:
   ```bash
   pnpm test              # Run unit tests
@@ -253,7 +253,7 @@ For non-React environments (Thymeleaf, JSP, PHP, Django, etc.)
 ### Build Output
 ```
 dist/vanilla/
-├── bigtablet.css       # Full CSS (~38KB)
+├── bigtablet.css       # Full CSS (~40KB)
 ├── bigtablet.min.css   # Minified CSS (~31KB)
 ├── bigtablet.js        # Full JS (~30KB)
 ├── bigtablet.min.js    # Minified JS (~13KB)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,7 +424,7 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 // Manual initialization
 const select = Bigtablet.Select('#my-select', {
   options: [{ value: '1', label: 'One' }],
-  onChange: (value, option) => console.log(value)
+  onValueChange: (value, option) => console.log(value)
 });
 select.getValue();
 select.setValue('1');
@@ -440,7 +440,7 @@ modal.open();
 modal.close();
 
 const sw = Bigtablet.Toggle('#my-toggle', {
-  onChange: (checked) => console.log(checked)
+  onCheckedChange: (checked) => console.log(checked)
 });
 sw.toggle();
 sw.setChecked(true);
@@ -448,7 +448,7 @@ sw.setChecked(true);
 const pagination = Bigtablet.Pagination('#my-pagination', {
   page: 1,
   totalPages: 10,
-  onChange: (page) => console.log(page)
+  onPageChange: (page) => console.log(page)
 });
 pagination.setPage(5);
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ return <animated.div style={style}>...</animated.div>;
 
 - **Test Runner**: Vitest (multi-project: `unit` + `storybook`)
 - **a11y Testing**: axe-core via `@storybook/addon-a11y` + Playwright (headless Chromium)
-- **Coverage**: 86%
+- **Coverage**: 90% (stmts 90.01 / branch 85.59 / funcs 90.07 / lines 91.97 - 자세한 표는 [docs/TESTING.md](./docs/TESTING.md#커버리지))
 - **Commands**:
   ```bash
   pnpm test              # Run unit tests
@@ -253,10 +253,10 @@ For non-React environments (Thymeleaf, JSP, PHP, Django, etc.)
 ### Build Output
 ```
 dist/vanilla/
-├── bigtablet.css       # Full CSS (27KB)
-├── bigtablet.min.css   # Minified CSS (21KB)
-├── bigtablet.js        # Full JS (20KB)
-├── bigtablet.min.js    # Minified JS (9KB)
+├── bigtablet.css       # Full CSS (~38KB)
+├── bigtablet.min.css   # Minified CSS (~31KB)
+├── bigtablet.js        # Full JS (~30KB)
+├── bigtablet.min.js    # Minified JS (~13KB)
 └── examples/           # HTML examples
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,7 +622,7 @@ EOF
 ```bash
 gh pr create --base develop --title "label/domain" \
   --label "Feature" --assignee @me --body "$(cat <<'EOF'
-## 작업 개요
+## 제목
 
 ## 작업한 내용
 - [x] 작업1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,32 +270,46 @@ dist/vanilla/
 
 ### Component Classes Reference
 
+클래스 이름은 대응하는 React 컴포넌트의 prop 값과 같게 맞춘다. 이름이 갈라진 구 클래스는
+deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크업/문서에는 canonical 이름만 쓴다.
+
 | Component | Base Class | Modifiers | States |
 |-----------|------------|-----------|--------|
-| Button | `.bt-button` | `--sm/md/lg`, `--primary/secondary/ghost/danger` | `:disabled` |
+| Button | `.bt-button` | `--sm/md/lg/xl`, `--filled/tonal/outline/text`, `--danger`(variant 와 직교), `--full-width` | `:disabled` |
 | TextField | `.bt-text-field` | `--full-width` | |
 | TextField Input | `.bt-text-field__input` | `--outline/filled`, `--sm/md/lg`, `--error/success` | `:disabled` |
 | Checkbox | `.bt-checkbox` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Radio | `.bt-radio` | `--sm/md/lg` | `:checked`, `:disabled` |
-| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` |
+| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` / `:disabled` |
 | Select | `.bt-select` | | |
 | Select Control | `.bt-select__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
 | Select List | `.bt-select__list` | `--up` (opens upward) | |
 | Select Option | `.bt-select__option` | | `.is-selected`, `.is-active`, `.is-disabled` |
 | Modal | `.bt-modal` | | `.is-open` |
-| Card | `.bt-card` | `--bordered`, `--elevation-1/2/3`, `--p-sm/md/lg` | |
+| Card | `.bt-card` | `--bordered`, `--shadow-none/sm/md/lg`, `--p-none/sm/md/lg` | |
 | Spinner | `.bt-spinner` | `--sm/md/lg/xl` | |
 | Pagination | `.bt-pagination` | | |
 | DatePicker | `.bt-date-picker` | `--full-width` | |
 | FileInput | `.bt-file-input` | | `.bt-file-input--disabled` |
 
+**Deprecated 별칭** (계속 동작 - v4.0.0 제거 예정):
+
+| 구 클래스 | 대체 |
+|---|---|
+| `.bt-button--primary` | `.bt-button--filled` |
+| `.bt-button--secondary` | `.bt-button--outline` |
+| `.bt-button--ghost` | `.bt-button--text` |
+| `.bt-card--elevation-1/2/3` | `.bt-card--shadow-sm/md/lg` |
+
 ### HTML Examples
 
 #### Button
 ```html
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
-<button class="bt-button bt-button--md bt-button--secondary">Secondary</button>
-<button class="bt-button bt-button--md bt-button--danger">Danger</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
+<button class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+<button class="bt-button bt-button--md bt-button--outline">Outline</button>
+<button class="bt-button bt-button--md bt-button--text">Text</button>
+<button class="bt-button bt-button--md bt-button--outline bt-button--danger">Delete</button>
 ```
 
 #### TextField
@@ -371,8 +385,8 @@ dist/vanilla/
     <div class="bt-modal__header">Title</div>
     <div class="bt-modal__body">Content</div>
     <div class="bt-modal__footer">
-      <button class="bt-button bt-button--md bt-button--secondary" data-modal-close>Cancel</button>
-      <button class="bt-button bt-button--md bt-button--primary" data-modal-close>Confirm</button>
+      <button class="bt-button bt-button--md bt-button--outline" data-modal-close>Cancel</button>
+      <button class="bt-button bt-button--md bt-button--filled" data-modal-close>Confirm</button>
     </div>
   </div>
 </div>
@@ -385,7 +399,7 @@ dist/vanilla/
   <p>Content</p>
 </div>
 
-<div class="bt-card bt-card--elevation-2 bt-card--p-lg">
+<div class="bt-card bt-card--shadow-md bt-card--p-lg">
   Elevation card
 </div>
 ```
@@ -486,7 +500,7 @@ All design tokens available as CSS variables:
           th:errors="*{name}"></span>
   </div>
 
-  <button type="submit" class="bt-button bt-button--md bt-button--primary">Submit</button>
+  <button type="submit" class="bt-button bt-button--md bt-button--filled">Submit</button>
 </form>
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,36 +270,28 @@ dist/vanilla/
 
 ### Component Classes Reference
 
-클래스 이름은 대응하는 React 컴포넌트의 prop 값과 같게 맞춘다. 이름이 갈라진 구 클래스는
-deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크업/문서에는 canonical 이름만 쓴다.
+클래스 이름·JS 옵션 이름은 대응하는 React 컴포넌트의 prop 값과 **같게 맞춘다**. deprecated 별칭은
+두지 않는다 - 이름이 갈라지면 별칭을 추가하는 대신 구 이름을 제거하고
+[docs/MIGRATION.md](./docs/MIGRATION.md) 에 old → new 표를 남긴다 (v3.8.0 에서 정리 완료).
 
 | Component | Base Class | Modifiers | States |
 |-----------|------------|-----------|--------|
-| Button | `.bt-button` | `--sm/md/lg/xl`, `--filled/tonal/outline/text`, `--danger`(variant 와 직교), `--full-width` | `:disabled` |
+| Button | `.bt-button` | `--sm/md/lg/xl`, `--filled/tonal/outline/text`, `--danger`(variant 와 직교), `--radius-none/xs/sm/md/lg/xl/full`(기본 full), `--full-width` | `:disabled` |
 | TextField | `.bt-text-field` | `--full-width` | |
 | TextField Input | `.bt-text-field__input` | `--outline/filled`, `--sm/md/lg`, `--error/success` | `:disabled` |
 | Checkbox | `.bt-checkbox` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Radio | `.bt-radio` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` / `:disabled` |
-| Select | `.bt-select` | | |
-| Select Control | `.bt-select__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
-| Select List | `.bt-select__list` | `--up` (opens upward) | |
-| Select Option | `.bt-select__option` | | `.is-selected`, `.is-active`, `.is-disabled` |
+| Dropdown | `.bt-dropdown` | | |
+| Dropdown Control | `.bt-dropdown__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
+| Dropdown List | `.bt-dropdown__list` | `--up` (opens upward) | |
+| Dropdown Option | `.bt-dropdown__option` | | `.is-selected`, `.is-active`, `.is-disabled` |
 | Modal | `.bt-modal` | | `.is-open` |
-| Card | `.bt-card` | `--bordered`, `--shadow-none/sm/md/lg`, `--p-none/sm/md/lg` | |
-| Spinner | `.bt-spinner` | `--sm/md/lg/xl` | |
+| Card | `.bt-card` | `--bordered`, `--shadow-none/sm/md/lg`(기본 sm), `--p-none/sm/md/lg`(기본 md), `--accent/glass/outlined`, `--interactive` | |
+| Spinner | `.bt-spinner` | 없음 - 크기는 `--bt-spinner-size` (기본 24px) | |
 | Pagination | `.bt-pagination` | | |
 | DatePicker | `.bt-date-picker` | `--full-width` | |
 | FileInput | `.bt-file-input` | | `.bt-file-input--disabled` |
-
-**Deprecated 별칭** (계속 동작 - v4.0.0 제거 예정):
-
-| 구 클래스 | 대체 |
-|---|---|
-| `.bt-button--primary` | `.bt-button--filled` |
-| `.bt-button--secondary` | `.bt-button--outline` |
-| `.bt-button--ghost` | `.bt-button--text` |
-| `.bt-card--elevation-1/2/3` | `.bt-card--shadow-sm/md/lg` |
 
 ### HTML Examples
 
@@ -357,18 +349,18 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 </button>
 ```
 
-#### Select
+#### Dropdown
 ```html
-<div class="bt-select" data-bt-select>
-  <label class="bt-select__label">Label</label>
-  <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-    <span class="bt-select__placeholder">Select...</span>
-    <span class="bt-select__icon">▼</span>
+<div class="bt-dropdown" data-bt-dropdown>
+  <label class="bt-dropdown__label">Label</label>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">Select...</span>
+    <span class="bt-dropdown__icon">▼</span>
   </button>
-  <ul class="bt-select__list">
-    <li class="bt-select__option" data-value="1">Option 1</li>
-    <li class="bt-select__option" data-value="2">Option 2</li>
-    <li class="bt-select__option is-disabled" data-value="3">Disabled</li>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="1">Option 1</li>
+    <li class="bt-dropdown__option" data-value="2">Option 2</li>
+    <li class="bt-dropdown__option is-disabled" data-value="3">Disabled</li>
   </ul>
 </div>
 ```
@@ -400,13 +392,20 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 </div>
 
 <div class="bt-card bt-card--shadow-md bt-card--p-lg">
-  Elevation card
+  Shadow card
+</div>
+
+<div class="bt-card bt-card--accent bt-card--interactive">
+  Accent + interactive card
 </div>
 ```
 
 #### Spinner
 ```html
-<div class="bt-spinner bt-spinner--md"></div>
+<!-- 기본 24px (React <Spinner /> 기본값) -->
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
+<!-- 임의 크기 -->
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
 ```
 
 #### Pagination
@@ -422,14 +421,14 @@ deprecated 별칭으로 남겨 두고(제거 예정 버전 명시), 새 마크�
 // Auto-init: elements with data-bt-* are initialized on DOMContentLoaded
 
 // Manual initialization
-const select = Bigtablet.Select('#my-select', {
+const dropdown = Bigtablet.Dropdown('#my-dropdown', {
   options: [{ value: '1', label: 'One' }],
   onValueChange: (value, option) => console.log(value)
 });
-select.getValue();
-select.setValue('1');
-select.open();
-select.close();
+dropdown.getValue();
+dropdown.setValue('1');
+dropdown.open();
+dropdown.close();
 
 const modal = Bigtablet.Modal('#my-modal', {
   closeOnOverlay: true,
@@ -481,6 +480,7 @@ All design tokens available as CSS variables:
   --bt-spacing-lg: 1rem;
   --bt-radius-sm: 6px;
   --bt-radius-md: 8px;
+  --bt-radius-full: 9999px;
   --bt-elevation-1: 0 1px 1px -1px rgba(0,0,0,0.20), 0 3px 3px 0 rgba(0,0,0,0.12);
   --bt-transition-base: 0.2s ease-in-out;
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ dist/vanilla/
 | TextField Input | `.bt-text-field__input` | `--outline/filled`, `--sm/md/lg`, `--error/success` | `:disabled` |
 | Checkbox | `.bt-checkbox` | `--sm/md/lg` | `:checked`, `:disabled` |
 | Radio | `.bt-radio` | `--sm/md/lg` | `:checked`, `:disabled` |
-| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `.bt-toggle--disabled` / `:disabled` |
+| Toggle | `.bt-toggle` | `--sm/md` | `.bt-toggle--on`, `:disabled` |
 | Dropdown | `.bt-dropdown` | | |
 | Dropdown Control | `.bt-dropdown__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
 | Dropdown List | `.bt-dropdown__list` | `--up` (opens upward) | |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,9 +600,28 @@ EOF
 - **Base branch**: `develop` (NOT main!)
 - **PR title**: Same as branch name
 - **PR body**: Write in Korean
+- **Label**: 브랜치 접두사에 대응하는 라벨 1개 (아래 표)
+- **Assignee**: PR 작성자 본인 (`@me`)
+
+#### 브랜치 접두사 → PR 라벨 매핑
+
+| 브랜치 접두사 | 라벨 |
+|--------------|------|
+| `feat` | `Feature` |
+| `fix`, `style`, `refactor`, `config`, `delete`, `note`, `ci`, `etc` | `Fix` |
+| `bug` | `Bug` |
+| `docs` | `Docs` |
+| `release`, `deploy`, `develop`, `sync` | `Deploy` |
+
+> `.github/workflows/pr-labeler.yml` 이 PR open/reopen/edit 시 위 매핑을 **자동 적용**하고,
+> 담당자가 비어 있으면 작성자를 자동 지정한다. 아래 `--label` / `--assignee @me` 는
+> 워크플로가 안 돌거나(예: 워크플로 자체를 바꾸는 PR) 늦게 붙는 경우를 위한 이중 안전장치다.
+> 이미 붙은 라벨은 워크플로가 제거하지 않으니 수동 지정과 충돌하지 않는다.
+> 봇(dependabot 등) PR 은 assignee 가 될 수 없어 담당자 지정 대상에서 제외된다.
 
 ```bash
-gh pr create --base develop --title "label/domain" --body "$(cat <<'EOF'
+gh pr create --base develop --title "label/domain" \
+  --label "Feature" --assignee @me --body "$(cat <<'EOF'
 ## 작업 개요
 
 ## 작업한 내용
@@ -621,6 +640,7 @@ EOF
 ### Important Notes
 - Always create PRs targeting `develop` branch
 - Write PR body in Korean
+- 라벨/담당자를 항상 확인 - 워크플로가 자동으로 붙이지만 누락 시 수동 보정
 - Create issues first if needed and link them to PR
 - Requires team review before merging
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,53 @@
+# Bigtablet Inc. Open Source License
+
+## Table of Contents / 목차
+- [English Version](#english-version)
+- [한국어 버전](#한국어-버전)
+
+---
+
+## English Version
+
+This license is issued by **Bigtablet Inc.** (hereinafter referred to as the "Copyright Holder") and is intended to provide the source code to developers, researchers, and other users (hereinafter referred to as "Users").  
+Any use that contradicts the purposes stated below is strictly prohibited.
+
+### Terms and Conditions
+
+1. All copyrights for the source code and files opened within this GitHub organization belong to the Copyright Holder.  
+2. All open-source materials are, by default, permitted for **non-commercial use only**.  
+3. Any User who uses, modifies, processes, redistributes, or conducts research with part or all of the open source must clearly indicate the source by referencing the link to the original GitHub repository.  
+4. Commercial use of the open source without explicit or implicit permission from the Copyright Holder is strictly prohibited. For inquiries regarding commercial use, please contact the email address provided in the profile.  
+5. Users are obligated to report any issues, errors, or security vulnerabilities discovered or encountered while using the open source to the Copyright Holder, and are prohibited from exploiting or disclosing them to external parties. 
+6. If unauthorized commercial use is detected, the Copyright Holder reserves the right to take legal action.  
+7. By cloning, forking, or otherwise copying and using a repository containing this open source, the User is deemed to have fully understood and agreed to all the terms of this license.  
+8. This license shall take effect from **September 9, 2025**, and shall have legal force and effect from that date.  
+9. For any additional inquiries, please contact the email address listed in the profile.  
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+## 한국어 버전
+
+본 라이선스는 **Bigtablet Inc.**(이하 “저작권자”)에서 발행하였으며, 개발자, 연구자 등 (이하 “사용자”)에게 소스코드를 제공하기 위한 목적으로 공개합니다.  
+아래에 기재된 목적에 반하는 사용은 엄격히 금지됩니다.
+
+### 조항
+
+1. 본 GitHub 조직에 공개된 모든 소스코드와 파일에 대한 저작권은 저작권자에게 있습니다.  
+2. 모든 오픈소스는 원칙적으로 **비상업적 목적**으로만 이용할 수 있습니다.  
+3. 모든 사용자는 오픈소스의 일부 또는 전체를 사용, 수정, 가공, 재배포, 연구할 경우 반드시 해당 GitHub 저장소 링크를 통해 출처를 명시해야 합니다.  
+4. 저작권자의 명시적 또는 묵시적 허가 없이 오픈소스를 상업적 목적으로 이용하는 것을 금합니다. 상업적 이용 문의는 프로필에 기재된 이메일로 연락하시기 바랍니다.  
+5. 사용자는 오픈소스를 이용하는 중 발견되거나 발생한 문제, 오류, 보안 취약점을 저작권자에게 보고할 의무가 있으며 이를 악용하거나 외부로 공유하는 것을 금합니다.  
+6. 무단으로 상업적 이용이 적발될 경우 저작권자는 법적 조치를 취할 권리를 가집니다.  
+7. 오픈소스가 포함된 저장소를 clone, fork 또는 기타 방법으로 복제하여 이용하는 경우, 사용자는 본 라이선스의 모든 조항을 충분히 숙지하였으며 이에 동의한 것으로 간주됩니다.  
+8. 본 라이선스는 **2025년 9월 9일**부터 발효되며, 해당 시점부터 법적 효력을 가집니다.  
+9. 기타 문의 사항은 프로필에 기재된 이메일로 연락하시기 바랍니다.  
+
+### 면책 조항
+
+이 소프트웨어는 **“있는 그대로(As-Is)”** 제공되며, 상품성, 특정 목적에의 적합성, 비침해를 포함하되 이에 국한되지 않는 어떠한 형태의 명시적 또는 묵시적 보증도 하지 않습니다.  
+저작권자 또는 기여자는 계약, 불법행위, 기타 어떠한 법적 근거에 의한 것이든 간에, 본 소프트웨어 또는 이를 사용하거나 다른 방식으로 이용함으로 인해 발생하는 모든 청구, 손해, 기타 법적 책임에 대해 책임을 지지 않습니다.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A complete React + TypeScript design system maintained by Bigtablet for internal
 ## What's inside
 
 - **40+ components** across forms, display, feedback, navigation, overlay, and layout<br />
-- **11 token domains** - colors, typography, spacing, motion, radius, elevation, and more - exposed as SCSS variables and CSS custom properties<br />
+- **13 token domains** - colors, typography, spacing, motion, radius, elevation, and more - exposed as SCSS variables and CSS custom properties (plus a SCSS-only `layout` domain)<br />
 - **Light + dark mode** out of the box. `[data-theme="dark"]` or `prefers-color-scheme`, no theme provider required (but available via `ThemeProvider` for runtime toggling)<br />
 - **Vanilla JS bundle** for non-React backends - Thymeleaf, JSP, PHP, Django<br />
 - **Accessibility tested** with axe-core in CI · keyboard nav · ARIA throughout
@@ -58,7 +58,7 @@ A complete React + TypeScript design system maintained by Bigtablet for internal
 pnpm add @bigtablet/design-system react@^19 react-dom@^19 lucide-react
 ```
 
-Requires React 19 + lucide-react ≥ 0.552. Compatible with Next.js 13+.
+Requires React 19 + lucide-react ≥ 0.552. Next.js is an optional peer dependency at `>=15`.
 
 <details>
 <summary><b>One-line setup</b> - auto-detect package manager + framework</summary>
@@ -102,12 +102,13 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 ## Components
 
 <table>
-<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Textarea · Checkbox · Radio · Toggle · Dropdown · DatePicker · FileInput · OTPInput</td></tr>
+<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Textarea · Checkbox · Radio · RadioGroup · Toggle · Dropdown · DatePicker · FileInput · ImageCropper · OtpInput</td></tr>
 <tr><td><b>Display</b></td><td>Card · MediaCard · Hero · Avatar · Badge · Chip · ListItem · Table · Divider · Icon · Accordion</td></tr>
 <tr><td><b>Feedback</b></td><td>Alert · Toast · Spinner · TopLoading · LinearProgress · Skeleton · EmptyState · ErrorState</td></tr>
 <tr><td><b>Navigation</b></td><td>Tabs · Sidebar · BottomNav · NavBar · Breadcrumb · Menu · Pagination</td></tr>
-<tr><td><b>Overlay</b></td><td>Modal · Tooltip</td></tr>
+<tr><td><b>Overlay</b></td><td>Modal · Drawer · Tooltip · Popover</td></tr>
 <tr><td><b>Layout</b></td><td>Container · Section · Stack · Grid</td></tr>
+<tr><td><b>System</b></td><td>ThemeProvider</td></tr>
 </table>
 
 →&nbsp;Full API · [`docs/COMPONENTS.md`](./docs/COMPONENTS.md)
@@ -117,7 +118,7 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 ## Design tokens
 
 ```scss
-@use "src/styles/token" as token;
+@use "@bigtablet/design-system/scss/token" as token;
 
 .card {
   background: token.$color_bg_solid;
@@ -129,16 +130,18 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 ```
 
 ```css
+/* from @bigtablet/design-system/style.css */
 .card {
   background: var(--bt-color-bg-solid);
   color: var(--bt-color-text-heading);
-  padding: var(--bt-spacing-16);
-  border-radius: var(--bt-radius-md);
+  border: 1px solid var(--bt-color-border-default);
   box-shadow: var(--bt-elevation-level1);
 }
 ```
 
-`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`a11y`
+> The React entry's `style.css` only emits `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, and `--bt-bottom-nav-*`. Spacing, radius, and typography are **SCSS-only** on this entry - use `scss/token` for them (`--bt-spacing-*` / `--bt-radius-*` exist only in the [Vanilla bundle](./docs/VANILLA.md)).
+
+`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS only</sup>
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For server-rendered apps (Thymeleaf, JSP, PHP, Django):
 <link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 <script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
 
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 ```
 
 →&nbsp;Full guide · [`docs/VANILLA.md`](./docs/VANILLA.md)

--- a/README_KR.md
+++ b/README_KR.md
@@ -45,7 +45,7 @@ Bigtablet 인하우스 React + TypeScript 디자인 시스템. 커뮤니티 참�
 ## 구성
 
 - **40+ 컴포넌트** - forms, display, feedback, navigation, overlay, layout<br />
-- **11 개 토큰 도메인** - colors, typography, spacing, motion, radius, elevation 등. SCSS 변수 + CSS custom property 양쪽 제공<br />
+- **13 개 토큰 도메인** - colors, typography, spacing, motion, radius, elevation 등. SCSS 변수 + CSS custom property 양쪽 제공 (SCSS 전용 `layout` 도메인 별도)<br />
 - **라이트 + 다크 모드** 기본 내장. `[data-theme="dark"]` 또는 `prefers-color-scheme` 만으로 동작. 런타임 토글이 필요하면 `ThemeProvider`<br />
 - **Vanilla JS 번들** - Thymeleaf, JSP, PHP, Django 등 서버 템플릿 환경 지원<br />
 - **접근성 테스트** - CI 에서 axe-core 자동 검증. 키보드 네비 + ARIA 속성 완비
@@ -58,7 +58,7 @@ Bigtablet 인하우스 React + TypeScript 디자인 시스템. 커뮤니티 참�
 pnpm add @bigtablet/design-system react@^19 react-dom@^19 lucide-react
 ```
 
-React 19 + lucide-react ≥ 0.552 필요. Next.js 13+ 호환.
+React 19 + lucide-react ≥ 0.552 필요. Next.js 는 optional peer dependency 로 `>=15`.
 
 <details>
 <summary><b>한 줄 설치</b> - 패키지 매니저 + 프레임워크 자동 감지</summary>
@@ -102,12 +102,13 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 ## 컴포넌트
 
 <table>
-<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Checkbox · Radio · Toggle · Dropdown · DatePicker · FileInput · OTPInput</td></tr>
+<tr><td><b>Forms</b></td><td>Button · IconButton · TextField · Textarea · Checkbox · Radio · RadioGroup · Toggle · Dropdown · DatePicker · FileInput · ImageCropper · OtpInput</td></tr>
 <tr><td><b>Display</b></td><td>Card · MediaCard · Hero · Avatar · Badge · Chip · ListItem · Table · Divider · Icon · Accordion</td></tr>
-<tr><td><b>Feedback</b></td><td>Alert · Toast · Spinner · TopLoading · LinearProgress · Skeleton · EmptyState</td></tr>
-<tr><td><b>Navigation</b></td><td>Tabs · Sidebar · NavBar · Breadcrumb · Menu · Pagination</td></tr>
-<tr><td><b>Overlay</b></td><td>Modal · Tooltip</td></tr>
+<tr><td><b>Feedback</b></td><td>Alert · Toast · Spinner · TopLoading · LinearProgress · Skeleton · EmptyState · ErrorState</td></tr>
+<tr><td><b>Navigation</b></td><td>Tabs · Sidebar · BottomNav · NavBar · Breadcrumb · Menu · Pagination</td></tr>
+<tr><td><b>Overlay</b></td><td>Modal · Drawer · Tooltip · Popover</td></tr>
 <tr><td><b>Layout</b></td><td>Container · Section · Stack · Grid</td></tr>
+<tr><td><b>System</b></td><td>ThemeProvider</td></tr>
 </table>
 
 →&nbsp;전체 API · [`docs/COMPONENTS.md`](./docs/COMPONENTS.md)
@@ -117,7 +118,7 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 ## 디자인 토큰
 
 ```scss
-@use "src/styles/token" as token;
+@use "@bigtablet/design-system/scss/token" as token;
 
 .card {
   background: token.$color_bg_solid;
@@ -129,16 +130,18 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 ```
 
 ```css
+/* @bigtablet/design-system/style.css 에서 제공 */
 .card {
   background: var(--bt-color-bg-solid);
   color: var(--bt-color-text-heading);
-  padding: var(--bt-spacing-16);
-  border-radius: var(--bt-radius-md);
+  border: 1px solid var(--bt-color-border-default);
   box-shadow: var(--bt-elevation-level1);
 }
 ```
 
-`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`a11y`
+> React entry 의 `style.css` 가 내보내는 CSS 변수는 `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*` 뿐이다. spacing / radius / typography 는 이 entry 에선 **SCSS 전용**이라 `scss/token` 을 써야 한다 (`--bt-spacing-*` / `--bt-radius-*` 는 [Vanilla 번들](./docs/VANILLA.md) 에만 존재).
+
+`colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS 전용</sup>
 
 <br />
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -153,7 +153,7 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 <link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 <script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
 
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 ```
 
 →&nbsp;자세히 · [`docs/VANILLA.md`](./docs/VANILLA.md)

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -115,18 +115,30 @@ Composite shorthands `$transition_enter_*` / `$transition_exit_*` already includ
 
 ### Inline style usage
 
+**Prefer a `style.scss` rule with SCSS tokens.** It is the only place where every token - colour *and* spacing - is available by name:
+
+```scss
+// ✓ Best - both colour and spacing come from tokens
+.my-panel {
+  background: token.$color_bg_solid_dim;
+  padding: token.$spacing_16;
+}
+```
+
+Reach for an inline style only when the value is genuinely dynamic (computed at runtime). Then:
+
 ```tsx
-// ✓ Correct - --bt-color-* IS emitted by the React entry's style.css
-<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: 16 }} />
+// ✓ OK - --bt-color-* IS emitted by the React entry's style.css
+<div style={{ background: "var(--bt-color-bg-solid-dim)" }} />
 
 // ✗ Never - hardcoded hex breaks dark mode
-<div style={{ background: "#F2F5F8", padding: 16 }} />
+<div style={{ background: "#F2F5F8" }} />
 
 // ✗ Never - --bt-spacing-* is Vanilla-only, resolves to nothing in a React app
 <div style={{ padding: "var(--bt-spacing-16)" }} />
 ```
 
-Spacing in inline styles has no CSS var to reference on the React entry - prefer moving the rule into a `style.scss` and using `token.$spacing_16`.
+Spacing has no CSS var to reference on the React entry, so an inline `padding` has to be a bare number (`padding: 16`). That is a last resort - it is an untokenised literal. If you find yourself writing one, move the rule into `style.scss` and use `token.$spacing_16` instead.
 
 ---
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -52,7 +52,11 @@ Providers needed:
 
 ## Design Tokens
 
-All tokens are CSS custom properties prefixed with `--bt-color-*`, `--bt-spacing-*`, etc. Always reference them - never inline a hex value.
+Always reference tokens - never inline a hex value.
+
+Two surfaces, and they are **not** interchangeable:
+- **SCSS tokens** (`@use "src/styles/token" as token;` → `token.$spacing_16`) - the full set. Use these in component `style.scss`.
+- **CSS custom properties** (`var(--bt-color-bg-solid)`) - the React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`. Spacing / radius / typography CSS vars exist only in the Vanilla bundle.
 
 ### Color tokens
 
@@ -81,11 +85,15 @@ All tokens are CSS custom properties prefixed with `--bt-color-*`, `--bt-spacing
 
 ### Spacing
 
-`--bt-spacing-4` (4px) through `--bt-spacing-48` (48px). Standard scale: 4, 8, 12, 16, 20, 24, 32, 40, 48.
+SCSS: `$spacing_4` (4px) through `$spacing_48` (48px). Standard scale: 4, 8, 12, 16, 20, 24, 32, 40, 48.
+
+CSS vars (`--bt-spacing-4` … `--bt-spacing-48`) exist **only in the Vanilla bundle** - the React entry's `style.css` does not emit them. In React/Next code use the SCSS token.
 
 ### Radius
 
-`--bt-radius-xs` (2px), `-sm` (6px), `-md` (8px), `-lg` (12px), `-xl` (16px), `-full` (9999px).
+SCSS: `$radius_none` (0), `$radius_xs` (4px), `$radius_sm` (6px), `$radius_md` (8px), `$radius_lg` (12px), `$radius_xl` (16px), `$radius_full` (9999px).
+
+CSS vars exist **only in the Vanilla bundle**, and only for a subset: `--bt-radius-sm` / `-md` / `-lg` / `-full`. There is no `--bt-radius-xs` or `-xl`.
 
 ### Elevation
 
@@ -108,12 +116,17 @@ Composite shorthands `$transition_enter_*` / `$transition_exit_*` already includ
 ### Inline style usage
 
 ```tsx
-// ✓ Correct
-<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: "var(--bt-spacing-16)" }} />
+// ✓ Correct - --bt-color-* IS emitted by the React entry's style.css
+<div style={{ background: "var(--bt-color-bg-solid-dim)", padding: 16 }} />
 
-// ✗ Never
+// ✗ Never - hardcoded hex breaks dark mode
 <div style={{ background: "#F2F5F8", padding: 16 }} />
+
+// ✗ Never - --bt-spacing-* is Vanilla-only, resolves to nothing in a React app
+<div style={{ padding: "var(--bt-spacing-16)" }} />
 ```
+
+Spacing in inline styles has no CSS var to reference on the React entry - prefer moving the rule into a `style.scss` and using `token.$spacing_16`.
 
 ---
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -465,16 +465,18 @@ For non-React contexts (Thymeleaf, JSP, PHP, Django):
 <link rel="stylesheet" href="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 <script src="https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js"></script>
 
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 ```
 
 Class naming: `.bt-{component}` + `--{modifier}` + `.is-{state}` (BEM-like).
 
-Components available: Button, TextField, Checkbox, Radio, Toggle, Select, Modal, Card, Spinner, Pagination, DatePicker, FileInput.
+Components available: Button, TextField, Checkbox, Radio, Toggle, Dropdown, Modal, Card, Spinner, Pagination, DatePicker, FileInput.
+
+Class names and JS option names mirror the React API exactly - there are no deprecated aliases. See [MIGRATION.md](./MIGRATION.md#v380-vanilla-패키지-정리) for the v3.8.0 old → new map.
 
 JS API (auto-init on DOMContentLoaded, or manual):
 ```js
-const select = Bigtablet.Select("#my-select", { options, onChange });
+const dropdown = Bigtablet.Dropdown("#my-dropdown", { options, onValueChange });
 const modal = Bigtablet.Modal("#my-modal", { onOpen, onClose });
 Bigtablet.Alert({ title, message, showCancel: true, onConfirm });
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,16 +24,19 @@ bigtablet-design-system/
 │   ├── ui/                  # UI 컴포넌트 - 8 카테고리 폴더 하위에 컴포넌트
 │   │   ├── display/         # accordion avatar badge card chip divider hero icon list-item media-card table
 │   │   ├── feedback/        # alert empty-state error-state linear-progress skeleton spinner toast top-loading
-│   │   ├── forms/           # checkbox date-picker dropdown file otp-input radio radio-group textarea textfield toggle
+│   │   ├── forms/           # checkbox date-picker dropdown file image-cropper otp-input radio radio-group textarea textfield toggle
 │   │   ├── general/         # button icon-button
 │   │   ├── layout/          # container grid section stack
 │   │   ├── navigation/      # bottom-nav breadcrumb menu nav-bar pagination sidebar tabs
-│   │   ├── overlay/         # modal popover tooltip
+│   │   ├── overlay/         # drawer modal popover tooltip
 │   │   └── system/          # theme-provider
 │   │
 │   ├── utils/               # cn + 훅
 │   │   ├── cn.ts
+│   │   ├── overlay-stack.ts        # 공유 오버레이 Escape 스택 (registerOverlay / useOverlayEscape)
+│   │   ├── use-anchored-position.ts
 │   │   ├── use-focus-trap.ts
+│   │   ├── use-is-mounted.ts
 │   │   ├── use-reduced-motion.ts
 │   │   ├── use-spring-presence.ts  /  use-spring-hover.ts
 │   │   ├── use-safe-layout-effect.ts
@@ -80,36 +83,72 @@ import type * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-    variant?: "primary" | "secondary" | "ghost" | "danger";
-    size?: "sm" | "md" | "lg";
+export type ButtonVariant = "filled" | "tonal" | "outline" | "text";
+export type ButtonSize = "sm" | "md" | "lg" | "xl";
+
+/** button/anchor 공통 스타일·콘텐츠 props (export 하지 않는 내부 베이스) */
+interface ButtonBaseProps {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
     fullWidth?: boolean;
+    /** 위험한 액션 - variant 와 조합되는 boolean modifier */
+    danger?: boolean;
+    disabled?: boolean;
 }
 
-export const Button = ({
-    variant = "primary",
-    size = "md",
-    fullWidth,
-    className,
-    children,
-    ...props
-}: ButtonProps) => {
+export interface ButtonAsButton
+    extends ButtonBaseProps,
+        Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonBaseProps> {
+    as?: "button";
+    href?: never;
+    ref?: React.Ref<HTMLButtonElement>;
+}
+
+export interface ButtonAsAnchor
+    extends ButtonBaseProps,
+        Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof ButtonBaseProps> {
+    as?: "a";
+    href: string;
+    ref?: React.Ref<HTMLAnchorElement>;
+}
+
+/** `as`/`href` 로 button ↔ anchor 를 가르는 discriminated union */
+export type ButtonProps = ButtonAsButton | ButtonAsAnchor;
+
+export const Button = (props: ButtonProps) => {
+    const {
+        variant = "filled",
+        size = "md",
+        fullWidth = false,
+        danger = false,
+        disabled = false,
+        as,
+        className,
+        children,
+        ref,
+        ...rest
+    } = props;
+
+    const buttonClassName = cn(
+        "button",
+        `button_variant_${variant}`,
+        `button_size_${size}`,
+        fullWidth && "button_full_width",
+        danger && "button_danger",
+        disabled && "button_disabled",
+        className
+    );
+
+    // as="a" 또는 (as 미지정 + href 존재) 시 anchor 로 렌더링 (생략)
     return (
-        <button
-            className={cn(
-                "button",
-                `button_variant_${variant}`,
-                `button_size_${size}`,
-                fullWidth && "button_full_width",
-                className
-            )}
-            {...props}
-        >
+        <button ref={ref as React.Ref<HTMLButtonElement>} disabled={disabled} className={buttonClassName} {...rest}>
             {children}
         </button>
     );
 };
 ```
+
+> 여러 요소로 렌더될 수 있는 컴포넌트는 이렇게 **discriminated union** 으로 만든다. 대신 소비자가 `interface X extends ButtonProps` 로 확장할 수 없으므로 `React.ComponentProps<typeof Button>` 을 안내한다 ([MIGRATION.md](./MIGRATION.md) 참고).
 
 ---
 
@@ -131,18 +170,34 @@ export const Button = ({
     justify-content: center;
     border: none;
     cursor: pointer;
-    transition: all token.$transition_base;
+    border-radius: token.$radius_full;
+    // `transition: all` 금지 - 바뀌는 속성만 명시한다 (CLAUDE.md 애니메이션 규칙)
+    transition:
+        background-color token.$transition_fast,
+        color token.$transition_fast,
+        box-shadow token.$transition_fast;
+
+    &_variant_filled {
+        background-color: token.$color_brand_primary;
+        color: token.$color_brand_on_primary;
+    }
+
+    &_size_md {
+        height: 40px;
+        padding: 0 token.$spacing_16;
+        font-size: token.$font_size_15;
+    }
+
+    &_danger {
+        background-color: token.$color_status_error;
+        color: token.$color_status_error_on_default;
+    }
 }
 
-.variant_primary {
-    background-color: token.$color_primary;
-    color: token.$color_white;
-}
-
-.size_md {
-    height: 40px;
-    padding: 0 token.$spacing_lg;
-    font-size: token.$font_size_base;
+@media (prefers-reduced-motion: reduce) {
+    .button {
+        transition: none;
+    }
 }
 ```
 
@@ -173,12 +228,23 @@ cn(styles.button, styles[`size_${size}`], className);
 ### React / Next.js (`.`)
 
 ```ts
-// src/index.ts - 모든 컴포넌트·훅·유틸 re-export
-export * from "./ui/general/button";
-export * from "./ui/forms/textfield";
-export { cn, useReducedMotion } from "./utils";
-// ... 모든 컴포넌트 export
+// src/index.ts - 컴포넌트·타입·토큰을 명시적 named export 로 나열한다.
+// `export *` 는 쓰지 않는다 - 공개 API 표면이 파일 구조에 따라 조용히 늘어나는 걸 막기 위해서다.
+import "./styles/theme.scss"; // :root / [data-theme="dark"] CSS 변수 (dist/index.css 에 1회 포함)
+
+export { cn, useFocusTrap, useReducedMotion, useSpringHover, useSpringPresence } from "./utils";
+
+export type { ButtonProps } from "./ui/general/button";
+export { Button } from "./ui/general/button";
+export type { ImeStrategy, TextFieldProps, TextFieldSize } from "./ui/forms/textfield";
+export { TextField } from "./ui/forms/textfield";
+
+export { colors, baseColors } from "./styles/colors";
+export { spacing } from "./styles/spacing";
+// ... 나머지 컴포넌트 / 타입 / 토큰도 동일하게 명시적으로 나열
 ```
+
+> 새 컴포넌트를 추가하면 `src/index.ts` 에 **직접 export 를 추가해야** 소비자에게 노출된다. 반대로 `src/utils/index.ts` 에만 있고 `src/index.ts` 에 없는 항목(`registerOverlay` / `useOverlayEscape` / `useIsMounted` / `useAnchoredPosition`)은 **내부 전용**이다.
 
 별도 `/next` entry 는 없다. 컴포넌트가 `"use client"` 로 마킹되고(빌드 시 tsup 가 `dist/index.js` 선두에 자동 주입) `next` 가 optional peer dependency 라, 동일한 `.` export 로 Next.js App Router 에서 그대로 동작한다.
 
@@ -195,47 +261,79 @@ CDN 또는 직접 import로 사용:
 
 ## 디자인 토큰
 
+토큰은 **base(원시값) → semantic(용도별 별칭)** 2계층이다. 컴포넌트는 **semantic 만** 쓴다 - 다크 모드가 semantic 계층에서 갈리기 때문이다.
+
 ### TypeScript 토큰
 
 ```ts
 // src/styles/colors/index.ts
-export const colors = {
-    primary: "#000000",
-    primaryHover: "#333333",
-    error: "#ef4444",
-    success: "#047857",
+export const baseColors = {
+    brandPrimary: "#121212",
+    neutral0: "#FFFFFF",
+    neutral200: "#E5E5E5",
+    statusError: "#B91C1C",
     // ...
-};
+} as const;
+
+// semantic - 컴포넌트가 참조하는 계층 (용도별로 중첩)
+export const colors = {
+    brand:  { primary: baseColors.brandPrimary, onPrimary: baseColors.neutral0 },
+    text:   { heading: baseColors.neutral900, body: baseColors.neutral700, /* ... */ },
+    bg:     { solid: baseColors.neutral0, solidDim: baseColors.neutral50, /* ... */ },
+    border: { default: baseColors.neutral200, focus: baseColors.neutral900, /* ... */ },
+    // ...
+} as const;
+
+// src/styles/spacing/index.ts - 숫자 스케일 (px 값 문자열)
+export const spacing = { "4": "4px", "8": "8px", "16": "16px", "24": "24px", /* ... */ } as const;
 ```
 
 ### SCSS 토큰
 
+semantic 색상은 `var(--bt-*)` 를 가리킨다. SCSS 변수 자체가 CSS 변수 참조라서 `[data-theme="dark"]` 전환이 재컴파일 없이 그대로 따라온다.
+
 ```scss
-// src/styles/colors/_index.scss
-$color_primary: #000000;
-$color_primary_hover: #333333;
-$color_error: #ef4444;
-$color_success: #047857;
+// src/styles/colors/_index.scss - semantic 은 CSS 변수 참조
+$color_brand_primary:  var(--bt-color-brand-primary);
+$color_bg_solid:       var(--bt-color-bg-solid);
+$color_bg_solid_dim:   var(--bt-color-bg-solid-dim);
+$color_text_heading:   var(--bt-color-text-heading);
+$color_text_body:      var(--bt-color-text-body);
+$color_border_default: var(--bt-color-border-default);
+$color_status_error:   var(--bt-color-status-error);
 
-$spacing_xs: 0.25rem;
-$spacing_sm: 0.5rem;
-$spacing_md: 0.75rem;
-$spacing_lg: 1rem;
+// src/styles/spacing/_index.scss - 숫자 스케일 (t-shirt 사이즈 아님)
+$spacing_4:  4px;
+$spacing_8:  8px;
+$spacing_16: 16px;
+$spacing_24: 24px;
+$spacing_32: 32px;
 
-$font_size_sm: 0.875rem;
-$font_size_base: 0.9375rem;
-$font_size_md: 1rem;
+// src/styles/typography/_index.scss - 숫자 스케일
+$font_size_14: 14px;
+$font_size_15: 15px;
+$font_size_16: 16px;
+$font_weight_medium: 500;
 
-$radius_sm: 6px;
-$radius_md: 8px;
-$radius_lg: 12px;
+// src/styles/radius/_index.scss
+$radius_xs:   4px;
+$radius_sm:   6px;
+$radius_md:   8px;
+$radius_full: 9999px;
 
-$shadow_sm: 0 2px 4px rgba(0, 0, 0, 0.04);
-$shadow_md: 0 4px 12px rgba(0, 0, 0, 0.08);
+// src/styles/elevation/_index.scss - shadow 도 CSS 변수 참조 (다크 모드 대응)
+$elevation_level1: var(--bt-elevation-level1);
+$elevation_level2: var(--bt-elevation-level2);
 
-$transition_fast: 0.1s ease-in-out;
-$transition_base: 0.2s ease-in-out;
+// src/styles/motion/_index.scss
+$duration_base:   0.2s;
+$transition_fast: $duration_fast ease-in-out;
+$transition_base: $duration_base ease-in-out;
+$easing_enter:    cubic-bezier(0.16, 1, 0.3, 1);
+$easing_exit:     cubic-bezier(0.4, 0, 1, 1);
 ```
+
+> `$color_primary` / `$color_white` / `$spacing_xs|sm|md|lg` / `$shadow_sm|md` 같은 t-shirt·원시 네이밍 토큰은 **존재하지 않는다**. semantic 이름과 숫자 스케일만 쓴다.
 
 ---
 
@@ -318,8 +416,13 @@ describe("Button", () => {
     });
 
     it("applies variant class", () => {
-        const { container } = render(<Button variant="danger">Delete</Button>);
-        expect(container.firstChild).toHaveClass("variant_danger");
+        const { container } = render(<Button variant="outline">Delete</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_outline");
+    });
+
+    it("applies the danger modifier", () => {
+        const { container } = render(<Button danger>Delete</Button>);
+        expect(container.firstChild).toHaveClass("button_danger");
     });
 });
 ```
@@ -330,32 +433,36 @@ describe("Button", () => {
 
 ### GitHub Actions
 
-```yaml
-# .github/workflows/ci.yml
-name: CI
+정본은 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) 이다. 아래는 그 구조 요약이므로, 실제 값(액션 버전·Node 버전 등)은 워크플로 파일을 확인할 것.
 
-on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+**트리거**
+- `pull_request` → `develop`, `main`
+- `push` → `develop`
+- 양쪽 모두 `paths-ignore` 로 `**.md` · `docs/**` · `.github/ISSUE_TEMPLATE/**` · `LICENSE` 는 제외 (docs-only PR 은 CI 를 돌리지 않는다)
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "pnpm"
-      - run: pnpm install
-      - run: pnpm test
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm test:storybook
-      - run: pnpm build
-```
+**job 구성**
+
+| Job | 역할 |
+|------|------|
+| `changes` | `dorny/paths-filter` 로 `code` / `stories` / `deps` / `vanilla` 변경 여부를 한 번만 판정해 후속 step 의 조건으로 넘긴다 |
+| `test` | 위 4개 중 하나라도 변경됐을 때만 실행 |
+
+**`test` job 의 step (실행 조건 포함)**
+
+| Step | 조건 |
+|------|------|
+| Checkout (`actions/checkout@v6`, `fetch-depth: 0`) | 항상 |
+| Setup pnpm (`pnpm/action-setup@v4`) + Node (`actions/setup-node@v6`, `node-version: 22.14.0`, `cache: pnpm`) | 항상 |
+| `pnpm install --frozen-lockfile` | 항상 |
+| `pnpm exec commitlint` | `develop` 대상 PR 이고 dependabot 이 아닐 때 |
+| `pnpm lint:css` (Stylelint - raw hex / named color 금지) | `code` 또는 `stories` 변경 |
+| `pnpm test:coverage` | `code` 또는 `deps` 변경 |
+| `pnpm exec playwright install --with-deps chromium` → `pnpm test:storybook` | `code` 또는 `stories` 변경 (Chromium ~200MB 라 무겁다) |
+| `pnpm build` | 항상 |
+| `pnpm size` (size-limit - dist 산출물 기반) | 항상 |
+| `davelosert/vitest-coverage-report-action@v2` | PR 이면서 `code` 또는 `deps` 변경 |
+
+배포는 별도 워크플로다 - `v*` 태그 push 시 [`.github/workflows/release.yml`](../.github/workflows/release.yml) 이 `npm publish --provenance` + GitHub Release 를 처리한다.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -139,7 +139,8 @@ export const Button = (props: ButtonProps) => {
         className
     );
 
-    // as="a" 또는 (as 미지정 + href 존재) 시 anchor 로 렌더링 (생략)
+    // 지면상 button 분기만 표시한 부분 예시. 실제 구현은 as="a" 또는 (as 미지정 + href 존재) 시
+    // <a href={href} {...rest}>{children}</a> 로 렌더링해야 한다 - 그대로 복사하면 링크가 동작하지 않음.
     return (
         <button ref={ref as React.Ref<HTMLButtonElement>} disabled={disabled} className={buttonClassName} {...rest}>
             {children}
@@ -326,6 +327,7 @@ $elevation_level1: var(--bt-elevation-level1);
 $elevation_level2: var(--bt-elevation-level2);
 
 // src/styles/motion/_index.scss
+$duration_fast:   0.1s;
 $duration_base:   0.2s;
 $transition_fast: $duration_fast ease-in-out;
 $transition_base: $duration_base ease-in-out;

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -360,7 +360,19 @@ import { Settings } from 'lucide-react';
 | `variant` | `'standard' \| 'filled' \| 'tonal' \| 'outlined'` | `'standard'` | 스타일 |
 | `size` | `'sm' \| 'md'` | `'md'` | 크기 |
 | `icon` | `ReactNode` | required | 표시할 아이콘 |
+| `aria-label` | `string` | **둘 중 하나 필수** | 아이콘 버튼의 접근성 이름 |
+| `aria-labelledby` | `string` | **둘 중 하나 필수** | 접근성 이름을 제공하는 외부 요소의 id |
 | `disabled` | `boolean` | `false` | 비활성화 |
+
+> ⚠️ **접근성 이름은 타입 레벨에서 필수다.** `icon` 은 항상 `aria-hidden="true"` span 으로 감싸지므로, `aria-label` / `aria-labelledby` 중 하나를 주지 않으면 버튼에 접근성 이름이 전혀 없다 (WCAG 2.1 SC 4.1.2 Name, Role, Value). `IconButtonProps` 는 이를 강제하는 `IconButtonWithAriaLabel | IconButtonWithAriaLabelledBy` union 이라 `<IconButton icon={<X />} />` 는 **컴파일되지 않는다**.
+>
+> ```tsx
+> // ❌ 타입 에러 - 접근성 이름 없음
+> <IconButton icon={<X />} />
+> // ✅
+> <IconButton icon={<X />} aria-label="닫기" />
+> <IconButton icon={<X />} aria-labelledby="dialog-title" />
+> ```
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -23,12 +23,15 @@ Bigtablet Design System의 모든 React 컴포넌트 문서입니다.
   - [Toggle](#toggle)
   - [DatePicker](#datepicker)
   - [FileInput](#fileinput)
+  - [ImageCropper](#imagecropper)
+  - [OtpInput](#otpinput)
 - [Feedback](#feedback)
   - [Alert](#alert)
   - [Toast](#toast)
   - [Spinner](#spinner)
   - [TopLoading](#toploading)
   - [LinearProgress](#linearprogress)
+  - [Skeleton](#skeleton)
 - [Navigation](#navigation)
   - [Pagination](#pagination)
   - [Tabs](#tabs)
@@ -53,6 +56,8 @@ Bigtablet Design System의 모든 React 컴포넌트 문서입니다.
   - [EmptyState](#emptystate)
   - [ErrorState](#errorstate)
   - [Accordion](#accordion)
+  - [Table](#table)
+  - [Icon](#icon)
 - [Layout](#layout)
   - [Container](#container)
   - [Section](#section)
@@ -155,28 +160,47 @@ import { Button } from '@bigtablet/design-system';
 <Button>클릭</Button>
 
 // Variants
-<Button variant="primary">Primary</Button>
-<Button variant="secondary">Secondary</Button>
-<Button variant="ghost">Ghost</Button>
-<Button variant="danger">Danger</Button>
+<Button variant="filled">Filled</Button>
+<Button variant="tonal">Tonal</Button>
+<Button variant="outline">Outline</Button>
+<Button variant="text">Text</Button>
+
+// 위험한 액션 - variant 와 조합하는 boolean prop (variant="danger" 는 존재하지 않음)
+<Button danger>삭제</Button>
+<Button variant="outline" danger>삭제</Button>
 
 // Sizes
 <Button size="sm">Small</Button>
 <Button size="md">Medium</Button>
 <Button size="lg">Large</Button>
+<Button size="xl">XLarge</Button>
+
+// 아이콘
+import { Plus } from 'lucide-react';
+<Button leadingIcon={<Plus size={16} />}>추가</Button>
 
 // 너비 조절
-<Button width="200px">고정 너비</Button>
 <Button fullWidth>전체 너비</Button>
+
+// anchor 로 렌더링 - href 만 줘도 자동 분기
+<Button href="/pricing">요금제 보기</Button>
+<Button as="a" href="https://example.com" target="_blank" rel="noreferrer">외부 링크</Button>
 ```
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `variant` | `'primary' \| 'secondary' \| 'ghost' \| 'danger'` | `'primary'` | 버튼 스타일 |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 버튼 크기 |
-| `width` | `string` | - | 버튼 너비 |
+| `variant` | `'filled' \| 'tonal' \| 'outline' \| 'text'` | `'filled'` | 버튼 스타일 |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | 버튼 크기 |
+| `danger` | `boolean` | `false` | 위험한 액션(삭제/취소) 빨간 강조. `variant` 와 조합해서 사용 |
+| `leadingIcon` | `ReactNode` | - | 버튼 앞에 표시할 아이콘 |
+| `trailingIcon` | `ReactNode` | - | 버튼 뒤에 표시할 아이콘 |
+| `radius` | `'none' \| 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'full'` | border-radius 토큰 |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
-| `disabled` | `boolean` | `false` | 비활성화 |
+| `as` | `'button' \| 'a'` | `'button'` | 렌더링할 요소. `href` 만 줘도 anchor 로 분기 |
+| `href` | `string` | - | 링크 대상 (`as="a"` 일 때 필수) |
+| `disabled` | `boolean` | `false` | 비활성화. anchor 는 `aria-disabled` + 클릭 차단으로 처리 |
+
+> `ButtonProps` 는 `ButtonAsButton | ButtonAsAnchor` discriminated union 이라 `interface X extends ButtonProps` 로 확장할 수 없다. 확장이 필요하면 `React.ComponentProps<typeof Button>` 을 쓴다 ([MIGRATION.md](./MIGRATION.md) 참고).
 
 ---
 
@@ -220,18 +244,47 @@ const [fruit, setFruit] = useState<string | null>(null);
     { value: 'nyc', label: '뉴욕', supportingText: '미국' },
   ]}
 />
+
+// 검색 가능 (label 부분 일치 필터)
+<Dropdown options={options} searchable searchPlaceholder="과일 검색…" emptyText="일치하는 과일 없음" />
+
+// 다중 선택
+const [fruits, setFruits] = useState<string[]>([]);
+<Dropdown
+  multiple
+  options={options}
+  value={fruits}
+  onValueChange={(values, opts) => setFruits(values)}
+  selectedSummary={(count) => `${count}개 담김`}
+/>
+
+// 네이티브 폼 제출 참여 - 선택 값이 hidden input 으로 렌더됨
+<form action="/submit" method="post">
+  <Dropdown name="fruit" options={options} />
+</form>
 ```
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `options` | `DropdownOption[]` | required | 옵션 목록 |
-| `value` | `string \| null` | - | 선택된 값 (controlled) |
-| `defaultValue` | `string \| null` | `null` | 기본 선택값 |
-| `onValueChange` | `(value, option) => void` | - | 변경 핸들러 |
+| `value` | `string \| null` (single) · `string[]` (multiple) | - | 선택된 값 (controlled) |
+| `defaultValue` | `string \| null` (single) · `string[]` (multiple) | - | 기본 선택값 |
+| `onValueChange` | `(value, option) => void` (single) · `(values, options) => void` (multiple) | - | 변경 핸들러 (canonical) |
+| ~~`onChange`~~ | `onValueChange` 와 동일 시그니처 | - | **deprecated** (v3.3.0, `onValueChange` 의 alias). [MIGRATION.md](./MIGRATION.md) 참고 |
+| `multiple` | `boolean` | `false` | 다중 선택 모드. `value`/`onValueChange` 시그니처가 배열로 바뀜 |
+| `searchable` | `boolean` | `false` | 열린 패널 상단에 검색 입력 표시 (`label` 부분 일치 필터) |
+| `searchPlaceholder` | `string` | `'검색…'` | 검색 입력 플레이스홀더 |
+| `emptyText` | `string` | `'결과 없음'` | 필터 결과가 0개일 때 표시할 텍스트 |
+| `selectedSummary` | `(count: number) => string` | ``(count) => `${count}개 선택` `` | 다중 선택 요약 텍스트 |
 | `label` | `string` | - | 플로팅 라벨 (값 선택 시 또는 열릴 때 표시) |
 | `placeholder` | `string` | `'Select…'` | 플레이스홀더 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
+| `name` | `string` | - | 네이티브 폼 제출용 name. 선택 값이 hidden input 으로 렌더됨 (multiple 은 같은 name 반복) |
+| `id` | `string` | 자동 생성 | 드롭다운 요소 id |
+| `className` | `string` | - | 루트 요소에 추가할 className |
 | ~~`fullWidth`~~ | `boolean` | - | **deprecated** (v3.0.0, no-op - 항상 부모 너비를 채움). [MIGRATION.md](./MIGRATION.md) 참고 |
+| ~~`variant`~~ | `'outline' \| 'filled' \| 'ghost'` | - | **deprecated** (no-op - outline 스타일만 사용) |
+| ~~`textAlign`~~ | `'left' \| 'center'` | - | **deprecated** (no-op) |
 | `disabled` | `boolean` | `false` | 비활성화 |
 
 **DropdownOption:**
@@ -323,17 +376,14 @@ import { TextField } from '@bigtablet/design-system';
 
 // 상태 표시
 <TextField label="이메일" error supportingText="유효하지 않은 이메일입니다" />
-<TextField label="이메일" success supportingText="사용 가능한 이메일입니다" />
 
 // 아이콘
 import { Search, Eye } from 'lucide-react';
-<TextField leftIcon={<Search size={16} />} placeholder="검색..." />
-<TextField rightIcon={<Eye size={16} />} type="password" />
+<TextField leadingIcon={<Search size={16} />} placeholder="검색..." />
+<TextField trailingIcon={<Eye size={16} />} type="password" />
 
-// Variants
-<TextField variant="outline" label="Outline" />
-<TextField variant="filled" label="Filled" />
-<TextField variant="ghost" label="Ghost" />
+// 지우기 버튼
+<TextField label="검색어" clearable onValueChange={(v) => setQuery(v)} />
 
 // 값 변환 (자동 포맷팅)
 <TextField
@@ -346,17 +396,20 @@ import { Search, Eye } from 'lucide-react';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `label` | `string` | - | 라벨 |
+| `showLabel` | `boolean` | `true` | 라벨 표시 여부 (false 면 SR 전용) |
 | `supportingText` | `string` | - | 도움말 텍스트 |
 | `error` | `boolean` | `false` | 에러 상태 |
-| `success` | `boolean` | `false` | 성공 상태 |
-| `variant` | `'outline' \| 'filled' \| 'ghost'` | `'outline'` | 스타일 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
-| `leftIcon` | `ReactNode` | - | 왼쪽 아이콘 |
-| `rightIcon` | `ReactNode` | - | 오른쪽 아이콘 |
+| `leadingIcon` | `ReactNode` | - | 왼쪽 아이콘 |
+| `trailingIcon` | `ReactNode` | - | 오른쪽 아이콘 |
+| `clearable` | `boolean` | `false` | 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
 | `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 (호출 시점은 `imeStrategy` 에 따름) |
+| ~~`onChangeAction`~~ | `(value: string) => void` | - | **deprecated** (v3.3.0, `onValueChange` alias). Next 서버 액션 전달용 `Action` 접미사가 필요하면 계속 사용 가능 |
 | `imeStrategy` | `'delayed' \| 'immediate'` | `'delayed'` | IME 조합 중 콜백 전략 (v3.1). `immediate` = 조합 중에도 즉시 호출 |
 | `transformValue` | `(value: string) => string` | - | 값 변환 함수 |
+
+> TextField 에는 `variant` · `success` prop 이 없다. outline 스타일 하나만 제공하며, 성공 상태는 별도 표현이 없다 (에러만 `error` 로 표시).
 
 > **v3.0 변경**: 내부 마크업이 `<fieldset>` + `<legend>` 구조에서 standalone `<label htmlFor>` 구조로 변경되었습니다. 공개 props는 동일하지만, 커스텀 SCSS에서 `.text_field_legend` 같은 내부 셀렉터를 오버라이드했다면 점검이 필요합니다.
 
@@ -675,22 +728,180 @@ import { FileInput } from '@bigtablet/design-system';
   onFiles={(files) => console.log(files)}
 />
 
-// 여러 파일
+// 여러 파일 + 도움말
 <FileInput
   label="이미지 업로드"
   accept="image/*"
   multiple
+  supportingText="PNG, JPG 파일만 업로드 가능합니다"
+  onFiles={(files) => console.log(files)}
+/>
+
+// 썸네일 미리보기 (variant="button" + preview)
+<FileInput label="사진 첨부" accept="image/*" multiple preview />
+
+// 큰 박스 이미지 업로더 (아바타 패턴) - 단일 이미지
+<FileInput
+  variant="preview"
+  previewSize={120}
+  label="프로필 사진 선택"
+  accept="image/*"
   onFiles={(files) => console.log(files)}
 />
 ```
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `label` | `string` | `'파일 선택'` | 버튼 라벨 |
+| `label` | `string` | `'Choose file'` | 파일 선택 버튼 라벨 / `variant="preview"` 의 빈 상태 텍스트 |
+| `variant` | `'button' \| 'preview'` | `'button'` | 표시 형태. `preview` 는 큰 박스에 이미지를 채우는 단일 이미지 업로더 |
+| `previewSize` | `number` | `160` | `variant="preview"` 박스 한 변 크기 (px) |
+| `preview` | `boolean` | `false` | 이미지 선택 시 64×64 썸네일을 버튼 아래 나열 (`variant="button"` 전용) |
+| `supportingText` | `string` | - | 입력 아래 도움말 텍스트 |
 | `accept` | `string` | - | 허용 파일 타입 |
-| `onFiles` | `(files: FileList \| null) => void` | - | 파일 선택 핸들러 |
-| `multiple` | `boolean` | `false` | 다중 선택 |
+| `onFiles` | `(files: FileList \| null) => void` | - | 파일 선택 핸들러. 미리보기 제거 시 `null` 로 호출 |
+| `multiple` | `boolean` | `false` | 다중 선택 (`variant="preview"` 는 항상 단일 이미지) |
 | `disabled` | `boolean` | `false` | 비활성화 |
+
+> 나머지 `input[type=file]` 네이티브 속성(`name`, `required`, `onChange` 등)은 그대로 전달된다. `onChange` 를 함께 넘기면 `onFiles` 뒤에 이어서 호출된다.
+
+---
+
+### ImageCropper
+
+업로드 전에 이미지에서 **보일 정사각 영역**을 정하는 크로퍼 (v3.7.0). 뷰포트 안에서 드래그(또는 방향키)로 위치를, 휠·슬라이더·＋/－ 버튼(또는 <kbd>+</kbd>/<kbd>-</kbd> 키)으로 배율을 맞춘다.
+
+모달을 포함하지 않으므로 소비자가 [`Modal`](#modal) 등으로 감싸고, "적용" 버튼에서 `ref.crop()` 을 호출해 `Blob` 을 받는다.
+
+#### 언제 쓰는가
+
+| 상황 | 선택 |
+|------|------|
+| 프로필/아바타 이미지 업로드 전 원형 크롭 | ✅ ImageCropper (`circular`) |
+| 썸네일·커버 이미지의 정사각 영역 지정 | ✅ ImageCropper |
+| 자유 비율(16:9 등) 크롭 | ❌ 미지원 - 결과는 항상 정사각 |
+| 크롭 없이 단순 파일 선택 + 미리보기 | ❌ [FileInput](#fileinput) `variant="preview"` 권장 |
+
+**Props**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `src` | `File \| Blob \| string` | required | 크롭할 이미지. 로컬 `File`/`Blob` 또는 이미지 URL |
+| `ref` | `Ref<ImageCropperHandle>` | - | `crop()` / `reset()` 을 호출할 imperative 핸들 (React 19 ref-as-prop) |
+| `outputSize` | `number` | `512` | 결과물 한 변 길이 (px) |
+| `outputType` | `'auto' \| 'image/jpeg' \| 'image/png' \| 'image/webp'` | `'auto'` | 결과 MIME. `auto` 는 PNG 만 PNG 로, 나머지는 JPEG |
+| `quality` | `number` | `0.92` | JPEG/WebP 인코딩 품질 (0~1) |
+| `circular` | `boolean` | `false` | 원형 가이드 (아바타용). false 면 둥근 사각형 |
+| `viewportSize` | `number` | `240` | 뷰포트 한 변 길이 (px) |
+| `minZoom` | `number` | `1` | 최소 배율 (1 = 이미지가 뷰포트를 딱 덮음) |
+| `maxZoom` | `number` | `3` | 최대 배율 |
+| `onReady` | `(size: CropImageSize) => void` | - | 이미지 로드 완료 콜백 |
+| `onError` | `() => void` | - | 이미지 디코딩 실패 콜백 (손상 파일 등) |
+| `label` | `string` | `'이미지 위치와 배율 조정'` | 뷰포트 접근성 레이블 |
+| `hint` | `string` | `'드래그(또는 방향키)로 위치, 휠·슬라이더로 배율을 맞추세요.'` | 뷰포트 아래 조작 안내 문구 |
+| `zoomOutLabel` | `string` | `'축소'` | 축소 버튼 접근성 레이블 |
+| `zoomLabel` | `string` | `'배율'` | 배율 슬라이더 접근성 레이블 |
+| `zoomInLabel` | `string` | `'확대'` | 확대 버튼 접근성 레이블 |
+| `noPanHint` | `string` | `'이미지가 뷰포트를 딱 채워 이동 여유가 없습니다.'` | 이동 여유가 없을 때 SR 안내 문구 |
+| `className` | `string` | - | 루트 요소에 추가할 className |
+
+> 루트는 표준 `div` 속성(`id` / `data-*` / `aria-*` / `style` 등)을 그대로 전달받는다. 단 `onError` 는 이미지 디코드 실패 콜백으로 재정의되어 있고, `children` / `dangerouslySetInnerHTML` 은 루트가 항상 자체 자식을 렌더하므로 받지 않는다.
+
+**`ImageCropperHandle` (ref)**
+
+| 메서드 | Type | Description |
+|------|------|-------------|
+| `crop` | `() => Promise<Blob>` | 현재 보이는 정사각 영역을 잘라 `Blob` 반환. 소비자의 "적용" 버튼에서 호출 |
+| `reset` | `() => void` | 배율·위치를 초기 상태(zoom=min, 중앙)로 되돌림 |
+
+**Usage**
+
+```tsx
+import { useRef, useState } from "react";
+import { ImageCropper, Modal, Button, FileInput } from "@bigtablet/design-system";
+import type { ImageCropperHandle } from "@bigtablet/design-system";
+
+function AvatarUploader() {
+  const cropperRef = useRef<ImageCropperHandle>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleApply = async () => {
+    const blob = await cropperRef.current!.crop();
+    const form = new FormData();
+    form.append("avatar", blob, "avatar.jpg");
+    await fetch("/api/avatar", { method: "POST", body: form });
+    setFile(null);
+  };
+
+  return (
+    <>
+      <FileInput
+        accept="image/*"
+        label="프로필 사진 선택"
+        onFiles={(files) => setFile(files?.[0] ?? null)}
+      />
+
+      <Modal open={!!file} onClose={() => setFile(null)} title="사진 자르기">
+        {file && <ImageCropper ref={cropperRef} src={file} circular outputSize={256} />}
+        <Button variant="text" onClick={() => cropperRef.current?.reset()}>초기화</Button>
+        <Button onClick={handleApply}>적용</Button>
+      </Modal>
+    </>
+  );
+}
+```
+
+#### 키보드 / 포인터 조작
+
+| 입력 | 동작 |
+|------|------|
+| 드래그 (pointer) | 이미지 위치 이동 |
+| 방향키 | 8px 단위 위치 이동 |
+| <kbd>+</kbd> / <kbd>-</kbd> | 0.1 단위 배율 변경 |
+| 마우스 휠 | 연속 배율 변경 |
+| 슬라이더 / ＋·－ 버튼 | 배율 변경 |
+
+> ⚠️ 원격 URL 을 넘기면 `canvas.drawImage` 결과가 서버의 CORS(`Access-Control-Allow-Origin`) 설정에 의존한다. 확실하게 자르려면 로컬 `File`/`Blob` 을 넘겨라.
+
+---
+
+### OtpInput
+
+인증 코드(OTP) 입력. 각 자리를 개별 `input` 으로 분리하고 자동 포커스 이동·붙여넣기·SMS 자동완성(`autocomplete="one-time-code"`)을 지원한다.
+
+```tsx
+import { OtpInput } from '@bigtablet/design-system';
+
+const [code, setCode] = useState('');
+
+// 기본 (6자리)
+<OtpInput value={code} onValueChange={setCode} />
+
+// 4자리 + 자동 포커스
+<OtpInput length={4} value={code} onValueChange={setCode} autoFocus />
+
+// 에러 상태 + 도움말
+<OtpInput
+  value={code}
+  onValueChange={setCode}
+  error
+  supportingText="인증번호가 일치하지 않습니다"
+/>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `length` | `4 \| 6` | `6` | OTP 자릿수 |
+| `value` | `string` | `''` | 제어형 값 (controlled 전용) |
+| `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 (canonical) |
+| ~~`onChange`~~ | `(value: string) => void` | - | **deprecated** (v3.3.0, `onValueChange` alias). [MIGRATION.md](./MIGRATION.md) 참고 |
+| `error` | `boolean` | `false` | 에러 상태 |
+| `disabled` | `boolean` | `false` | 비활성화 |
+| `supportingText` | `string` | - | 하단 도움말 텍스트 |
+| `autoFocus` | `boolean` | `false` | 첫 번째 입력에 자동 포커스 |
+| `ariaLabel` | `string` | `'OTP 입력'` | 그룹 접근성 레이블 |
+| `className` | `string` | - | 루트 요소에 추가할 className |
+
+> **제어형 전용**: `value` + `onValueChange` 를 항상 함께 넘겨야 한다 (비제어 모드 없음). 전체 코드를 한 번에 붙여넣거나 SMS 자동완성으로 받으면 각 자리에 자동 분배된다.
 
 ---
 
@@ -839,6 +1050,46 @@ import { LinearProgress } from '@bigtablet/design-system';
 | `totalSteps` | `number` | required | 전체 단계 수 |
 | `currentStep` | `number` | required | 현재 단계 (0~totalSteps) |
 | `aria-label` | `string` | required | 접근성 라벨 (필수) |
+
+---
+
+### Skeleton
+
+콘텐츠가 로드되기 전 자리를 잡아 두는 플레이스홀더. 실제 콘텐츠와 **같은 크기·모양**으로 맞춰야 로드 후 레이아웃이 흔들리지 않는다.
+
+```tsx
+import { Skeleton } from '@bigtablet/design-system';
+
+// 텍스트 한 줄
+<Skeleton />
+<Skeleton width="60%" />
+
+// 제목
+<Skeleton variant="title" width={240} />
+
+// 아바타 (width 만 주면 height 자동 동일)
+<Skeleton variant="avatar" width={40} />
+
+// 임의 블록
+<Skeleton variant="rect" width="100%" height={180} radius="md" />
+
+// 카드 스켈레톤 조합
+<Stack gap={12}>
+  <Skeleton variant="rect" height={160} radius="md" />
+  <Skeleton variant="title" width="70%" />
+  <Skeleton width="100%" />
+  <Skeleton width="85%" />
+</Stack>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'text' \| 'title' \| 'avatar' \| 'rect'` | `'text'` | 스켈레톤 모양 |
+| `width` | `number \| string` | - | CSS width (`200` → `200px`, `'100%'`, `'16rem'`). `variant="avatar"` 는 height 미지정 시 width 와 동일하게 적용 |
+| `height` | `number \| string` | - | CSS height |
+| `radius` | `'sm' \| 'md' \| 'lg' \| 'full' \| string` | - | border-radius 토큰 또는 임의 CSS 값 |
+
+> 루트는 `div` 이고 `aria-hidden="true"` 가 자동으로 붙는다 (스크린리더 노이즈 방지). 로딩 상태 자체를 알려야 하면 부모에 `aria-busy` / `role="status"` 를 직접 걸어라. `children` 은 받지 않으며, 그 외 `div` 속성은 그대로 전달된다.
 
 ---
 
@@ -1281,7 +1532,7 @@ import { NavBar, NavLink, Button } from "@bigtablet/design-system";
 // default - 일반 마케팅 헤더
 <NavBar
   brand={<Logo />}
-  actions={<Button variant="primary">로그인</Button>}
+  actions={<Button variant="filled">로그인</Button>}
   sticky
 >
   <NavLink href="/about">소개</NavLink>
@@ -1484,13 +1735,13 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 | 아이콘 버튼의 의미를 짧게 설명 (Save / Delete 등) | ✅ Tooltip |
 | 잘린(ellipsis) 텍스트의 전체 내용 노출 | ✅ Tooltip |
 | 단축키 안내 (`Cmd+S`) | ✅ Tooltip |
-| 클릭/포커스가 필요한 상호작용 요소 (링크, 버튼) 포함 | ❌ Popover 권장 - tooltip은 `pointer-events: none` |
+| 클릭/포커스가 필요한 상호작용 요소 (링크, 버튼) 포함 | ❌ Popover 권장 - tooltip은 포커스를 받지 않는 보조 설명 |
 | 폼 필드 도움말 (상시 표시) | ❌ helper text 권장 |
 | 모바일 주 트리거 | ⚠️ hover가 없으므로 focus/long-press 시나리오 검토 |
 
 **Tooltip vs Popover**
-- **Tooltip**: hover/focus로 짧은 텍스트만, dismissable 아님, `pointer-events: none`
-- **Popover**: 클릭으로 열고 외부 클릭/Esc로 닫음, 상호작용 가능한 콘텐츠 (버튼/링크/입력) 포함 가능
+- **Tooltip**: hover/focus로 뜨는 **짧은 텍스트**. `role="tooltip"`, 포커스를 옮기지 않음. 포인터를 툴팁 위로 올려 읽을 수 있고 <kbd>Esc</kbd>로 닫힌다 (WCAG 1.4.13).
+- **Popover**: 클릭으로 열고 외부 클릭/Esc로 닫음. `role="dialog"`, 열릴 때 포커스가 패널로 이동. 상호작용 가능한 콘텐츠 (버튼/링크/입력) 포함 가능.
 
 #### 선택 가이드
 
@@ -1524,9 +1775,10 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 
 - 툴팁 노드: `role="tooltip"`, `id={useId()}`
 - 트리거: 열렸을 때 `aria-describedby={tooltipId}` 자동 주입 → 스크린리더가 보조 설명으로 읽음
-- **키보드**: <kbd>Tab</kbd>으로 트리거 포커스 → 자동 노출, <kbd>Tab</kbd>으로 벗어나면 닫힘
+- **키보드**: <kbd>Tab</kbd>으로 트리거 포커스 → 자동 노출, <kbd>Tab</kbd>으로 벗어나면 닫힘, <kbd>Esc</kbd>로 즉시 닫힘
 - focus / blur 모두 핸들링 - 키보드 전용 사용자도 동일하게 접근 가능
-- 툴팁 자체는 `pointer-events: none` → 마우스로 잡을 수 없음 (포커스 트랩 / 상호작용 요소 금지)
+- **WCAG 1.4.13 Hoverable**: 툴팁에 `pointer-events` 가 살아 있어 포인터를 툴팁 위로 옮겨도 닫히지 않는다 (`onMouseEnter` 로 지연 닫힘 취소). 다만 툴팁 안에 포커스 가능한 요소를 넣는 것은 여전히 금지 - `role="tooltip"` 은 포커스를 받지 않는다.
+- **WCAG 1.4.13 Dismissable**: 공유 오버레이 스택(`useOverlayEscape`)에 등록되어 최상단일 때만 <kbd>Esc</kbd>를 소비한다. 다른 오버레이나 소비자 앱의 Escape 핸들러를 삼키지 않는다.
 
 > 📌 트리거 자체에도 라벨이 필요하다. IconButton에는 `aria-label`을 따로 줘야 SR-only 환경에서도 의미가 전달된다 (tooltip은 보조이므로 시각 비의존 라벨이 우선).
 
@@ -1539,20 +1791,26 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 - **퇴출**: `clamp: true`로 진동 없이 빠르게 사라짐 (비대칭)
 - spring config: `tension: 280, friction: 28` (Vercel/Linear 톤)
 
-#### 외부 클릭/Esc 처리
+#### 닫힘 처리
 
-Tooltip은 **dismissable 오버레이가 아님**:
-- blur(focus 잃음) / mouseleave 시 즉시 닫힘
-- 외부 클릭 / Esc로 따로 닫는 로직 없음 (필요 없음 - pointer-events가 차단되어 있어 트랩 안 됨)
-- unmount 시 timer cleanup 자동 처리
+| 트리거 | 동작 |
+|------|------|
+| blur (트리거가 focus 잃음) | **즉시** 닫힘 |
+| <kbd>Esc</kbd> | **즉시** 닫힘 (`useOverlayEscape` - 스택 최상단일 때만) |
+| mouseleave (트리거 또는 툴팁) | **120ms 지연** 후 닫힘 (`HIDE_DELAY`) - 포인터가 트리거↔툴팁 사이 6px 갭을 건널 시간 |
+| 툴팁 위로 mouseenter | 지연 닫힘 **취소** (열림 유지) |
+
+- 외부 클릭으로 닫는 로직은 없다 (hover/focus 기반이라 불필요).
+- unmount 시 timer cleanup 자동 처리.
 
 #### DOM 구조 (SCSS override 시 참고)
 
 ```
-span.tooltip_wrapper           ← position: relative; display: inline-flex
+span.tooltip_wrapper           ← position: relative; display: inline-block
 ├── {children}                 ← cloneElement로 핸들러/aria 주입된 trigger
 └── span.tooltip_position      ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
-    └── span.tooltip           ← role="tooltip", spring transform
+    │                            pointer-events 유지 + onMouseEnter/onMouseLeave (WCAG 1.4.13 Hoverable)
+    └── span.tooltip           ← role="tooltip", spring transform, max-width 240px
 ```
 
 `document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition`이 계산한 좌표로 배치되므로, 트리거의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5`.
@@ -1580,7 +1838,7 @@ import { Save, Trash } from "lucide-react";
 
 // 4) 긴 텍스트 (max-width 240px에서 자동 줄바꿈)
 <Tooltip content="버튼을 누르면 데이터가 영구 삭제됩니다. 되돌릴 수 없습니다.">
-  <Button variant="danger">삭제</Button>
+  <Button danger>삭제</Button>
 </Tooltip>
 
 // 5) 지연 조정 - 빈번하게 hover되는 영역
@@ -1739,7 +1997,7 @@ import { MoreVertical, Edit, Copy, Trash, Share, Archive } from "lucide-react";
 
 // 4) 명시적 액션 그룹 - Button trigger
 <Menu
-  trigger={<Button variant="secondary">Actions ▾</Button>}
+  trigger={<Button variant="outline">Actions ▾</Button>}
   items={[
     { key: "export", label: "내보내기", onSelect: handleExport },
     { key: "import", label: "가져오기", onSelect: handleImport },
@@ -1760,14 +2018,14 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 | 클릭으로 여는 작은 폼/필터 (체크박스, 입력, 적용 버튼) | ✅ Popover |
 | 프로필 카드, 미리보기, 부가 설명 + 액션 버튼 | ✅ Popover |
 | 단순 액션 리스트 (Edit / Duplicate / Delete) | ❌ Menu 권장 |
-| hover로 뜨는 짧은 텍스트 라벨 | ❌ Tooltip 권장 (`pointer-events: none`) |
+| hover로 뜨는 짧은 텍스트 라벨 | ❌ Tooltip 권장 (포커스를 옮기지 않는 보조 설명) |
 | 화면 중앙 차단(modal) 다이얼로그 / 확인창 | ❌ Modal · `useAlert()` 권장 |
 | 폼 필드 상시 도움말 | ❌ helper text 권장 |
 
 **Popover vs Menu vs Tooltip**
 - **Popover**: 클릭으로 열고 외부 클릭/Esc로 닫음. `role="dialog"` (non-modal). 임의의 상호작용 콘텐츠. 열릴 때 포커스가 패널로 이동.
 - **Menu**: 클릭으로 열리는 **액션 리스트**. `role="menu"` + `menuitem`. 선택 시 사이드 이펙트.
-- **Tooltip**: hover/focus로 뜨는 **짧은 정보**. `pointer-events: none`, dismissable 아님.
+- **Tooltip**: hover/focus로 뜨는 **짧은 정보**. `role="tooltip"`, 포커스를 옮기지 않음. Esc 로 닫히고 툴팁 위 hover 도 가능하지만, 안에 상호작용 요소를 넣을 수는 없음.
 
 #### 선택 가이드
 
@@ -1829,7 +2087,7 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 #### DOM 구조 (SCSS override 시 참고)
 
 ```
-span.popover_wrapper               ← position: relative; ref 부착 (외부 클릭 판정)
+div.popover_wrapper                ← position: relative; display: inline-flex; ref 부착 (외부 클릭 판정)
 ├── {trigger}                      ← cloneElement로 onClick/aria 주입
 └── div.popover_position           ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
     └── div.popover                ← role="dialog", spring transform
@@ -2840,6 +3098,142 @@ const [open, setOpen] = useState<string[]>(initialFromUrl);
 
 ---
 
+### Table
+
+컬럼 정의 기반 데이터 테이블. 로딩 중에는 헤더를 유지한 채 바디만 [Skeleton](#skeleton) 행으로 대체하고, 정렬·행 선택·행 클릭을 지원한다.
+
+> DS 는 데이터를 **직접 정렬하지 않는다**. `sortable` 헤더 클릭 시 `onSortChange` 만 발화하므로, 소비자가 정렬된 `data` 를 다시 내려줘야 한다.
+
+**Props**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `columns` | `TableColumn<T>[]` | required | 컬럼 정의 |
+| `data` | `T[]` | required | 표시할 데이터 배열 |
+| `keyExtractor` | `(item: T, index: number) => string \| number` | required | 행의 고유 key 추출 함수 |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 테이블 크기 |
+| `emptyMessage` | `ReactNode` | `'데이터가 없습니다'` | 데이터가 없을 때 표시 |
+| `isLoading` | `boolean` | `false` | 로딩 상태 - 헤더 유지, 바디만 스켈레톤 |
+| `skeletonRows` | `number` | `5` | 로딩 시 스켈레톤 행 개수 |
+| `hoverable` | `boolean` | `true` | 행 hover 강조 |
+| `stickyHeader` | `boolean` | `false` | thead sticky 고정 |
+| `ariaLabel` | `string` | - | 스크린리더용 테이블 레이블 |
+| `onRowClick` | `(item: T, index: number) => void` | - | 행 클릭 콜백 |
+| `rowClickHint` | `string` | `'클릭 가능한 행'` | clickable 행에 `aria-describedby` 로 연결되는 동작 설명. `''` 면 힌트 미부착 |
+| `sort` | `TableSort` | - | 현재 정렬 상태 (제어형). `undefined` 는 정렬 없음 |
+| `onSortChange` | `(sort: TableSort \| undefined) => void` | - | 정렬 헤더 클릭 시 발화 (none→asc→desc→none 순환) |
+| `selectable` | `boolean` | `false` | 행 선택(체크박스 컬럼) 활성화. `true` 면 `rowKey` **필수** |
+| `rowKey` | `(row: T) => string` | - | 행 고유 key 추출 함수 (`selectable` 시 필수) |
+| `selectedKeys` | `string[]` | - | 선택된 행 key 배열 (제어형) |
+| `onSelectionChange` | `(keys: string[]) => void` | - | 선택 변경 콜백 |
+| `selectAllAriaLabel` | `string` | `'전체 선택'` | 전체 선택 체크박스 aria-label |
+| `selectRowAriaLabel` | `(index: number) => string` | ``(i) => `${i + 1}번째 행 선택` `` | 개별 행 체크박스 aria-label |
+| `className` | `string` | - | 루트 wrapper 에 추가할 className |
+
+**`TableColumn<T>`**
+
+| 필드 | Type | Default | Description |
+|------|------|---------|-------------|
+| `key` | `string` | required | 컬럼 식별자. `render` 가 없으면 `item[key]` 를 자동 렌더 |
+| `header` | `ReactNode` | required | thead 에 표시할 헤더 |
+| `render` | `(item: T, index: number) => ReactNode` | - | 셀 렌더 함수 |
+| `width` | `string` | - | CSS width 값 (예: `"120px"`, `"20%"`) |
+| `align` | `'left' \| 'center' \| 'right'` | `'left'` | 정렬 |
+| `sortable` | `boolean` | `false` | 정렬 가능 여부. 클릭 시 `onSortChange` 발화 |
+
+**`TableSort`**
+
+| 필드 | Type | Description |
+|------|------|-------------|
+| `key` | `string` | 정렬 중인 컬럼의 `TableColumn.key` |
+| `direction` | `'asc' \| 'desc'` | 정렬 방향 |
+
+**Usage**
+
+```tsx
+import { useMemo, useState } from "react";
+import { Table, Chip } from "@bigtablet/design-system";
+import type { TableColumn, TableSort } from "@bigtablet/design-system";
+
+type User = { id: string; name: string; email: string; active: boolean };
+
+const columns: TableColumn<User>[] = [
+  { key: "name", header: "이름", sortable: true, width: "180px" },
+  { key: "email", header: "이메일" },
+  {
+    key: "active",
+    header: "상태",
+    align: "center",
+    render: (u) => <Chip type="static" tone={u.active ? "success" : "default"} label={u.active ? "활성" : "휴면"} />,
+  },
+];
+
+function UserTable({ users, isLoading }: { users: User[]; isLoading: boolean }) {
+  const [sort, setSort] = useState<TableSort | undefined>();
+  const [selected, setSelected] = useState<string[]>([]);
+
+  // 정렬은 소비자 책임 - DS 는 상태만 알려준다
+  const rows = useMemo(() => (sort ? sortBy(users, sort) : users), [users, sort]);
+
+  return (
+    <Table
+      ariaLabel="사용자 목록"
+      columns={columns}
+      data={rows}
+      keyExtractor={(u) => u.id}
+      isLoading={isLoading}
+      stickyHeader
+      sort={sort}
+      onSortChange={setSort}
+      selectable
+      rowKey={(u) => u.id}
+      selectedKeys={selected}
+      onSelectionChange={setSelected}
+      onRowClick={(u) => router.push(`/users/${u.id}`)}
+      rowClickHint="선택하면 상세 화면으로 이동"
+    />
+  );
+}
+```
+
+#### 접근성
+
+- 정렬 헤더는 `<button>` 이고 현재 상태가 `aria-sort` 로 노출된다.
+- `onRowClick` 이 있는 행에는 `rowClickHint` 가 `aria-describedby` 로 연결된다. `<tr>` 에 `aria-label` / `role="button"` 을 쓰면 셀 데이터를 스크린리더가 못 읽으므로 의도적으로 `aria-describedby` 를 쓴다.
+- 선택 체크박스는 [Checkbox](#checkbox) 를 사용하며 `selectAllAriaLabel` / `selectRowAriaLabel` 로 레이블을 커스터마이즈한다.
+
+---
+
+### Icon
+
+[lucide-react](https://lucide.dev/icons/) 아이콘 래퍼. `aria-label` 이 없으면 `aria-hidden` + `focusable={false}` 를 자동 적용해 스크린리더 노이즈를 막는다.
+
+```tsx
+import { Icon } from '@bigtablet/design-system';
+import { Search, X } from 'lucide-react';
+
+// 장식용 - aria-hidden 자동
+<Icon icon={Search} size={20} />
+
+// 의미 있는 아이콘 - aria-label 을 주면 aria-hidden 이 붙지 않음
+<Icon icon={X} size={16} strokeWidth={2.5} aria-label="닫기" />
+
+// 토큰 사이즈와 함께
+import { iconSize } from '@bigtablet/design-system';
+<Icon icon={Search} size={iconSize.md} />
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `icon` | `LucideIcon` | required | lucide-react 아이콘 컴포넌트 |
+| `size` | `number \| string` | `24` (lucide 기본) | 아이콘 크기 (px). `iconSize` 토큰 사용 권장 |
+| `strokeWidth` | `number \| string` | `2` (lucide 기본) | 선 두께 |
+| `color` | `string` | `currentColor` | 색상 |
+
+> 나머지 `LucideProps`(= SVG 속성)는 그대로 전달된다 (`ref` 제외). `iconSize` 토큰: `xs` 14 · `sm` 16 · `md` 18 · `lg` 20 · `xl` 32.
+
+---
+
 ## Layout
 
 페이지 레이아웃을 구성하는 4가지 프리미티브. 모두 토큰 기반의 일관된 spacing/breakpoint(compact 600 · expanded 840 · large 1200)를 사용합니다.
@@ -3162,8 +3556,8 @@ export function LandingPage() {
             <h1>가장 빠른 결제 솔루션</h1>
             <p>3분 안에 결제 시스템을 구축하세요.</p>
             <Stack direction="horizontal" gap={12}>
-              <Button variant="primary">시작하기</Button>
-              <Button variant="secondary">데모 보기</Button>
+              <Button variant="filled">시작하기</Button>
+              <Button variant="outline">데모 보기</Button>
             </Stack>
           </Stack>
         </Container>
@@ -3203,7 +3597,7 @@ export function LandingPage() {
         <Container size="md">
           <Stack gap={24} align="center">
             <h2>지금 시작하세요</h2>
-            <Button variant="primary">무료로 시작하기</Button>
+            <Button variant="filled">무료로 시작하기</Button>
           </Stack>
         </Container>
       </Section>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1555,7 +1555,7 @@ span.tooltip_wrapper           ← position: relative; display: inline-flex
     └── span.tooltip           ← role="tooltip", spring transform
 ```
 
-Portal을 **쓰지 않음** → 트리거의 `position: relative` 조상 기준으로 absolute 배치. `overflow: hidden`인 컨테이너 안에서는 잘릴 수 있으니 주의 (필요 시 컨테이너의 overflow를 풀거나 Popover 사용).
+`document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition`이 계산한 좌표로 배치되므로, 트리거의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5`.
 
 **Usage**
 
@@ -1698,7 +1698,7 @@ span.menu_wrapper                  ← position: relative; ref 부착 (외부 �
         └── span.menu_item_label   ← ellipsis
 ```
 
-Portal을 **쓰지 않음** → trigger의 `position: relative` 조상 기준 absolute. `overflow: hidden` 컨테이너 안에서 잘릴 수 있으니 주의. `z-index`는 `z_level5` 사용.
+`document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition` 좌표로 배치되므로 trigger의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5` 사용.
 
 **Usage**
 
@@ -1835,7 +1835,7 @@ span.popover_wrapper               ← position: relative; ref 부착 (외부 �
     └── div.popover                ← role="dialog", spring transform
 ```
 
-Portal을 **쓰지 않음** → trigger의 `position: relative` 조상 기준 absolute. `overflow: hidden` 컨테이너 안에서 잘릴 수 있으니 주의. `z-index`는 `z_level5` 사용.
+`document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition` 좌표로 배치되므로 trigger의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5` 사용.
 
 **Usage**
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1499,7 +1499,7 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 - `"bottom"` - 트리거가 화면 상단에 가깝거나, 위에 다른 패널이 있을 때.
 - `"left"` / `"right"` - 가로 리스트(아이콘 툴바)에서 항목별 라벨, 또는 위/아래 공간이 부족할 때.
 
-> ℹ️ 현재 구현은 **자동 flipping이 없으니** 뷰포트 경계 근처라면 placement를 직접 지정하라.
+> ℹ️ `placement`는 **선호값**이다. 뷰포트를 벗어나면 반대편으로 **flip**, 교차축으로 **shift**, 그래도 넘치면 `max-width` 축소가 자동 적용되고 `body`로 포탈된다(Radix `side` + `collisionPadding` 계약). 경계 근처라도 직접 조정할 필요가 없다.
 
 **delay 가이드**
 - 200ms (기본) - 마우스가 잠깐 머무를 때만 노출, 빠른 휙휙 이동에는 안 뜸
@@ -1551,8 +1551,8 @@ Tooltip은 **dismissable 오버레이가 아님**:
 ```
 span.tooltip_wrapper           ← position: relative; display: inline-flex
 ├── {children}                 ← cloneElement로 핸들러/aria 주입된 trigger
-└── span.tooltip               ← position: absolute, role="tooltip"
-    └── tooltip_placement_*    ← top|bottom|left|right
+└── span.tooltip_position      ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
+    └── span.tooltip           ← role="tooltip", spring transform
 ```
 
 Portal을 **쓰지 않음** → 트리거의 `position: relative` 조상 기준으로 absolute 배치. `overflow: hidden`인 컨테이너 안에서는 잘릴 수 있으니 주의 (필요 시 컨테이너의 overflow를 풀거나 Popover 사용).
@@ -1776,7 +1776,7 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 - `"top"` - trigger가 화면 하단에 가까울 때.
 - `"left"` / `"right"` - 가로 공간이 충분하고 위/아래가 막혔을 때.
 
-> ℹ️ 현재 구현은 **자동 flipping이 없으니** 뷰포트 경계 근처라면 placement를 직접 지정하라.
+> ℹ️ `placement`는 **선호값**이다. 뷰포트를 벗어나면 반대편으로 **flip**, 교차축으로 **shift**, 그래도 넘치면 `max-width` 축소가 자동 적용되고 `body`로 포탈된다(Radix `side` + `collisionPadding` 계약). 경계 근처라도 직접 조정할 필요가 없다.
 
 **제어 / 비제어**
 - 비제어 (기본) - `defaultOpen`만 주고 내부 state로 토글. 가장 간단.
@@ -1831,9 +1831,8 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 ```
 span.popover_wrapper               ← position: relative; ref 부착 (외부 클릭 판정)
 ├── {trigger}                      ← cloneElement로 onClick/aria 주입
-└── span.popover_position          ← position: absolute, placement별 정렬
-    └── popover_placement_*        ← top|bottom|left|right
-        └── div.popover            ← role="dialog", spring transform
+└── div.popover_position           ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
+    └── div.popover                ← role="dialog", spring transform
 ```
 
 Portal을 **쓰지 않음** → trigger의 `position: relative` 조상 기준 absolute. `overflow: hidden` 컨테이너 안에서 잘릴 수 있으니 주의. `z-index`는 `z_level5` 사용.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -422,9 +422,9 @@ import { Search, Eye } from 'lucide-react';
 | `transformValue` | `(value: string) => string` | - | 값 변환 함수 |
 
 > TextField 에는 `variant` · `success` prop 이 없다. outline 스타일 하나만 제공하며, 성공 상태는 별도 표현이 없다 (에러만 `error` 로 표시).
-
+>
 > **v3.0 변경**: 내부 마크업이 `<fieldset>` + `<legend>` 구조에서 standalone `<label htmlFor>` 구조로 변경되었습니다. 공개 props는 동일하지만, 커스텀 SCSS에서 `.text_field_legend` 같은 내부 셀렉터를 오버라이드했다면 점검이 필요합니다.
-
+>
 > **v3.1 추가**: `imeStrategy` prop - 한글 IME 조합 중 콜백 전략. 기본 `"delayed"` (조합 완료 후 `onValueChange`), 실시간 검색/필터엔 `"immediate"` (조합 중에도 즉시 호출).
 
 ---
@@ -1817,11 +1817,13 @@ hover/focus 시 보조 설명을 띄우는 비차단 오버레이. **아이콘 �
 
 #### DOM 구조 (SCSS override 시 참고)
 
-```
+```text
 span.tooltip_wrapper           ← position: relative; display: inline-block
-├── {children}                 ← cloneElement로 핸들러/aria 주입된 trigger
-└── span.tooltip_position      ← createPortal(body), position: fixed (좌표는 useAnchoredPosition)
-    │                            pointer-events 유지 + onMouseEnter/onMouseLeave (WCAG 1.4.13 Hoverable)
+└── {children}                 ← cloneElement로 핸들러/aria 주입된 trigger
+
+document.body (createPortal)   ← wrapper 밖으로 포탈됨 (DOM 상 트리거의 자식이 아님)
+└── span.tooltip_position      ← position: fixed (좌표는 useAnchoredPosition)
+        pointer-events 유지 + onMouseEnter/onMouseLeave (WCAG 1.4.13 Hoverable)
     └── span.tooltip           ← role="tooltip", spring transform, max-width 240px
 ```
 
@@ -1968,7 +1970,7 @@ span.menu_wrapper                  ← position: relative; ref 부착 (외부 �
         └── span.menu_item_label   ← ellipsis
 ```
 
-`document.body`로 **포탈**되고 `position: fixed` + `useAnchoredPosition` 좌표로 배치되므로 trigger의 `overflow: hidden`/`transform` 조상에 갇히거나 잘리지 않는다. `z-index`는 `z_level5` 사용.
+Menu 는 Tooltip/Popover 와 달리 **포탈하지 않는다** - `.menu_wrapper` 안에서 `position: absolute` 로 배치되고 `z-index`는 `z_level5` 를 쓴다. 따라서 트리거에 `overflow: hidden` 이나 `transform` 조상이 있으면 메뉴가 잘릴 수 있으니, 그런 컨테이너 안에서 쓸 때는 오버플로를 열어두거나 Popover 를 사용한다.
 
 **Usage**
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -181,17 +181,24 @@ export const Button = ({
     display: inline-flex;
     align-items: center;
     border-radius: token.$radius_md;
-    transition: all token.$transition_base;
+    // `transition: all` 금지 - 바뀌는 속성만 명시한다
+    transition: background-color token.$transition_fast, color token.$transition_fast;
+
+    &_variant_filled {
+        background-color: token.$color_brand_primary;
+        color: token.$color_brand_on_primary;
+    }
+
+    &_size_md {
+        height: 40px;
+        padding: 0 token.$spacing_16;
+    }
 }
 
-.variant_primary {
-    background-color: token.$color_primary;
-    color: token.$color_white;
-}
-
-.size_md {
-    height: 40px;
-    padding: 0 token.$spacing_lg;
+@media (prefers-reduced-motion: reduce) {
+    .button {
+        transition: none;
+    }
 }
 ```
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,7 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 ## 목차
 
 - [개요](#개요)
+- [v3.8.0 (Vanilla 패키지 정리)](#v380-vanilla-패키지-정리)
 - [v3.5.0](#v350)
 - [v3.3.0](#v330)
 - [v3.0.0](#v300)
@@ -21,8 +22,148 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 - `@deprecated` 로 표시된 prop 은 삭제되지 않고 계속 동작합니다. 실제 제거는 다음 major 릴리즈에서 이루어집니다.
 - deprecated prop 외에, **동작·타입 레벨 변경**(예: 렌더링 위치 변경, 타입 형태 변경)도 소비자에게 영향이 있으면 해당 버전 섹션에 함께 정리합니다 (v3.5.0 참고).
 - 변경 콜백(`onChange` 계열) 은 신규(canonical) prop 과 구(deprecated) prop 을 동시에 넘겨도 안전합니다. 컴포넌트 내부는 `canonical ?? deprecated` 순서로 우선 적용하므로, 신규 prop 을 넘기면 그 값만 호출되고 신규 prop 이 없을 때만 구 prop 이 fallback 으로 호출됩니다.
-- 이 문서는 `grep -rn "@deprecated" src/ui --include=index.tsx` 로 코드에 실제 존재하는 deprecated prop 전체를 기준으로 작성했습니다 (React 컴포넌트 공개 prop 기준 - Vanilla JS 패키지는 별도).
+- React 컴포넌트 섹션은 `grep -rn "@deprecated" src/ui --include=index.tsx` 로 코드에 실제 존재하는 deprecated prop 전체를 기준으로 작성했습니다.
+- **Vanilla JS 패키지(`/vanilla`)는 deprecated 유예 없이 한 번에 정리**했습니다. 클래스 이름은 컴파일러가 잡아주지 않으므로 [v3.8.0 섹션](#v380-vanilla-패키지-정리)의 old → new 표와 치환 스크립트를 그대로 사용하세요.
 - 버전은 semver 내림차순으로 정렬되어 있습니다.
+
+---
+
+## v3.8.0 (Vanilla 패키지 정리)
+
+> ⚠️ **Vanilla 패키지(`@bigtablet/design-system/vanilla`, `dist/vanilla/*`)의 파괴적 변경입니다.**
+> React export 는 영향이 없습니다.
+
+Vanilla 번들의 클래스·JS API 이름이 React 컴포넌트 API 와 갈라져 있어, 같은 디자인 시스템인데도 두 벌의 이름을 외워야 했습니다. v3.8.0 에서 **구 이름을 별칭으로 남기지 않고 전부 제거**하고 React 쪽 이름으로 통일했습니다. 처음부터 React API 를 보고 설계한 것처럼 보이게 하는 것이 목표라, deprecated 별칭은 두지 않았습니다.
+
+**타입 검사가 잡아주지 않습니다.** 구 클래스를 쓰면 에러 없이 스타일만 조용히 사라지므로, 아래 표와 치환 스크립트로 마크업 전체를 한 번에 훑으세요.
+
+### 1. Button - variant 이름
+
+React `<Button variant>` 값과 동일하게 맞췄습니다.
+
+| 구 클래스 (제거됨) | 대체 |
+|---|---|
+| `.bt-button--primary` | `.bt-button--filled` |
+| `.bt-button--secondary` | `.bt-button--outline` |
+| `.bt-button--ghost` | `.bt-button--text` |
+
+`.bt-button--danger` 는 그대로입니다. React 의 `danger` boolean 처럼 variant 와 **직교**하므로 `--outline --danger` 같이 조합해 쓸 수 있고, variant 없이 단독으로 쓰면 React `<Button danger />`(기본 variant `filled`)와 같은 red filled 입니다.
+
+### 2. Button - 기본 radius 와 filled 채움색 (클래스 이름은 그대로, 렌더링이 바뀜)
+
+| 항목 | 구 동작 | 신 동작 (React 와 동일) |
+|---|---|---|
+| 기본 `border-radius` | `--bt-radius-md` (8px) | `--bt-radius-full` (pill) |
+| `--filled` 배경 | `--bt-color-primary` (양 테마 검정 고정) | `--bt-color-accent` (light 검정 / dark 흰색 자동 반전) |
+
+- **각진 버튼을 유지하려면** 새로 추가된 `.bt-button--radius-md` 를 명시하세요 (React `radius` prop 과 같은 `none/xs/sm/md/lg/xl/full` 스케일 전체 제공).
+- filled 색 변경은 **다크 테마에서만** 눈에 띕니다. 구 동작은 다크에서도 검정 채움이라 페이지 배경에 묻혔습니다. 양 테마 고정색이 꼭 필요하면 `--bt-color-primary` 를 직접 적용하세요.
+
+### 3. Card - elevation → shadow, 기본값 도입
+
+| 구 클래스 (제거됨) | 대체 |
+|---|---|
+| `.bt-card--elevation-1` | `.bt-card--shadow-sm` |
+| `.bt-card--elevation-2` | `.bt-card--shadow-md` |
+| `.bt-card--elevation-3` | `.bt-card--shadow-lg` |
+
+`.bt-card` 의 **기본값도 React `<Card>` 와 같아졌습니다** - shadow 클래스를 안 붙이면 `shadow=sm`, padding 클래스를 안 붙이면 `padding=md` 가 적용됩니다 (구 Vanilla 는 둘 다 없음). 그림자·여백이 없는 맨 카드가 필요하면 `.bt-card--shadow-none .bt-card--p-none` 을 명시하세요.
+
+React 의 `variant`(`accent` / `glass` / `outlined`)와 `interactive` 도 새로 추가됐습니다 (`.bt-card--accent` / `--glass` / `--outlined` / `--interactive`) - 추가라 마이그레이션은 불필요합니다.
+
+### 4. Select → Dropdown 전면 개명
+
+React 컴포넌트 이름이 `Dropdown` 이므로 블록 이름·data 속성·JS 팩토리를 모두 맞췄습니다. **CSS 만의 변경이 아니라 JS 런타임까지 걸쳐 있습니다.**
+
+| 구 이름 (제거됨) | 대체 |
+|---|---|
+| `.bt-select` | `.bt-dropdown` |
+| `.bt-select__label` | `.bt-dropdown__label` |
+| `.bt-select__control` | `.bt-dropdown__control` |
+| `.bt-select__control--outline` / `--filled` | `.bt-dropdown__control--outline` / `--filled` |
+| `.bt-select__control--sm` / `--md` / `--lg` | `.bt-dropdown__control--sm` / `--md` / `--lg` |
+| `.bt-select__value` | `.bt-dropdown__value` |
+| `.bt-select__placeholder` | `.bt-dropdown__placeholder` |
+| `.bt-select__icon` | `.bt-dropdown__icon` |
+| `.bt-select__list` | `.bt-dropdown__list` |
+| `.bt-select__list--up` | `.bt-dropdown__list--up` |
+| `.bt-select__option` | `.bt-dropdown__option` |
+| `data-bt-select` (자동 초기화 속성) | `data-bt-dropdown` |
+| `Bigtablet.Select(el, options)` | `Bigtablet.Dropdown(el, options)` |
+| `el._btSelect` (자동 초기화 인스턴스) | `el._btDropdown` |
+
+`.is-open` / `.is-selected` / `.is-active` / `.is-disabled` 상태 클래스와 인스턴스 API(`getValue` / `setValue` / `open` / `close` / `toggle` / `setDisabled` / `destroy`)는 그대로입니다.
+
+> **남은 격차**: React `Dropdown` 의 `multiple`(다중 선택)·`searchable`(검색 필터)은 Vanilla 에 아직 없습니다. 이름만 맞췄을 뿐 기능까지 동등하지는 않으니, 두 기능이 필요하면 React 쪽을 쓰세요.
+
+### 5. Spinner - size enum → px 커스텀 프로퍼티
+
+React `<Spinner size>` 는 enum 이 아니라 px 숫자(기본 24)를 받습니다. Vanilla 도 자유 스케일로 맞췄습니다.
+
+| 구 클래스 (제거됨) | 대체 |
+|---|---|
+| `.bt-spinner--sm` | `style="--bt-spinner-size: 16px"` |
+| `.bt-spinner--md` | (기본값 24px - 아무것도 안 붙이면 됨) |
+| `.bt-spinner--lg` | `style="--bt-spinner-size: 32px"` |
+| `.bt-spinner--xl` | `style="--bt-spinner-size: 48px"` |
+
+React `<Spinner>` 가 자동으로 붙이는 `role="status"` + `aria-label` 은 Vanilla 에선 마크업에서 직접 지정해야 합니다.
+
+### 6. JS 변경 콜백 - `onChange` 제거
+
+v3.3.0 에서 React 가 `on*Change` 패밀리로 통일된 것에 맞춰 Vanilla 도 canonical 이름만 남겼습니다. `onChange` 를 계속 넘기면 **조용히 무시**됩니다(에러 없음).
+
+| 팩토리 | 구 옵션 (제거됨) | 대체 |
+|---|---|---|
+| `Bigtablet.Dropdown` | `onChange(value, option)` | `onValueChange(value, option)` |
+| `Bigtablet.Toggle` | `onChange(checked)` | `onCheckedChange(checked)` |
+| `Bigtablet.Pagination` | `onChange(page)` | `onPageChange(page)` |
+
+### 7. Alert - 오버레이·Escape 닫힘이 `onCancel` 을 경유
+
+구 동작에서는 오버레이 클릭이나 Escape 로 닫으면 `onCancel` 이 호출되지 않아, 취소 정리 로직(롤백 등)이 조용히 우회됐습니다. React `Alert`(`dismiss = onCancel ?? onClose`)와 동일하게 두 경로 모두 `onCancel` 을 먼저 호출한 뒤 닫습니다 (WAI-ARIA APG alertdialog).
+
+- **영향**: `onCancel` 안에서 "취소 버튼을 눌렀다"고 가정하고 로그를 남기거나 카운트를 올리던 코드는 이제 오버레이/Escape 에서도 실행됩니다.
+- 오버레이 닫힘 자체를 막고 싶으면 `closeOnOverlay: false` 를 쓰세요.
+
+또한 `Bigtablet.Alert` 가 생성하는 확인/취소 버튼의 클래스가 `bt-button--primary` / `bt-button--secondary` → `bt-button--filled` / `bt-button--outline` 로 바뀝니다. 생성된 마크업의 클래스를 셀렉터로 잡아 스타일을 덮어쓰던 CSS 가 있다면 함께 수정하세요.
+
+### 치환 스크립트
+
+기계적으로 바꿀 수 있는 항목만 모았습니다. **순서대로** 실행하세요 (`bt-select` → `bt-dropdown` 을 먼저 돌려야 다른 규칙과 겹치지 않습니다).
+
+```bash
+# 대상 디렉터리로 이동 후 실행. 확장자는 프로젝트에 맞게 조정하세요.
+# macOS(BSD sed)는 -i '' , GNU sed 는 -i 를 사용합니다.
+FILES=$(grep -rl -E 'bt-select|bt-button--(primary|secondary|ghost)|bt-card--elevation|bt-spinner--|Bigtablet\.Select|_btSelect' \
+  --include='*.html' --include='*.jsp' --include='*.php' --include='*.js' --include='*.css' --include='*.scss' .)
+
+# 1) Select → Dropdown (클래스 / data 속성 / JS 팩토리 / 인스턴스 프로퍼티)
+sed -i '' -e 's/bt-select/bt-dropdown/g' \
+          -e 's/Bigtablet\.Select/Bigtablet.Dropdown/g' \
+          -e 's/_btSelect/_btDropdown/g' $FILES
+
+# 2) Button variant
+sed -i '' -e 's/bt-button--primary/bt-button--filled/g' \
+          -e 's/bt-button--secondary/bt-button--outline/g' \
+          -e 's/bt-button--ghost/bt-button--text/g' $FILES
+
+# 3) Card elevation → shadow
+sed -i '' -e 's/bt-card--elevation-1/bt-card--shadow-sm/g' \
+          -e 's/bt-card--elevation-2/bt-card--shadow-md/g' \
+          -e 's/bt-card--elevation-3/bt-card--shadow-lg/g' $FILES
+
+# 4) 확인 - 남은 구 이름이 없어야 합니다
+grep -rn -E 'bt-select|bt-button--(primary|secondary|ghost)|bt-card--elevation|bt-spinner--|Bigtablet\.Select|_btSelect|data-bt-select' . || echo "clean"
+```
+
+기계적으로 치환할 수 없어 **손으로 확인해야 하는 항목**:
+
+- `.bt-spinner--*` → `--bt-spinner-size` 인라인 스타일 (클래스 삭제 + `style` 추가라 1:1 치환 불가)
+- JS 옵션의 `onChange:` → `onValueChange:` / `onCheckedChange:` / `onPageChange:` (같은 이름이 다른 팩토리에서 다른 이름으로 바뀌므로 호출부별 판단 필요)
+- 각진 버튼을 유지할지(`.bt-button--radius-md` 추가) 아니면 pill 기본값을 받아들일지
+- 그림자·여백 없는 `.bt-card` 를 유지할지(`--shadow-none --p-none` 추가) 아니면 React 기본값을 받아들일지
+- `onCancel` 이 오버레이/Escape 에서도 불리게 된 것에 대한 영향
 
 ---
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -135,26 +135,31 @@ v3.3.0 에서 React 가 `on*Change` 패밀리로 통일된 것에 맞춰 Vanilla
 ```bash
 # 대상 디렉터리로 이동 후 실행. 확장자는 프로젝트에 맞게 조정하세요.
 # macOS(BSD sed)는 -i '' , GNU sed 는 -i 를 사용합니다.
-FILES=$(grep -rl -E 'bt-select|bt-button--(primary|secondary|ghost)|bt-card--elevation|bt-spinner--|Bigtablet\.Select|_btSelect' \
-  --include='*.html' --include='*.jsp' --include='*.php' --include='*.js' --include='*.css' --include='*.scss' .)
+# 소스만 대상으로 하고 의존성/빌드 산출물은 제외. 경로에 공백이 있어도 안전하도록 NUL 구분 사용.
+INCLUDES=(--include='*.html' --include='*.jsp' --include='*.php' --include='*.js' --include='*.css' --include='*.scss')
+EXCLUDES=(--exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git)
 
 # 1) Select → Dropdown (클래스 / data 속성 / JS 팩토리 / 인스턴스 프로퍼티)
-sed -i '' -e 's/bt-select/bt-dropdown/g' \
-          -e 's/Bigtablet\.Select/Bigtablet.Dropdown/g' \
-          -e 's/_btSelect/_btDropdown/g' $FILES
+grep -rlZ -E 'bt-select|Bigtablet\.Select|_btSelect' "${INCLUDES[@]}" "${EXCLUDES[@]}" . \
+  | xargs -0 sed -i '' -e 's/bt-select/bt-dropdown/g' \
+                       -e 's/Bigtablet\.Select/Bigtablet.Dropdown/g' \
+                       -e 's/_btSelect/_btDropdown/g'
 
 # 2) Button variant
-sed -i '' -e 's/bt-button--primary/bt-button--filled/g' \
-          -e 's/bt-button--secondary/bt-button--outline/g' \
-          -e 's/bt-button--ghost/bt-button--text/g' $FILES
+grep -rlZ -E 'bt-button--(primary|secondary|ghost)' "${INCLUDES[@]}" "${EXCLUDES[@]}" . \
+  | xargs -0 sed -i '' -e 's/bt-button--primary/bt-button--filled/g' \
+                       -e 's/bt-button--secondary/bt-button--outline/g' \
+                       -e 's/bt-button--ghost/bt-button--text/g'
 
 # 3) Card elevation → shadow
-sed -i '' -e 's/bt-card--elevation-1/bt-card--shadow-sm/g' \
-          -e 's/bt-card--elevation-2/bt-card--shadow-md/g' \
-          -e 's/bt-card--elevation-3/bt-card--shadow-lg/g' $FILES
+grep -rlZ -E 'bt-card--elevation' "${INCLUDES[@]}" "${EXCLUDES[@]}" . \
+  | xargs -0 sed -i '' -e 's/bt-card--elevation-1/bt-card--shadow-sm/g' \
+                       -e 's/bt-card--elevation-2/bt-card--shadow-md/g' \
+                       -e 's/bt-card--elevation-3/bt-card--shadow-lg/g'
 
-# 4) 확인 - 남은 구 이름이 없어야 합니다
-grep -rn -E 'bt-select|bt-button--(primary|secondary|ghost)|bt-card--elevation|bt-spinner--|Bigtablet\.Select|_btSelect|data-bt-select' . || echo "clean"
+# 4) 확인 - 남은 구 이름이 없어야 합니다 (동일 --include 로 이 문서(.md) 는 대상에서 제외됨)
+grep -rn -E 'bt-select|bt-button--(primary|secondary|ghost)|bt-card--elevation|bt-spinner--|Bigtablet\.Select|_btSelect|data-bt-select' \
+  "${INCLUDES[@]}" "${EXCLUDES[@]}" . || echo "clean"
 ```
 
 기계적으로 치환할 수 없어 **손으로 확인해야 하는 항목**:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -56,7 +56,7 @@ Button 이 `as`/`href` 로 anchor 렌더링을 지원하면서 `ButtonProps` 가
 
 - **런타임·공개 prop 은 100% 호환** — 기존 `<Button variant size onClick disabled>` 사용은 그대로 동작합니다.
 - **타입 레벨만 영향**: TS interface 는 union 을 확장할 수 없어 `interface X extends ButtonProps {}` 형태가 깨집니다.
-- **해결**: 스타일 props 만 확장하려면 공통 베이스 `ButtonBaseProps` 를, 전체 prop 을 참조하려면 `React.ComponentProps<typeof Button>` 을 쓰세요.
+- **해결**: `React.ComponentProps<typeof Button>` 로 참조한 뒤 교차 타입(`&`) 으로 확장하세요. (내부 공통 베이스 `ButtonBaseProps` 는 export 되지 않으므로 소비자가 쓸 수 없습니다.)
   ```tsx
   // ❌ An interface can only extend an object type...
   interface MyButtonProps extends ButtonProps { extra?: string }
@@ -72,7 +72,6 @@ Button 이 `as`/`href` 로 anchor 렌더링을 지원하면서 `ButtonProps` 가
 | Dropdown | `name` | hidden input 으로 네이티브 폼 제출 참여 |
 | Alert | `closeOnOverlay` | 오버레이 클릭 닫힘 on/off (기본 true) |
 | Chip | `removeLabel` | 삭제 버튼 접근성 레이블 커스터마이즈 (기본 `"{label} 제거"`) |
-| utils | `useOverlayEscape` / `registerOverlay` / `useIsMounted` | 공유 오버레이 Escape 스택, 클라이언트 마운트 훅 |
 
 > Vanilla JS 패키지도 폼 참여(`data-name` on Select/Toggle)·combobox ARIA 등이 추가됐습니다. HTML/CSS/JS 환경 사용법은 [docs/VANILLA.md](./VANILLA.md) 참고.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -338,30 +338,56 @@ it("calls callback with correct arguments", () => {
 
 ### 현재 커버리지 현황
 
-| 카테고리 | 커버리지 |
-|----------|----------|
-| **전체** | 86% |
-| Button | 100% |
-| Card | 100% |
-| Radio | 100% |
-| Alert | 100% |
-| Spinner | 100% |
-| Pagination | 100% |
-| TopLoading | 100% |
-| FileInput | 100% |
-| Chip | 95% |
-| Modal | 97% |
-| Toggle | 93% |
-| Checkbox | 91% |
-| DatePicker | 90% |
-| Toast | 90% |
-| TextField | 74% |
-| Dropdown | 89% |
+`pnpm test:coverage` (v8, `unit` 프로젝트) 기준 - 55 test files / 779 passed · 9 skipped.
+
+| 전체 | Stmts | Branch | Funcs | Lines |
+|------|-------|--------|-------|-------|
+| **All files** | **90.01%** | **85.59%** | **90.07%** | **91.97%** |
+
+아래는 **100% 미만**인 파일만 나열한 것이다 (미표기 컴포넌트 = 전 지표 100%: Button · Card · Radio · Spinner · Pagination · TopLoading · Badge · Divider · Skeleton · Toggle · Breadcrumb · EmptyState · ErrorState · IconButton · Container/Section/Stack/Grid 등).
+
+| 파일 | Stmts | Branch | Funcs | Lines |
+|------|-------|--------|-------|-------|
+| ui/display/accordion | 100% | 80% | 100% | 100% |
+| ui/display/avatar | 84.61% | 88% | 66.66% | 90.9% |
+| ui/display/chip | 86.95% | 80.43% | 66.66% | 95.23% |
+| ui/display/hero | 92.85% | 88.88% | 100% | 100% |
+| **ui/display/icon** | **0%** | **0%** | **0%** | **0%** |
+| ui/display/list-item | 100% | 93.33% | 100% | 100% |
+| ui/display/media-card | 100% | 96.29% | 100% | 100% |
+| ui/display/table | 98.07% | 92.79% | 95.65% | 97.77% |
+| ui/feedback/alert | 96.92% | 93.44% | 100% | 98.27% |
+| ui/feedback/linear-progress | 100% | 66.66% | 100% | 100% |
+| ui/feedback/toast | 100% | 84.21% | 100% | 100% |
+| ui/forms/checkbox | 91.66% | 90% | 100% | 100% |
+| ui/forms/date-picker | 91.86% | 80.16% | 100% | 97.1% |
+| ui/forms/dropdown | 96.42% | 90.64% | 100% | 96.49% |
+| ui/forms/file | 80.43% | 65% | 83.33% | 80% |
+| **ui/forms/image-cropper** | **57.04%** | **55.29%** | **50%** | **58.33%** |
+| ui/forms/otp-input | 89.28% | 91.66% | 100% | 89.33% |
+| ui/forms/radio-group | 100% | 95.45% | 100% | 100% |
+| ui/forms/textarea | 88.33% | 74.69% | 100% | 92.85% |
+| ui/forms/textfield | 90.47% | 82.75% | 77.77% | 92.68% |
+| ui/navigation/bottom-nav | 94.73% | 95% | 100% | 94.73% |
+| ui/navigation/menu | 97.29% | 89.13% | 100% | 100% |
+| ui/navigation/nav-bar | 80.19% | 69.23% | 81.81% | 85.39% |
+| ui/navigation/sidebar | 83.33% | 88.63% | 75% | 86.95% |
+| ui/navigation/tabs | 91.42% | 78.18% | 88.88% | 100% |
+| ui/overlay/drawer | 97.91% | 95.16% | 100% | 100% |
+| ui/overlay/modal | 97.67% | 93.93% | 100% | 100% |
+| ui/overlay/popover | 91.3% | 83.87% | 100% | 92.68% |
+| ui/overlay/tooltip | 92.98% | 83.33% | 93.33% | 91.66% |
+| ui/system/theme-provider | 93.87% | 85.71% | 100% | 100% |
+| utils | 90.14% | 83.18% | 78.57% | 91.93% |
+
+> ⚠️ **80% 기준선 미달 (개선 필요)**
+> - **`ui/display/icon` — 0%**: 단위 테스트가 아예 없다. `aria-hidden` 자동 적용 / `aria-label` 지정 시 미적용 두 분기만이라도 커버해야 한다.
+> - **`ui/forms/image-cropper` — 57.04%**: canvas·pointer 조작 경로(`crop()`, 드래그, 휠 줌)가 jsdom 에서 대부분 미커버. `utils/use-spring-hover.ts` 도 10% 로 낮다.
 
 ### 커버리지 목표
 
 - 새 컴포넌트: 최소 80% 커버리지
-- 전체 목표: 85% 이상 유지
+- 전체 목표: 85% 이상 유지 (현재 90.01%)
 
 ### 커버리지 리포트 확인
 
@@ -395,19 +421,25 @@ describe("Button", () => {
     });
 
     it("applies variant classes", () => {
-        const { container, rerender } = render(<Button variant="primary">Test</Button>);
-        expect(container.firstChild).toHaveClass("variant_primary");
+        const { container, rerender } = render(<Button variant="filled">Test</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_filled");
 
-        rerender(<Button variant="danger">Test</Button>);
-        expect(container.firstChild).toHaveClass("variant_danger");
+        rerender(<Button variant="outline">Test</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_outline");
+    });
+
+    it("applies the danger modifier independently of variant", () => {
+        const { container } = render(<Button variant="outline" danger>Delete</Button>);
+        expect(container.firstChild).toHaveClass("button_variant_outline");
+        expect(container.firstChild).toHaveClass("button_danger");
     });
 
     it("applies size classes", () => {
         const { container, rerender } = render(<Button size="sm">Test</Button>);
-        expect(container.firstChild).toHaveClass("size_sm");
+        expect(container.firstChild).toHaveClass("button_size_sm");
 
-        rerender(<Button size="lg">Test</Button>);
-        expect(container.firstChild).toHaveClass("size_lg");
+        rerender(<Button size="xl">Test</Button>);
+        expect(container.firstChild).toHaveClass("button_size_xl");
     });
 
     it("calls onClick when clicked", () => {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -338,11 +338,11 @@ it("calls callback with correct arguments", () => {
 
 ### 현재 커버리지 현황
 
-`pnpm test:coverage` (v8, `unit` 프로젝트) 기준 - 55 test files / 779 passed · 9 skipped.
+`pnpm test:coverage` (v8, `unit` 프로젝트) 기준 - 55 test files / 788 passed · 9 skipped.
 
 | 전체 | Stmts | Branch | Funcs | Lines |
 |------|-------|--------|-------|-------|
-| **All files** | **90.01%** | **85.59%** | **90.07%** | **91.97%** |
+| **All files** | **90.02%** | **85.69%** | **90.07%** | **91.97%** |
 
 아래는 **100% 미만**인 파일만 나열한 것이다 (미표기 컴포넌트 = 전 지표 100%: Button · Card · Radio · Spinner · Pagination · TopLoading · Badge · Divider · Skeleton · Toggle · Breadcrumb · EmptyState · ErrorState · IconButton · Container/Section/Stack/Grid 등).
 
@@ -370,12 +370,12 @@ it("calls callback with correct arguments", () => {
 | ui/forms/textfield | 90.47% | 82.75% | 77.77% | 92.68% |
 | ui/navigation/bottom-nav | 94.73% | 95% | 100% | 94.73% |
 | ui/navigation/menu | 97.29% | 89.13% | 100% | 100% |
-| ui/navigation/nav-bar | 80.19% | 69.23% | 81.81% | 85.39% |
+| ui/navigation/nav-bar | 80.39% | 71.25% | 81.81% | 85.55% |
 | ui/navigation/sidebar | 83.33% | 88.63% | 75% | 86.95% |
 | ui/navigation/tabs | 91.42% | 78.18% | 88.88% | 100% |
 | ui/overlay/drawer | 97.91% | 95.16% | 100% | 100% |
 | ui/overlay/modal | 97.67% | 93.93% | 100% | 100% |
-| ui/overlay/popover | 91.3% | 83.87% | 100% | 92.68% |
+| ui/overlay/popover | 91.3% | 85.71% | 100% | 92.68% |
 | ui/overlay/tooltip | 92.98% | 83.33% | 93.33% | 91.66% |
 | ui/system/theme-provider | 93.87% | 85.71% | 100% | 100% |
 | utils | 90.14% | 83.18% | 78.57% | 91.93% |
@@ -387,7 +387,7 @@ it("calls callback with correct arguments", () => {
 ### 커버리지 목표
 
 - 새 컴포넌트: 최소 80% 커버리지
-- 전체 목표: 85% 이상 유지 (현재 90.01%)
+- 전체 목표: 85% 이상 유지 (현재 90.02%)
 
 ### 커버리지 리포트 확인
 

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -167,7 +167,7 @@ SCSS 변수/믹스인(spacing, radius, typography, motion 등)이 필요하면 �
 @use "@bigtablet/design-system/scss/token" as token;
 
 .my-component {
-  padding: token.$spacing_md;
+  padding: token.$spacing_16;
   border-radius: token.$radius_md;
 }
 ```

--- a/docs/VANILLA-PROMPT.md
+++ b/docs/VANILLA-PROMPT.md
@@ -21,15 +21,15 @@ JS: https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js
 - .is-{state} (상태)
 
 사용 가능한 컴포넌트:
-- Button: .bt-button --sm/md/lg --primary/secondary/ghost/danger
+- Button: .bt-button --sm/md/lg/xl --filled/tonal/outline/text (+ --danger 조합, --radius-* 기본 full)
 - TextField: .bt-text-field, .bt-text-field__input --outline/filled --sm/md/lg --error/success
 - Checkbox: .bt-checkbox --sm/md/lg
 - Radio: .bt-radio --sm/md/lg
 - Toggle: .bt-toggle --sm/md --on --disabled
-- Select: .bt-select, .bt-select__control --outline/filled --sm/md/lg
+- Dropdown: .bt-dropdown, .bt-dropdown__control --outline/filled --sm/md/lg
 - Modal: .bt-modal .is-open
-- Card: .bt-card --bordered --shadow-sm/md/lg --p-sm/md/lg
-- Spinner: .bt-spinner --sm/md/lg/xl
+- Card: .bt-card --bordered --shadow-none/sm/md/lg(기본 sm) --p-none/sm/md/lg(기본 md) --accent/glass/outlined --interactive
+- Spinner: .bt-spinner (크기는 --bt-spinner-size 커스텀 프로퍼티, 기본 24px)
 - Pagination: .bt-pagination
 - DatePicker: .bt-date-picker --full-width
 - FileInput: .bt-file-input --disabled
@@ -155,7 +155,7 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
 
 ### Button
 ```html
-<button class="bt-button bt-button--md bt-button--primary">버튼</button>
+<button class="bt-button bt-button--md bt-button--filled">버튼</button>
 ```
 
 ### TextField
@@ -194,15 +194,15 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
 </button>
 ```
 
-### Select
+### Dropdown
 ```html
-<div class="bt-select" data-bt-select>
-  <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-    <span class="bt-select__placeholder">선택...</span>
-    <span class="bt-select__icon">▼</span>
+<div class="bt-dropdown" data-bt-dropdown>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">선택...</span>
+    <span class="bt-dropdown__icon">▼</span>
   </button>
-  <ul class="bt-select__list">
-    <li class="bt-select__option" data-value="1">옵션 1</li>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="1">옵션 1</li>
   </ul>
 </div>
 ```
@@ -215,8 +215,8 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
     <div class="bt-modal__header">제목</div>
     <div class="bt-modal__body">내용</div>
     <div class="bt-modal__footer">
-      <button class="bt-button bt-button--md bt-button--secondary" data-modal-close>취소</button>
-      <button class="bt-button bt-button--md bt-button--primary" data-modal-close>확인</button>
+      <button class="bt-button bt-button--md bt-button--outline" data-modal-close>취소</button>
+      <button class="bt-button bt-button--md bt-button--filled" data-modal-close>확인</button>
     </div>
   </div>
 </div>
@@ -232,7 +232,8 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
 
 ### Spinner
 ```html
-<div class="bt-spinner bt-spinner--md"></div>
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
 ```
 
 ### Pagination

--- a/docs/VANILLA-PROMPT.md
+++ b/docs/VANILLA-PROMPT.md
@@ -25,7 +25,7 @@ JS: https://unpkg.com/@bigtablet/design-system/dist/vanilla/bigtablet.min.js
 - TextField: .bt-text-field, .bt-text-field__input --outline/filled --sm/md/lg --error/success
 - Checkbox: .bt-checkbox --sm/md/lg
 - Radio: .bt-radio --sm/md/lg
-- Toggle: .bt-toggle --sm/md --on --disabled
+- Toggle: .bt-toggle --sm/md --on (비활성화는 native disabled 속성)
 - Dropdown: .bt-dropdown, .bt-dropdown__control --outline/filled --sm/md/lg
 - Modal: .bt-modal .is-open
 - Card: .bt-card --bordered --shadow-none/sm/md/lg(기본 sm) --p-none/sm/md/lg(기본 md) --accent/glass/outlined --interactive

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -818,4 +818,4 @@ cleanup();  // 리스너 제거
 
 ## 라이센스
 
-[MIT License](../LICENSE)
+[Bigtablet Inc. Open Source License](../LICENSE)

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -302,7 +302,7 @@ npm install @bigtablet/design-system
   const toggleEl = document.getElementById('my-toggle');
   const myToggle = Bigtablet.Toggle(toggleEl, {
     defaultChecked: false,
-    onChange: (checked) => {
+    onCheckedChange: (checked) => {
       console.log('Toggle:', checked);
     }
   });
@@ -401,7 +401,7 @@ npm install @bigtablet/design-system
       { value: 'banana', label: '바나나' },
       { value: 'mango', label: '망고', disabled: true },
     ],
-    onChange: (value, option) => {
+    onValueChange: (value, option) => {
       console.log('Selected:', value, option);
     }
   });
@@ -586,7 +586,7 @@ Alert는 JavaScript로만 사용합니다.
   const pagination = Bigtablet.Pagination(paginationEl, {
     page: 1,
     totalPages: 20,
-    onChange: (page) => {
+    onPageChange: (page) => {
       console.log('Page:', page);
       // 데이터 로드 등
     }
@@ -778,6 +778,17 @@ document.addEventListener('DOMContentLoaded', function() {
 // 전체 재초기화
 Bigtablet.init();
 ```
+
+### 콜백 이름 (React 와 동일)
+
+값 변경 콜백은 React 컴포넌트와 같은 이름을 사용합니다. 구 `onChange` 도 계속 동작하지만
+**deprecated** 이며 v4.0.0 에서 제거됩니다. 둘 다 주면 canonical 쪽만 호출됩니다.
+
+| 컴포넌트 | canonical | deprecated |
+|---|---|---|
+| `Bigtablet.Select` | `onValueChange(value, option)` | `onChange` |
+| `Bigtablet.Toggle` | `onCheckedChange(checked)` | `onChange` |
+| `Bigtablet.Pagination` | `onPageChange(page)` | `onChange` |
 
 ### 유틸리티
 

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -671,10 +671,12 @@ Alert는 JavaScript로만 사용합니다.
   --bt-radius-md: 8px;
   --bt-radius-lg: 12px;
 
-  /* Shadows */
-  --bt-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.04);
-  --bt-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --bt-shadow-lg: 0 8px 20px rgba(0, 0, 0, 0.12);
+  /* Elevation (구 --bt-shadow-* 는 존재하지 않음) */
+  --bt-elevation-1: var(--bt-elevation-level1);
+  --bt-elevation-2: var(--bt-elevation-level2);
+  --bt-elevation-3: var(--bt-elevation-level3);
+  --bt-elevation-4: var(--bt-elevation-level4);
+  --bt-elevation-5: var(--bt-elevation-level5);
 
   /* Transitions */
   --bt-transition-fast: 0.1s ease-in-out;

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -280,11 +280,8 @@ npm install @bigtablet/design-system
 <button type="button" class="bt-toggle bt-toggle--sm" data-bt-toggle>...</button>  <!-- 기본값 -->
 <button type="button" class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
 
-<!-- 비활성화 - native disabled 또는 --disabled 클래스 -->
+<!-- 비활성화 - React Toggle 과 동일하게 native disabled 속성을 쓴다 -->
 <button type="button" class="bt-toggle" data-bt-toggle disabled>
-  <span class="bt-toggle__thumb"></span>
-</button>
-<button type="button" class="bt-toggle bt-toggle--disabled" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
 ```
@@ -397,8 +394,11 @@ React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
 
 ```html
 <script>
-  const dropdownEl = document.querySelector('[data-bt-dropdown]');
-  const myDropdown = Bigtablet.Dropdown(dropdownEl, {
+  // 옵션을 직접 넘겨 수동 초기화할 때는 `data-bt-dropdown` 을 붙이지 않는다.
+  // 그 속성이 있으면 DOMContentLoaded 에 자동 초기화되어 인스턴스가 두 개 생기고
+  // (각각 리스너·상태를 갖는다) 클릭 처리와 상태 동기화가 어긋난다.
+  // 자동 초기화된 요소를 다루려면 새로 만들지 말고 `el._btDropdown` 을 재사용할 것.
+  const myDropdown = Bigtablet.Dropdown('#fruit-dropdown', {
     placeholder: '선택하세요',
     options: [
       { value: 'apple', label: '사과' },
@@ -606,8 +606,9 @@ React `<Spinner size>` 가 px 숫자를 그대로 받는 것과 맞춰, 크기�
 
 ```html
 <script>
-  const paginationEl = document.querySelector('[data-bt-pagination]');
-  const pagination = Bigtablet.Pagination(paginationEl, {
+  // Dropdown 과 마찬가지로, 수동 초기화 대상에는 `data-bt-pagination` 을 붙이지 않는다
+  // (붙이면 자동 초기화와 인스턴스가 겹친다).
+  const pagination = Bigtablet.Pagination('#article-pagination', {
     page: 1,
     totalPages: 20,
     onPageChange: (page) => {

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -58,10 +58,10 @@ npm install @bigtablet/design-system
 
 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases)에서 다운로드:
 
-- `bigtablet.css` - 비압축 CSS (27KB)
-- `bigtablet.min.css` - 압축 CSS (21KB)
-- `bigtablet.js` - 비압축 JS (20KB)
-- `bigtablet.min.js` - 압축 JS (9KB)
+- `bigtablet.css` - 비압축 CSS (~40KB)
+- `bigtablet.min.css` - 압축 CSS (~31KB)
+- `bigtablet.js` - 비압축 JS (~30KB)
+- `bigtablet.min.js` - 압축 JS (~13KB)
 
 ---
 

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -85,7 +85,7 @@ npm install @bigtablet/design-system
   <div style="padding: 2rem;">
     <h1>Hello Bigtablet</h1>
 
-    <button class="bt-button bt-button--md bt-button--primary">
+    <button class="bt-button bt-button--md bt-button--filled">
       버튼
     </button>
 
@@ -111,31 +111,47 @@ npm install @bigtablet/design-system
 
 ```html
 <!-- 기본 -->
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
 
-<!-- Variants -->
-<button class="bt-button bt-button--md bt-button--primary">Primary</button>
-<button class="bt-button bt-button--md bt-button--secondary">Secondary</button>
-<button class="bt-button bt-button--md bt-button--ghost">Ghost</button>
-<button class="bt-button bt-button--md bt-button--danger">Danger</button>
+<!-- Variants (React <Button variant> 와 동일) -->
+<button class="bt-button bt-button--md bt-button--filled">Filled</button>
+<button class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+<button class="bt-button bt-button--md bt-button--outline">Outline</button>
+<button class="bt-button bt-button--md bt-button--text">Text</button>
+
+<!-- danger 는 variant 와 직교하는 modifier (React <Button danger /> 와 동일) -->
+<button class="bt-button bt-button--md bt-button--filled bt-button--danger">Delete</button>
+<button class="bt-button bt-button--md bt-button--outline bt-button--danger">Delete</button>
+<button class="bt-button bt-button--md bt-button--danger">Delete</button> <!-- variant 생략 시 filled -->
 
 <!-- Sizes -->
-<button class="bt-button bt-button--sm bt-button--primary">Small</button>
-<button class="bt-button bt-button--md bt-button--primary">Medium</button>
-<button class="bt-button bt-button--lg bt-button--primary">Large</button>
+<button class="bt-button bt-button--sm bt-button--filled">Small</button>
+<button class="bt-button bt-button--md bt-button--filled">Medium</button>
+<button class="bt-button bt-button--lg bt-button--filled">Large</button>
+<button class="bt-button bt-button--xl bt-button--filled">XLarge</button>
 
 <!-- 전체 너비 -->
-<button class="bt-button bt-button--md bt-button--primary bt-button--full-width">전체 너비</button>
+<button class="bt-button bt-button--md bt-button--filled bt-button--full-width">전체 너비</button>
 
 <!-- 비활성화 -->
-<button class="bt-button bt-button--md bt-button--primary" disabled>Disabled</button>
+<button class="bt-button bt-button--md bt-button--filled" disabled>Disabled</button>
 ```
 
 **클래스 조합:**
 - `.bt-button` (필수)
-- `.bt-button--{size}`: `sm`, `md`, `lg`
-- `.bt-button--{variant}`: `primary`, `secondary`, `ghost`, `danger`
+- `.bt-button--{size}`: `sm`, `md`, `lg`, `xl`
+- `.bt-button--{variant}`: `filled`, `tonal`, `outline`, `text`
+- `.bt-button--danger` (선택) - variant 와 함께 조합
 - `.bt-button--full-width` (선택)
+
+> **Deprecated 별칭** - 구 variant 이름은 계속 동작하지만 **v4.0.0 에서 제거**됩니다.
+> 새 마크업에는 오른쪽 이름을 사용하세요.
+>
+> | 구 이름 (deprecated) | 대체 |
+> |---|---|
+> | `.bt-button--primary` | `.bt-button--filled` |
+> | `.bt-button--secondary` | `.bt-button--outline` |
+> | `.bt-button--ghost` | `.bt-button--text` |
 
 ---
 
@@ -259,11 +275,14 @@ npm install @bigtablet/design-system
   <span class="bt-toggle__thumb"></span>
 </button>
 
-<!-- Sizes -->
-<button type="button" class="bt-toggle" data-bt-toggle>...</button>  <!-- 기본 sm -->
+<!-- Sizes (React ToggleSize 와 동일) -->
+<button type="button" class="bt-toggle bt-toggle--sm" data-bt-toggle>...</button>  <!-- 기본값 -->
 <button type="button" class="bt-toggle bt-toggle--md" data-bt-toggle>...</button>
 
-<!-- 비활성화 -->
+<!-- 비활성화 - native disabled 또는 --disabled 클래스 -->
+<button type="button" class="bt-toggle" data-bt-toggle disabled>
+  <span class="bt-toggle__thumb"></span>
+</button>
 <button type="button" class="bt-toggle bt-toggle--disabled" data-bt-toggle>
   <span class="bt-toggle__thumb"></span>
 </button>
@@ -402,7 +421,7 @@ npm install @bigtablet/design-system
 
 ```html
 <!-- 트리거 버튼 -->
-<button class="bt-button bt-button--md bt-button--primary" data-bt-modal-open="my-modal">
+<button class="bt-button bt-button--md bt-button--filled" data-bt-modal-open="my-modal">
   모달 열기
 </button>
 
@@ -418,8 +437,8 @@ npm install @bigtablet/design-system
       <p>여러 줄의 콘텐츠도 가능합니다.</p>
     </div>
     <div class="bt-modal__footer">
-      <button class="bt-button bt-button--md bt-button--secondary" data-modal-close>취소</button>
-      <button class="bt-button bt-button--md bt-button--primary" data-modal-close>확인</button>
+      <button class="bt-button bt-button--md bt-button--outline" data-modal-close>취소</button>
+      <button class="bt-button bt-button--md bt-button--filled" data-modal-close>확인</button>
     </div>
   </div>
 </div>
@@ -452,7 +471,7 @@ npm install @bigtablet/design-system
 Alert는 JavaScript로만 사용합니다.
 
 ```html
-<button class="bt-button bt-button--md bt-button--primary" onclick="showAlert()">
+<button class="bt-button bt-button--md bt-button--filled" onclick="showAlert()">
   알림 표시
 </button>
 
@@ -497,7 +516,9 @@ Alert는 JavaScript로만 사용합니다.
 | `confirmText` | `string` | `'확인'` | 확인 버튼 텍스트 |
 | `cancelText` | `string` | `'취소'` | 취소 버튼 텍스트 |
 | `showCancel` | `boolean` | `false` | 취소 버튼 표시 |
+| `destructive` | `boolean` | `false` | 확인 버튼을 danger(빨강)로 강조 (React `AlertOptions.destructive` 와 동일) |
 | `actionsAlign` | `string` | `'right'` | 버튼 정렬 |
+| `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭으로 닫기 허용 (React `AlertOptions.closeOnOverlay` 와 동일) |
 | `onConfirm` | `function` | - | 확인 콜백 |
 | `onCancel` | `function` | - | 취소 콜백 |
 
@@ -512,16 +533,29 @@ Alert는 JavaScript로만 사용합니다.
   <p>카드 내용입니다.</p>
 </div>
 
-<!-- Shadow -->
+<!-- Shadow (React Card shadow prop 과 동일) -->
+<div class="bt-card bt-card--shadow-none bt-card--p-md">내용</div>
 <div class="bt-card bt-card--shadow-sm bt-card--p-md">내용</div>
 <div class="bt-card bt-card--shadow-md bt-card--p-md">내용</div>
 <div class="bt-card bt-card--shadow-lg bt-card--p-md">내용</div>
 
-<!-- Padding -->
+<!-- Padding (React Card padding prop 과 동일) -->
+<div class="bt-card bt-card--bordered bt-card--p-none">No padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-sm">Small padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-md">Medium padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-lg">Large padding</div>
 ```
+
+> **Deprecated 별칭** - **v4.0.0 에서 제거** 예정.
+>
+> | 구 이름 (deprecated) | 대체 |
+> |---|---|
+> | `.bt-card--elevation-1` | `.bt-card--shadow-sm` |
+> | `.bt-card--elevation-2` | `.bt-card--shadow-md` |
+> | `.bt-card--elevation-3` | `.bt-card--shadow-lg` |
+>
+> React `Card` 는 `shadow` 기본값이 `sm` 이지만, Vanilla `.bt-card` 는 기존 동작대로
+> shadow 클래스를 붙이지 않으면 그림자가 없습니다.
 
 ---
 
@@ -640,6 +674,7 @@ Alert는 JavaScript로만 사용합니다.
   /* Colors */
   --bt-color-primary: #000000;
   --bt-color-primary-hover: #333333;
+  --bt-color-primary-container: rgba(0, 0, 0, 0.05);  /* .bt-button--tonal 채움색 */
   --bt-color-background: #ffffff;
   --bt-color-background-secondary: #fafafa;
   --bt-color-text-primary: #1a1a1a;
@@ -797,7 +832,7 @@ cleanup();  // 리스너 제거
     </div>
 
     <!-- Button -->
-    <button type="submit" class="bt-button bt-button--md bt-button--primary">
+    <button type="submit" class="bt-button bt-button--md bt-button--filled">
       제출
     </button>
   </form>

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -15,7 +15,7 @@ React 없이 순수 HTML/CSS/JS 환경에서 사용하는 가이드입니다.
   - [Checkbox](#checkbox)
   - [Radio](#radio)
   - [Toggle](#toggle)
-  - [Select](#select)
+  - [Dropdown](#dropdown)
   - [Modal](#modal)
   - [Alert](#alert)
   - [Card](#card)
@@ -142,16 +142,17 @@ npm install @bigtablet/design-system
 - `.bt-button--{size}`: `sm`, `md`, `lg`, `xl`
 - `.bt-button--{variant}`: `filled`, `tonal`, `outline`, `text`
 - `.bt-button--danger` (선택) - variant 와 함께 조합
+- `.bt-button--radius-{none|xs|sm|md|lg|xl|full}` (선택) - React `radius` prop 과 동일. 기본값은 `full`(pill)
 - `.bt-button--full-width` (선택)
 
-> **Deprecated 별칭** - 구 variant 이름은 계속 동작하지만 **v4.0.0 에서 제거**됩니다.
-> 새 마크업에는 오른쪽 이름을 사용하세요.
->
-> | 구 이름 (deprecated) | 대체 |
-> |---|---|
-> | `.bt-button--primary` | `.bt-button--filled` |
-> | `.bt-button--secondary` | `.bt-button--outline` |
-> | `.bt-button--ghost` | `.bt-button--text` |
+```html
+<!-- radius 는 기본이 pill - 사각형에 가깝게 하려면 modifier 로 -->
+<button class="bt-button bt-button--md bt-button--filled bt-button--radius-md">Radius md</button>
+```
+
+> `--filled` 는 React `variant="filled"` 와 동일하게 accent 색을 씁니다 - 라이트에선 검정,
+> 다크에선 흰색으로 자동 반전되어 다크 테마에서 버튼이 배경에 묻히지 않습니다.
+> 양 테마 고정색이 필요하면 `--bt-color-primary` 를 직접 적용하세요.
 
 ---
 
@@ -341,25 +342,28 @@ npm install @bigtablet/design-system
 
 ---
 
-### Select
+### Dropdown
+
+React `<Dropdown>` 의 Vanilla 대응입니다. 단일 선택 전용이며,
+React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
 
 ```html
-<div class="bt-select" data-bt-select style="width: 300px;">
-  <label class="bt-select__label">과일 선택</label>
-  <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-    <span class="bt-select__placeholder">선택하세요...</span>
-    <span class="bt-select__icon">
+<div class="bt-dropdown" data-bt-dropdown style="width: 300px;">
+  <label class="bt-dropdown__label">과일 선택</label>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">선택하세요...</span>
+    <span class="bt-dropdown__icon">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M6 9l6 6 6-6"/>
       </svg>
     </span>
   </button>
-  <ul class="bt-select__list">
-    <li class="bt-select__option" data-value="apple">사과</li>
-    <li class="bt-select__option" data-value="banana">바나나</li>
-    <li class="bt-select__option" data-value="cherry">체리</li>
-    <li class="bt-select__option is-disabled" data-value="mango">망고 (품절)</li>
-    <li class="bt-select__option" data-value="orange">오렌지</li>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="apple">사과</li>
+    <li class="bt-dropdown__option" data-value="banana">바나나</li>
+    <li class="bt-dropdown__option" data-value="cherry">체리</li>
+    <li class="bt-dropdown__option is-disabled" data-value="mango">망고 (품절)</li>
+    <li class="bt-dropdown__option" data-value="orange">오렌지</li>
   </ul>
 </div>
 ```
@@ -370,31 +374,31 @@ npm install @bigtablet/design-system
 **폼 제출 참여 (Thymeleaf/JSP):**
 
 `data-name` 을 지정하면 hidden input 이 생성되어 선택 값이 폼 POST 에 포함됩니다.
-서버 템플릿이 `.bt-select` 안에 hidden input 을 미리 렌더링해 두면 (예: `th:field`)
+서버 템플릿이 `.bt-dropdown` 안에 hidden input 을 미리 렌더링해 두면 (예: `th:field`)
 그 input 의 name/초기값을 그대로 이어받아 표시·동기화합니다.
 
 ```html
-<div class="bt-select" data-bt-select data-name="fruit">
+<div class="bt-dropdown" data-bt-dropdown data-name="fruit">
   <!-- 또는 서버 바인딩: <input type="hidden" th:field="*{fruit}"> -->
   ...
 </div>
 ```
 
 **Variants:**
-- `.bt-select__control--outline` (기본)
-- `.bt-select__control--filled`
+- `.bt-dropdown__control--outline` (기본) - React `Dropdown` 과 동등한 스타일
+- `.bt-dropdown__control--filled` - Vanilla 전용 (React `Dropdown` 에는 대응 prop 없음)
 
 **Sizes:**
-- `.bt-select__control--sm`
-- `.bt-select__control--md`
-- `.bt-select__control--lg`
+- `.bt-dropdown__control--sm`
+- `.bt-dropdown__control--md`
+- `.bt-dropdown__control--lg`
 
 **JavaScript 연동:**
 
 ```html
 <script>
-  const selectEl = document.querySelector('[data-bt-select]');
-  const mySelect = Bigtablet.Select(selectEl, {
+  const dropdownEl = document.querySelector('[data-bt-dropdown]');
+  const myDropdown = Bigtablet.Dropdown(dropdownEl, {
     placeholder: '선택하세요',
     options: [
       { value: 'apple', label: '사과' },
@@ -407,11 +411,11 @@ npm install @bigtablet/design-system
   });
 
   // API
-  mySelect.getValue();       // 현재 값
-  mySelect.setValue('apple'); // 값 설정
-  mySelect.open();           // 드롭다운 열기
-  mySelect.close();          // 드롭다운 닫기
-  mySelect.setDisabled(true); // 비활성화
+  myDropdown.getValue();       // 현재 값
+  myDropdown.setValue('apple'); // 값 설정
+  myDropdown.open();           // 드롭다운 열기
+  myDropdown.close();          // 드롭다운 닫기
+  myDropdown.setDisabled(true); // 비활성화
 </script>
 ```
 
@@ -544,29 +548,49 @@ Alert는 JavaScript로만 사용합니다.
 <div class="bt-card bt-card--bordered bt-card--p-sm">Small padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-md">Medium padding</div>
 <div class="bt-card bt-card--bordered bt-card--p-lg">Large padding</div>
+
+<!-- Variant (React Card variant prop 과 동일) -->
+<div class="bt-card bt-card--accent bt-card--p-md">Accent</div>
+<div class="bt-card bt-card--outlined bt-card--p-md">Outlined (shadow 무시)</div>
+<div class="bt-card bt-card--glass bt-card--p-md">Glass (컬러/이미지 배경 위에서)</div>
+
+<!-- interactive - hover 시 살짝 떠오름 (React interactive prop) -->
+<div class="bt-card bt-card--interactive bt-card--p-md">클릭 가능한 카드</div>
 ```
 
-> **Deprecated 별칭** - **v4.0.0 에서 제거** 예정.
->
-> | 구 이름 (deprecated) | 대체 |
-> |---|---|
-> | `.bt-card--elevation-1` | `.bt-card--shadow-sm` |
-> | `.bt-card--elevation-2` | `.bt-card--shadow-md` |
-> | `.bt-card--elevation-3` | `.bt-card--shadow-lg` |
->
-> React `Card` 는 `shadow` 기본값이 `sm` 이지만, Vanilla `.bt-card` 는 기존 동작대로
-> shadow 클래스를 붙이지 않으면 그림자가 없습니다.
+**클래스 조합:**
+- `.bt-card` (필수) - 기본값은 React 와 동일하게 `shadow=sm` / `padding=md`
+- `.bt-card--shadow-{none|sm|md|lg}` (선택)
+- `.bt-card--p-{none|sm|md|lg}` (선택)
+- `.bt-card--bordered` (선택)
+- `.bt-card--{accent|outlined|glass}` (선택) - variant. 미지정 시 `default`
+- `.bt-card--interactive` (선택)
+
+> `.bt-card` 는 클래스를 하나도 더 붙이지 않아도 React `<Card>` 기본값과 같은
+> 그림자(sm)·여백(md)을 갖습니다. 없애려면 `--shadow-none` / `--p-none` 을 명시하세요.
 
 ---
 
 ### Spinner
 
+React `<Spinner size>` 가 px 숫자를 그대로 받는 것과 맞춰, 크기는 size enum 클래스가 아니라
+`--bt-spinner-size` CSS 커스텀 프로퍼티로 지정합니다. 기본값은 React 와 같은 **24px** 입니다.
+
 ```html
-<div class="bt-spinner bt-spinner--sm"></div>  <!-- 16px -->
-<div class="bt-spinner bt-spinner--md"></div>  <!-- 24px -->
-<div class="bt-spinner bt-spinner--lg"></div>  <!-- 32px -->
-<div class="bt-spinner bt-spinner--xl"></div>  <!-- 48px -->
+<!-- 기본 24px -->
+<span class="bt-spinner" role="status" aria-label="Loading"></span>
+
+<!-- 임의 크기 -->
+<span class="bt-spinner" style="--bt-spinner-size: 16px" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 48px" role="status" aria-label="Loading"></span>
 ```
+
+> `role="status"` + `aria-label` 을 직접 붙이세요 - React `<Spinner>` 는 이 둘을 자동으로
+> 렌더링하지만 Vanilla 는 CSS 만 제공하므로 마크업에서 지정해야 스크린리더에 로딩 상태가 전달됩니다.
+>
+> 회전 모양은 React 와 다릅니다 - React 는 12개 bar 가 페이드하는 iOS 스타일이고
+> Vanilla 는 단일 border spinner 입니다 (CSS 만으로 동일 렌더 불가 - 의도된 차이).
 
 ---
 
@@ -701,10 +725,14 @@ Alert는 JavaScript로만 사용합니다.
   --bt-font-size-md: 1rem;
   --bt-font-size-lg: 1.125rem;
 
-  /* Radius */
+  /* Radius (React `radius` prop 스케일과 동일) */
+  --bt-radius-none: 0px;
+  --bt-radius-xs: 4px;
   --bt-radius-sm: 6px;
   --bt-radius-md: 8px;
   --bt-radius-lg: 12px;
+  --bt-radius-xl: 16px;
+  --bt-radius-full: 9999px;
 
   /* Elevation (구 --bt-shadow-* 는 존재하지 않음) */
   --bt-elevation-1: var(--bt-elevation-level1);
@@ -748,7 +776,7 @@ Alert는 JavaScript로만 사용합니다.
 `data-bt-*` 속성이 있는 요소는 페이지 로드 시 자동으로 초기화됩니다.
 
 ```html
-<div data-bt-select>...</div>     <!-- Select 자동 초기화 -->
+<div data-bt-dropdown>...</div>   <!-- Dropdown 자동 초기화 -->
 <div data-bt-modal>...</div>      <!-- Modal 자동 초기화 -->
 <button data-bt-toggle>...</button> <!-- Toggle 자동 초기화 -->
 <nav data-bt-pagination>...</nav> <!-- Pagination 자동 초기화 -->
@@ -759,8 +787,8 @@ Alert는 JavaScript로만 사용합니다.
 ```javascript
 // 페이지 로드 후 수동 초기화
 document.addEventListener('DOMContentLoaded', function() {
-  // Select
-  const select = Bigtablet.Select('#my-select', options);
+  // Dropdown
+  const dropdown = Bigtablet.Dropdown('#my-dropdown', options);
 
   // Modal
   const modal = Bigtablet.Modal('#my-modal', options);
@@ -781,14 +809,14 @@ Bigtablet.init();
 
 ### 콜백 이름 (React 와 동일)
 
-값 변경 콜백은 React 컴포넌트와 같은 이름을 사용합니다. 구 `onChange` 도 계속 동작하지만
-**deprecated** 이며 v4.0.0 에서 제거됩니다. 둘 다 주면 canonical 쪽만 호출됩니다.
+값 변경 콜백은 React 컴포넌트와 같은 이름을 사용합니다. 구 `onChange` 는 **더 이상 호출되지
+않습니다** (v3.8.0 제거 - [마이그레이션 가이드](./MIGRATION.md#v380-vanilla-패키지-정리) 참고).
 
-| 컴포넌트 | canonical | deprecated |
-|---|---|---|
-| `Bigtablet.Select` | `onValueChange(value, option)` | `onChange` |
-| `Bigtablet.Toggle` | `onCheckedChange(checked)` | `onChange` |
-| `Bigtablet.Pagination` | `onPageChange(page)` | `onChange` |
+| 컴포넌트 | 콜백 |
+|---|---|
+| `Bigtablet.Dropdown` | `onValueChange(value, option)` |
+| `Bigtablet.Toggle` | `onCheckedChange(checked)` |
+| `Bigtablet.Pagination` | `onPageChange(page)` |
 
 ### 유틸리티
 

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
 		"@types/node": "^25.9.1",
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.4",
-		"@vitest/browser-playwright": "^4.1.6",
-		"@vitest/coverage-v8": "^4.1.6",
+		"@vitest/browser-playwright": "^4.1.10",
+		"@vitest/coverage-v8": "^4.1.10",
 		"esbuild-sass-plugin": "^3.7.0",
 		"husky": "^9.1.7",
 		"jsdom": "^29.1.1",
@@ -110,7 +110,7 @@
 		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
 		"vite": "^8.1.0",
-		"vitest": "^4.1.6"
+		"vitest": "^4.1.10"
 	},
 	"publishConfig": {
 		"access": "public",
@@ -119,7 +119,8 @@
 	"size-limit": [
 		{
 			"path": "dist/index.js",
-			"limit": "50 kB"
+			"limit": "60 kB",
+			"message": "Raised 50 kB -> 60 kB on 2026-08-05: measured baseline was 49.34 kB (1.3% headroom), so the next component addition would have failed CI. Re-measure before raising again."
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.7.0",
+	"version": "3.8.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"css"
 	],
 	"author": "sangmin",
-	"license": "MIT",
+	"license": "SEE LICENSE IN LICENSE",
 	"packageManager": "pnpm@10.20.0",
 	"peerDependencies": {
 		"lucide-react": ">=0.552.0",
@@ -120,7 +120,7 @@
 		{
 			"path": "dist/index.js",
 			"limit": "60 kB",
-			"message": "Raised 50 kB -> 60 kB on 2026-08-05: measured baseline was 49.34 kB (1.3% headroom), so the next component addition would have failed CI. Re-measure before raising again."
+			"message": "Raised 50 kB -> 60 kB on 2026-08-05: baseline was 49.34 kB, leaving 0.66 kB (1.3%) under the old 50 kB limit. The current limit leaves 10.66 kB. Re-measure before raising again."
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 10.5.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
       '@storybook/addon-vitest':
         specifier: ^10.4.6
-        version: 10.5.3(@vitest/browser-playwright@4.1.6)(@vitest/browser@4.1.10)(@vitest/runner@4.1.6)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.6)
+        version: 10.5.3(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.10)
       '@storybook/react':
         specifier: ^10.4.6
         version: 10.5.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(typescript@6.0.3)
@@ -70,11 +70,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
       '@vitest/browser-playwright':
-        specifier: ^4.1.6
-        version: 4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
       '@vitest/coverage-v8':
-        specifier: ^4.1.6
-        version: 4.1.6(@vitest/browser@4.1.10)(vitest@4.1.6)
+        specifier: ^4.1.10
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       esbuild-sass-plugin:
         specifier: ^3.7.0
         version: 3.7.0(esbuild@0.28.1)(sass-embedded@1.100.0)
@@ -127,8 +127,8 @@ importers:
         specifier: ^8.1.0
         version: 8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)
       vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
 
 packages:
 
@@ -188,10 +188,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -212,11 +208,6 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
@@ -232,10 +223,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -1714,22 +1701,22 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
-  '@vitest/browser-playwright@4.1.6':
-    resolution: {integrity: sha512-4csoeyl/qwHyxU2zNL0++WaoDr8YJDXOQPwWPNJoTZ+QzcdO3INYKgF5Zfz730Io7zbkuv914aZmfQ+QE+1Hvw==}
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.6
+      vitest: 4.1.10
 
   '@vitest/browser@4.1.10':
     resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
     peerDependencies:
       vitest: 4.1.10
 
-  '@vitest/coverage-v8@4.1.6':
-    resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
       '@vitest/browser': ^4.1.10
-      vitest: 4.1.6
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -1737,22 +1724,11 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
   '@vitest/mocker@4.1.10':
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1768,14 +1744,11 @@ packages:
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
-
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
@@ -1783,17 +1756,11 @@ packages:
   '@vitest/spy@4.1.10':
     resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
-
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
-
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
@@ -3165,10 +3132,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -3341,20 +3304,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3548,8 +3511,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -3562,10 +3523,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.3':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -3590,11 +3547,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -4590,16 +4542,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.5.3(@vitest/browser-playwright@4.1.6)(@vitest/browser@4.1.10)(@vitest/runner@4.1.6)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.6)':
+  '@storybook/addon-vitest@10.5.3(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.3(@types/react@19.2.18)(react@19.2.8))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.1.0(react@19.2.8)
       storybook: 10.5.3(@types/react@19.2.18)(react@19.2.8)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/browser-playwright': 4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/runner': 4.1.6
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/runner': 4.1.10
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
     transitivePeerDependencies:
       - react
 
@@ -4774,20 +4726,20 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
-  '@vitest/browser-playwright@4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/mocker': 4.1.6(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
       playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)':
+  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
@@ -4796,7 +4748,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -4804,10 +4756,10 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.6(@vitest/browser@4.1.10)(vitest@4.1.6)':
+  '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.10
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -4816,9 +4768,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -4828,26 +4780,18 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@4.1.6':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
   '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))':
     dependencies:
       '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)
-
-  '@vitest/mocker@4.1.6(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))':
-    dependencies:
-      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -4861,19 +4805,15 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/pretty-format@4.1.6':
+  '@vitest/runner@4.1.10':
     dependencies:
-      tinyrainbow: 3.1.0
-
-  '@vitest/runner@4.1.6':
-    dependencies:
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.6':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -4882,8 +4822,6 @@ snapshots:
       tinyspy: 4.0.4
 
   '@vitest/spy@4.1.10': {}
-
-  '@vitest/spy@4.1.6': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -4894,12 +4832,6 @@ snapshots:
   '@vitest/utils@4.1.10':
     dependencies:
       '@vitest/pretty-format': 4.1.10
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.6':
-    dependencies:
-      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -5535,8 +5467,8 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -6254,8 +6186,6 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.1.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
@@ -6389,32 +6319,32 @@ snapshots:
       sass-embedded: 1.100.0
       tsx: 4.23.1
 
-  vitest@4.1.6(@types/node@25.9.5)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)):
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)):
     dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
-      '@vitest/browser-playwright': 4.1.6(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.6)
-      '@vitest/coverage-v8': 4.1.6(@vitest/browser@4.1.10)(vitest@4.1.6)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,13 @@ export type { AccordionItem, AccordionProps } from "./ui/display/accordion";
 export { Accordion } from "./ui/display/accordion";
 export type { AvatarProps, AvatarShape, AvatarSize } from "./ui/display/avatar";
 export { Avatar } from "./ui/display/avatar";
-export type { BadgeProps, BadgeShape, BadgeSize, BadgeVariant } from "./ui/display/badge";
+export type {
+	BadgeAppearance,
+	BadgeProps,
+	BadgeShape,
+	BadgeSize,
+	BadgeVariant,
+} from "./ui/display/badge";
 export { Badge } from "./ui/display/badge";
 export type { EmptyStateProps } from "./ui/feedback/empty-state";
 export { EmptyState } from "./ui/feedback/empty-state";
@@ -100,6 +106,7 @@ export type {
 	TableSortDirection,
 } from "./ui/display/table";
 export { Table } from "./ui/display/table";
+export type { AlertActionsAlign, AlertOptions, AlertVariant } from "./ui/feedback/alert";
 export { AlertProvider, useAlert } from "./ui/feedback/alert";
 export type { LinearProgressProps } from "./ui/feedback/linear-progress";
 export { LinearProgress } from "./ui/feedback/linear-progress";
@@ -107,6 +114,7 @@ export type { SkeletonProps, SkeletonVariant } from "./ui/feedback/skeleton";
 export { Skeleton } from "./ui/feedback/skeleton";
 export type { SpinnerProps } from "./ui/feedback/spinner";
 export { Spinner } from "./ui/feedback/spinner";
+export type { ToastProviderProps, ToastVariant } from "./ui/feedback/toast";
 export { ToastProvider } from "./ui/feedback/toast";
 export { useToast } from "./ui/feedback/toast/use-toast";
 export type { TopLoadingProps } from "./ui/feedback/top-loading";
@@ -115,9 +123,15 @@ export type { CheckboxProps } from "./ui/forms/checkbox";
 export { Checkbox } from "./ui/forms/checkbox";
 export type { DatePickerProps } from "./ui/forms/date-picker";
 export { DatePicker } from "./ui/forms/date-picker";
-export type { DropdownOption, DropdownProps, DropdownSize } from "./ui/forms/dropdown";
+export type {
+	DropdownMultipleProps,
+	DropdownOption,
+	DropdownProps,
+	DropdownSingleProps,
+	DropdownSize,
+} from "./ui/forms/dropdown";
 export { Dropdown } from "./ui/forms/dropdown";
-export type { FileInputProps } from "./ui/forms/file";
+export type { FileInputProps, FileInputVariant } from "./ui/forms/file";
 export { FileInput } from "./ui/forms/file";
 export type {
 	CropImageSize,
@@ -132,11 +146,12 @@ export { OtpInput } from "./ui/forms/otp-input";
 export type { RadioProps } from "./ui/forms/radio";
 export { Radio } from "./ui/forms/radio";
 export type {
+	RadioGroupContextValue,
 	RadioGroupOrientation,
 	RadioGroupProps,
 	RadioGroupSize,
 } from "./ui/forms/radio-group";
-export { RadioGroup } from "./ui/forms/radio-group";
+export { RadioGroup, useRadioGroupContext } from "./ui/forms/radio-group";
 export type {
 	TextareaProps,
 	TextareaResize,
@@ -147,7 +162,13 @@ export type { ImeStrategy, TextFieldProps, TextFieldSize } from "./ui/forms/text
 export { TextField } from "./ui/forms/textfield";
 export type { ToggleProps } from "./ui/forms/toggle";
 export { Toggle } from "./ui/forms/toggle";
-export type { ButtonProps } from "./ui/general/button";
+export type {
+	ButtonAsAnchor,
+	ButtonAsButton,
+	ButtonProps,
+	ButtonSize,
+	ButtonVariant,
+} from "./ui/general/button";
 export { Button } from "./ui/general/button";
 export type { IconButtonProps, IconButtonSize, IconButtonVariant } from "./ui/general/icon-button";
 export { IconButton } from "./ui/general/icon-button";
@@ -155,7 +176,7 @@ export type { PaginationProps } from "./ui/navigation/pagination";
 export { Pagination } from "./ui/navigation/pagination";
 export type { DrawerPlacement, DrawerProps } from "./ui/overlay/drawer";
 export { Drawer } from "./ui/overlay/drawer";
-export type { ModalProps } from "./ui/overlay/modal";
+export type { ModalFooterAlign, ModalProps } from "./ui/overlay/modal";
 export { Modal } from "./ui/overlay/modal";
 export type { ResolvedTheme, ThemeMode, ThemeProviderProps } from "./ui/system/theme-provider";
 export { ThemeProvider, useTheme } from "./ui/system/theme-provider";

--- a/src/stories/getting-started/installation.stories.tsx
+++ b/src/stories/getting-started/installation.stories.tsx
@@ -101,7 +101,7 @@ export const Vanilla: Story = {
 						description="BEM-like 클래스 네이밍. data-bt-* 속성으로 컴포넌트 식별."
 						lang="html"
 						code={`<!-- 버튼 -->
-<button class="bt-button bt-button--md bt-button--primary">
+<button class="bt-button bt-button--md bt-button--filled">
   저장
 </button>
 
@@ -119,13 +119,13 @@ export const Vanilla: Story = {
 						description="data-bt-* 속성 가진 요소는 DOMContentLoaded 에 자동 동작. 수동 init 도 가능."
 						lang="html"
 						code={`<!-- 자동 -->
-<div class="bt-select" data-bt-select>...</div>
+<div class="bt-dropdown" data-bt-dropdown>...</div>
 <div class="bt-modal" data-bt-modal>...</div>
 
 <!-- 수동 -->
 <script>
-  const select = Bigtablet.Select('#my-select', {
-    onChange: (value) => console.log(value)
+  const dropdown = Bigtablet.Dropdown('#my-dropdown', {
+    onValueChange: (value) => console.log(value)
   });
 </script>`}
 					/>

--- a/src/styles/colors/_index.scss
+++ b/src/styles/colors/_index.scss
@@ -163,3 +163,33 @@ $color_accent_light:          var(--bt-color-accent-light);
 $color_accent_default:        var(--bt-color-accent-default);
 $color_accent_strong:         var(--bt-color-accent-strong);
 $color_accent_on_surface:     var(--bt-color-accent-on-surface);
+
+// ── Fixed-surface semantics (raw alpha, theme 무관) ────────────────────
+// hero scrim / media-card overlay / accent·transparent nav bar 처럼 표면 명암이
+// 테마와 무관하게 고정된 자리의 콘텐츠용 어휘.
+// `$color_state_*_on_dark` 와 이름 규칙(`_on_dark`)은 공유하지만 구조는 다르다:
+// state 계열은 [data-theme="dark"] 에서 black alpha 로 뒤집히는 반면, 여기 값들은
+// 배경이 항상 어둡거나(밝거나) 하므로 뒤집히면 안 된다. 그래서 var() 가 아닌
+// raw alpha 로 두고 SCSS 컴파일 시점에 그대로 박힌다.
+
+// Text on a permanently dark surface (강조 → 캡션 순 램프)
+$color_text_on_dark_strong:   rgba(255, 255, 255, 0.9);   // 인터랙티브 라벨 (text button)
+$color_text_on_dark_body:     rgba(255, 255, 255, 0.85);  // 본문 / 설명문
+$color_text_on_dark_label:    rgba(255, 255, 255, 0.75);  // eyebrow / 오버레이 라벨
+$color_text_on_dark_muted:    rgba(255, 255, 255, 0.7);   // 비활성 nav link / 보조 라벨
+$color_text_on_dark_caption:  rgba(255, 255, 255, 0.6);   // meta / 캡션
+
+// Text on a permanently light surface (light scrim 위 forced dark text)
+$color_text_on_light_body:    rgba(0, 0, 0, 0.85);
+$color_text_on_light_muted:   rgba(0, 0, 0, 0.6);
+
+// Border on a permanently dark surface (outline button 등 hairline)
+$color_border_on_dark:        rgba(255, 255, 255, 0.55);
+
+// Scrim - 이미지 위 텍스트 가독성 확보용 gradient stop (clear → heavy 세기 램프)
+$color_scrim_dark_clear:      rgba(0, 0, 0, 0);
+$color_scrim_dark_soft:       rgba(0, 0, 0, 0.1);
+$color_scrim_dark_strong:     rgba(0, 0, 0, 0.55);
+$color_scrim_dark_heavy:      rgba(0, 0, 0, 0.85);
+$color_scrim_light_soft:      rgba(255, 255, 255, 0.1);
+$color_scrim_light_strong:    rgba(255, 255, 255, 0.7);

--- a/src/styles/layout/_index.scss
+++ b/src/styles/layout/_index.scss
@@ -1,3 +1,5 @@
+@use "../motion" as motion;
+
 /* Flex Utilities */
 @mixin flex_center { display: flex; align-items: center; justify-content: center; }
 @mixin flex_left { display: flex; align-items: center; justify-content: flex-start; }
@@ -32,22 +34,34 @@
 }
 
 /* Hover Lift Effect */
+// motion.$transition_lift = transform/box-shadow 0.25s $ease_out_expo (= $easing_enter) -
+// 기존 하드코딩 값과 동일한 전용 토큰.
 @mixin hover_lift($y: -4px, $shadow: 0 12px 24px rgba(0, 0, 0, 0.15)) {
-  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1),
-              box-shadow 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: motion.$transition_lift;
 
   &:hover {
     transform: translateY($y);
     box-shadow: $shadow;
   }
+
+  // WCAG 2.1 SC 2.3.3 - mixin 은 호출 지점을 모르므로 guard 를 body 안에 둔다.
+  // Sass 가 @media 를 호출 선택자와 함께 밖으로 빼주어 소비처마다 자동 적용된다.
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 /* Glow on Hover */
 @mixin hover_glow($color: rgba(59, 130, 246, 0.4)) {
-  transition: box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: box-shadow motion.$duration_slow motion.$easing_enter;
 
   &:hover {
     box-shadow: 0 0 30px $color;
+  }
+
+  // WCAG 2.1 SC 2.3.3 - hover_lift 와 동일하게 mixin body 안에서 guard.
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
   }
 }
 

--- a/src/styles/motion/_index.scss
+++ b/src/styles/motion/_index.scss
@@ -53,4 +53,4 @@ $transition_lift: transform 0.25s $ease_out_expo, box-shadow 0.25s $ease_out_exp
 // ($skeleton_animation_duration / _timing 과 같은 역할의 컴포넌트 스코프 토큰)
 $duration_loading_spinner:  1.2s;    // Spinner spoke fade 1 cycle
 $duration_loading_bar:      1.5s;    // TopLoading indeterminate sweep 1 cycle
-$duration_progress_default: 3000ms;  // Toast progress bar 기본값 (--toast-duration fallback)
+$duration_progress_default: 3s;      // Toast progress bar 기본값 (--toast-duration fallback)

--- a/src/styles/motion/_index.scss
+++ b/src/styles/motion/_index.scss
@@ -8,6 +8,12 @@ $transition_fast: $duration_fast ease-in-out;   // hover, icon
 $transition_base: $duration_base ease-in-out;   // 메뉴 열림
 $transition_slow: $duration_slow ease-in-out;   // 레이아웃 변화
 
+// Keyword easing - animation shorthand 에서 duration 과 조합할 때.
+// ($transition_* composite 는 easing 이 이미 들어있어 animation 에 쓰면 중복된다)
+// `//` 주석 사용 - `/* */` 는 vanilla CSS 번들에 그대로 실려 나간다.
+$easing_linear:   linear;
+$easing_standard: ease-in-out;
+
 /* Easing Curves */
 $ease_out_expo: cubic-bezier(0.16, 1, 0.3, 1);
 $ease_out_quart: cubic-bezier(0.25, 1, 0.5, 1);
@@ -41,3 +47,10 @@ $transition_dramatic: 0.6s $ease_out_quart;
 
 /* Hover Lift */
 $transition_lift: transform 0.25s $ease_out_expo, box-shadow 0.25s $ease_out_expo;
+
+// Loading & progress indicators
+// 무한 반복(`infinite`) 이 허용되는 유일한 자리 - loading affordance 전용.
+// ($skeleton_animation_duration / _timing 과 같은 역할의 컴포넌트 스코프 토큰)
+$duration_loading_spinner:  1.2s;    // Spinner spoke fade 1 cycle
+$duration_loading_bar:      1.5s;    // TopLoading indeterminate sweep 1 cycle
+$duration_progress_default: 3000ms;  // Toast progress bar 기본값 (--toast-duration fallback)

--- a/src/styles/tokens.json
+++ b/src/styles/tokens.json
@@ -35,6 +35,41 @@
 				"disabled": {
 					"$value": "{base.color.alpha-black-38}",
 					"$type": "color"
+				},
+				"on-dark-strong": {
+					"$value": "rgba(255, 255, 255, 0.9)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 인터랙티브 라벨 - theme 무관 고정 alpha"
+				},
+				"on-dark-body": {
+					"$value": "rgba(255, 255, 255, 0.85)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 본문/설명문"
+				},
+				"on-dark-label": {
+					"$value": "rgba(255, 255, 255, 0.75)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 eyebrow/오버레이 라벨"
+				},
+				"on-dark-muted": {
+					"$value": "rgba(255, 255, 255, 0.7)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 비활성 nav link/보조 라벨"
+				},
+				"on-dark-caption": {
+					"$value": "rgba(255, 255, 255, 0.6)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 meta/캡션"
+				},
+				"on-light-body": {
+					"$value": "rgba(0, 0, 0, 0.85)",
+					"$type": "color",
+					"$description": "항상 밝은 표면(light scrim) 위 본문 - theme 무관 고정 alpha"
+				},
+				"on-light-muted": {
+					"$value": "rgba(0, 0, 0, 0.6)",
+					"$type": "color",
+					"$description": "항상 밝은 표면(light scrim) 위 보조 라벨"
 				}
 			},
 			"bg": {
@@ -101,6 +136,43 @@
 				"disabled": {
 					"$value": "{base.color.neutral-100}",
 					"$type": "color"
+				},
+				"on-dark": {
+					"$value": "rgba(255, 255, 255, 0.55)",
+					"$type": "color",
+					"$description": "항상 어두운 표면 위 hairline border (outline button 등) - theme 무관 고정 alpha"
+				}
+			},
+			"scrim": {
+				"dark-clear": {
+					"$value": "rgba(0, 0, 0, 0)",
+					"$type": "color",
+					"$description": "이미지 위 scrim gradient 시작 - 완전 투명"
+				},
+				"dark-soft": {
+					"$value": "rgba(0, 0, 0, 0.1)",
+					"$type": "color",
+					"$description": "이미지 위 dark scrim - 약한 tint"
+				},
+				"dark-strong": {
+					"$value": "rgba(0, 0, 0, 0.55)",
+					"$type": "color",
+					"$description": "이미지 위 dark scrim - hero 하단 마감"
+				},
+				"dark-heavy": {
+					"$value": "rgba(0, 0, 0, 0.85)",
+					"$type": "color",
+					"$description": "이미지 위 dark scrim - 텍스트가 직접 얹히는 media overlay 하단"
+				},
+				"light-soft": {
+					"$value": "rgba(255, 255, 255, 0.1)",
+					"$type": "color",
+					"$description": "이미지 위 light scrim - 약한 tint"
+				},
+				"light-strong": {
+					"$value": "rgba(255, 255, 255, 0.7)",
+					"$type": "color",
+					"$description": "이미지 위 light scrim - hero 하단 마감"
 				}
 			},
 			"status": {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,13 +8,12 @@ Globals.assign({ skipAnimation: true });
 
 // Modal/Drawer/Alert 는 document.body 에 스크롤락 카운터(dataset.openModals)와
 // overflow 를 공유한다(여러 오버레이 동시 오픈 조율용 - production 의도된 설계).
-// 이 전역이 테스트 간 누수되면 스크롤락 상태가 새어 flaky 해진다:
-// react-spring 퇴출(useSpringPresence) 의 unmount 가 skipAnimation 이라도 onRest 스케줄
-// 때문에 한 tick 늦게 실행될 수 있어, 앞 테스트 오버레이의 스크롤락 cleanup 이 테스트
-// 경계를 넘어 body 를 더럽히는 경우가 있다(coverage 계측 타이밍에서 재현).
+// 이 전역이 테스트 간 누수되면 오버레이가 originalOverflow 를 오염된 값으로 저장한다.
+// beforeEach 로 각 테스트 렌더 직전 초기화, afterEach 는 teardown 위생용.
 //
-// beforeEach 가 결정적 방어선: 각 테스트 렌더 직전 body 스크롤락 전역을 초기화해, 오버레이가
-// originalOverflow 를 항상 깨끗한 값으로 저장하도록 보장한다. afterEach 는 teardown 위생용.
+// 주의: 이건 테스트 간 격리용일 뿐, 한 테스트 안의 비동기 unmount 를 대신 처리하지 않는다.
+// 퇴출 spring 은 act 밖에서 setState 하므로 portal 제거 커밋과 useEffect cleanup flush 가
+// 한 tick 벌어진다 - 잠금 해제를 단언하려면 waitFor 안에서 함께 기다릴 것.
 function resetBodyScrollLock() {
 	document.body.style.overflow = "";
 	delete document.body.dataset.openModals;

--- a/src/ui/display/chip/style.scss
+++ b/src/ui/display/chip/style.scss
@@ -249,3 +249,13 @@
         }
     }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+    .chip,
+    .chip::before,
+    .chip_content::before,
+    .chip_icon {
+        transition: none;
+    }
+}

--- a/src/ui/display/hero/style.scss
+++ b/src/ui/display/hero/style.scss
@@ -34,24 +34,24 @@
   &_overlay_dark .hero_overlay {
     background: linear-gradient(
       180deg,
-      rgba(0, 0, 0, 0.1) 0%,
-      rgba(0, 0, 0, 0.55) 100%
+      token.$color_scrim_dark_soft 0%,
+      token.$color_scrim_dark_strong 100%
     );
   }
 
   &_overlay_light .hero_overlay {
     background: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.1) 0%,
-      rgba(255, 255, 255, 0.7) 100%
+      token.$color_scrim_light_soft 0%,
+      token.$color_scrim_light_strong 100%
     );
   }
 
   // Light overlay 는 항상 흰색계 표면 - 텍스트는 theme 무관 forced dark.
   &_overlay_light.hero_text_default {
-    .hero_eyebrow  { color: rgba(0, 0, 0, 0.6); }
+    .hero_eyebrow  { color: token.$color_text_on_light_muted; }
     .hero_title    { color: token.$color_brand_primary; }
-    .hero_subtitle { color: rgba(0, 0, 0, 0.85); }
+    .hero_subtitle { color: token.$color_text_on_light_body; }
   }
 
   // ── Content area ──────────────────────────────────────────────────────
@@ -89,14 +89,14 @@
   }
 
   &_text_inverse {
-    .hero_eyebrow  { color: rgba(255, 255, 255, 0.7); }
+    .hero_eyebrow  { color: token.$color_text_on_dark_muted; }
     .hero_title    { color: token.$color_brand_on_primary; }
-    .hero_subtitle { color: rgba(255, 255, 255, 0.85); }
+    .hero_subtitle { color: token.$color_text_on_dark_body; }
 
     // 어두운 배경 위 버튼 - outline/text 를 흰색 계열로 강제
     .hero_actions {
       .button_variant_outline {
-        border-color: rgba(255, 255, 255, 0.55);
+        border-color: token.$color_border_on_dark;
         color: token.$color_brand_on_primary;
 
         &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
@@ -105,7 +105,7 @@
       }
 
       .button_variant_text {
-        color: rgba(255, 255, 255, 0.9);
+        color: token.$color_text_on_dark_strong;
 
         &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
         &:focus-visible:not(:disabled)::before { background: token.$color_state_focus_on_dark; }

--- a/src/ui/display/list-item/style.scss
+++ b/src/ui/display/list-item/style.scss
@@ -134,3 +134,8 @@
     pointer-events: none;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .list_item_interactive .list_item_state_layer::before { transition: none; }
+}

--- a/src/ui/display/media-card/style.scss
+++ b/src/ui/display/media-card/style.scss
@@ -134,8 +134,8 @@
       inset: 0;
       background: linear-gradient(
         180deg,
-        rgba(0, 0, 0, 0) 30%,
-        rgba(0, 0, 0, 0.85) 100%
+        token.$color_scrim_dark_clear 30%,
+        token.$color_scrim_dark_heavy 100%
       );
       pointer-events: none;
       z-index: 1;
@@ -150,13 +150,13 @@
       justify-content: flex-end;
     }
 
-    .media_card_eyebrow  { color: rgba(255, 255, 255, 0.75); }
+    .media_card_eyebrow  { color: token.$color_text_on_dark_label; }
     .media_card_heading  { color: token.$color_brand_on_primary; }
     .media_card_content  {
-      color: rgba(255, 255, 255, 0.85);
+      color: token.$color_text_on_dark_body;
       flex: 0 0 auto; // overlay에선 늘어나지 않음 - 텍스트 블록이 하단에 모이도록
     }
-    .media_card_meta     { color: rgba(255, 255, 255, 0.6); }
+    .media_card_meta     { color: token.$color_text_on_dark_caption; }
   }
 }
 

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -270,11 +270,13 @@ describe("Alert", () => {
 		expect(document.body.dataset.openModals).toBe("1");
 
 		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
-		// 스크롤락 해제는 언마운트 cleanup 이라 alertdialog 가 사라진 틱과 같지 않을 수 있다.
-		// overflow 도 waitFor 안에서 기다려야 CI 부하에서 'hidden' 을 잡는 flake 가 안 난다.
+		// 퇴출 spring 은 act 밖에서 setState 하므로 portal 이 DOM 에서 빠진 커밋 시점과
+		// useEffect cleanup(스크롤락 해제) flush 시점이 한 tick 벌어진다. DOM 제거만 기다리면
+		// 부하가 걸린 러너에서 cleanup 전에 단언이 실행돼 flaky - 잠금 해제까지 함께 기다린다.
 		await waitFor(() => {
 			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
 			expect(document.body.style.overflow).toBe("");
+			expect(document.body.dataset.openModals).toBeUndefined();
 		});
 	});
 });

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -270,7 +270,11 @@ describe("Alert", () => {
 		expect(document.body.dataset.openModals).toBe("1");
 
 		fireEvent.keyDown(document.activeElement as Element, { key: "Escape" });
-		await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
-		expect(document.body.style.overflow).toBe("");
+		// 스크롤락 해제는 언마운트 cleanup 이라 alertdialog 가 사라진 틱과 같지 않을 수 있다.
+		// overflow 도 waitFor 안에서 기다려야 CI 부하에서 'hidden' 을 잡는 flake 가 안 난다.
+		await waitFor(() => {
+			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+			expect(document.body.style.overflow).toBe("");
+		});
 	});
 });

--- a/src/ui/feedback/spinner/style.scss
+++ b/src/ui/feedback/spinner/style.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "src/styles/token" as token;
 
 @keyframes spinner_fade {
@@ -28,7 +29,8 @@
   @for $i from 0 through 11 {
     &_bar:nth-child(#{$i + 1}) {
       transform: rotate(#{$i * 30}deg);
-      animation-delay: (-1 * token.$duration_loading_spinner) + ($i * 0.1s);
+      // 12개 spoke 를 한 주기에 균등 분산 - 간격을 duration/12 로 계산해 토큰 값이 바뀌어도 유지.
+      animation-delay: math.div(token.$duration_loading_spinner, 12) * ($i - 12);
     }
   }
 }

--- a/src/ui/feedback/spinner/style.scss
+++ b/src/ui/feedback/spinner/style.scss
@@ -21,13 +21,14 @@
     border-radius: 5px;
     background: currentColor;
     transform-origin: 250% 50%; // bar 의 우측 (= 컨테이너 정중앙) 기준 회전
-    animation: spinner_fade 1.2s linear infinite;
+    animation: spinner_fade token.$duration_loading_spinner token.$easing_linear infinite;
   }
 
+  // 12개 bar 를 한 사이클에 균등 분산 - 음수 delay 로 시작부터 서로 다른 위상.
   @for $i from 0 through 11 {
     &_bar:nth-child(#{$i + 1}) {
       transform: rotate(#{$i * 30}deg);
-      animation-delay: #{-1.2 + $i * 0.1}s;
+      animation-delay: (-1 * token.$duration_loading_spinner) + ($i * 0.1s);
     }
   }
 }

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -147,7 +147,7 @@
   left: 0;
   height: token.$spacing_3;
   border-radius: 0 0 0 token.$radius_lg;
-  animation: toast_progress var(--toast-duration, 3000ms) linear forwards;
+  animation: toast_progress var(--toast-duration, #{token.$duration_progress_default}) token.$easing_linear forwards;
 
   &_success { background: token.$color_status_success; }
   &_error   { background: token.$color_status_error; }

--- a/src/ui/feedback/top-loading/style.scss
+++ b/src/ui/feedback/top-loading/style.scss
@@ -18,7 +18,7 @@
 
   &_indeterminate {
     width: 30%;
-    animation: top_loading_indeterminate 1.5s ease-in-out infinite;
+    animation: top_loading_indeterminate token.$duration_loading_bar token.$easing_standard infinite;
   }
 }
 

--- a/src/ui/forms/otp-input/style.scss
+++ b/src/ui/forms/otp-input/style.scss
@@ -85,3 +85,8 @@
     color: token.$color_status_error_on_surface;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .otp_input_box { transition: none; }
+}

--- a/src/ui/forms/textfield/style.scss
+++ b/src/ui/forms/textfield/style.scss
@@ -232,3 +232,13 @@
     }
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .text_field_label,
+  .text_field_container,
+  .text_field_clear,
+  .text_field_helper {
+    transition: none;
+  }
+}

--- a/src/ui/general/icon-button/IconButton.test.tsx
+++ b/src/ui/general/icon-button/IconButton.test.tsx
@@ -75,4 +75,28 @@ describe("IconButton", () => {
 		expect(node).toBeInstanceOf(HTMLButtonElement);
 	});
 
+	describe("accessible name", () => {
+		it("accepts aria-labelledby instead of aria-label", () => {
+			render(
+				<>
+					<span id="icon-button-label">저장</span>
+					<IconButton icon={<TestIcon />} aria-labelledby="icon-button-label" />
+				</>,
+			);
+			expect(screen.getByRole("button", { name: "저장" })).toBeInTheDocument();
+		});
+
+		it("keeps the icon hidden from the accessibility tree", () => {
+			render(<IconButton icon={<TestIcon />} aria-label="action" />);
+			expect(screen.getByTestId("test-icon").parentElement).toHaveAttribute("aria-hidden", "true");
+		});
+
+		// 타입 레벨 회귀 방지 - 접근성 이름 없는 IconButton 은 컴파일되면 안 된다.
+		// 아래 무시 지시자가 "불필요"로 판정되면 tsc 가 실패하므로 이 단언은 tsc 가 검증한다.
+		it("requires aria-label or aria-labelledby at the type level", () => {
+			// @ts-expect-error - aria-label / aria-labelledby 둘 다 없으면 타입 에러여야 한다.
+			const nameless = <IconButton icon={<TestIcon />} />;
+			expect(nameless).toBeTruthy();
+		});
+	});
 });

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -7,7 +7,9 @@ import "./style.scss";
 export type IconButtonVariant = "standard" | "filled" | "tonal" | "outlined";
 export type IconButtonSize = "sm" | "md";
 
-export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+/** 접근성 이름을 제외한 IconButton 공통 props */
+interface IconButtonBaseProps
+	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "aria-label" | "aria-labelledby"> {
 	/** 아이콘 버튼 스타일 변형 (기본값: "standard") */
 	variant?: IconButtonVariant;
 	/** 아이콘 버튼 크기 (기본값: "md") */
@@ -18,9 +20,43 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
 	ref?: React.Ref<HTMLButtonElement>;
 }
 
+/** `aria-label` 로 접근성 이름을 직접 지정 */
+export interface IconButtonWithAriaLabel extends IconButtonBaseProps {
+	/** 아이콘 버튼의 접근성 이름 (필수) */
+	"aria-label": string;
+	/** 접근성 이름을 제공하는 요소 id (선택) */
+	"aria-labelledby"?: string;
+}
+
+/** `aria-labelledby` 로 외부 요소를 참조해 접근성 이름을 지정 */
+export interface IconButtonWithAriaLabelledBy extends IconButtonBaseProps {
+	/** 아이콘 버튼의 접근성 이름 (선택) */
+	"aria-label"?: string;
+	/** 접근성 이름을 제공하는 요소 id (필수) */
+	"aria-labelledby": string;
+}
+
+/**
+ * IconButton props - 접근성 이름을 타입 레벨에서 강제하는 union.
+ * `icon` 은 항상 `aria-hidden` 으로 감싸지므로 `aria-label` 또는 `aria-labelledby` 중
+ * 최소 하나를 반드시 지정해야 한다 (WCAG 2.1 SC 4.1.2 Name, Role, Value).
+ *
+ * @deprecated 형태의 주의 - v3.7.0 이하에서는 두 속성 모두 optional 이었다.
+ * 접근성 이름 없이 `<IconButton icon={<X />} />` 로 사용하던 코드는 이제 **타입 에러**가 난다.
+ * 런타임 렌더링은 바뀌지 않았으므로 `aria-label`(또는 `aria-labelledby`)만 추가하면 된다.
+ * ```tsx
+ * // before (타입 에러 - 접근성 이름 없음)
+ * <IconButton icon={<X />} />
+ * // after
+ * <IconButton icon={<X />} aria-label="닫기" />
+ * ```
+ */
+export type IconButtonProps = IconButtonWithAriaLabel | IconButtonWithAriaLabelledBy;
+
 /**
  * 아이콘만 표시하는 버튼을 렌더링한다.
  * Figma DS 기준 4가지 variant(standard/filled/tonal/outlined)와 2가지 size(sm/md)를 지원한다.
+ * 아이콘은 `aria-hidden` 이므로 `aria-label` 또는 `aria-labelledby` 가 타입 레벨에서 필수다.
  * @param props 아이콘 버튼 속성
  * @returns 렌더링된 아이콘 버튼 요소
  */

--- a/src/ui/general/icon-button/index.tsx
+++ b/src/ui/general/icon-button/index.tsx
@@ -41,7 +41,7 @@ export interface IconButtonWithAriaLabelledBy extends IconButtonBaseProps {
  * `icon` 은 항상 `aria-hidden` 으로 감싸지므로 `aria-label` 또는 `aria-labelledby` 중
  * 최소 하나를 반드시 지정해야 한다 (WCAG 2.1 SC 4.1.2 Name, Role, Value).
  *
- * @deprecated 형태의 주의 - v3.7.0 이하에서는 두 속성 모두 optional 이었다.
+ * @remarks **Breaking change (타입 레벨)** - v3.7.0 이하에서는 두 속성 모두 optional 이었다.
  * 접근성 이름 없이 `<IconButton icon={<X />} />` 로 사용하던 코드는 이제 **타입 에러**가 난다.
  * 런타임 렌더링은 바뀌지 않았으므로 `aria-label`(또는 `aria-labelledby`)만 추가하면 된다.
  * ```tsx

--- a/src/ui/navigation/breadcrumb/style.scss
+++ b/src/ui/navigation/breadcrumb/style.scss
@@ -50,3 +50,8 @@
     color: token.$color_text_caption;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumb_link { transition: none; }
+}

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -32,7 +32,7 @@ export interface MenuProps {
  * @example
  * ```tsx
  * <Menu
- *   trigger={<IconButton icon={<MoreIcon />} />}
+ *   trigger={<IconButton icon={<MoreIcon />} aria-label="더보기" />}
  *   items={[
  *     { key: "edit", label: "편집", onSelect: handleEdit },
  *     { key: "del", label: "삭제", onSelect: handleDel, destructive: true },

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -72,6 +72,29 @@ describe("NavBar", () => {
 			expect(items[1]).toHaveFocus();
 		});
 
+		it("trigger has an accessible name matching the visible label", () => {
+			render(<NavBar locale={makeLocale()} />);
+			expect(screen.getByRole("button", { name: "한국어" })).toBeInTheDocument();
+		});
+
+		it("trigger keeps an accessible name when hideLabel hides the text", () => {
+			render(<NavBar locale={{ ...makeLocale(), hideLabel: true }} />);
+			const trigger = screen.getByRole("button", { name: "한국어" });
+			// 라벨 텍스트는 렌더되지 않지만 접근성 이름은 남아 있어야 한다.
+			expect(trigger).toHaveTextContent("");
+			expect(trigger).toHaveAttribute("aria-label", "한국어");
+		});
+
+		it("falls back to the uppercased current code when no option matches", () => {
+			render(<NavBar locale={{ current: "ja", options: [], hideLabel: true }} />);
+			expect(screen.getByRole("button", { name: "JA" })).toBeInTheDocument();
+		});
+
+		it("ariaLabel overrides the derived accessible name", () => {
+			render(<NavBar locale={{ ...makeLocale(), hideLabel: true, ariaLabel: "언어 선택" }} />);
+			expect(screen.getByRole("button", { name: "언어 선택" })).toBeInTheDocument();
+		});
+
 		it("Escape closes and returns focus to the trigger", () => {
 			render(<NavBar locale={makeLocale()} />);
 			const trigger = screen.getByRole("button");

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -29,6 +29,10 @@ export interface NavBarLocaleConfig {
 	/**
 	 * locale 트리거 버튼의 접근성 이름 (기본값: 현재 옵션의 label, 없으면 `current` 대문자).
 	 * `hideLabel` 이 true 면 버튼 안이 아이콘뿐이라 이 값이 유일한 접근성 이름이 된다.
+	 *
+	 * ⚠️ `hideLabel` 이 false(기본값)일 때는 이 값이 화면에 보이는 라벨을 덮어쓰므로,
+	 * 보이는 라벨 텍스트를 **포함**하는 문자열이어야 한다. 그렇지 않으면 음성 제어 사용자가
+	 * 보이는 대로 말해도 버튼이 잡히지 않는다 (WCAG 2.1 SC 2.5.3 Label in Name 위반).
 	 */
 	ariaLabel?: string;
 }

--- a/src/ui/navigation/nav-bar/index.tsx
+++ b/src/ui/navigation/nav-bar/index.tsx
@@ -26,6 +26,11 @@ export interface NavBarLocaleConfig {
 	onChange?: (next: string) => void;
 	/** 표시 라벨 - 기본은 옵션의 label, 미지정 시 short code 표시 */
 	hideLabel?: boolean;
+	/**
+	 * locale 트리거 버튼의 접근성 이름 (기본값: 현재 옵션의 label, 없으면 `current` 대문자).
+	 * `hideLabel` 이 true 면 버튼 안이 아이콘뿐이라 이 값이 유일한 접근성 이름이 된다.
+	 */
+	ariaLabel?: string;
 }
 
 export interface NavBarProps extends React.HTMLAttributes<HTMLElement> {
@@ -181,6 +186,8 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 	const menuId = useId();
 
 	const currentOption = locale.options.find((o) => o.value === locale.current);
+	// 트리거에 보이는 라벨. hideLabel 이면 렌더되지 않으므로 aria-label 로만 노출된다.
+	const currentLabel = currentOption?.label ?? locale.current.toUpperCase();
 
 	useEffect(() => {
 		if (!open) return;
@@ -264,14 +271,13 @@ const LocaleSwitcher = ({ locale }: { locale: NavBarLocaleConfig }) => {
 				aria-haspopup="menu"
 				aria-expanded={open}
 				aria-controls={menuId}
+				// Globe/Chevron 은 aria-hidden 이라 hideLabel 이면 버튼에 접근성 이름이 전혀 없다.
+				// 보이는 라벨과 동일한 문자열을 쓰므로 label-in-name(WCAG 2.5.3)도 유지된다.
+				aria-label={locale.ariaLabel ?? currentLabel}
 				onClick={() => setOpen((p) => !p)}
 			>
 				<Globe size={iconSize.sm} aria-hidden="true" />
-				{!locale.hideLabel && (
-					<span className="nav_bar_locale_label">
-						{currentOption?.label ?? locale.current.toUpperCase()}
-					</span>
-				)}
+				{!locale.hideLabel && <span className="nav_bar_locale_label">{currentLabel}</span>}
 				<ChevronDown
 					size={iconSize.xs}
 					aria-hidden="true"

--- a/src/ui/navigation/nav-bar/style.scss
+++ b/src/ui/navigation/nav-bar/style.scss
@@ -243,7 +243,7 @@
     color: token.$color_brand_on_primary;
 
     .nav_bar_link {
-      color: rgba(255, 255, 255, 0.7);
+      color: token.$color_text_on_dark_muted;
 
       &:hover:not(.nav_bar_link_active) {
         color: token.$color_brand_on_primary;
@@ -261,7 +261,7 @@
 
     // dark accent bg 위 button - outline/text variant 강제 흰 텍스트 + 흰 border
     .button_variant_outline {
-      border-color: rgba(255, 255, 255, 0.55);
+      border-color: token.$color_border_on_dark;
       color: token.$color_brand_on_primary;
 
       &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
@@ -270,7 +270,7 @@
     }
 
     .button_variant_text {
-      color: rgba(255, 255, 255, 0.9);
+      color: token.$color_text_on_dark_strong;
 
       &:hover:not(:disabled)::before  { background: token.$color_state_hover_on_dark; }
       &:focus-visible:not(:disabled)::before { background: token.$color_state_focus_on_dark; }
@@ -282,7 +282,7 @@
 
   &_variant_transparent {
     .nav_bar_link {
-      color: rgba(255, 255, 255, 0.7);
+      color: token.$color_text_on_dark_muted;
 
       &:hover:not(.nav_bar_link_active) {
         color: token.$color_brand_on_primary;

--- a/src/ui/navigation/pagination/style.scss
+++ b/src/ui/navigation/pagination/style.scss
@@ -88,3 +88,11 @@
     color: token.$color_text_caption;
   }
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .pagination_item,
+  .pagination_page_button {
+    transition: none;
+  }
+}

--- a/src/ui/overlay/modal/style.scss
+++ b/src/ui/overlay/modal/style.scss
@@ -100,3 +100,8 @@
   }
 
 }
+
+// ── Reduced motion (WCAG 2.3.3) ──────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .modal_close { transition: none; }
+}

--- a/src/ui/overlay/overlay-escape.test.tsx
+++ b/src/ui/overlay/overlay-escape.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Modal } from "./modal";
 import { Popover } from "./popover";
@@ -9,44 +9,37 @@ import { Tooltip } from "./tooltip";
  * 컴포넌트 조합에서도 보장하는지, 그리고 자식 요소의 자체 Escape 처리(critical)를 막지 않는지 검증.
  */
 describe("overlay Escape composition (shared stack)", () => {
-	it("Tooltip over Popover: Escape closes only the topmost (Tooltip), Popover stays; next Escape closes Popover", () => {
-		vi.useFakeTimers();
-		try {
-			const onOpenChange = vi.fn();
-			render(
-				<Popover
-					defaultOpen
-					onOpenChange={onOpenChange}
-					trigger={<button type="button">trigger</button>}
-					aria-label="pop"
-					content={
-						<Tooltip content="tip" delay={0}>
-							<button type="button">inner</button>
-						</Tooltip>
-					}
-				/>,
-			);
+	it("Tooltip over Popover: Escape closes only the topmost (Tooltip), Popover stays; next Escape closes Popover", async () => {
+		// Tooltip 은 퇴장 애니메이션 후 언마운트하므로 real timer + waitFor 로 검증한다.
+		const onOpenChange = vi.fn();
+		render(
+			<Popover
+				defaultOpen
+				onOpenChange={onOpenChange}
+				trigger={<button type="button">trigger</button>}
+				aria-label="pop"
+				content={
+					<Tooltip content="tip" delay={0}>
+						<button type="button">inner</button>
+					</Tooltip>
+				}
+			/>,
+		);
 
-			// Popover 는 이미 열림. inner 버튼에 hover 해 Tooltip 을 나중에 연다 → Tooltip 이 최상단.
-			expect(screen.getByRole("dialog")).toBeInTheDocument();
-			fireEvent.mouseEnter(screen.getByRole("button", { name: "inner" }));
-			act(() => {
-				vi.advanceTimersByTime(10);
-			});
-			expect(screen.getByRole("tooltip")).toBeInTheDocument();
+		// Popover 는 이미 열림. inner 버튼에 hover 해 Tooltip 을 나중에 연다 → Tooltip 이 최상단.
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		fireEvent.mouseEnter(screen.getByRole("button", { name: "inner" }));
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
 
-			// 1차 Escape - 최상단(Tooltip)만 닫히고 Popover 는 유지, onOpenChange 도 안 불림
-			fireEvent.keyDown(document.body, { key: "Escape" });
-			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-			expect(screen.getByRole("dialog")).toBeInTheDocument();
-			expect(onOpenChange).not.toHaveBeenCalled();
+		// 1차 Escape - 최상단(Tooltip)만 닫히고 Popover 는 유지, onOpenChange 도 안 불림
+		fireEvent.keyDown(document.body, { key: "Escape" });
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(onOpenChange).not.toHaveBeenCalled();
 
-			// 2차 Escape - 이제 최상단이 된 Popover 가 닫힌다
-			fireEvent.keyDown(document.body, { key: "Escape" });
-			expect(onOpenChange).toHaveBeenCalledWith(false);
-		} finally {
-			vi.useRealTimers();
-		}
+		// 2차 Escape - 이제 최상단이 된 Popover 가 닫힌다
+		fireEvent.keyDown(document.body, { key: "Escape" });
+		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
 
 	it("Popover inside Modal: Escape closes only the Popover, Modal stays (topmost)", () => {

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -178,6 +178,33 @@ describe("Popover", () => {
 		expect(screen.getByRole("dialog", { name: "필터 옵션" })).toBeInTheDocument();
 	});
 
+	it('falls back to a "Dialog" accessible name when no label is given', () => {
+		render(
+			<Popover
+				trigger={<button type="button">Open</button>}
+				content={<span>Panel content</span>}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		expect(screen.getByRole("dialog", { name: "Dialog" })).toBeInTheDocument();
+	});
+
+	it("does not add the fallback label when aria-labelledby is provided", () => {
+		render(
+			<>
+				<h2 id="popover-title">필터</h2>
+				<Popover
+					trigger={<button type="button">Open</button>}
+					content={<span>Panel content</span>}
+					aria-labelledby="popover-title"
+				/>
+			</>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Open" }));
+		const dialog = screen.getByRole("dialog", { name: "필터" });
+		expect(dialog).not.toHaveAttribute("aria-label");
+	});
+
 	it("preserves the trigger's own onClick handler", () => {
 		const onClick = vi.fn();
 		render(

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { Popover } from "./index";
 
@@ -149,8 +148,9 @@ describe("Popover", () => {
 		expect(trigger).not.toHaveAttribute("aria-controls");
 	});
 
-	it("applies placement class (default bottom)", () => {
-		const { rerender } = render(
+	it("portals the panel to the body and positions it fixed", () => {
+		// placement 는 이제 CSS 클래스가 아니라 useAnchoredPosition 이 계산한 fixed 좌표로 적용된다.
+		const { container } = render(
 			<Popover
 				trigger={<button type="button">Open</button>}
 				content={<span>Panel content</span>}
@@ -158,19 +158,12 @@ describe("Popover", () => {
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		expect(screen.getByRole("dialog").parentElement).toHaveClass("popover_placement_bottom");
-
-		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		rerender(
-			<Popover
-				trigger={<button type="button">Open</button>}
-				content={<span>Panel content</span>}
-				placement="right"
-				aria-label="popover"
-			/>,
-		);
-		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		expect(screen.getByRole("dialog").parentElement).toHaveClass("popover_placement_right");
+		const dialog = screen.getByRole("dialog");
+		// 포탈 - 트리거 wrapper 밖(body)으로 렌더된다.
+		expect(container.querySelector(".popover_wrapper")?.contains(dialog)).toBe(false);
+		// 위치 컨테이너는 fixed.
+		const position = dialog.closest(".popover_position") as HTMLElement;
+		expect(position.style.position).toBe("fixed");
 	});
 
 	it("propagates aria-label to the dialog", () => {

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -33,7 +33,7 @@ export interface PopoverProps {
 	defaultOpen?: boolean;
 	/** 열림 상태 변경 콜백 */
 	onOpenChange?: (open: boolean) => void;
-	/** dialog 의 접근성 라벨 - content 에 제목이 없을 때 권장 */
+	/** 팝오버 접근성 레이블(기본값: "Dialog") - content 에 제목이 없을 때 권장 */
 	"aria-label"?: string;
 	/** dialog 의 접근성 라벨 요소 id */
 	"aria-labelledby"?: string;
@@ -188,7 +188,9 @@ export const Popover = ({
 							ref={popoverRef}
 							role="dialog"
 							tabIndex={-1}
-							aria-label={ariaLabel}
+							// aria-labelledby 가 없으면 이름 없는 dialog 가 되므로 Modal/Drawer 와 동일하게
+							// "Dialog" 로 폴백한다 (WCAG 2.1 SC 4.1.2).
+							aria-label={ariaLabelledby ? ariaLabel : (ariaLabel ?? "Dialog")}
 							aria-labelledby={ariaLabelledby}
 							style={style}
 							className={cn("popover", className)}

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -2,8 +2,12 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
+import { createPortal } from "react-dom";
+import { cn, useAnchoredPosition, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
+
+/** 트리거와 팝오버 사이 간격(px). */
+const POPOVER_GAP = 8;
 
 export type PopoverPlacement = "top" | "bottom" | "left" | "right";
 
@@ -12,7 +16,10 @@ export interface PopoverProps {
 	trigger: React.ReactElement;
 	/** 팝오버 내부 콘텐츠 - 임의 ReactNode (폼/설명/액션 조합) */
 	content: React.ReactNode;
-	/** 위치 (기본값: "bottom") */
+	/**
+	 * 선호 위치 (기본값: "bottom"). 뷰포트를 벗어나면 반대편으로 flip 되고 교차축으로 shift 되므로
+	 * 실제 위치는 계산 결과를 따른다(Radix `side` + `collisionPadding` 계약). body 로 포탈된다.
+	 */
 	placement?: PopoverPlacement;
 	/** 제어 모드 - 열림 상태 */
 	open?: boolean;
@@ -75,6 +82,7 @@ export const Popover = ({
 	if (open && !shouldRender) setShouldRender(true);
 
 	const wrapperRef = React.useRef<HTMLDivElement>(null);
+	const positionRef = React.useRef<HTMLDivElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
 	/** 팝오버 열기 직전의 포커스 요소 (보통 trigger) - Esc 닫힘 시 복귀 대상 */
 	const previousFocusRef = React.useRef<HTMLElement | null>(null);
@@ -88,8 +96,19 @@ export const Popover = ({
 		[isControlled, onOpenChange],
 	);
 
+	// 열릴 때 트리거 rect + 뷰포트로 flip/shift/shrink 를 계산해 body 로 포탈(fixed).
+	// shouldRender 로 게이트해 퇴장 애니메이션 동안에도 위치를 유지한다.
+	const pos = useAnchoredPosition({
+		open: shouldRender,
+		anchorRef: wrapperRef,
+		floatingRef: positionRef,
+		placement,
+		gap: POPOVER_GAP,
+		padding: 8,
+	});
+
 	const fromTransform = (() => {
-		switch (placement) {
+		switch (pos.placement) {
 			case "top":
 				return "translateY(4px)";
 			case "bottom":
@@ -101,7 +120,11 @@ export const Popover = ({
 		}
 	})();
 
-	const style = useSpringPresence({ visible: open, from: fromTransform, onExitComplete: () => setShouldRender(false) });
+	const style = useSpringPresence({
+		visible: open,
+		from: fromTransform,
+		onExitComplete: () => setShouldRender(false),
+	});
 
 	// 열릴 때 content 첫 focusable(없으면 패널 자체)로 포커스 이동
 	React.useEffect(() => {
@@ -117,7 +140,11 @@ export const Popover = ({
 	React.useEffect(() => {
 		if (!open) return;
 		const handleClick = (e: MouseEvent) => {
-			if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+			const target = e.target as Node;
+			// 팝오버가 body 로 포탈되므로 wrapper(트리거) + popover 패널 둘 다 "내부"로 본다.
+			if (!wrapperRef.current?.contains(target) && !popoverRef.current?.contains(target)) {
+				setOpen(false);
+			}
 		};
 		document.addEventListener("mousedown", handleClick);
 		return () => document.removeEventListener("mousedown", handleClick);
@@ -151,22 +178,35 @@ export const Popover = ({
 	return (
 		<div className="popover_wrapper" ref={wrapperRef}>
 			{triggerWithProps}
-			{shouldRender && (
-				<div className={cn("popover_position", `popover_placement_${placement}`)}>
-					<animated.div
-						id={popoverId}
-						ref={popoverRef}
-						role="dialog"
-						tabIndex={-1}
-						aria-label={ariaLabel}
-						aria-labelledby={ariaLabelledby}
-						style={style}
-						className={cn("popover", className)}
+			{shouldRender &&
+				typeof document !== "undefined" &&
+				createPortal(
+					<div
+						ref={positionRef}
+						className="popover_position"
+						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
+						style={{
+							position: "fixed",
+							left: pos.x,
+							top: pos.y,
+							visibility: pos.ready ? undefined : "hidden",
+						}}
 					>
-						{content}
-					</animated.div>
-				</div>
-			)}
+						<animated.div
+							id={popoverId}
+							ref={popoverRef}
+							role="dialog"
+							tabIndex={-1}
+							aria-label={ariaLabel}
+							aria-labelledby={ariaLabelledby}
+							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
+							className={cn("popover", className)}
+						>
+							{content}
+						</animated.div>
+					</div>,
+					document.body,
+				)}
 		</div>
 	);
 };

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -3,7 +3,13 @@
 import { animated } from "@react-spring/web";
 import * as React from "react";
 import { createPortal } from "react-dom";
-import { cn, useAnchoredPosition, useOverlayEscape, useSpringPresence } from "../../../utils";
+import {
+	cn,
+	useAnchoredPosition,
+	useFocusTrap,
+	useOverlayEscape,
+	useSpringPresence,
+} from "../../../utils";
 import "./style.scss";
 
 /** 트리거와 팝오버 사이 간격(px). */
@@ -34,15 +40,6 @@ export interface PopoverProps {
 	/** 추가 className - 팝오버 패널에 적용 */
 	className?: string;
 }
-
-const FOCUSABLE_SELECTORS = [
-	"a[href]",
-	"button:not([disabled])",
-	"input:not([disabled])",
-	"select:not([disabled])",
-	"textarea:not([disabled])",
-	'[tabindex]:not([tabindex="-1"])',
-].join(", ");
 
 /**
  * 클릭 트리거로 임의의 interactive content 를 띄우는 범용 non-modal 팝오버.
@@ -84,8 +81,6 @@ export const Popover = ({
 	const wrapperRef = React.useRef<HTMLDivElement>(null);
 	const positionRef = React.useRef<HTMLDivElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
-	/** 팝오버 열기 직전의 포커스 요소 (보통 trigger) - Esc 닫힘 시 복귀 대상 */
-	const previousFocusRef = React.useRef<HTMLElement | null>(null);
 	const popoverId = React.useId();
 
 	const setOpen = React.useCallback(
@@ -126,15 +121,9 @@ export const Popover = ({
 		onExitComplete: () => setShouldRender(false),
 	});
 
-	// 열릴 때 content 첫 focusable(없으면 패널 자체)로 포커스 이동
-	React.useEffect(() => {
-		if (!open) return;
-		previousFocusRef.current = document.activeElement as HTMLElement | null;
-		const node = popoverRef.current;
-		if (!node) return;
-		const focusable = node.querySelector<HTMLElement>(FOCUSABLE_SELECTORS);
-		(focusable ?? node).focus();
-	}, [open]);
+	// body 로 포탈되면 트리거 뒤 tab 순서가 끊기므로 다른 포탈 오버레이(Modal/Drawer/Alert)와 동일하게
+	// 포커스를 패널 안에 트랩한다 - 열릴 때 첫 focusable 로 이동, Tab 순환, 닫힐 때 트리거로 복귀.
+	useFocusTrap(popoverRef, open);
 
 	// 외부 클릭으로 닫기. Escape 는 아래 wrapper 의 React onKeyDown 에서 처리한다.
 	React.useEffect(() => {
@@ -156,9 +145,9 @@ export const Popover = ({
 	// 하면 이벤트가 document 까지 오지 않아 Popover 는 닫히지 않는다(자식 우선 - 이전 리뷰 critical).
 	// 아무도 소비하지 않고 document 까지 오면 최상단(=이 Popover)만 닫고, 상위 Modal 이나 소비자
 	// 앱으로의 전파를 끊어 "최상단만 닫힘"(APG)을 지킨다.
+	// 포커스 복귀(트리거로)는 useFocusTrap 의 cleanup 이 담당한다.
 	useOverlayEscape(open, () => {
 		setOpen(false);
-		previousFocusRef.current?.focus();
 	});
 
 	const triggerWithProps = React.cloneElement(
@@ -184,11 +173,13 @@ export const Popover = ({
 					<div
 						ref={positionRef}
 						className="popover_position"
+						// 측정 대상(이 컨테이너)에 max-width 상한을 걸어 자식이 좁아져도 측정값이 진동하지 않게 한다.
 						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
 						style={{
 							position: "fixed",
 							left: pos.x,
 							top: pos.y,
+							maxWidth: pos.maxWidth,
 							visibility: pos.ready ? undefined : "hidden",
 						}}
 					>
@@ -199,7 +190,7 @@ export const Popover = ({
 							tabIndex={-1}
 							aria-label={ariaLabel}
 							aria-labelledby={ariaLabelledby}
-							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
+							style={style}
 							className={cn("popover", className)}
 						>
 							{content}

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -179,7 +179,9 @@ export const Popover = ({
 							position: "fixed",
 							left: pos.x,
 							top: pos.y,
-							maxWidth: pos.maxWidth,
+							// 최초 측정 전(ready=false)에는 maxWidth(=0)를 걸지 않는다 - 걸면 자연 폭 대신
+							// 0px 로 측정돼 첫 프레임 좌표가 어긋난다. ready 후에만 상한 적용.
+							maxWidth: pos.ready ? pos.maxWidth : undefined,
 							visibility: pos.ready ? undefined : "hidden",
 						}}
 					>

--- a/src/ui/overlay/popover/popover.stories.tsx
+++ b/src/ui/overlay/popover/popover.stories.tsx
@@ -89,7 +89,9 @@ export const Placements: Story = {
 					placement={placement}
 					aria-label={`${placement} 팝오버`}
 					trigger={<Button variant="outline">{placement}</Button>}
-					content={<div style={{ color: "var(--bt-color-text-body)" }}>{}</div>}
+					content={
+						<div style={{ color: "var(--bt-color-text-body)" }}>{`placement="${placement}"`}</div>
+					}
 				/>
 			))}
 		</div>

--- a/src/ui/overlay/popover/popover.stories.tsx
+++ b/src/ui/overlay/popover/popover.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
-import { Button } from "../../general/button";
 import { Checkbox } from "../../forms/checkbox";
+import { Button } from "../../general/button";
 import { Stack } from "../../layout/stack";
 import { Popover } from ".";
 
@@ -13,7 +13,8 @@ const meta: Meta<typeof Popover> = {
 		placement: {
 			control: "select",
 			options: ["top", "bottom", "left", "right"],
-			description: "trigger 기준 위치. / Position relative to the trigger.",
+			description:
+				"선호 위치. 뷰포트를 벗어나면 자동 flip/shift, body 로 포탈. / Preferred side — auto flip/shift on viewport overflow, portaled to body.",
 		},
 		trigger: {
 			control: false,
@@ -88,11 +89,7 @@ export const Placements: Story = {
 					placement={placement}
 					aria-label={`${placement} 팝오버`}
 					trigger={<Button variant="outline">{placement}</Button>}
-					content={
-						<div style={{ color: "var(--bt-color-text-body)" }}>
-							{}
-						</div>
-					}
+					content={<div style={{ color: "var(--bt-color-text-body)" }}>{}</div>}
 				/>
 			))}
 		</div>
@@ -112,9 +109,7 @@ export const RichContent: Story = {
 						<strong id="pop-title" style={{ color: "var(--bt-color-text-heading)" }}>
 							박상민
 						</strong>
-						<span style={{ color: "var(--bt-color-text-caption)" }}>
-							sangmin@bigtablet.com
-						</span>
+						<span style={{ color: "var(--bt-color-text-caption)" }}>sangmin@bigtablet.com</span>
 						<Stack direction="horizontal" gap={8}>
 							<Button size="sm" variant="outline">
 								메시지

--- a/src/ui/overlay/popover/style.scss
+++ b/src/ui/overlay/popover/style.scss
@@ -21,8 +21,12 @@
   border-radius: token.$radius_lg;
   box-shadow: token.$elevation_level2;
   padding: token.$spacing_16;
-  min-width: 200px;
-  max-width: 320px;
+  // 위치 컨테이너(.popover_position)는 useAnchoredPosition 의 maxWidth(가용 폭) 로 제한된다.
+  // 패널이 그보다 넓으면 좁은 뷰포트에서 오른쪽으로 다시 넘치므로, border-box + 부모 폭(100%)
+  // 이하로 min/max 를 묶어 위치 컨테이너 밖으로 새지 않게 한다.
+  box-sizing: border-box;
+  min-width: min(200px, 100%);
+  max-width: min(320px, 100%);
   color: token.$color_text_body;
   @include token.body_small;
   will-change: transform, opacity;

--- a/src/ui/overlay/popover/style.scss
+++ b/src/ui/overlay/popover/style.scss
@@ -5,37 +5,13 @@
   display: inline-flex;
 }
 
-// 위치 정렬 wrapper - placement 별 translateX/Y 로 trigger 기준 중앙 잡음.
+// body 로 포탈된 위치 컨테이너 - left/top 은 useAnchoredPosition 이 inline(fixed)으로 지정.
 // 안의 .popover 는 spring 으로 entrance transform 사용 - 두 transform context 분리해서 충돌 X.
 // Tooltip 과 달리 interactive content 라 pointer-events 유지.
 .popover_position {
-  position: absolute;
+  // position/left/top 은 컴포넌트에서 inline 으로 지정(fixed). 여기선 나머지만.
   z-index: token.$z_level5;
   width: max-content;
-
-  &.popover_placement_top {
-    bottom: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.popover_placement_bottom {
-    top: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.popover_placement_left {
-    right: calc(100% + 8px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
-
-  &.popover_placement_right {
-    left: calc(100% + 8px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
 }
 
 .popover {

--- a/src/ui/overlay/tooltip/Tooltip.test.tsx
+++ b/src/ui/overlay/tooltip/Tooltip.test.tsx
@@ -109,8 +109,9 @@ describe("Tooltip", () => {
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
-	it("applies placement class", () => {
-		render(
+	it("portals the tooltip to the body and positions it fixed", () => {
+		// placement 는 이제 CSS 클래스가 아니라 useAnchoredPosition 이 계산한 fixed 좌표로 적용된다.
+		const { container } = render(
 			<Tooltip content="hint" delay={0} placement="bottom">
 				<button type="button">btn</button>
 			</Tooltip>,
@@ -119,6 +120,11 @@ describe("Tooltip", () => {
 		act(() => {
 			vi.advanceTimersByTime(10);
 		});
-		expect(screen.getByRole("tooltip")).toHaveClass("tooltip_placement_bottom");
+		const tip = screen.getByRole("tooltip");
+		// 포탈 - 트리거 wrapper 밖(body)으로 렌더된다.
+		expect(container.querySelector(".tooltip_wrapper")?.contains(tip)).toBe(false);
+		// 위치 컨테이너는 fixed 로 배치된다.
+		const position = tip.closest(".tooltip_position") as HTMLElement;
+		expect(position.style.position).toBe("fixed");
 	});
 });

--- a/src/ui/overlay/tooltip/Tooltip.test.tsx
+++ b/src/ui/overlay/tooltip/Tooltip.test.tsx
@@ -1,14 +1,9 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import { Tooltip } from "./index";
 
-beforeEach(() => {
-	vi.useFakeTimers();
-});
-
-afterEach(() => {
-	vi.useRealTimers();
-});
+// react-spring 은 setup.ts 에서 skipAnimation 이지만 퇴장 언마운트(onExitComplete)는 한 tick 늦게
+// 스케줄되므로, 열림/닫힘은 fake timer 동기 단언 대신 real timer + waitFor 로 검증한다 (Popover 패턴).
 
 describe("Tooltip", () => {
 	it("does not show tooltip initially", () => {
@@ -20,80 +15,64 @@ describe("Tooltip", () => {
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
-	it("shows tooltip after delay on mouseEnter", () => {
+	it("shows tooltip after delay on mouseEnter", async () => {
 		render(
-			<Tooltip content="hint" delay={100}>
+			<Tooltip content="hint" delay={50}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
+		// delay 전에는 아직 안 보인다.
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-		act(() => {
-			vi.advanceTimersByTime(150);
-		});
-		expect(screen.getByRole("tooltip")).toHaveTextContent("hint");
+		await waitFor(() => expect(screen.getByRole("tooltip")).toHaveTextContent("hint"));
 	});
 
-	it("hides on mouseLeave (after the hoverable grace period)", () => {
+	it("hides on mouseLeave (after the hoverable grace period)", async () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
-		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
 		fireEvent.mouseLeave(screen.getByRole("button"));
 		// WCAG 1.4.13 Hoverable - 포인터가 툴팁으로 건너갈 유예(120ms) 동안은 유지
 		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
-		act(() => {
-			vi.advanceTimersByTime(150);
-		});
-		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
 	});
 
-	it("stays open while the pointer is over the tooltip itself (WCAG 1.4.13 Hoverable)", () => {
+	it("stays open while the pointer is over the tooltip itself (WCAG 1.4.13 Hoverable)", async () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
 		fireEvent.mouseLeave(screen.getByRole("button"));
-		// 유예 시간 안에 툴팁 위로 포인터 이동 → 열림 유지
+		// 유예 시간 안에 툴팁 위로 포인터 이동 → 닫힘 타이머 취소, 열림 유지
 		const positionWrap = screen.getByRole("tooltip").parentElement as HTMLElement;
 		fireEvent.mouseEnter(positionWrap);
-		act(() => {
-			vi.advanceTimersByTime(500);
-		});
 		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+
 		// 툴팁에서 떠나면 유예 후 닫힘
 		fireEvent.mouseLeave(positionWrap);
-		act(() => {
-			vi.advanceTimersByTime(150);
-		});
-		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
 	});
 
-	it("dismisses with Escape without moving the pointer (WCAG 1.4.13 Dismissable)", () => {
+	it("dismisses with Escape without moving the pointer (WCAG 1.4.13 Dismissable)", async () => {
 		render(
 			<Tooltip content="hint" delay={0}>
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
-		expect(screen.queryByRole("tooltip")).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
 
 		fireEvent.keyDown(document.body, { key: "Escape" });
-		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
 	});
 
 	it("disabled=true: never shows tooltip", () => {
@@ -102,14 +81,12 @@ describe("Tooltip", () => {
 				<button type="button">btn</button>
 			</Tooltip>,
 		);
+		// disabled 는 children 만 렌더 - Tooltip 로직 자체가 없어 hover 해도 마운트되지 않는다.
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(500);
-		});
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
-	it("portals the tooltip to the body and positions it fixed", () => {
+	it("portals the tooltip to the body and positions it fixed", async () => {
 		// placement 는 이제 CSS 클래스가 아니라 useAnchoredPosition 이 계산한 fixed 좌표로 적용된다.
 		const { container } = render(
 			<Tooltip content="hint" delay={0} placement="bottom">
@@ -117,9 +94,8 @@ describe("Tooltip", () => {
 			</Tooltip>,
 		);
 		fireEvent.mouseEnter(screen.getByRole("button"));
-		act(() => {
-			vi.advanceTimersByTime(10);
-		});
+		await waitFor(() => expect(screen.getByRole("tooltip")).toBeInTheDocument());
+
 		const tip = screen.getByRole("tooltip");
 		// 포탈 - 트리거 wrapper 밖(body)으로 렌더된다.
 		expect(container.querySelector(".tooltip_wrapper")?.contains(tip)).toBe(false);

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -32,7 +32,7 @@ export interface TooltipProps {
  * @example
  * ```tsx
  * <Tooltip content="저장하기">
- *   <IconButton icon={<SaveIcon />} />
+ *   <IconButton icon={<SaveIcon />} aria-label="저장" />
  * </Tooltip>
  * ```
  */

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -2,15 +2,22 @@
 
 import { animated } from "@react-spring/web";
 import * as React from "react";
-import { cn, useOverlayEscape, useSpringPresence } from "../../../utils";
+import { createPortal } from "react-dom";
+import { useAnchoredPosition, useOverlayEscape, useSpringPresence } from "../../../utils";
 import "./style.scss";
+
+/** 트리거와 툴팁 사이 간격(px). */
+const TOOLTIP_GAP = 6;
 
 export type TooltipPlacement = "top" | "bottom" | "left" | "right";
 
 export interface TooltipProps {
 	/** 툴팁 콘텐츠 */
 	content: React.ReactNode;
-	/** 위치 (기본값: "top") */
+	/**
+	 * 선호 위치 (기본값: "top"). 뷰포트를 벗어나면 반대편으로 flip 되고 교차축으로 shift 되므로
+	 * 실제 위치는 계산 결과를 따른다(Radix `side` + `collisionPadding` 계약). body 로 포탈된다.
+	 */
 	placement?: TooltipPlacement;
 	/** hover 후 지연 시간 ms (기본 200) */
 	delay?: number;
@@ -39,6 +46,9 @@ export const Tooltip = ({
 	const [open, setOpen] = React.useState(false);
 	const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const tooltipId = React.useId();
+	// wrapper = 앵커(트리거) 측정 대상, position = 플로팅(뷰포트 fixed 배치) 측정 대상.
+	const wrapperRef = React.useRef<HTMLSpanElement>(null);
+	const positionRef = React.useRef<HTMLSpanElement>(null);
 
 	// 포인터가 trigger→tooltip 사이 갭(6px)을 건널 시간 (WCAG 1.4.13 Hoverable)
 	const HIDE_DELAY = 120;
@@ -77,8 +87,18 @@ export const Tooltip = ({
 	// 레지스트리가 그 역할을 대신한다.
 	useOverlayEscape(open, hideNow);
 
+	// 열릴 때 트리거 rect + 뷰포트로 flip/shift/shrink 를 계산해 body 로 포탈(fixed).
+	const pos = useAnchoredPosition({
+		open,
+		anchorRef: wrapperRef,
+		floatingRef: positionRef,
+		placement,
+		gap: TOOLTIP_GAP,
+		padding: 8,
+	});
+
 	const fromTransform = (() => {
-		switch (placement) {
+		switch (pos.placement) {
 			case "top":
 				return "translateY(4px)";
 			case "bottom":
@@ -121,25 +141,36 @@ export const Tooltip = ({
 	if (disabled) return children;
 
 	return (
-		<span className="tooltip_wrapper">
+		<span className="tooltip_wrapper" ref={wrapperRef}>
 			{trigger}
-			{open && (
-				<span
-					className={cn("tooltip_position", `tooltip_placement_${placement}`)}
-					// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
-					onMouseEnter={cancelHide}
-					onMouseLeave={hide}
-				>
-					<animated.span
-						id={tooltipId}
-						role="tooltip"
-						style={style}
-						className={cn("tooltip", `tooltip_placement_${placement}`)}
+			{open &&
+				typeof document !== "undefined" &&
+				createPortal(
+					<span
+						ref={positionRef}
+						className="tooltip_position"
+						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
+						style={{
+							position: "fixed",
+							left: pos.x,
+							top: pos.y,
+							visibility: pos.ready ? undefined : "hidden",
+						}}
+						// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
+						onMouseEnter={cancelHide}
+						onMouseLeave={hide}
 					>
-						{content}
-					</animated.span>
-				</span>
-			)}
+						<animated.span
+							id={tooltipId}
+							role="tooltip"
+							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
+							className="tooltip"
+						>
+							{content}
+						</animated.span>
+					</span>,
+					document.body,
+				)}
 		</span>
 	);
 };

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -163,7 +163,9 @@ export const Tooltip = ({
 							position: "fixed",
 							left: pos.x,
 							top: pos.y,
-							maxWidth: pos.maxWidth,
+							// 최초 측정 전(ready=false)에는 maxWidth(=0)를 걸지 않는다 - 걸면 자연 폭 대신
+							// 0px 로 측정돼 첫 프레임 좌표가 어긋난다. ready 후에만 상한 적용.
+							maxWidth: pos.ready ? pos.maxWidth : undefined,
 							visibility: pos.ready ? undefined : "hidden",
 						}}
 						// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -149,23 +149,20 @@ export const Tooltip = ({
 					<span
 						ref={positionRef}
 						className="tooltip_position"
+						// 측정 대상(이 컨테이너)에 max-width 상한을 걸어 자식이 좁아져도 측정값이 진동하지 않게 한다.
 						// 최초 측정 전에는 숨겨 (0,0) 깜빡임을 막는다.
 						style={{
 							position: "fixed",
 							left: pos.x,
 							top: pos.y,
+							maxWidth: pos.maxWidth,
 							visibility: pos.ready ? undefined : "hidden",
 						}}
 						// WCAG 1.4.13 Hoverable - 툴팁 위로 포인터가 오면 열림 유지
 						onMouseEnter={cancelHide}
 						onMouseLeave={hide}
 					>
-						<animated.span
-							id={tooltipId}
-							role="tooltip"
-							style={{ ...style, maxWidth: pos.maxWidth ?? undefined }}
-							className="tooltip"
-						>
+						<animated.span id={tooltipId} role="tooltip" style={style} className="tooltip">
 							{content}
 						</animated.span>
 					</span>,

--- a/src/ui/overlay/tooltip/index.tsx
+++ b/src/ui/overlay/tooltip/index.tsx
@@ -44,6 +44,9 @@ export const Tooltip = ({
 	children,
 }: TooltipProps) => {
 	const [open, setOpen] = React.useState(false);
+	// 퇴장 스프링이 끝난 뒤 언마운트 - open&& 로 바로 지우면 fade+slide 퇴장 모션이 잘린다 (Popover 와 동일).
+	const [shouldRender, setShouldRender] = React.useState(false);
+	if (open && !shouldRender) setShouldRender(true);
 	const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const tooltipId = React.useId();
 	// wrapper = 앵커(트리거) 측정 대상, position = 플로팅(뷰포트 fixed 배치) 측정 대상.
@@ -88,8 +91,9 @@ export const Tooltip = ({
 	useOverlayEscape(open, hideNow);
 
 	// 열릴 때 트리거 rect + 뷰포트로 flip/shift/shrink 를 계산해 body 로 포탈(fixed).
+	// shouldRender 로 게이트해 퇴장 애니메이션 동안에도 위치를 유지한다.
 	const pos = useAnchoredPosition({
-		open,
+		open: shouldRender,
 		anchorRef: wrapperRef,
 		floatingRef: positionRef,
 		placement,
@@ -110,7 +114,11 @@ export const Tooltip = ({
 		}
 	})();
 
-	const style = useSpringPresence({ visible: open, from: fromTransform });
+	const style = useSpringPresence({
+		visible: open,
+		from: fromTransform,
+		onExitComplete: () => setShouldRender(false),
+	});
 
 	const child = children as React.ReactElement<React.HTMLAttributes<HTMLElement>>;
 	const childProps = child.props;
@@ -143,7 +151,7 @@ export const Tooltip = ({
 	return (
 		<span className="tooltip_wrapper" ref={wrapperRef}>
 			{trigger}
-			{open &&
+			{shouldRender &&
 				typeof document !== "undefined" &&
 				createPortal(
 					<span

--- a/src/ui/overlay/tooltip/style.scss
+++ b/src/ui/overlay/tooltip/style.scss
@@ -6,39 +6,15 @@
   vertical-align: middle; // baseline 정렬로 인한 미세 offset 제거
 }
 
-// 위치 정렬 wrapper - placement 별 translateX/Y 로 trigger 기준 중앙 잡음.
+// body 로 포탈된 위치 컨테이너 - left/top 은 useAnchoredPosition 이 inline(fixed)으로 지정.
 // 안의 .tooltip 은 spring 으로 entrance transform 사용 - 두 transform context 분리해서 충돌 X.
 .tooltip_position {
-  position: absolute;
+  // position/left/top 은 컴포넌트에서 inline 으로 지정(fixed). 여기선 나머지만.
   z-index: token.$z_level5;
   // pointer-events 를 살려 둔다 - WCAG 1.4.13 Hoverable: 포인터를 툴팁 위로
   // 옮겨 내용을 읽을 수 있어야 함 (none 이면 mouseenter 가 발화하지 않아 즉시 닫힘)
   display: block;
-  width: max-content; // 내부 .tooltip 의 max-content 와 일치 - translateX(-50%) 정확
-
-  &.tooltip_placement_top {
-    bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.tooltip_placement_bottom {
-    top: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
-  &.tooltip_placement_left {
-    right: calc(100% + 6px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
-
-  &.tooltip_placement_right {
-    left: calc(100% + 6px);
-    top: 50%;
-    transform: translateY(-50%);
-  }
+  width: max-content; // 내부 .tooltip 의 max-content 와 일치
 }
 
 .tooltip {

--- a/src/ui/overlay/tooltip/tooltip.stories.tsx
+++ b/src/ui/overlay/tooltip/tooltip.stories.tsx
@@ -13,7 +13,8 @@ const meta: Meta<typeof Tooltip> = {
 		placement: {
 			control: "select",
 			options: ["top", "bottom", "left", "right"],
-			description: "trigger 기준 툴팁 위치. 자동 flipping 없음.",
+			description:
+				"선호 위치. 뷰포트를 벗어나면 반대편으로 flip + 교차축 shift 되어 실제 위치는 계산 결과를 따른다.",
 		},
 		delay: {
 			control: "number",
@@ -40,7 +41,7 @@ const meta: Meta<typeof Tooltip> = {
 				component: `
 **Tooltip** - Non-blocking supplementary description on hover/focus. For click interactions use Popover. / hover/focus 시 비차단 보조 설명. 클릭 상호작용은 Popover.
 
-Key props: \`content\`, \`placement\` (\`top\`/\`bottom\`/\`left\`/\`right\`, no auto-flip), \`delay\` (default 200ms), \`disabled\`. / 주요 prop: \`content\`, \`placement\` (\`top\`/\`bottom\`/\`left\`/\`right\`, 자동 flip 없음), \`delay\` (기본 200ms), \`disabled\`.
+Key props: \`content\`, \`placement\` (preferred side — auto flip/shift when it would overflow the viewport; portaled to \`body\`), \`delay\` (default 200ms), \`disabled\`. / 주요 prop: \`content\`, \`placement\` (선호 위치 — 뷰포트를 벗어나면 자동 flip/shift, \`body\` 로 포탈), \`delay\` (기본 200ms), \`disabled\`.
 \`role="tooltip"\` + \`aria-describedby\` set automatically. / \`role="tooltip"\` + \`aria-describedby\` 자동.
 				`.trim(),
 			},
@@ -97,6 +98,37 @@ export const Placements: Story = {
 					</Tooltip>
 				</div>
 			))}
+		</div>
+	),
+};
+
+export const ViewportCollision: Story = {
+	name: "뷰포트 경계 (flip/shift)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'화면 왼쪽 끝 트리거에 `placement="left"`. left 로 두면 화면 밖이라 자동으로 right 로 flip 되어 온전히 보인다. 좁은 뷰포트(모바일 프리뷰)에서 확인. / Trigger at the left edge with `placement="left"` auto-flips to `right` so it stays fully visible.',
+			},
+		},
+	},
+	render: () => (
+		<div style={{ display: "flex", justifyContent: "flex-start", padding: "80px 0 0 4px" }}>
+			<Tooltip content="왼쪽 끝이라 right 로 flip 됩니다" placement="left">
+				<button
+					type="button"
+					style={{
+						padding: "8px 16px",
+						background: "var(--bt-color-bg-solid-dim)",
+						border: "1px solid var(--bt-color-border-default)",
+						color: "var(--bt-color-text-heading)",
+						borderRadius: 8,
+						cursor: "pointer",
+					}}
+				>
+					왼쪽 끝
+				</button>
+			</Tooltip>
 		</div>
 	),
 };

--- a/src/ui/overlay/tooltip/tooltip.stories.tsx
+++ b/src/ui/overlay/tooltip/tooltip.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Tooltip> = {
 			control: "select",
 			options: ["top", "bottom", "left", "right"],
 			description:
-				"선호 위치. 뷰포트를 벗어나면 반대편으로 flip + 교차축 shift 되어 실제 위치는 계산 결과를 따른다.",
+				"선호 위치. 뷰포트를 벗어나면 반대편으로 flip + 교차축 shift 되어 실제 위치는 계산 결과를 따른다. / Preferred side. On viewport overflow it flips to the opposite side and shifts on the cross axis, so the final position follows the computed result.",
 		},
 		delay: {
 			control: "number",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,11 +1,16 @@
 export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export {
+	type AnchoredOptions,
 	type AnchoredResult,
 	type AnchoredSide,
 	type AnchoredState,
+	type AnchorRect,
 	computeAnchoredPosition,
+	type FloatingSize,
+	type UseAnchoredPositionArgs,
 	useAnchoredPosition,
+	type Viewport,
 } from "./use-anchored-position";
 export { useFocusTrap } from "./use-focus-trap";
 export { useIsMounted } from "./use-is-mounted";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,12 @@
 export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
+export {
+	type AnchoredResult,
+	type AnchoredSide,
+	type AnchoredState,
+	computeAnchoredPosition,
+	useAnchoredPosition,
+} from "./use-anchored-position";
 export { useFocusTrap } from "./use-focus-trap";
 export { useIsMounted } from "./use-is-mounted";
 export { useReducedMotion } from "./use-reduced-motion";

--- a/src/utils/use-anchored-position.test.ts
+++ b/src/utils/use-anchored-position.test.ts
@@ -14,7 +14,24 @@ describe("computeAnchoredPosition", () => {
 		expect(r.placement).toBe("top");
 		expect(r.y).toBe(300 - 8 - 40); // anchor.top - gap - height
 		expect(r.x).toBe(400 + 20 - 60); // 중앙정렬: center(420) - width/2(60)
-		expect(r.maxWidth).toBeNull();
+		expect(r.maxWidth).toBe(1024 - 16); // 항상 가용 폭(상한). 240 등 컴포넌트 max-width 안에서만 의미.
+	});
+
+	it("is idempotent — feeding the already-capped width back yields the same maxWidth (no oscillation)", () => {
+		// 측정폭이 available 로 줄어든 뒤 다시 계산해도 maxWidth 가 null 로 튀지 않아야 RO 루프가 안 생긴다.
+		const anchor: AnchorRect = { top: 300, left: 90, width: 20, height: 20 };
+		const first = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(200, 800), {
+			placement: "top",
+			padding: 8,
+		});
+		const second = computeAnchoredPosition(
+			anchor,
+			{ width: first.maxWidth, height: 40 },
+			vp(200, 800),
+			{ placement: "top", padding: 8 },
+		);
+		expect(second.maxWidth).toBe(first.maxWidth);
+		expect(second.x).toBe(first.x);
 	});
 
 	it("flips left → right when the preferred side overflows the viewport (issue #429 repro)", () => {

--- a/src/utils/use-anchored-position.test.ts
+++ b/src/utils/use-anchored-position.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { type AnchorRect, computeAnchoredPosition } from "./use-anchored-position";
+
+const vp = (width: number, height: number) => ({ width, height });
+
+describe("computeAnchoredPosition", () => {
+	it("keeps the preferred side when it fits", () => {
+		// 넉넉한 뷰포트 중앙 트리거 — top 선호가 그대로 유지된다.
+		const anchor: AnchorRect = { top: 300, left: 400, width: 40, height: 40 };
+		const r = computeAnchoredPosition(anchor, { width: 120, height: 40 }, vp(1024, 768), {
+			placement: "top",
+			gap: 8,
+		});
+		expect(r.placement).toBe("top");
+		expect(r.y).toBe(300 - 8 - 40); // anchor.top - gap - height
+		expect(r.x).toBe(400 + 20 - 60); // 중앙정렬: center(420) - width/2(60)
+		expect(r.maxWidth).toBeNull();
+	});
+
+	it("flips left → right when the preferred side overflows the viewport (issue #429 repro)", () => {
+		// 375px 뷰포트, 트리거 x=16 폭32, 툴팁 240. left 는 x=-230 로 화면 밖 → right 로 flip.
+		const anchor: AnchorRect = { top: 100, left: 16, width: 32, height: 32 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 34 }, vp(375, 812), {
+			placement: "left",
+			gap: 6,
+			padding: 8,
+		});
+		expect(r.placement).toBe("right");
+		expect(r.x).toBe(16 + 32 + 6); // 트리거 오른쪽: left + width + gap = 54
+		expect(r.x).toBeGreaterThanOrEqual(8);
+		expect(r.x + 240).toBeLessThanOrEqual(375 - 8); // 오른쪽 여백 안에 들어옴
+	});
+
+	it("flips top → bottom near the top edge", () => {
+		const anchor: AnchorRect = { top: 4, left: 200, width: 40, height: 24 };
+		const r = computeAnchoredPosition(anchor, { width: 100, height: 60 }, vp(800, 600), {
+			placement: "top",
+			gap: 8,
+		});
+		expect(r.placement).toBe("bottom");
+		expect(r.y).toBe(4 + 24 + 8); // anchor 아래
+	});
+
+	it("shifts a centered tooltip back inside when it would clip the left edge", () => {
+		// top 배치, 트리거가 왼쪽 끝(중심 x=32) → 중앙정렬이면 왼쪽 -88, padding 으로 shift.
+		const anchor: AnchorRect = { top: 300, left: 16, width: 32, height: 32 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(375, 812), {
+			placement: "top",
+			gap: 8,
+			padding: 8,
+		});
+		expect(r.placement).toBe("top");
+		expect(r.x).toBe(8); // 왼쪽 여백으로 밀림
+	});
+
+	it("shifts back inside when it would clip the right edge", () => {
+		const anchor: AnchorRect = { top: 300, left: 350, width: 32, height: 32 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(375, 812), {
+			placement: "top",
+			padding: 8,
+		});
+		expect(r.x).toBe(375 - 8 - 240); // 오른쪽 여백에 맞춰 밀림 = 127
+	});
+
+	it("shrinks max-width when the floating is wider than the viewport", () => {
+		const anchor: AnchorRect = { top: 300, left: 90, width: 20, height: 20 };
+		const r = computeAnchoredPosition(anchor, { width: 240, height: 40 }, vp(200, 800), {
+			placement: "top",
+			padding: 8,
+		});
+		expect(r.maxWidth).toBe(200 - 16); // viewport - padding*2 = 184
+		expect(r.x).toBe(8); // 줄인 폭으로도 왼쪽 여백에 고정
+	});
+
+	it("keeps the preferred side when neither side fits (no worse than before)", () => {
+		// 좌우 모두 넘치는 경우 flip 하지 않고 선호 유지.
+		const anchor: AnchorRect = { top: 300, left: 100, width: 40, height: 40 };
+		const r = computeAnchoredPosition(anchor, { width: 300, height: 40 }, vp(360, 800), {
+			placement: "left",
+			gap: 8,
+		});
+		expect(r.placement).toBe("left");
+	});
+});

--- a/src/utils/use-anchored-position.ts
+++ b/src/utils/use-anchored-position.ts
@@ -40,8 +40,8 @@ export interface AnchoredResult {
 	y: number;
 	/** flip 반영된 실제 배치. */
 	placement: AnchoredSide;
-	/** 가용 폭보다 넓어 줄여야 하면 그 값, 아니면 null. */
-	maxWidth: number | null;
+	/** 뷰포트 가용 폭(px) - max-width 상한. 컴포넌트 기본 max-width 안에서만 의미. */
+	maxWidth: number;
 }
 
 const OPPOSITE: Record<AnchoredSide, AnchoredSide> = {
@@ -116,15 +116,16 @@ export function computeAnchoredPosition(
 	const gap = options.gap ?? 8;
 	const padding = options.padding ?? 8;
 
-	// 1. shrink — 가용 폭 초과 시 max-width 축소
+	// 1. shrink — max-width 는 항상 가용 폭(available)으로 돌려준다. 상수(뷰포트만 의존)라 idempotent:
+	// 측정된 폭을 임계값과 비교하면(축소 → 재측정 축소 → …) max-content 컨테이너에서 진동/무한 루프가
+	// 난다. available 을 max-width **상한**으로 걸면 컴포넌트 기본 max-width(예: 240) 안에서 콘텐츠
+	// 폭은 그대로고, 좁은 뷰포트에서만 실제로 좁아진다.
 	const available = viewport.width - padding * 2;
-	let maxWidth: number | null = null;
-	let width = floating.width;
-	if (width > available) {
-		width = available;
-		maxWidth = available;
-	}
-	const sized: FloatingSize = { width, height: floating.height };
+	const maxWidth = available;
+	const sized: FloatingSize = {
+		width: Math.min(floating.width, available),
+		height: floating.height,
+	};
 
 	// 2. flip — 선호가 안 맞고 반대편이 맞으면 뒤집기
 	let side = options.placement;
@@ -181,7 +182,7 @@ export function useAnchoredPosition({
 		x: 0,
 		y: 0,
 		placement,
-		maxWidth: null,
+		maxWidth: 0,
 		ready: false,
 	});
 
@@ -206,16 +207,29 @@ export function useAnchoredPosition({
 			setState({ ...result, ready: true });
 		};
 
-		update();
+		// scroll/resize/observer 는 rAF 로 배칭 - 잦은 스크롤에도 프레임당 한 번만 재계산.
+		let frame = 0;
+		const schedule = () => {
+			if (frame) return;
+			frame = requestAnimationFrame(() => {
+				frame = 0;
+				update();
+			});
+		};
+
+		update(); // 최초는 페인트 전 동기 배치.
 		// capture=true 로 스크롤 조상까지 잡는다(스크롤 이벤트는 버블링하지 않음).
-		window.addEventListener("scroll", update, true);
-		window.addEventListener("resize", update);
-		const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+		window.addEventListener("scroll", schedule, true);
+		window.addEventListener("resize", schedule);
+		// 앵커·플로팅 둘 다 관찰 - 트리거 자체 크기 변화(폰트 로드·리플로우)도 반영.
+		const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(schedule) : null;
 		observer?.observe(floating);
+		observer?.observe(anchor);
 
 		return () => {
-			window.removeEventListener("scroll", update, true);
-			window.removeEventListener("resize", update);
+			if (frame) cancelAnimationFrame(frame);
+			window.removeEventListener("scroll", schedule, true);
+			window.removeEventListener("resize", schedule);
 			observer?.disconnect();
 		};
 	}, [open, placement, gap, padding, anchorRef, floatingRef]);

--- a/src/utils/use-anchored-position.ts
+++ b/src/utils/use-anchored-position.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import * as React from "react";
+import { useSafeLayoutEffect } from "./use-safe-layout-effect";
+
+/** 앵커(트리거) 기준 선호 배치 방향. 넘칠 때 반대편으로 flip 될 수 있다. */
+export type AnchoredSide = "top" | "bottom" | "left" | "right";
+
+/** getBoundingClientRect 에서 필요한 값만. 뷰포트 기준 좌표(fixed). */
+export interface AnchorRect {
+	top: number;
+	left: number;
+	width: number;
+	height: number;
+}
+
+export interface FloatingSize {
+	width: number;
+	height: number;
+}
+
+export interface Viewport {
+	width: number;
+	height: number;
+}
+
+export interface AnchoredOptions {
+	/** 선호 배치. 넘치면 반대편으로 뒤집힐 수 있다. */
+	placement: AnchoredSide;
+	/** 앵커와 플로팅 사이 간격(px). 기본 8. */
+	gap?: number;
+	/** 뷰포트 가장자리 최소 여백(px, collisionPadding). 기본 8. */
+	padding?: number;
+}
+
+export interface AnchoredResult {
+	/** fixed left(px). */
+	x: number;
+	/** fixed top(px). */
+	y: number;
+	/** flip 반영된 실제 배치. */
+	placement: AnchoredSide;
+	/** 가용 폭보다 넓어 줄여야 하면 그 값, 아니면 null. */
+	maxWidth: number | null;
+}
+
+const OPPOSITE: Record<AnchoredSide, AnchoredSide> = {
+	top: "bottom",
+	bottom: "top",
+	left: "right",
+	right: "left",
+};
+
+const isVertical = (side: AnchoredSide) => side === "top" || side === "bottom";
+
+const clamp = (value: number, min: number, max: number) =>
+	// max < min(가용 공간이 플로팅보다 작을 때)이면 min(가장자리 여백)에 고정.
+	Math.max(min, Math.min(max, value));
+
+/** 주축(placement 방향) 좌표 — 플로팅 top-left 의 x 또는 y. */
+const mainAxisStart = (
+	side: AnchoredSide,
+	anchor: AnchorRect,
+	floating: FloatingSize,
+	gap: number,
+): number => {
+	switch (side) {
+		case "top":
+			return anchor.top - gap - floating.height;
+		case "bottom":
+			return anchor.top + anchor.height + gap;
+		case "left":
+			return anchor.left - gap - floating.width;
+		case "right":
+			return anchor.left + anchor.width + gap;
+	}
+};
+
+/** 해당 side 로 뒀을 때 주축이 뷰포트(여백 포함) 안에 들어오는가. */
+const fitsMainAxis = (
+	side: AnchoredSide,
+	anchor: AnchorRect,
+	floating: FloatingSize,
+	viewport: Viewport,
+	gap: number,
+	padding: number,
+): boolean => {
+	const start = mainAxisStart(side, anchor, floating, gap);
+	switch (side) {
+		case "top":
+			return start >= padding;
+		case "bottom":
+			return start + floating.height <= viewport.height - padding;
+		case "left":
+			return start >= padding;
+		case "right":
+			return start + floating.width <= viewport.width - padding;
+	}
+};
+
+/**
+ * 순수 배치 계산 — 앵커/플로팅/뷰포트 rect 로 fixed 좌표를 낸다. DOM·React 의존 없음(테스트 용이).
+ *
+ * 1. **shrink** — 플로팅이 뷰포트 가용 폭보다 넓으면 `maxWidth` 로 줄인다.
+ * 2. **flip** — 선호 side 가 주축으로 넘치고 반대편은 맞으면 반대편으로 뒤집는다.
+ * 3. **shift** — 교차축(중앙 정렬)이 뷰포트를 벗어나면 여백 안으로 민다.
+ *
+ * `placement` 는 선호값이고 결과의 `placement` 가 실제 적용된 방향(Radix `side` + `collisionPadding` 계약).
+ */
+export function computeAnchoredPosition(
+	anchor: AnchorRect,
+	floating: FloatingSize,
+	viewport: Viewport,
+	options: AnchoredOptions,
+): AnchoredResult {
+	const gap = options.gap ?? 8;
+	const padding = options.padding ?? 8;
+
+	// 1. shrink — 가용 폭 초과 시 max-width 축소
+	const available = viewport.width - padding * 2;
+	let maxWidth: number | null = null;
+	let width = floating.width;
+	if (width > available) {
+		width = available;
+		maxWidth = available;
+	}
+	const sized: FloatingSize = { width, height: floating.height };
+
+	// 2. flip — 선호가 안 맞고 반대편이 맞으면 뒤집기
+	let side = options.placement;
+	if (
+		!fitsMainAxis(side, anchor, sized, viewport, gap, padding) &&
+		fitsMainAxis(OPPOSITE[side], anchor, sized, viewport, gap, padding)
+	) {
+		side = OPPOSITE[side];
+	}
+
+	// 3. 주축 좌표 + 교차축 중앙정렬 후 shift(clamp)
+	let x: number;
+	let y: number;
+	if (isVertical(side)) {
+		y = mainAxisStart(side, anchor, sized, gap);
+		x = anchor.left + anchor.width / 2 - sized.width / 2;
+		x = clamp(x, padding, viewport.width - padding - sized.width);
+	} else {
+		x = mainAxisStart(side, anchor, sized, gap);
+		y = anchor.top + anchor.height / 2 - sized.height / 2;
+		y = clamp(y, padding, viewport.height - padding - sized.height);
+	}
+
+	return { x, y, placement: side, maxWidth };
+}
+
+export interface UseAnchoredPositionArgs extends AnchoredOptions {
+	/** 열림 상태 — false 면 계산을 멈추고 ready 를 내린다. */
+	open: boolean;
+	/** 앵커(트리거) 요소 ref. */
+	anchorRef: React.RefObject<HTMLElement | null>;
+	/** 측정할 플로팅 요소 ref. */
+	floatingRef: React.RefObject<HTMLElement | null>;
+}
+
+export interface AnchoredState extends AnchoredResult {
+	/** 최초 측정 전에는 false — 이때 플로팅을 숨겨 (0,0) 깜빡임을 막는다. */
+	ready: boolean;
+}
+
+/**
+ * 앵커/플로팅 ref 를 재서 fixed 좌표를 돌려주는 훅. 열려 있는 동안 scroll(캡처)·resize·플로팅
+ * 크기 변화(ResizeObserver)에 재계산한다. 실제 배치는 {@link computeAnchoredPosition} 가 담당.
+ */
+export function useAnchoredPosition({
+	open,
+	anchorRef,
+	floatingRef,
+	placement,
+	gap,
+	padding,
+}: UseAnchoredPositionArgs): AnchoredState {
+	const [state, setState] = React.useState<AnchoredState>({
+		x: 0,
+		y: 0,
+		placement,
+		maxWidth: null,
+		ready: false,
+	});
+
+	useSafeLayoutEffect(() => {
+		if (!open) {
+			setState((prev) => (prev.ready ? { ...prev, ready: false } : prev));
+			return;
+		}
+		const anchor = anchorRef.current;
+		const floating = floatingRef.current;
+		if (!anchor || !floating) return;
+
+		const update = () => {
+			const a = anchor.getBoundingClientRect();
+			const f = floating.getBoundingClientRect();
+			const result = computeAnchoredPosition(
+				{ top: a.top, left: a.left, width: a.width, height: a.height },
+				{ width: f.width, height: f.height },
+				{ width: window.innerWidth, height: window.innerHeight },
+				{ placement, gap, padding },
+			);
+			setState({ ...result, ready: true });
+		};
+
+		update();
+		// capture=true 로 스크롤 조상까지 잡는다(스크롤 이벤트는 버블링하지 않음).
+		window.addEventListener("scroll", update, true);
+		window.addEventListener("resize", update);
+		const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+		observer?.observe(floating);
+
+		return () => {
+			window.removeEventListener("scroll", update, true);
+			window.removeEventListener("resize", update);
+			observer?.disconnect();
+		};
+	}, [open, placement, gap, padding, anchorRef, floatingRef]);
+
+	return state;
+}

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -834,7 +834,8 @@
 		}
 
 		function toggle() {
-			if (!config.disabled && !toggleEl.classList.contains("bt-toggle--disabled")) {
+			// React Toggle 과 동일하게 native `disabled` 만 본다 (구 --disabled 클래스는 v3.8.0 에서 제거).
+			if (!config.disabled && !toggleEl.disabled) {
 				setChecked(!state.checked);
 			}
 		}
@@ -860,7 +861,7 @@
 			toggle,
 			setDisabled: (disabled) => {
 				config.disabled = disabled;
-				toggleEl.classList.toggle("bt-toggle--disabled", disabled);
+				toggleEl.disabled = disabled;
 			},
 			destroy: () => cleanup(),
 		};

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -144,6 +144,13 @@
 			return null;
 		}
 
+		// 초기 비활성 상태 흡수 - 서버가 native `disabled` 또는 `is-disabled` 로 렌더링했으면 config 에 반영.
+		// 이후 native disabled / aria-disabled / 스타일 클래스를 함께 동기화한다 (React 는 native disabled 사용).
+		if (control.disabled || control.classList.contains("is-disabled")) config.disabled = true;
+		control.disabled = config.disabled;
+		control.setAttribute("aria-disabled", config.disabled ? "true" : "false");
+		control.classList.toggle("is-disabled", config.disabled);
+
 		// Parse options: data-options JSON > JS config > 서버 렌더링된 <li data-value> 마크업.
 		// Thymeleaf/JSP 처럼 서버가 옵션 li 를 직접 렌더링하는 경우(문서화된 기본 마크업)를
 		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
@@ -240,7 +247,7 @@
 		}
 
 		function open() {
-			if (config.disabled) return;
+			if (config.disabled || control.disabled) return;
 
 			state.isOpen = true;
 			control.classList.add("is-open");
@@ -441,6 +448,8 @@
 			toggle,
 			setDisabled: (disabled) => {
 				config.disabled = disabled;
+				control.disabled = disabled;
+				control.setAttribute("aria-disabled", disabled ? "true" : "false");
 				control.classList.toggle("is-disabled", disabled);
 			},
 			destroy: () => {
@@ -786,6 +795,11 @@
 		const state = {
 			checked: config.defaultChecked || toggleEl.classList.contains("bt-toggle--on"),
 		};
+
+		// 초기 비활성 상태 흡수 - config.disabled 또는 native disabled 를 native `disabled` 로 통일
+		// (React Toggle 과 동일하게 native disabled 사용 → 포커스 제외·:disabled 스타일 적용).
+		if (toggleEl.disabled) config.disabled = true;
+		toggleEl.disabled = config.disabled;
 
 		// Switch 시맨틱 (React Toggle 과 패리티): role + aria-checked 를 항상 유지
 		if (!toggleEl.hasAttribute("role")) toggleEl.setAttribute("role", "switch");

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -116,6 +116,8 @@
 		const config = {
 			placeholder: "Select...",
 			disabled: false,
+			// React Dropdown 과 동일하게 onValueChange 가 canonical, onChange 는 @deprecated 별칭.
+			onValueChange: null,
 			onChange: null,
 			...options,
 		};
@@ -229,8 +231,9 @@
 				el.setAttribute("aria-selected", selected ? "true" : "false");
 			});
 
-			if (config.onChange) {
-				config.onChange(newValue, option);
+			const emit = config.onValueChange ?? config.onChange;
+			if (emit) {
+				emit(newValue, option);
 			}
 		}
 
@@ -766,6 +769,8 @@
 		const config = {
 			defaultChecked: false,
 			disabled: false,
+			// React Toggle 과 동일하게 onCheckedChange 가 canonical, onChange 는 @deprecated 별칭.
+			onCheckedChange: null,
 			onChange: null,
 			...options,
 		};
@@ -815,8 +820,9 @@
 				hiddenInput.value = checked ? "true" : "false";
 			}
 
-			if (config.onChange) {
-				config.onChange(checked);
+			const emit = config.onCheckedChange ?? config.onChange;
+			if (emit) {
+				emit(checked);
 			}
 		}
 
@@ -870,6 +876,8 @@
 			page: 1,
 			totalPages: 1,
 			sibling: 2,
+			// React Pagination 과 동일하게 onPageChange 가 canonical, onChange 는 @deprecated 별칭.
+			onPageChange: null,
 			onChange: null,
 			...options,
 		};
@@ -971,8 +979,9 @@
 			config.page = page;
 			render();
 
-			if (config.onChange) {
-				config.onChange(page);
+			const emit = config.onPageChange ?? config.onChange;
+			if (emit) {
+				emit(page);
 			}
 		}
 

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -101,24 +101,25 @@
 	}
 
 	/* ========================================
-     Select Component
+     Dropdown Component
      ======================================== */
 
 	/**
-	 * Initialize Select component
-	 * @param {HTMLElement|string} element - Select wrapper element or selector
+	 * Initialize Dropdown component (React `<Dropdown>` 의 Vanilla 대응)
+	 *
+	 * React 의 `multiple` / `searchable` 은 아직 지원하지 않는다 - 단일 선택 전용.
+	 * @param {HTMLElement|string} element - Dropdown wrapper element or selector
 	 * @param {Object} options - Configuration options
 	 */
-	function Select(element, options = {}) {
+	function Dropdown(element, options = {}) {
 		const wrapper = typeof element === "string" ? $(element) : element;
 		if (!wrapper) return null;
 
 		const config = {
 			placeholder: "Select...",
 			disabled: false,
-			// React Dropdown 과 동일하게 onValueChange 가 canonical, onChange 는 @deprecated 별칭.
+			// React Dropdown 과 동일한 값 변경 콜백.
 			onValueChange: null,
-			onChange: null,
 			...options,
 		};
 
@@ -130,14 +131,16 @@
 		};
 
 		// Create DOM structure
-		const controlId = wrapper.id || generateId("select");
+		const controlId = wrapper.id || generateId("dropdown");
 		const _listId = `${controlId}_listbox`;
 
-		const control = wrapper.querySelector(".bt-select__control");
-		const list = wrapper.querySelector(".bt-select__list");
+		const control = wrapper.querySelector(".bt-dropdown__control");
+		const list = wrapper.querySelector(".bt-dropdown__list");
 
 		if (!control || !list) {
-			console.warn("Select: Missing required elements (.bt-select__control, .bt-select__list)");
+			console.warn(
+				"Dropdown: Missing required elements (.bt-dropdown__control, .bt-dropdown__list)",
+			);
 			return null;
 		}
 
@@ -146,7 +149,7 @@
 		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
 		// data-options 는 잘못된 JSON(작은따옴표 등)이면 스크립트 전체가 크래시하므로 방어적 파싱.
 		const parseDomOptions = () =>
-			$$(".bt-select__option", list).map((el) => ({
+			$$(".bt-dropdown__option", list).map((el) => ({
 				value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
 				label: el.textContent.trim(),
 				disabled: el.classList.contains("is-disabled"),
@@ -159,9 +162,9 @@
 			try {
 				const parsed = JSON.parse(wrapper.dataset.options);
 				if (Array.isArray(parsed)) optionsData = parsed;
-				else console.warn("Select: data-options is not a JSON array");
+				else console.warn("Dropdown: data-options is not a JSON array");
 			} catch (e) {
-				console.warn("Select: invalid JSON in data-options", e);
+				console.warn("Dropdown: invalid JSON in data-options", e);
 			}
 		}
 		if (optionsData === undefined) {
@@ -179,7 +182,7 @@
 		control.setAttribute("aria-haspopup", "listbox");
 		control.setAttribute("aria-expanded", "false");
 		control.setAttribute("aria-controls", list.id);
-		$$(".bt-select__option", list).forEach((el, i) => {
+		$$(".bt-dropdown__option", list).forEach((el, i) => {
 			el.id = el.id || `${controlId}_option_${i}`;
 			el.setAttribute("role", "option");
 			el.setAttribute("aria-selected", "false");
@@ -210,30 +213,29 @@
 				hiddenInput.value = newValue == null ? "" : newValue;
 			}
 
-			const valueEl = control.querySelector(".bt-select__value, .bt-select__placeholder");
+			const valueEl = control.querySelector(".bt-dropdown__value, .bt-dropdown__placeholder");
 			if (valueEl) {
 				if (option) {
 					valueEl.textContent = option.label;
-					valueEl.classList.remove("bt-select__placeholder");
-					valueEl.classList.add("bt-select__value");
+					valueEl.classList.remove("bt-dropdown__placeholder");
+					valueEl.classList.add("bt-dropdown__value");
 				} else {
 					valueEl.textContent = config.placeholder;
-					valueEl.classList.remove("bt-select__value");
-					valueEl.classList.add("bt-select__placeholder");
+					valueEl.classList.remove("bt-dropdown__value");
+					valueEl.classList.add("bt-dropdown__placeholder");
 				}
 			}
 
 			// Update selected state in list
-			$$(".bt-select__option", list).forEach((el, i) => {
+			$$(".bt-dropdown__option", list).forEach((el, i) => {
 				// String 비교(#374: 숫자 value vs 문자열 hidden 초기값) + aria-selected(#379: AT 노출)
 				const selected = String(state.options[i]?.value) === String(newValue);
 				el.classList.toggle("is-selected", selected);
 				el.setAttribute("aria-selected", selected ? "true" : "false");
 			});
 
-			const emit = config.onValueChange ?? config.onChange;
-			if (emit) {
-				emit(newValue, option);
+			if (config.onValueChange) {
+				config.onValueChange(newValue, option);
 			}
 		}
 
@@ -252,9 +254,9 @@
 			const spaceAbove = rect.top;
 
 			if (spaceBelow < listHeight && spaceAbove > spaceBelow) {
-				list.classList.add("bt-select__list--up");
+				list.classList.add("bt-dropdown__list--up");
 			} else {
-				list.classList.remove("bt-select__list--up");
+				list.classList.remove("bt-dropdown__list--up");
 			}
 
 			// Set active index
@@ -263,7 +265,7 @@
 			updateActiveOption();
 
 			// Rotate icon
-			const icon = control.querySelector(".bt-select__icon");
+			const icon = control.querySelector(".bt-dropdown__icon");
 			if (icon) icon.classList.add("is-open");
 		}
 
@@ -274,7 +276,7 @@
 			control.removeAttribute("aria-activedescendant");
 			list.style.display = "none";
 
-			const icon = control.querySelector(".bt-select__icon");
+			const icon = control.querySelector(".bt-dropdown__icon");
 			if (icon) icon.classList.remove("is-open");
 		}
 
@@ -288,7 +290,7 @@
 
 		function updateActiveOption() {
 			let activeId = null;
-			$$(".bt-select__option", list).forEach((el, i) => {
+			$$(".bt-dropdown__option", list).forEach((el, i) => {
 				const active = i === state.activeIndex;
 				el.classList.toggle("is-active", active);
 				if (active) activeId = el.id;
@@ -416,7 +418,7 @@
 			on(document, "mousedown", onDocumentClick),
 		];
 
-		$$(".bt-select__option", list).forEach((el, i) => {
+		$$(".bt-dropdown__option", list).forEach((el, i) => {
 			cleanups.push(on(el, "click", onOptionClick(i)));
 			cleanups.push(on(el, "mouseenter", onOptionMouseEnter(i)));
 		});
@@ -601,10 +603,8 @@
      ======================================== */
 
 	// React Alert 와 동일한 버튼 variant (confirm=filled / cancel=outline).
-	// canonical 이름과 함께 구 이름(--primary / --secondary)도 붙여 둔다 - 생성된 마크업의
-	// 클래스를 기준으로 스타일을 덮어쓰던 소비자 CSS 가 깨지지 않도록. 구 이름은 v4.0.0 에서 제거.
-	const CONFIRM_BUTTON_VARIANT = "bt-button--filled bt-button--primary";
-	const CANCEL_BUTTON_VARIANT = "bt-button--outline bt-button--secondary";
+	const CONFIRM_BUTTON_VARIANT = "bt-button--filled";
+	const CANCEL_BUTTON_VARIANT = "bt-button--outline";
 
 	/**
 	 * Show Alert dialog
@@ -697,6 +697,15 @@
 			}, 200);
 		}
 
+		// 오버레이 클릭 / Escape 는 "취소"와 동등한 동작이어야 한다 (WAI-ARIA APG alertdialog).
+		// React Alert 의 `dismiss = onCancel ?? onClose` 와 동일하게 onCancel 경로로 보내
+		// 소비자의 취소 정리 로직(롤백 등)이 조용히 우회되지 않게 한다.
+		function dismiss() {
+			if (!isOpen) return;
+			if (config.onCancel) config.onCancel();
+			close();
+		}
+
 		// Event handlers
 		const confirmBtn = overlay.querySelector("[data-alert-confirm]");
 		const cancelBtn = overlay.querySelector("[data-alert-cancel]");
@@ -718,14 +727,14 @@
 		// Close on overlay click (React Alert 와 동일하게 closeOnOverlay 로 끌 수 있다)
 		overlay.addEventListener("click", (e) => {
 			if (config.closeOnOverlay && e.target === overlay) {
-				close();
+				dismiss();
 			}
 		});
 
 		// Close on Escape + Tab 포커스 트랩 (WAI-ARIA APG Dialog) - Modal 과 동일 패턴
 		function onKeyDown(e) {
 			if (e.key === "Escape") {
-				close();
+				dismiss();
 				return;
 			}
 			if (e.key === "Tab" && alertPanel) {
@@ -769,9 +778,8 @@
 		const config = {
 			defaultChecked: false,
 			disabled: false,
-			// React Toggle 과 동일하게 onCheckedChange 가 canonical, onChange 는 @deprecated 별칭.
+			// React Toggle 과 동일한 체크 변경 콜백.
 			onCheckedChange: null,
-			onChange: null,
 			...options,
 		};
 
@@ -820,9 +828,8 @@
 				hiddenInput.value = checked ? "true" : "false";
 			}
 
-			const emit = config.onCheckedChange ?? config.onChange;
-			if (emit) {
-				emit(checked);
+			if (config.onCheckedChange) {
+				config.onCheckedChange(checked);
 			}
 		}
 
@@ -876,9 +883,8 @@
 			page: 1,
 			totalPages: 1,
 			sibling: 2,
-			// React Pagination 과 동일하게 onPageChange 가 canonical, onChange 는 @deprecated 별칭.
+			// React Pagination 과 동일한 페이지 변경 콜백.
 			onPageChange: null,
-			onChange: null,
 			...options,
 		};
 
@@ -979,9 +985,8 @@
 			config.page = page;
 			render();
 
-			const emit = config.onPageChange ?? config.onChange;
-			if (emit) {
-				emit(page);
+			if (config.onPageChange) {
+				config.onPageChange(page);
 			}
 		}
 
@@ -1012,10 +1017,10 @@
 	 * Auto-initialize all components with data-bt attribute
 	 */
 	function init() {
-		// Select
-		$$("[data-bt-select]").forEach((el) => {
-			if (!el._btSelect) {
-				el._btSelect = Select(el);
+		// Dropdown
+		$$("[data-bt-dropdown]").forEach((el) => {
+			if (!el._btDropdown) {
+				el._btDropdown = Dropdown(el);
 			}
 		});
 
@@ -1069,7 +1074,7 @@
 
 	return {
 		// Components
-		Select,
+		Dropdown,
 		Modal,
 		Alert,
 		Toggle,

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -597,6 +597,12 @@
      Alert Component
      ======================================== */
 
+	// React Alert 와 동일한 버튼 variant (confirm=filled / cancel=outline).
+	// canonical 이름과 함께 구 이름(--primary / --secondary)도 붙여 둔다 - 생성된 마크업의
+	// 클래스를 기준으로 스타일을 덮어쓰던 소비자 CSS 가 깨지지 않도록. 구 이름은 v4.0.0 에서 제거.
+	const CONFIRM_BUTTON_VARIANT = "bt-button--filled bt-button--primary";
+	const CANCEL_BUTTON_VARIANT = "bt-button--outline bt-button--secondary";
+
 	/**
 	 * Show Alert dialog
 	 * @param {Object} options - Alert configuration
@@ -609,7 +615,11 @@
 			confirmText: "확인",
 			cancelText: "취소",
 			showCancel: false,
+			// React AlertOptions.destructive 와 동일 - true 면 확인 버튼이 danger(빨강)로 강조된다.
+			destructive: false,
 			actionsAlign: "right", // left, center, right
+			// React AlertOptions.closeOnOverlay 와 동일 - false 면 오버레이 클릭으로 닫히지 않는다.
+			closeOnOverlay: true,
 			onConfirm: null,
 			onCancel: null,
 			...options,
@@ -632,10 +642,12 @@
 				}">
           ${
 						config.showCancel
-							? `<button class="bt-button bt-button--md bt-button--secondary" data-alert-cancel>${escapeHtml(config.cancelText)}</button>`
+							? `<button class="bt-button bt-button--md ${CANCEL_BUTTON_VARIANT}" data-alert-cancel>${escapeHtml(config.cancelText)}</button>`
 							: ""
 					}
-          <button class="bt-button bt-button--md bt-button--primary" data-alert-confirm>${escapeHtml(config.confirmText)}</button>
+          <button class="bt-button bt-button--md ${CONFIRM_BUTTON_VARIANT}${
+						config.destructive ? " bt-button--danger" : ""
+					}" data-alert-confirm>${escapeHtml(config.confirmText)}</button>
         </div>
       </div>
     `;
@@ -700,9 +712,9 @@
 			});
 		}
 
-		// Close on overlay click
+		// Close on overlay click (React Alert 와 동일하게 closeOnOverlay 로 끌 수 있다)
 		overlay.addEventListener("click", (e) => {
-			if (e.target === overlay) {
+			if (config.closeOnOverlay && e.target === overlay) {
 				close();
 			}
 		});

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -3,7 +3,8 @@
  * For use with plain HTML/CSS/JS, Thymeleaf, JSP, etc.
  *
  * @version 1.0.0
- * @license MIT
+ * @license Bigtablet Inc. Open Source License - see LICENSE at the repo root
+ *          (https://github.com/Bigtablet/.github/blob/main/BIGTABLET_LICENSE.md)
  */
 
 ((global, factory) => {

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -25,6 +25,9 @@
   /* Colors - Accent (light=검정/dark=흰 자동 반전 - indicator/checked/focus 강조) */
   --bt-color-accent: #{token.$color_accent_default};
 
+  /* Colors - Primary container (React Button variant="tonal" 의 채움색) */
+  --bt-color-primary-container: #{token.$color_brand_primary_container};
+
   /* Colors - Background */
   --bt-color-background: #{token.$color_bg_solid};
   --bt-color-background-dim: #{token.$color_bg_solid_dim};
@@ -130,7 +133,15 @@
 
 /* ========================================
    Button
-   ======================================== */
+   ========================================
+   variant 이름은 React `<Button variant>` 와 동일한 filled / tonal / outline / text 가 정식이다.
+   구 이름은 @deprecated 별칭으로 계속 동작하며 v4.0.0 에서 제거 예정:
+     --primary   → --filled
+     --secondary → --outline
+     --ghost     → --text
+   danger 는 React 의 `danger` boolean 처럼 variant 와 직교(orthogonal)한 modifier 다.
+   `--danger` 단독은 기존과 동일하게 red filled 로 렌더링되고, variant 클래스와 함께 쓰면
+   해당 variant 의 red 표현(outline=빨간 테두리, tonal=빨간 wash, text=빨간 텍스트)이 된다. */
 .bt-button {
   display: inline-flex;
   align-items: center;
@@ -151,7 +162,7 @@
     opacity: 0.6;
   }
 
-  /* Sizes */
+  /* Sizes - React ButtonSize(sm/md/lg/xl) 와 동일 */
   &--sm {
     padding: var(--bt-spacing-sm) var(--bt-spacing-lg);
     font-size: var(--bt-font-size-sm);
@@ -167,7 +178,14 @@
     font-size: var(--bt-font-size-md);
   }
 
+  &--xl {
+    padding: var(--bt-spacing-xl) var(--bt-spacing-3xl);
+    font-size: var(--bt-font-size-lg);
+  }
+
   /* Variants */
+  /* --primary 는 @deprecated 별칭 (→ --filled, v4.0.0 제거 예정) */
+  &--filled,
   &--primary {
     background: var(--bt-color-primary);
     color: var(--bt-color-background);
@@ -181,6 +199,22 @@
     }
   }
 
+  /* React Button variant="tonal" - 구 Vanilla 에는 없던 variant */
+  &--tonal {
+    background: var(--bt-color-primary-container);
+    color: var(--bt-color-text-primary);
+
+    &:hover:not(:disabled) {
+      background: var(--bt-color-pressed);
+    }
+
+    &:active:not(:disabled) {
+      transform: scale(0.98);
+    }
+  }
+
+  /* --secondary 는 @deprecated 별칭 (→ --outline, v4.0.0 제거 예정) */
+  &--outline,
   &--secondary {
     background: transparent;
     border: 1px solid var(--bt-color-border);
@@ -195,6 +229,8 @@
     }
   }
 
+  /* --ghost 는 @deprecated 별칭 (→ --text, v4.0.0 제거 예정) */
+  &--text,
   &--ghost {
     background: transparent;
     color: var(--bt-color-text-primary);
@@ -208,6 +244,7 @@
     }
   }
 
+  /* --danger 단독 = React `<Button variant="filled" danger />` (하위 호환 유지) */
   &--danger {
     background: var(--bt-color-error);
     color: var(--bt-color-background);
@@ -223,6 +260,38 @@
 
   &--full-width {
     width: 100%;
+  }
+}
+
+/* danger × variant - React 의 `variant` + `danger` 조합과 동일한 렌더링.
+   클래스 2개라 단독 `--danger`(클래스 1개)보다 우선순위가 높다. */
+.bt-button--danger.bt-button--outline,
+.bt-button--danger.bt-button--secondary {
+  background: transparent;
+  border-color: var(--bt-color-error);
+  color: var(--bt-color-error);
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--bt-color-error) 8%, transparent);
+  }
+}
+
+.bt-button--danger.bt-button--tonal {
+  background: color-mix(in srgb, var(--bt-color-error) 12%, transparent);
+  color: var(--bt-color-error);
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--bt-color-error) 18%, transparent);
+  }
+}
+
+.bt-button--danger.bt-button--text,
+.bt-button--danger.bt-button--ghost {
+  background: transparent;
+  color: var(--bt-color-error);
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--bt-color-error) 8%, transparent);
   }
 }
 
@@ -275,7 +344,8 @@
       opacity: 0.7;
     }
 
-    /* Variants */
+    /* Variants - React TextField 에는 variant prop 이 없고 outline 스타일만 있다.
+       --outline 이 React 와 동등한 기본값이고, --filled 는 Vanilla 전용이다. */
     &--outline {
       border: 1px solid var(--bt-color-border);
 
@@ -586,7 +656,13 @@
     }
   }
 
-  /* Sizes */
+  /* Sizes - React ToggleSize(sm/md) 와 동일. sm 은 기본값이라 클래스 없이도 같게 렌더링되지만,
+     React 의 `size="sm"` 를 그대로 옮겨 적을 수 있도록 명시적 클래스를 제공한다. */
+  &--sm {
+    width: 40px;
+    height: 24px;
+  }
+
   &--md {
     width: 48px;
     height: 28px;
@@ -603,7 +679,10 @@
     }
   }
 
-  &--disabled {
+  /* React Toggle 은 native `disabled` 를 쓰는 <button> 이라 :disabled 도 함께 받는다.
+     (--disabled 는 JS 가 토글하는 기존 클래스 - 계속 지원) */
+  &--disabled,
+  &:disabled {
     cursor: not-allowed;
     background: var(--bt-color-border-light);
 
@@ -657,7 +736,8 @@
       color: var(--bt-color-text-tertiary);
     }
 
-    /* Variants */
+    /* Variants - React Dropdown 은 variant prop 을 @deprecated 처리하고 outline 만 쓴다.
+       --outline 이 React 와 동등한 기본값이고, --filled 는 Vanilla 전용이다. */
     &--outline {
       border: 1px solid var(--bt-color-border);
 
@@ -945,10 +1025,21 @@
     border: 1px solid var(--bt-color-border);
   }
 
+  /* Shadow - React Card `shadow` prop(none/sm/md/lg) 과 이름·토큰이 동일한 쪽이 정식.
+     --elevation-1/2/3 은 @deprecated 별칭 (v4.0.0 제거 예정). */
+  &--shadow-none { box-shadow: none; }
+
+  &--shadow-sm,
   &--elevation-1 { box-shadow: var(--bt-elevation-1); }
+
+  &--shadow-md,
   &--elevation-2 { box-shadow: var(--bt-elevation-2); }
+
+  &--shadow-lg,
   &--elevation-3 { box-shadow: var(--bt-elevation-3); }
 
+  /* Padding - React Card `padding` prop(none/sm/md/lg) 과 동일 */
+  &--p-none { padding: 0; }
   &--p-sm { padding: var(--bt-spacing-sm); }
   &--p-md { padding: var(--bt-spacing-lg); }
   &--p-lg { padding: var(--bt-spacing-2xl); }

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1214,3 +1214,36 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* ========================================
+   Reduced Motion (WCAG 2.1 SC 2.3.3)
+   ======================================== */
+/* 이 번들은 컴포넌트별 파일이 아닌 단일 플랫 스타일시트라 마지막에 한 블록으로 모아 처리한다.
+   Button / TextField / Checkbox / Radio / Toggle / Select / Modal / Pagination /
+   DatePicker / FileInput 의 transition 은 전부 --bt-transition-* 를 경유하므로,
+   선택자를 나열하는 대신 토큰 자체를 0s 로 눌러 일괄 무효화한다.
+   (이후 추가되는 규칙과, 같은 var 를 쓰는 소비자 커스텀 스타일까지 자동으로 커버된다.) */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --bt-transition-fast: 0s;
+    --bt-transition-base: 0s;
+    --bt-transition-slow: 0s;
+  }
+
+  /* Alert 진입 모션 - 장식 목적이고 bigtablet.js 가 animationend 에 의존하지 않는다.
+     keyframe 종료 상태(opacity:1 / translateY(0))가 요소의 기본값이라
+     animation 을 제거해도 최종 표시 상태는 동일하다. */
+  .bt-alert__overlay,
+  .bt-alert__modal {
+    animation: none;
+  }
+
+  /* Spinner 는 끄지 않는다 - 회전 자체가 "로딩 중"이라는 상태 정보라
+     animation:none 이면 멈춘 위젯처럼 보여 의미를 잃는다.
+     회전을 크게 늦춰(0.8s → 2.4s) 전정기관 자극만 줄인다.
+     (Toast progress 를 정적 keyframe 으로 바꿔 타이머를 살려두는 React 쪽과 같은 판단 -
+      모션만 줄이고 기능은 유지) */
+  .bt-spinner {
+    animation-duration: 2.4s;
+  }
+}

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -18,11 +18,11 @@
    CSS Custom Properties (Design Tokens)
    ======================================== */
 :root {
-  /* Colors - Brand (양 테마 검정/흰 고정 - Button --primary 등 의도된 다크 fill) */
+  /* Colors - Brand (양 테마 검정/흰 고정 - 의도적으로 반전되지 않아야 하는 표면용) */
   --bt-color-primary: #{token.$color_brand_primary};
   --bt-color-on-primary: #{token.$color_brand_on_primary};
 
-  /* Colors - Accent (light=검정/dark=흰 자동 반전 - indicator/checked/focus 강조) */
+  /* Colors - Accent (light=검정/dark=흰 자동 반전 - Button --filled / indicator / checked / focus) */
   --bt-color-accent: #{token.$color_accent_default};
 
   /* Colors - Primary container (React Button variant="tonal" 의 채움색) */
@@ -108,10 +108,13 @@
   --bt-font-size-xl:   var(--bt-font-size-20);
   --bt-line-height-normal: 1.5;
 
-  /* Radius */
+  /* Radius - React `radius` prop 스케일과 동일 */
+  --bt-radius-none: #{token.$radius_none};
+  --bt-radius-xs: #{token.$radius_xs};
   --bt-radius-sm: #{token.$radius_sm};
   --bt-radius-md: #{token.$radius_md};
   --bt-radius-lg: #{token.$radius_lg};
+  --bt-radius-xl: #{token.$radius_xl};
   --bt-radius-full: #{token.$radius_full};
 
   /* Elevation */
@@ -134,20 +137,18 @@
 /* ========================================
    Button
    ========================================
-   variant 이름은 React `<Button variant>` 와 동일한 filled / tonal / outline / text 가 정식이다.
-   구 이름은 @deprecated 별칭으로 계속 동작하며 v4.0.0 에서 제거 예정:
-     --primary   → --filled
-     --secondary → --outline
-     --ghost     → --text
+   variant 는 React `<Button variant>` 와 동일한 filled / tonal / outline / text 4종.
    danger 는 React 의 `danger` boolean 처럼 variant 와 직교(orthogonal)한 modifier 다.
-   `--danger` 단독은 기존과 동일하게 red filled 로 렌더링되고, variant 클래스와 함께 쓰면
-   해당 variant 의 red 표현(outline=빨간 테두리, tonal=빨간 wash, text=빨간 텍스트)이 된다. */
+   `--danger` 단독은 React `<Button danger />`(variant 기본값 filled)와 같이 red filled 이고,
+   variant 클래스와 함께 쓰면 해당 variant 의 red 표현(outline=빨간 테두리, tonal=빨간 wash,
+   text=빨간 텍스트)이 된다.
+   기본 radius 는 React `radius` 기본값과 동일한 full(pill) - `--radius-*` 로 덮어쓴다. */
 .bt-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--bt-spacing-sm);
-  border-radius: var(--bt-radius-md);
+  border-radius: var(--bt-radius-full);
   border: none;
   cursor: pointer;
   font-family: var(--bt-font-family);
@@ -184,14 +185,15 @@
   }
 
   /* Variants */
-  /* --primary 는 @deprecated 별칭 (→ --filled, v4.0.0 제거 예정) */
-  &--filled,
-  &--primary {
-    background: var(--bt-color-primary);
-    color: var(--bt-color-background);
+  /* React `variant="filled"` 와 동일하게 accent 계열을 쓴다 - light 는 검정(brand 와 같은 값),
+     dark 는 흰색으로 자동 반전되어 다크 테마에서 채움이 페이지 배경에 묻히지 않는다.
+     (구 Vanilla 는 양 테마 고정인 --bt-color-primary 를 써서 다크에서 React 와 갈라졌다.) */
+  &--filled {
+    background: var(--bt-color-accent);
+    color: var(--bt-color-accent-on-surface);
 
     &:hover:not(:disabled) {
-      background: var(--bt-color-primary-hover);
+      background: color-mix(in srgb, var(--bt-color-accent) 88%, var(--bt-color-accent-on-surface));
     }
 
     &:active:not(:disabled) {
@@ -199,7 +201,7 @@
     }
   }
 
-  /* React Button variant="tonal" - 구 Vanilla 에는 없던 variant */
+  /* React Button variant="tonal" */
   &--tonal {
     background: var(--bt-color-primary-container);
     color: var(--bt-color-text-primary);
@@ -213,9 +215,7 @@
     }
   }
 
-  /* --secondary 는 @deprecated 별칭 (→ --outline, v4.0.0 제거 예정) */
-  &--outline,
-  &--secondary {
+  &--outline {
     background: transparent;
     border: 1px solid var(--bt-color-border);
     color: var(--bt-color-text-primary);
@@ -229,9 +229,7 @@
     }
   }
 
-  /* --ghost 는 @deprecated 별칭 (→ --text, v4.0.0 제거 예정) */
-  &--text,
-  &--ghost {
+  &--text {
     background: transparent;
     color: var(--bt-color-text-primary);
 
@@ -244,19 +242,28 @@
     }
   }
 
-  /* --danger 단독 = React `<Button variant="filled" danger />` (하위 호환 유지) */
+  /* --danger 단독 = React `<Button danger />` (variant 기본값 filled) */
   &--danger {
     background: var(--bt-color-error);
-    color: var(--bt-color-background);
+    color: var(--bt-color-on-primary);
 
     &:hover:not(:disabled) {
-      background: color-mix(in srgb, var(--bt-color-error) 92%, #000);
+      background: color-mix(in srgb, var(--bt-color-error) 88%, #000);
     }
 
     &:active:not(:disabled) {
       transform: scale(0.98);
     }
   }
+
+  /* Radius overrides - React `radius` prop 과 동일 (기본값 full) */
+  &--radius-none { border-radius: var(--bt-radius-none); }
+  &--radius-xs   { border-radius: var(--bt-radius-xs); }
+  &--radius-sm   { border-radius: var(--bt-radius-sm); }
+  &--radius-md   { border-radius: var(--bt-radius-md); }
+  &--radius-lg   { border-radius: var(--bt-radius-lg); }
+  &--radius-xl   { border-radius: var(--bt-radius-xl); }
+  &--radius-full { border-radius: var(--bt-radius-full); }
 
   &--full-width {
     width: 100%;
@@ -265,8 +272,7 @@
 
 /* danger × variant - React 의 `variant` + `danger` 조합과 동일한 렌더링.
    클래스 2개라 단독 `--danger`(클래스 1개)보다 우선순위가 높다. */
-.bt-button--danger.bt-button--outline,
-.bt-button--danger.bt-button--secondary {
+.bt-button--danger.bt-button--outline {
   background: transparent;
   border-color: var(--bt-color-error);
   color: var(--bt-color-error);
@@ -285,8 +291,7 @@
   }
 }
 
-.bt-button--danger.bt-button--text,
-.bt-button--danger.bt-button--ghost {
+.bt-button--danger.bt-button--text {
   background: transparent;
   color: var(--bt-color-error);
 
@@ -693,9 +698,11 @@
 }
 
 /* ========================================
-   Select
-   ======================================== */
-.bt-select {
+   Dropdown
+   ========================================
+   React `<Dropdown>` 과 같은 블록 이름을 쓴다 (구 Vanilla 이름은 Select 였다).
+   React 의 `multiple` / `searchable` 은 Vanilla 에 아직 없다 - 단일 선택 전용. */
+.bt-dropdown {
   position: relative;
   display: inline-flex;
   flex-direction: column;
@@ -1016,33 +1023,82 @@
 
 /* ========================================
    Card
-   ======================================== */
+   ========================================
+   React `<Card>` 는 shadow / padding / bordered(조합형)와 variant(enum)를 모두 노출한다.
+   Vanilla 도 같은 모델을 그대로 따른다 - shadow·padding·bordered 는 서로 직교하는 modifier 고,
+   variant(accent / glass / outlined)는 그 위에 얹는 표면 스타일이다(기본 = default).
+   기본값도 React 와 동일하게 shadow=sm / padding=md - 끄려면 --shadow-none / --p-none. */
 .bt-card {
   background: var(--bt-color-background);
   border-radius: var(--bt-radius-lg);
+  box-shadow: var(--bt-elevation-1);
+  padding: var(--bt-spacing-lg);
+  transition: transform var(--bt-transition-base),
+              box-shadow var(--bt-transition-base);
 
   &--bordered {
     border: 1px solid var(--bt-color-border);
   }
 
-  /* Shadow - React Card `shadow` prop(none/sm/md/lg) 과 이름·토큰이 동일한 쪽이 정식.
-     --elevation-1/2/3 은 @deprecated 별칭 (v4.0.0 제거 예정). */
+  /* Shadow - React Card `shadow` prop(none/sm/md/lg) 과 동일 (기본값 sm) */
   &--shadow-none { box-shadow: none; }
+  &--shadow-sm { box-shadow: var(--bt-elevation-1); }
+  &--shadow-md { box-shadow: var(--bt-elevation-2); }
+  &--shadow-lg { box-shadow: var(--bt-elevation-3); }
 
-  &--shadow-sm,
-  &--elevation-1 { box-shadow: var(--bt-elevation-1); }
-
-  &--shadow-md,
-  &--elevation-2 { box-shadow: var(--bt-elevation-2); }
-
-  &--shadow-lg,
-  &--elevation-3 { box-shadow: var(--bt-elevation-3); }
-
-  /* Padding - React Card `padding` prop(none/sm/md/lg) 과 동일 */
+  /* Padding - React Card `padding` prop(none/sm/md/lg) 과 동일 (기본값 md) */
   &--p-none { padding: 0; }
   &--p-sm { padding: var(--bt-spacing-sm); }
   &--p-md { padding: var(--bt-spacing-lg); }
   &--p-lg { padding: var(--bt-spacing-2xl); }
+
+  /* Variant: accent - 반전 배경 + 대비 텍스트 (React card_variant_accent) */
+  &--accent {
+    background: var(--bt-color-accent);
+    color: var(--bt-color-accent-on-surface);
+
+    .bt-card__title {
+      color: var(--bt-color-accent-on-surface);
+    }
+  }
+
+  /* Variant: outlined - 투명 배경 + 테두리만, shadow 무시 (React card_variant_outlined) */
+  &--outlined {
+    background: transparent;
+    border: 1px solid var(--bt-color-border);
+    box-shadow: none;
+  }
+
+  /* Variant: glass - 반투명 frosted + backdrop blur (React card_variant_glass).
+     컬러/이미지 배경 위에서 쓴다. 흰 텍스트로 가독성 확보. */
+  &--glass {
+    @include token.glass_dark;
+    color: var(--bt-color-on-primary);
+
+    .bt-card__title {
+      color: var(--bt-color-on-primary);
+    }
+
+    /* 다크 표면 위에서는 밝은 frosted 로 뒤집는다 (React 와 동일) */
+    [data-theme="dark"] & {
+      @include token.glass_card;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme]) & {
+        @include token.glass_card;
+      }
+    }
+  }
+
+  /* React `interactive` prop - hover 시 살짝 떠오른다 */
+  &--interactive {
+    cursor: pointer;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--bt-elevation-2);
+    }
+  }
 
   &__title {
     font-size: var(--bt-font-size-xl);
@@ -1060,18 +1116,18 @@
   to { transform: rotate(360deg); }
 }
 
+/* React `<Spinner size>` 는 px 숫자를 그대로 받는 자유 스케일이라(기본 24) Vanilla 도
+   size enum 대신 --bt-spinner-size 커스텀 프로퍼티로 임의 px 을 받는다.
+   예) <span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span> */
 .bt-spinner {
   display: inline-block;
   box-sizing: border-box;
+  width: var(--bt-spinner-size, 24px);
+  height: var(--bt-spinner-size, 24px);
   border-radius: 50%;
   border: 2px solid var(--bt-color-border);
   border-top-color: var(--bt-color-accent);
   animation: bt-spinner-spin 0.8s linear infinite;
-
-  &--sm { width: 16px; height: 16px; }
-  &--md { width: 24px; height: 24px; }
-  &--lg { width: 32px; height: 32px; }
-  &--xl { width: 48px; height: 48px; }
 }
 
 /* ========================================
@@ -1313,7 +1369,7 @@
    Reduced Motion (WCAG 2.1 SC 2.3.3)
    ======================================== */
 /* 이 번들은 컴포넌트별 파일이 아닌 단일 플랫 스타일시트라 마지막에 한 블록으로 모아 처리한다.
-   Button / TextField / Checkbox / Radio / Toggle / Select / Modal / Pagination /
+   Button / TextField / Checkbox / Radio / Toggle / Dropdown / Card / Modal / Pagination /
    DatePicker / FileInput 의 transition 은 전부 --bt-transition-* 를 경유하므로,
    선택자를 나열하는 대신 토큰 자체를 0s 로 눌러 일괄 무효화한다.
    (이후 추가되는 규칙과, 같은 var 를 쓰는 소비자 커스텀 스타일까지 자동으로 커버된다.) */
@@ -1330,6 +1386,12 @@
   .bt-alert__overlay,
   .bt-alert__modal {
     animation: none;
+  }
+
+  /* Card --interactive 의 hover lift 는 transform 이라 토큰 무효화만으로는 안 사라진다
+     (transition 만 사라지고 이동은 즉시 일어남) - React Card 와 동일하게 아예 끈다. */
+  .bt-card--interactive:hover {
+    transform: none;
   }
 
   /* Spinner 는 끄지 않는다 - 회전 자체가 "로딩 중"이라는 상태 정보라

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -202,15 +202,19 @@
   }
 
   /* React Button variant="tonal" */
+  /* state 토큰(--bt-color-hover/pressed)은 반투명 alpha 라 background 를 교체하면 컨테이너 색이
+     사라진다. React 는 ::before 오버레이로 겹치는데 여기엔 그 레이어가 없으므로,
+     background-image 로 같은 알파를 컨테이너 위에 덧칠해 동일한 결과를 낸다. */
   &--tonal {
     background: var(--bt-color-primary-container);
     color: var(--bt-color-text-primary);
 
     &:hover:not(:disabled) {
-      background: var(--bt-color-pressed);
+      background-image: linear-gradient(var(--bt-color-hover), var(--bt-color-hover));
     }
 
     &:active:not(:disabled) {
+      background-image: linear-gradient(var(--bt-color-pressed), var(--bt-color-pressed));
       transform: scale(0.98);
     }
   }
@@ -684,9 +688,8 @@
     }
   }
 
-  /* React Toggle 은 native `disabled` 를 쓰는 <button> 이라 :disabled 도 함께 받는다.
-     (--disabled 는 JS 가 토글하는 기존 클래스 - 계속 지원) */
-  &--disabled,
+  /* React Toggle 과 동일하게 native `disabled` 속성만 지원한다.
+     (구 `--disabled` 클래스는 v3.8.0 에서 제거 - docs/MIGRATION.md 참고) */
   &:disabled {
     cursor: not-allowed;
     background: var(--bt-color-border-light);

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1,6 +1,9 @@
-/**
+/*!
  * Bigtablet Design System - Vanilla CSS
  * For use with plain HTML/CSS/JS, Thymeleaf, JSP, etc.
+ *
+ * @license Bigtablet Inc. Open Source License - see LICENSE at the repo root
+ *          (https://github.com/Bigtablet/.github/blob/main/BIGTABLET_LICENSE.md)
  */
 
 @use "../styles/token" as token;

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -94,24 +94,36 @@
     <div class="section">
       <h2>Button</h2>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary">Primary</button>
-        <button type="button" class="bt-button bt-button--md bt-button--secondary">Secondary</button>
-        <button type="button" class="bt-button bt-button--md bt-button--ghost">Ghost</button>
-        <button type="button" class="bt-button bt-button--md bt-button--danger">Danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled">Filled</button>
+        <button type="button" class="bt-button bt-button--md bt-button--tonal">Tonal</button>
+        <button type="button" class="bt-button bt-button--md bt-button--outline">Outline</button>
+        <button type="button" class="bt-button bt-button--md bt-button--text">Text</button>
       </div>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--sm bt-button--primary">Small</button>
-        <button type="button" class="bt-button bt-button--md bt-button--primary">Medium</button>
-        <button type="button" class="bt-button bt-button--lg bt-button--primary">Large</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled bt-button--danger">Filled danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--tonal bt-button--danger">Tonal danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--outline bt-button--danger">Outline danger</button>
+        <button type="button" class="bt-button bt-button--md bt-button--text bt-button--danger">Text danger</button>
       </div>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary" disabled>Disabled</button>
+        <button type="button" class="bt-button bt-button--sm bt-button--filled">Small</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled">Medium</button>
+        <button type="button" class="bt-button bt-button--lg bt-button--filled">Large</button>
+        <button type="button" class="bt-button bt-button--xl bt-button--filled">XLarge</button>
+      </div>
+      <div class="demo-row">
+        <button type="button" class="bt-button bt-button--md bt-button--filled" disabled>Disabled</button>
       </div>
 
-      <pre><code>&lt;button class="bt-button bt-button--md bt-button--primary"&gt;Primary&lt;/button&gt;
-&lt;button class="bt-button bt-button--md bt-button--secondary"&gt;Secondary&lt;/button&gt;
-&lt;button class="bt-button bt-button--md bt-button--ghost"&gt;Ghost&lt;/button&gt;
-&lt;button class="bt-button bt-button--md bt-button--danger"&gt;Danger&lt;/button&gt;</code></pre>
+      <pre><code>&lt;button class="bt-button bt-button--md bt-button--filled"&gt;Filled&lt;/button&gt;
+&lt;button class="bt-button bt-button--md bt-button--tonal"&gt;Tonal&lt;/button&gt;
+&lt;button class="bt-button bt-button--md bt-button--outline"&gt;Outline&lt;/button&gt;
+&lt;button class="bt-button bt-button--md bt-button--text"&gt;Text&lt;/button&gt;
+
+&lt;!-- danger 는 variant 와 직교 --&gt;
+&lt;button class="bt-button bt-button--md bt-button--outline bt-button--danger"&gt;Delete&lt;/button&gt;
+
+&lt;!-- 구 이름(--primary / --secondary / --ghost)도 계속 동작하지만 deprecated 입니다 --&gt;</code></pre>
     </div>
 
     <!-- TextField -->
@@ -288,7 +300,7 @@
           <div class="bt-card__title">Card Title</div>
           <p>This is a card component with bordered style and medium padding.</p>
         </div>
-        <div class="bt-card bt-card--elevation-2 bt-card--p-md" style="width: 300px;">
+        <div class="bt-card bt-card--shadow-md bt-card--p-md" style="width: 300px;">
           <div class="bt-card__title">Shadow Card</div>
           <p>This card uses shadow instead of border.</p>
         </div>
@@ -338,7 +350,7 @@ const pagination = Bigtablet.Pagination('#my-pagination', {
     <div class="section">
       <h2>Modal</h2>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary" data-bt-modal-open="demo-modal">
+        <button type="button" class="bt-button bt-button--md bt-button--filled" data-bt-modal-open="demo-modal">
           Open Modal
         </button>
       </div>
@@ -350,8 +362,8 @@ const pagination = Bigtablet.Pagination('#my-pagination', {
             <p>This is the modal content. You can put any HTML here.</p>
           </div>
           <div class="bt-modal__footer">
-            <button type="button" class="bt-button bt-button--md bt-button--secondary" data-modal-close>Cancel</button>
-            <button type="button" class="bt-button bt-button--md bt-button--primary" data-modal-close>Confirm</button>
+            <button type="button" class="bt-button bt-button--md bt-button--outline" data-modal-close>Cancel</button>
+            <button type="button" class="bt-button bt-button--md bt-button--filled" data-modal-close>Confirm</button>
           </div>
         </div>
       </div>
@@ -373,8 +385,8 @@ const pagination = Bigtablet.Pagination('#my-pagination', {
     <div class="section">
       <h2>Alert (JavaScript)</h2>
       <div class="demo-row">
-        <button type="button" class="bt-button bt-button--md bt-button--primary" onclick="showInfoAlert()">Info Alert</button>
-        <button type="button" class="bt-button bt-button--md bt-button--secondary" onclick="showConfirmAlert()">Confirm Alert</button>
+        <button type="button" class="bt-button bt-button--md bt-button--filled" onclick="showInfoAlert()">Info Alert</button>
+        <button type="button" class="bt-button bt-button--md bt-button--outline" onclick="showConfirmAlert()">Confirm Alert</button>
         <button type="button" class="bt-button bt-button--md bt-button--danger" onclick="showErrorAlert()">Error Alert</button>
       </div>
 

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -255,39 +255,39 @@
 &lt;/button&gt;</code></pre>
     </div>
 
-    <!-- Select -->
+    <!-- Dropdown -->
     <div class="section">
-      <h2>Select</h2>
+      <h2>Dropdown</h2>
       <div class="demo-row">
-        <div class="bt-select" data-bt-select style="width: 300px;">
-          <label class="bt-select__label">Select Option</label>
-          <button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md">
-            <span class="bt-select__placeholder">Select...</span>
-            <span class="bt-select__icon">
+        <div class="bt-dropdown" data-bt-dropdown style="width: 300px;">
+          <label class="bt-dropdown__label">Select Option</label>
+          <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+            <span class="bt-dropdown__placeholder">Select...</span>
+            <span class="bt-dropdown__icon">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M6 9l6 6 6-6"/>
               </svg>
             </span>
           </button>
-          <ul class="bt-select__list" style="display: none;">
-            <li class="bt-select__option" data-value="apple">Apple</li>
-            <li class="bt-select__option" data-value="banana">Banana</li>
-            <li class="bt-select__option" data-value="cherry">Cherry</li>
-            <li class="bt-select__option is-disabled" data-value="disabled">Disabled Option</li>
-            <li class="bt-select__option" data-value="elderberry">Elderberry</li>
+          <ul class="bt-dropdown__list" style="display: none;">
+            <li class="bt-dropdown__option" data-value="apple">Apple</li>
+            <li class="bt-dropdown__option" data-value="banana">Banana</li>
+            <li class="bt-dropdown__option" data-value="cherry">Cherry</li>
+            <li class="bt-dropdown__option is-disabled" data-value="disabled">Disabled Option</li>
+            <li class="bt-dropdown__option" data-value="elderberry">Elderberry</li>
           </ul>
         </div>
       </div>
 
-      <pre><code>&lt;div class="bt-select" data-bt-select&gt;
-  &lt;label class="bt-select__label"&gt;Select Option&lt;/label&gt;
-  &lt;button type="button" class="bt-select__control bt-select__control--outline bt-select__control--md"&gt;
-    &lt;span class="bt-select__placeholder"&gt;Select...&lt;/span&gt;
-    &lt;span class="bt-select__icon"&gt;▼&lt;/span&gt;
+      <pre><code>&lt;div class="bt-dropdown" data-bt-dropdown&gt;
+  &lt;label class="bt-dropdown__label"&gt;Select Option&lt;/label&gt;
+  &lt;button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md"&gt;
+    &lt;span class="bt-dropdown__placeholder"&gt;Select...&lt;/span&gt;
+    &lt;span class="bt-dropdown__icon"&gt;▼&lt;/span&gt;
   &lt;/button&gt;
-  &lt;ul class="bt-select__list"&gt;
-    &lt;li class="bt-select__option" data-value="apple"&gt;Apple&lt;/li&gt;
-    &lt;li class="bt-select__option" data-value="banana"&gt;Banana&lt;/li&gt;
+  &lt;ul class="bt-dropdown__list"&gt;
+    &lt;li class="bt-dropdown__option" data-value="apple"&gt;Apple&lt;/li&gt;
+    &lt;li class="bt-dropdown__option" data-value="banana"&gt;Banana&lt;/li&gt;
   &lt;/ul&gt;
 &lt;/div&gt;</code></pre>
     </div>
@@ -316,13 +316,17 @@
     <div class="section">
       <h2>Spinner</h2>
       <div class="demo-row">
-        <div class="bt-spinner bt-spinner--sm"></div>
-        <div class="bt-spinner bt-spinner--md"></div>
-        <div class="bt-spinner bt-spinner--lg"></div>
-        <div class="bt-spinner bt-spinner--xl"></div>
+        <div class="bt-spinner" style="--bt-spinner-size: 16px" role="status" aria-label="Loading"></div>
+        <div class="bt-spinner" role="status" aria-label="Loading"></div>
+        <div class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></div>
+        <div class="bt-spinner" style="--bt-spinner-size: 48px" role="status" aria-label="Loading"></div>
       </div>
 
-      <pre><code>&lt;div class="bt-spinner bt-spinner--md"&gt;&lt;/div&gt;</code></pre>
+      <pre><code>&lt;!-- 기본 24px (React &lt;Spinner /&gt; 기본값) --&gt;
+&lt;span class="bt-spinner" role="status" aria-label="Loading"&gt;&lt;/span&gt;
+
+&lt;!-- 임의 크기 --&gt;
+&lt;span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"&gt;&lt;/span&gt;</code></pre>
     </div>
 
     <!-- Pagination -->
@@ -520,12 +524,12 @@ Bigtablet.Alert({
       });
     }
 
-    // Select example with options
+    // Dropdown example with options
     document.addEventListener('DOMContentLoaded', () => {
-      const selectEl = document.querySelector('[data-bt-select]');
-      if (selectEl?._btSelect) {
+      const dropdownEl = document.querySelector('[data-bt-dropdown]');
+      if (dropdownEl?._btDropdown) {
         // Already initialized by auto-init
-      } else if (selectEl) {
+      } else if (dropdownEl) {
         const options = [
           { value: 'apple', label: 'Apple' },
           { value: 'banana', label: 'Banana' },
@@ -534,10 +538,10 @@ Bigtablet.Alert({
           { value: 'elderberry', label: 'Elderberry' }
         ];
 
-        Bigtablet.Select(selectEl, {
+        Bigtablet.Dropdown(dropdownEl, {
           options,
           placeholder: 'Select a fruit...',
-          onChange: (value, option) => {
+          onValueChange: (value, option) => {
             console.log('Selected:', value, option);
           }
         });
@@ -546,7 +550,7 @@ Bigtablet.Alert({
       // Pagination change handler
       const paginationEl = document.querySelector('[data-bt-pagination]');
       if (paginationEl?._btPagination) {
-        // You can set onChange after init if needed
+        // You can set onPageChange after init if needed
       }
     });
   </script>

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -123,7 +123,7 @@
 &lt;!-- danger 는 variant 와 직교 --&gt;
 &lt;button class="bt-button bt-button--md bt-button--outline bt-button--danger"&gt;Delete&lt;/button&gt;
 
-&lt;!-- 구 이름(--primary / --secondary / --ghost)도 계속 동작하지만 deprecated 입니다 --&gt;</code></pre>
+&lt;!-- 구 이름(--primary / --secondary / --ghost)은 v3.8.0 에서 제거되었습니다. docs/MIGRATION.md 참고 --&gt;</code></pre>
     </div>
 
     <!-- TextField -->

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -53,6 +53,10 @@ export default defineConfig([
 			// about the CommonJS `module` variable. Suppress this — the IIFE format handles
 			// the global export and the UMD check is irrelevant at runtime.
 			options.logOverride = { "commonjs-variable-in-esm": "silent" };
+			// min.js 는 files 에서 비minified bigtablet.js 를 제외해 실제로 배포되는 유일한 vanilla JS 다.
+			// esbuild 는 minify 시 legalComments 기본값이 "none" 이라 소스의 @license 배너를 떼버리는데,
+			// 그러면 배포물에 라이선스 표기가 하나도 남지 않는다. 원위치에 보존한다.
+			options.legalComments = "inline";
 		},
 	},
 ]);


### PR DESCRIPTION
## 제목
merge: release — v3.8.0

## 작업한 내용
- [x] Tooltip·Popover `body` 포탈 + 뷰포트 충돌 회피(flip→shift→shrink) + Tooltip 퇴출 애니메이션 (#429, #431)
- [x] IconButton `aria-label`/`aria-labelledby` 판별 유니온으로 접근 이름 필수화
- [x] NavBar 로케일 트리거·IconButton·Popover dialog accessible name 보강
- [x] 공개 컴포넌트 타입 16종 barrel re-export
- [x] Vanilla 번들 클래스명·JS 콜백 canonical 통일, 레거시 alias 제거 (docs/MIGRATION.md v3.8.0 가이드)
- [x] 라이선스 MIT → Bigtablet Inc. Open Source License
- [x] reduced-motion 가드 확대 (컴포넌트 SCSS·Vanilla·layout mixin, WCAG 2.3.3)
- [x] stylelint raw rgb/rgba/hsl/hsla 차단, 죽은 토큰 정리, PR 라벨 자동화, 문서 동기화
- [x] `package.json` 3.7.0 → 3.8.0, CHANGELOG 3.8.0 섹션 추가

## 전달할 추가 이슈
- 계약상 breaking(Vanilla 클래스 개편·IconButton 타입 강제)이나 minor 로 릴리즈 — Vanilla 는 사내 Thymeleaf 디자인 참조용 임시 방안, IconButton 은 타입 레벨 안전장치라 실사용 영향 작음. CHANGELOG 에 **(주의)** 로 명시
- 머지 후 `main` 에서 `git tag -a v3.8.0 -m "v3.8.0"` → `git push origin v3.8.0` → `release.yml` 자동 publish