### PR TITLE
feat/field-variant

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -283,7 +283,7 @@ const [fruits, setFruits] = useState<string[]>([]);
 | `id` | `string` | 자동 생성 | 드롭다운 요소 id |
 | `className` | `string` | - | 루트 요소에 추가할 className |
 | ~~`fullWidth`~~ | `boolean` | - | **deprecated** (v3.0.0, no-op - 항상 부모 너비를 채움). [MIGRATION.md](./MIGRATION.md) 참고 |
-| ~~`variant`~~ | `'outline' \| 'filled' \| 'ghost'` | - | **deprecated** (no-op - outline 스타일만 사용) |
+| `variant` | `'outline' \| 'filled'` | `'outline'` | 컨트롤 시각 변형. `filled` 는 테두리 대신 dim 배경으로 채우고, 열려 있는 동안 테두리가 드러남 |
 | ~~`textAlign`~~ | `'left' \| 'center'` | - | **deprecated** (no-op) |
 | `disabled` | `boolean` | `false` | 비활성화 |
 
@@ -403,6 +403,12 @@ import { Search, Eye } from 'lucide-react';
   transformValue={(v) => v.replace(/\D/g, '').slice(0, 11)}
   onValueChange={(value) => console.log(value)}
 />
+
+// filled variant - 테두리 대신 dim 배경, 포커스 시 테두리가 드러남
+<TextField label="검색" variant="filled" placeholder="검색어를 입력하세요" />
+
+// 성공 상태 - error 와 같은 구조지만 aria-invalid 는 켜지 않음
+<TextField label="이메일" success supportingText="사용 가능한 이메일입니다" />
 ```
 
 | Prop | Type | Default | Description |
@@ -410,8 +416,10 @@ import { Search, Eye } from 'lucide-react';
 | `label` | `string` | - | 라벨 |
 | `showLabel` | `boolean` | `true` | 라벨 표시 여부 (false 면 SR 전용) |
 | `supportingText` | `string` | - | 도움말 텍스트 |
-| `error` | `boolean` | `false` | 에러 상태 |
+| `error` | `boolean` | `false` | 에러 상태 (`success` 보다 우선) |
+| `success` | `boolean` | `false` | 성공(검증 통과) 상태. `error` 가 true 면 무시됨 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
+| `variant` | `'outline' \| 'filled'` | `'outline'` | 시각 변형. `filled` 는 테두리 대신 dim 배경으로 채우고, 포커스 시 테두리가 드러남 |
 | `leadingIcon` | `ReactNode` | - | 왼쪽 아이콘 |
 | `trailingIcon` | `ReactNode` | - | 오른쪽 아이콘 |
 | `clearable` | `boolean` | `false` | 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 |
@@ -421,7 +429,9 @@ import { Search, Eye } from 'lucide-react';
 | `imeStrategy` | `'delayed' \| 'immediate'` | `'delayed'` | IME 조합 중 콜백 전략 (v3.1). `immediate` = 조합 중에도 즉시 호출 |
 | `transformValue` | `(value: string) => string` | - | 값 변환 함수 |
 
-> TextField 에는 `variant` · `success` prop 이 없다. outline 스타일 하나만 제공하며, 성공 상태는 별도 표현이 없다 (에러만 `error` 로 표시).
+> **`error` vs `success` 우선순위**: 둘 다 `true` 면 `error` 가 이긴다. 검증 실패를 성공처럼 칠하면 사용자가 잘못된 값을 그대로 제출하게 되기 때문이다. `success` 는 `aria-invalid` 를 켜지 않는다 (`error` 만 `aria-invalid="true"`).
+>
+> `variant` · `success` 는 Vanilla 의 `.bt-text-field__input--filled` / `--success` 와 1:1 대응한다.
 >
 > **v3.0 변경**: 내부 마크업이 `<fieldset>` + `<legend>` 구조에서 standalone `<label htmlFor>` 구조로 변경되었습니다. 공개 props는 동일하지만, 커스텀 SCSS에서 `.text_field_legend` 같은 내부 셀렉터를 오버라이드했다면 점검이 필요합니다.
 >

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,7 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 ## 목차
 
 - [개요](#개요)
+- [Unreleased (다음 릴리즈)](#unreleased-다음-릴리즈)
 - [v3.8.0 (Vanilla 패키지 정리)](#v380-vanilla-패키지-정리)
 - [v3.5.0](#v350)
 - [v3.3.0](#v330)
@@ -25,6 +26,44 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 - React 컴포넌트 섹션은 `grep -rn "@deprecated" src/ui --include=index.tsx` 로 코드에 실제 존재하는 deprecated prop 전체를 기준으로 작성했습니다.
 - **Vanilla JS 패키지(`/vanilla`)는 deprecated 유예 없이 한 번에 정리**했습니다. 클래스 이름은 컴파일러가 잡아주지 않으므로 [v3.8.0 섹션](#v380-vanilla-패키지-정리)의 old → new 표와 치환 스크립트를 그대로 사용하세요.
 - 버전은 semver 내림차순으로 정렬되어 있습니다.
+
+---
+
+## Unreleased (다음 릴리즈)
+
+> 릴리즈 PR 에서 이 제목을 확정 버전으로 바꿔주세요.
+
+### Dropdown - `variant="ghost"` 제거 (타입 레벨 파괴적 변경)
+
+`Dropdown` 의 `variant` 는 v2.4.0 부터 `@deprecated` no-op 이었습니다. 이번 릴리즈에서 **다시 동작하게 되살리면서** Vanilla 번들과 같은 두 값만 남겼습니다.
+
+| 컴포넌트 | 구 타입 | 신 타입 | 비고 |
+|------|------|------|------|
+| Dropdown | `'outline' \| 'filled' \| 'ghost'` (no-op) | `'outline' \| 'filled'` (동작함, 기본 `'outline'`) | `'ghost'` 는 어떤 스타일도 구현된 적이 없고 대응하는 Vanilla 클래스도 없어 제거 |
+
+- **런타임 영향 없음** - `'ghost'` 는 no-op 이었으므로 지우면 렌더링이 그대로입니다. 다만 `variant="ghost"` 를 넘기던 호출부는 **타입 에러**가 납니다.
+- `variant` 를 아예 넘기지 않던 코드는 영향이 없습니다 (`'outline'` 이 기본값이고 기존 렌더링과 동일).
+
+Before:
+```tsx
+<Dropdown options={options} variant="ghost" />
+```
+
+After:
+```tsx
+{/* 기본(테두리) */}
+<Dropdown options={options} />
+{/* 채움 배경 */}
+<Dropdown options={options} variant="filled" />
+```
+
+### 신규 추가 (비파괴 — 마이그레이션 불필요, 참고용)
+
+| 컴포넌트 | 추가 | 설명 |
+|------|------|------|
+| TextField | `variant` | `'outline'`(기본) / `'filled'`. Vanilla `.bt-text-field__input--outline/--filled` 와 1:1 |
+| TextField | `success` | 검증 통과 상태. `error` 와 동시에 주면 `error` 우선, `aria-invalid` 는 켜지 않음. Vanilla `.bt-text-field__input--success` 와 1:1 |
+| Dropdown | `variant` | `'outline'`(기본) / `'filled'`. Vanilla `.bt-dropdown__control--outline/--filled` 와 1:1 |
 
 ---
 
@@ -255,7 +294,7 @@ Figma 스펙 기반으로 Dropdown 이 전면 재설계되면서 아래 prop 이
 
 | 컴포넌트 | 구 prop | 신 prop | 도입 버전 | 비고 |
 |------|------|------|------|------|
-| Dropdown | `variant` | 없음 | v2.4.0 | Dropdown 은 outline 스타일만 지원합니다 |
+| Dropdown | `variant` | 없음 | v2.4.0 | Dropdown 은 outline 스타일만 지원합니다. **다음 릴리즈에서 `'outline' \| 'filled'` 로 부활** - [Unreleased 섹션](#unreleased-다음-릴리즈) 참고 |
 | Dropdown | `textAlign` | 없음 | v2.4.0 | 더 이상 지원되지 않습니다 |
 
 ---
@@ -314,13 +353,15 @@ After:
 
 > Next.js 서버 액션에 값을 바로 넘겨야 해서 `Action` 접미사가 필요하다면 `onChangeAction` 을 그대로 사용해도 됩니다 - 두 prop 은 시그니처가 동일합니다.
 
-### 3. Dropdown - fullWidth / variant / textAlign 제거
+### 3. Dropdown - fullWidth / textAlign 제거
 
-`fullWidth`/`variant`/`textAlign` 은 넘겨도 에러가 나지는 않지만 아무 효과가 없습니다(no-op). Dropdown 은 항상 부모 너비를 채우고 outline 스타일만 지원합니다.
+`fullWidth`/`textAlign` 은 넘겨도 에러가 나지는 않지만 아무 효과가 없습니다(no-op). Dropdown 은 항상 부모 너비를 채웁니다.
+
+> `variant` 는 v2.4.0~v3.8.0 동안 no-op 이었지만 다음 릴리즈에서 `'outline' | 'filled'` 로 되살아납니다 - [Unreleased 섹션](#unreleased-다음-릴리즈) 참고.
 
 Before:
 ```tsx
-<Dropdown options={options} fullWidth variant="outline" textAlign="left" />
+<Dropdown options={options} fullWidth textAlign="left" />
 ```
 
 After:

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -167,7 +167,7 @@ npm install @bigtablet/design-system
   </div>
 </div>
 
-<!-- Variants -->
+<!-- Variants (React <TextField variant="outline" /> · variant="filled" 와 동등) -->
 <input class="bt-text-field__input bt-text-field__input--outline bt-text-field__input--md">
 <input class="bt-text-field__input bt-text-field__input--filled bt-text-field__input--md">
 
@@ -383,7 +383,7 @@ React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
 
 **Variants:**
 - `.bt-dropdown__control--outline` (기본) - React `Dropdown` 과 동등한 스타일
-- `.bt-dropdown__control--filled` - Vanilla 전용 (React `Dropdown` 에는 대응 prop 없음)
+- `.bt-dropdown__control--filled` - React `<Dropdown variant="filled" />` 와 동등
 
 **Sizes:**
 - `.bt-dropdown__control--sm`

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ export type {
 	DropdownProps,
 	DropdownSingleProps,
 	DropdownSize,
+	DropdownVariant,
 } from "./ui/forms/dropdown";
 export { Dropdown } from "./ui/forms/dropdown";
 export type { FileInputProps, FileInputVariant } from "./ui/forms/file";
@@ -158,7 +159,12 @@ export type {
 	TextareaSize,
 } from "./ui/forms/textarea";
 export { Textarea } from "./ui/forms/textarea";
-export type { ImeStrategy, TextFieldProps, TextFieldSize } from "./ui/forms/textfield";
+export type {
+	ImeStrategy,
+	TextFieldProps,
+	TextFieldSize,
+	TextFieldVariant,
+} from "./ui/forms/textfield";
 export { TextField } from "./ui/forms/textfield";
 export type { ToggleProps } from "./ui/forms/toggle";
 export { Toggle } from "./ui/forms/toggle";

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -403,6 +403,21 @@ describe("Dropdown", () => {
 		expect(container.querySelector(".dropdown")).toHaveClass("dropdown_size_md");
 	});
 
+	it("defaults to the outline variant", () => {
+		const { container } = render(<Dropdown options={options} />);
+		const root = container.querySelector(".dropdown");
+		expect(root).toHaveClass("dropdown_variant_outline");
+		expect(root).not.toHaveClass("dropdown_variant_filled");
+	});
+
+	it("applies variant class based on variant prop", () => {
+		const { container, rerender } = render(<Dropdown options={options} variant="filled" />);
+		expect(container.querySelector(".dropdown")).toHaveClass("dropdown_variant_filled");
+
+		rerender(<Dropdown options={options} variant="outline" />);
+		expect(container.querySelector(".dropdown")).toHaveClass("dropdown_variant_outline");
+	});
+
 	it("forwards className to root", () => {
 		const { container } = render(<Dropdown options={options} className="my-extra" />);
 		expect(container.querySelector(".dropdown")).toHaveClass("my-extra");

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -34,6 +34,7 @@ const meta: Meta<typeof Dropdown> = {
 	tags: ["autodocs"],
 	argTypes: {
 		size: { control: "select", options: ["sm", "md", "lg"] },
+		variant: { control: "inline-radio", options: ["outline", "filled"] },
 		disabled: { control: "boolean" },
 		fullWidth: { control: "boolean" },
 		searchable: { control: "boolean" },
@@ -58,6 +59,7 @@ const meta: Meta<typeof Dropdown> = {
 **Dropdown** - Single-select dropdown. Floating label (shows when a value is selected/opened). / **Dropdown** - 단일 선택 드롭다운. 플로팅 라벨 (값 선택/열림 시 표시).
 
 Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
+Variants: \`outline\` (default, bordered) / \`filled\` (dim fill, no border — the border appears while open). Same vocabulary as \`TextField\`. / Variants: \`outline\` (기본, 테두리) / \`filled\` (dim 배경 채움, 테두리 없음 — 열려 있는 동안 테두리가 드러남). \`TextField\` 와 같은 어휘입니다.
 \`DropdownOption\` fields: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`. / \`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
 Keyboard: ↑↓/Enter/Esc/Home/End. / 키보드: ↑↓/Enter/Esc/Home/End.
 
@@ -79,6 +81,34 @@ export const WithValue: Story = {
 
 export const Disabled: Story = {
 	args: { disabled: true, defaultValue: "apple" },
+};
+
+export const Filled: Story = {
+	args: { variant: "filled", defaultValue: "banana" },
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'`variant="filled"` swaps the border for a dim fill; opening the panel restores the solid background and reveals the border. Mirrors Vanilla `.bt-dropdown__control--filled`. / `variant="filled"` 는 테두리 대신 dim 배경으로 채웁니다. 패널을 열면 배경이 solid 로 돌아오며 테두리가 드러납니다. Vanilla `.bt-dropdown__control--filled` 와 동일합니다.',
+			},
+		},
+	},
+};
+
+export const Variants: Story = {
+	render: (args) => (
+		<div style={{ display: "flex", flexDirection: "column", gap: 16, width: 280 }}>
+			<Dropdown {...(args as DropdownSingleProps)} variant="outline" label="Outline (기본)" />
+			<Dropdown {...(args as DropdownSingleProps)} variant="filled" label="Filled" />
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story: "Side-by-side comparison of the two variants. / 두 variant 를 나란히 비교합니다.",
+			},
+		},
+	},
 };
 
 export const FullWidth: Story = {

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -10,6 +10,13 @@ import "./style.scss";
 
 export type DropdownSize = "sm" | "md" | "lg";
 
+/**
+ * 컨트롤 시각 변형. TextField 의 `variant` 와 같은 어휘를 쓴다.
+ * - `outline`: 테두리로 컨트롤을 구분 (기본).
+ * - `filled`: 테두리 대신 채워진 배경으로 구분, 열리면 배경이 solid 로 돌아오며 테두리가 드러남.
+ */
+export type DropdownVariant = "outline" | "filled";
+
 export interface DropdownOption {
 	value: string;
 	label: string;
@@ -44,10 +51,8 @@ interface DropdownCommonProps {
 	fullWidth?: boolean;
 	/** 루트 요소에 추가할 className */
 	className?: string;
-	/**
-	 * @deprecated variant는 더 이상 지원되지 않습니다. Dropdown은 outline 스타일만 사용합니다.
-	 */
-	variant?: "outline" | "filled" | "ghost";
+	/** 컨트롤 시각 변형 (기본값: "outline") */
+	variant?: DropdownVariant;
 	/**
 	 * @deprecated textAlign은 더 이상 지원되지 않습니다.
 	 */
@@ -118,6 +123,7 @@ export const Dropdown = (props: DropdownProps) => {
 		options,
 		disabled,
 		size = "md",
+		variant = "outline",
 		className,
 		searchable = false,
 		searchPlaceholder = "검색…",
@@ -391,7 +397,12 @@ export const Dropdown = (props: DropdownProps) => {
 			? currentOption.label
 			: placeholder;
 
-	const rootClassName = cn("dropdown", `dropdown_size_${size}`, className);
+	const rootClassName = cn(
+		"dropdown",
+		`dropdown_size_${size}`,
+		`dropdown_variant_${variant}`,
+		className,
+	);
 	const fieldsetClassName = cn("dropdown_fieldset", { is_open: isOpen, is_disabled: disabled });
 	const listClassName = cn("dropdown_list", { dropdown_list_up: dropUp });
 

--- a/src/ui/forms/dropdown/style.scss
+++ b/src/ui/forms/dropdown/style.scss
@@ -71,6 +71,32 @@
     }
   }
 
+  // ── Variant: filled ───────────────────────────────────────────────────────────
+  // Vanilla `.bt-dropdown__control--filled` 대응. TextField 의 filled 와 같은 어휘지만
+  // 상태 훅이 다르다 - TextField 는 `:focus-within`, Dropdown 은 열림 상태(`.is_open`).
+  // outline(기본)은 base 규칙 그대로라 `_variant_outline` 은 스타일을 갖지 않는다.
+  // Vanilla 의 `0 0 0 3px` 링은 옮기지 않는다 (React 컨트롤은 border-color 로만 표현).
+
+  &_variant_filled &_fieldset {
+    border-color: transparent;
+    background-color: token.$color_bg_solid_dim;
+
+    &:hover:not(.is_open):not(.is_disabled) {
+      border-color: token.$color_border_hover;
+    }
+
+    &.is_open {
+      border-color: token.$color_border_focus;
+      background-color: token.$color_bg_solid;
+    }
+
+    // filled 는 테두리가 없는 게 정체성이라 disabled 에서도 되살리지 않는다.
+    // 비활성 신호는 dim 배경 + control 의 opacity 로 준다.
+    &.is_disabled {
+      border-color: transparent;
+    }
+  }
+
   // ── Standalone label (above control) - modern 패턴, 어떤 배경에서도 작동 ──
 
   &_label {

--- a/src/ui/forms/textfield/TextField.test.tsx
+++ b/src/ui/forms/textfield/TextField.test.tsx
@@ -133,4 +133,51 @@ describe("TextField", () => {
 		expect(handleChange).toHaveBeenCalledWith("test@example.com");
 	});
 
+	// ── variant ────────────────────────────────────────────────────────────
+
+	it("defaults to the outline variant and emits no filled class", () => {
+		render(<TextField />);
+		const root = screen.getByRole("textbox").closest(".text_field");
+		expect(root).toHaveClass("text_field_variant_outline");
+		expect(root).not.toHaveClass("text_field_variant_filled");
+	});
+
+	it("emits the filled variant class", () => {
+		render(<TextField variant="filled" />);
+		const root = screen.getByRole("textbox").closest(".text_field");
+		expect(root).toHaveClass("text_field_variant_filled");
+		expect(root).not.toHaveClass("text_field_variant_outline");
+	});
+
+	// ── success ────────────────────────────────────────────────────────────
+
+	it("shows success state without marking the input invalid", () => {
+		render(<TextField success supportingText="사용 가능한 이메일입니다" />);
+		const input = screen.getByRole("textbox");
+		expect(input.closest(".text_field")).toHaveClass("text_field_success");
+		expect(input).toHaveAttribute("aria-invalid", "false");
+	});
+
+	it("links success helper text with aria-describedby", () => {
+		render(<TextField success label="Email" supportingText="Looks good" />);
+		const input = screen.getByRole("textbox");
+		const helperId = input.getAttribute("aria-describedby");
+		expect(helperId).toBeTruthy();
+		expect(document.getElementById(helperId!)).toHaveTextContent("Looks good");
+	});
+
+	it("lets error win over success when both are set", () => {
+		render(<TextField error success supportingText="Invalid email" />);
+		const input = screen.getByRole("textbox");
+		const root = input.closest(".text_field");
+		expect(root).toHaveClass("text_field_error");
+		expect(root).not.toHaveClass("text_field_success");
+		expect(input).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("combines the filled variant with the success state", () => {
+		render(<TextField variant="filled" success />);
+		const root = screen.getByRole("textbox").closest(".text_field");
+		expect(root).toHaveClass("text_field_variant_filled", "text_field_success");
+	});
 });

--- a/src/ui/forms/textfield/TextField.test.tsx
+++ b/src/ui/forms/textfield/TextField.test.tsx
@@ -180,4 +180,13 @@ describe("TextField", () => {
 		const root = screen.getByRole("textbox").closest(".text_field");
 		expect(root).toHaveClass("text_field_variant_filled", "text_field_success");
 	});
+
+	// filled 는 disabled 에서도 테두리를 되살리지 않는다. jsdom 은 스타일시트를 적용하지
+	// 않으므로 계산된 border-color 대신, 특이도 오버라이드가 겨냥하는 두 루트 클래스가
+	// 함께 붙는지를 확인한다 (`.text_field_disabled.text_field_variant_filled`).
+	it("keeps the filled variant class alongside disabled", () => {
+		render(<TextField variant="filled" disabled />);
+		const root = screen.getByRole("textbox").closest(".text_field");
+		expect(root).toHaveClass("text_field_variant_filled", "text_field_disabled");
+	});
 });

--- a/src/ui/forms/textfield/index.tsx
+++ b/src/ui/forms/textfield/index.tsx
@@ -10,6 +10,13 @@ import "./style.scss";
 export type TextFieldSize = "sm" | "md" | "lg";
 
 /**
+ * 입력 필드 시각 변형.
+ * - `outline`: 테두리로 입력 영역을 구분 (기본).
+ * - `filled`: 테두리 대신 채워진 배경으로 구분, 포커스 시 배경이 solid 로 돌아오며 테두리가 드러남.
+ */
+export type TextFieldVariant = "outline" | "filled";
+
+/**
  * IME 조합(한글/일본어/중국어) 중 외부 콜백 처리 전략.
  * - `delayed`: 조합 완료 후에만 `onChangeAction` 호출 (기본 - 폼 제출/검증용).
  * - `immediate`: 조합 중에도 매 입력마다 즉시 호출 (실시간 검색/필터/미리보기용).
@@ -23,14 +30,18 @@ export interface TextFieldProps
 	> {
 	/** 입력 필드 크기 (기본값: "md") */
 	size?: TextFieldSize;
+	/** 입력 필드 시각 변형 (기본값: "outline") */
+	variant?: TextFieldVariant;
 	/** 입력 필드 위에 표시할 라벨 텍스트 */
 	label?: string;
 	/** 라벨 표시 여부 (기본값: true) */
 	showLabel?: boolean;
 	/** 입력 필드 아래에 표시할 도움말 텍스트 */
 	supportingText?: string;
-	/** 에러 상태 여부 */
+	/** 에러 상태 여부. `success` 와 동시에 지정되면 `error` 가 우선한다. */
 	error?: boolean;
+	/** 성공(검증 통과) 상태 여부. `error` 가 true 면 무시된다. */
+	success?: boolean;
 	/** 입력 필드 왼쪽에 표시할 아이콘 */
 	leadingIcon?: React.ReactNode;
 	/** 입력 필드 오른쪽에 표시할 아이콘 */
@@ -74,11 +85,13 @@ export const TextField = ({
 	showLabel = true,
 	supportingText,
 	error,
+	success,
 	leadingIcon,
 	trailingIcon,
 	clearable,
 	fullWidth,
 	size = "md",
+	variant = "outline",
 	className,
 	onValueChange,
 	onChangeAction,
@@ -133,12 +146,19 @@ export const TextField = ({
 		emit("");
 	}, [emit]);
 
+	// error 가 success 를 이긴다 - 둘 다 켜진 건 대개 검증 상태 전환 중인 순간이고,
+	// 그때 실패를 성공처럼 보여주면 사용자가 잘못된 값을 그대로 제출하게 된다.
+	const isError = !!error;
+	const isSuccess = !!success && !isError;
+
 	const rootClassName = cn(
 		"text_field",
+		`text_field_variant_${variant}`,
 		size === "sm" && "text_field_size_sm",
 		size === "lg" && "text_field_size_lg",
 		fullWidth && "text_field_full_width",
-		error && "text_field_error",
+		isError && "text_field_error",
+		isSuccess && "text_field_success",
 		props.disabled && "text_field_disabled",
 		className,
 	);
@@ -181,7 +201,7 @@ export const TextField = ({
 							id={inputId}
 							ref={ref}
 							className="text_field_input"
-							aria-invalid={!!error}
+							aria-invalid={isError}
 							aria-describedby={helperId}
 							aria-label={!showLabel ? label : undefined}
 							{...props}

--- a/src/ui/forms/textfield/style.scss
+++ b/src/ui/forms/textfield/style.scss
@@ -210,6 +210,16 @@
     background-color: token.$color_bg_solid;
   }
 
+  // filled 는 테두리가 없는 게 정체성이라 disabled 에서도 되살리지 않는다 (Dropdown 의
+  // `_variant_filled &_fieldset.is_disabled` 와 동일한 판단). 비활성 신호는 dim 배경 +
+  // input 의 색으로 준다.
+  //
+  // 루트 클래스 2개를 겹쳐 (0,3,0) 으로 만들어, 뒤에 오는 disabled 블록(0,2,0)을 선언
+  // 순서와 무관하게 이긴다. 두 번째 `&` 는 compound 중간에 못 오므로 `#{&}` 로 보간한다.
+  &_disabled#{&}_variant_filled &_container {
+    border-color: transparent;
+  }
+
   // ── Error state ────────────────────────────────────────────────────────
 
   &_error {

--- a/src/ui/forms/textfield/style.scss
+++ b/src/ui/forms/textfield/style.scss
@@ -184,6 +184,32 @@
     transition: color token.$transition_base;
   }
 
+  // ── Variant: filled ────────────────────────────────────────────────────
+  // Vanilla `.bt-text-field__input--filled` 대응. 테두리를 지우고 dim 배경으로 입력 영역을
+  // 구분하다가, 포커스가 들어오면 배경을 solid 로 되돌리며 테두리를 드러낸다.
+  // outline(기본)은 base 규칙 그대로라 `_variant_outline` 은 스타일을 갖지 않는다 -
+  // variant 를 생략했을 때의 렌더링이 이 PR 이전과 완전히 동일해야 하기 때문.
+  //
+  // Vanilla 는 focus 에 `0 0 0 3px` 링을 더하지만 여기서는 옮기지 않는다. React 폼 컨트롤은
+  // 컨테이너에 링을 쓰지 않고 border-color 로만 포커스를 표현하며(outline variant·Dropdown
+  // 동일), filled 에만 링을 붙이면 같은 컴포넌트의 두 variant 가 서로 다른 포커스 언어를 쓴다.
+  //
+  // 순서 주의: error/success/disabled 블록보다 앞에 둬야 한다. 특이도가 같아(0,2,0)
+  // 선언 순서로 tie-break 되므로, 뒤로 옮기면 filled 가 상태 색을 덮는다.
+  &_variant_filled &_container {
+    border-color: transparent;
+    background-color: token.$color_bg_solid_dim;
+
+    &:hover {
+      border-color: token.$color_border_hover;
+    }
+  }
+
+  &_variant_filled &_container:focus-within {
+    border-color: token.$color_border_focus;
+    background-color: token.$color_bg_solid;
+  }
+
   // ── Error state ────────────────────────────────────────────────────────
 
   &_error {
@@ -203,6 +229,30 @@
 
     .text_field_helper {
       color: token.$color_status_error_on_surface;
+    }
+  }
+
+  // ── Success state ──────────────────────────────────────────────────────
+  // error 와 완전히 대칭 구조. 컴포넌트가 error 우선으로 둘 중 하나만 붙이므로
+  // 두 클래스가 동시에 존재하는 경우는 없다 (index.tsx 의 isError/isSuccess).
+
+  &_success {
+    .text_field_container {
+      border-color: token.$color_status_success;
+    }
+
+    .text_field_container:hover,
+    .text_field_container:focus-within {
+      border-color: token.$color_status_success;
+    }
+
+    .text_field_label {
+      // surface 위 직접 텍스트 - light/dark 자동 swap (다크 모드 가독성 보장)
+      color: token.$color_status_success_on_surface;
+    }
+
+    .text_field_helper {
+      color: token.$color_status_success_on_surface;
     }
   }
 

--- a/src/ui/forms/textfield/textfield.stories.tsx
+++ b/src/ui/forms/textfield/textfield.stories.tsx
@@ -37,7 +37,9 @@ const meta: Meta<typeof TextField> = {
 		label: { control: "text" },
 		showLabel: { control: "boolean" },
 		supportingText: { control: "text" },
+		variant: { control: "inline-radio", options: ["outline", "filled"] },
 		error: { control: "boolean" },
+		success: { control: "boolean" },
 		disabled: { control: "boolean" },
 		fullWidth: { control: "boolean" },
 		onChangeAction: { control: false },
@@ -50,7 +52,9 @@ const meta: Meta<typeof TextField> = {
 **TextField** - Single-line text input. Floating label + leading/trailing icon + supporting text. / **TextField** - 한 줄 텍스트 입력. 플로팅 라벨 + leading/trailing 아이콘 + supporting text.
 
 Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
+Variants: \`outline\` (default, bordered) / \`filled\` (dim fill, no border — the border appears on focus). / Variants: \`outline\` (기본, 테두리) / \`filled\` (dim 배경 채움, 테두리 없음 — 포커스 시 테두리가 드러남).
 \`error\` → \`aria-invalid\` + \`aria-describedby\` set automatically. / \`error\` → \`aria-invalid\` + \`aria-describedby\` 자동.
+\`success\` marks a passing validation and never sets \`aria-invalid\`. When \`error\` and \`success\` are both set, \`error\` wins. / \`success\` 는 검증 통과 표시이며 \`aria-invalid\` 를 켜지 않습니다. \`error\` 와 \`success\` 를 동시에 주면 \`error\` 가 우선합니다.
 				`,
 			},
 		},
@@ -68,6 +72,78 @@ export const WithIcons: Story = {
 		placeholder: "Search…",
 		leadingIcon: <SearchIcon />,
 		trailingIcon: <CloseIcon />,
+	},
+};
+
+export const Filled: Story = {
+	args: {
+		variant: "filled",
+		label: "Search",
+		placeholder: "검색어를 입력하세요",
+		supportingText: "Focus me — the border only appears while focused.",
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'`variant="filled"` swaps the border for a dim fill; focusing restores the solid background and reveals the border. Mirrors Vanilla `.bt-text-field__input--filled`. / `variant="filled"` 는 테두리 대신 dim 배경으로 채웁니다. 포커스하면 배경이 solid 로 돌아오며 테두리가 드러납니다. Vanilla `.bt-text-field__input--filled` 와 동일합니다.',
+			},
+		},
+	},
+};
+
+export const Variants: Story = {
+	render: (args) => (
+		<div style={{ display: "flex", flexDirection: "column", gap: 16, width: 280 }}>
+			<TextField {...args} variant="outline" label="Outline (기본)" />
+			<TextField {...args} variant="filled" label="Filled" />
+		</div>
+	),
+	args: { placeholder: "Input" },
+	parameters: {
+		docs: {
+			description: {
+				story: "Side-by-side comparison of the two variants. / 두 variant 를 나란히 비교합니다.",
+			},
+		},
+	},
+};
+
+export const SuccessState: Story = {
+	name: "Success",
+	args: {
+		label: "Email",
+		placeholder: "name@example.com",
+		defaultValue: "name@example.com",
+		supportingText: "사용 가능한 이메일입니다.",
+		success: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'`success` mirrors `error` (border + label + helper text recolored) but keeps `aria-invalid="false"`. / `success` 는 `error` 와 같은 구조(테두리 + 라벨 + 도움말 색 변경)이지만 `aria-invalid` 는 `false` 로 유지합니다.',
+			},
+		},
+	},
+};
+
+export const ErrorWinsOverSuccess: Story = {
+	args: {
+		label: "Email",
+		placeholder: "name@example.com",
+		defaultValue: "not-an-email",
+		supportingText: "이메일 형식이 올바르지 않습니다.",
+		error: true,
+		success: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"With both `error` and `success` set, `error` wins — a failed validation must never be painted as a pass. / `error` 와 `success` 가 동시에 켜지면 `error` 가 이깁니다 - 검증 실패를 성공처럼 보여주면 안 되기 때문입니다.",
+			},
+		},
 	},
 };
 

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -353,8 +353,8 @@
       opacity: 0.7;
     }
 
-    /* Variants - React TextField 에는 variant prop 이 없고 outline 스타일만 있다.
-       --outline 이 React 와 동등한 기본값이고, --filled 는 Vanilla 전용이다. */
+    /* Variants - React `<TextField variant>` 와 1:1 대응.
+       --outline 이 기본값(React `variant="outline"`), --filled 는 `variant="filled"` 다. */
     &--outline {
       border: 1px solid var(--bt-color-border);
 
@@ -746,8 +746,8 @@
       color: var(--bt-color-text-tertiary);
     }
 
-    /* Variants - React Dropdown 은 variant prop 을 @deprecated 처리하고 outline 만 쓴다.
-       --outline 이 React 와 동등한 기본값이고, --filled 는 Vanilla 전용이다. */
+    /* Variants - React `<Dropdown variant>` 와 1:1 대응.
+       --outline 이 기본값(React `variant="outline"`), --filled 는 `variant="filled"` 다. */
     &--outline {
       border: 1px solid var(--bt-color-border);
 


### PR DESCRIPTION
## 제목
feat/field-variant

## 작업한 내용
- [x] **TextField `variant` prop 추가** (`'outline'` 기본 / `'filled'`) - Vanilla `.bt-text-field__input--outline/--filled` 와 1:1. `filled` 는 테두리 대신 dim 배경으로 채우고 `:focus-within` 에서 배경이 solid 로 돌아오며 테두리가 드러남
- [x] **TextField `success` prop 추가** - 기존 `error` 와 완전히 대칭 구조(테두리 + 라벨 + helper 색). `error` 와 동시에 켜지면 **`error` 우선**(검증 실패를 성공처럼 칠하면 잘못된 값이 그대로 제출됨). `success` 는 `aria-invalid` 를 켜지 않음
- [x] **Dropdown `variant` 되살림** - v2.4.0 부터 `@deprecated` no-op 이던 prop 을 실제 동작하게 구현 (`'outline'` 기본 / `'filled'`). 상태 훅은 TextField(`:focus-within`) 와 달리 열림 상태(`.is_open`) 기준
- [x] **`variant="ghost"` 제거** - 구현도 대응 Vanilla 클래스도 없던 값 (아래 ⚠️ 참고)
- [x] Vanilla CSS 커스텀 프로퍼티를 SCSS 디자인 토큰으로 번역 (`--bt-color-background-secondary` → `token.$color_bg_solid_dim`, `--bt-color-accent`/포커스 테두리 → `token.$color_border_focus`, `--bt-color-background` → `token.$color_bg_solid`). 컴포넌트 SCSS 에 raw `var(--bt-*)` 는 넣지 않음
- [x] `TextFieldVariant` · `DropdownVariant` 타입 barrel re-export (`src/index.ts`)
- [x] 테스트 추가 (기존 co-located 스타일 - `fireEvent` + RTL + `vi.fn()`): 기본 variant 불변 / `filled` 클래스 / success 렌더 + a11y 속성 / error-success 우선순위 / Dropdown variant 클래스
- [x] Storybook 스토리 추가 (한/영 병기): TextField `Filled` · `Variants` · `Success` · `ErrorWinsOverSuccess`, Dropdown `Filled` · `Variants`
- [x] 문서 갱신 - `docs/COMPONENTS.md`(TextField 에 variant/success 없다는 서술 → 우선순위 규칙으로 교체, Dropdown `variant` 행 deprecated 해제), `docs/VANILLA.md`, `docs/MIGRATION.md`, `src/vanilla/bigtablet.scss` 의 "Vanilla 전용" 주석

### ⚠️ 타입 레벨 파괴적 변경 - `Dropdown variant="ghost"` 제거

`variant` 타입이 `'outline' | 'filled' | 'ghost'` → **`'outline' | 'filled'`** 로 좁혀졌습니다.

- `'ghost'` 는 어떤 스타일도 구현된 적이 없고 대응하는 Vanilla 클래스도 없었습니다 (prop 자체가 no-op).
- **런타임 영향 없음** - 지워도 렌더링이 그대로입니다. 다만 `variant="ghost"` 를 넘기던 호출부는 **타입 에러**가 납니다.
- `variant` 를 안 넘기던 코드는 영향 없음 (`'outline'` 기본값 = 기존 렌더링).
- `docs/MIGRATION.md` 의 `Unreleased (다음 릴리즈)` 섹션에 old → new 표로 기록했습니다.

### 확인한 것

- `pnpm build` / `pnpm exec stylelint "src/**/*.scss"` / `pnpm exec tsc --noEmit` / `pnpm test`(796 passed) / `pnpm test:storybook`(290 a11y passed) 전부 통과
- **기본(outline) 렌더링 무변경 검증** - `develop` 과 이번 브랜치의 컴파일된 `dist/index.css` 를 diff 한 결과 **추가된 규칙만 있고 기존 규칙 변경 0건**. `variant` 를 생략하면 이전과 완전히 동일합니다
- Storybook 육안 확인 - 라이트/다크 양쪽에서 outline 무변경, filled 정상 렌더(포커스/열림 시 배경 solid 복귀 + 테두리 노출), success(green) 와 error(red) 구분 명확

## 전달할 추가 이슈
- **릴리즈 PR 에서 처리 필요**: `package.json` version bump + `CHANGELOG.md` 항목 추가, 그리고 `docs/MIGRATION.md` 의 `Unreleased (다음 릴리즈)` 제목을 확정 버전으로 교체. 조직 버저닝 기준상 union 멤버 제거는 파괴적 변경이라 버전 등급(major vs minor)은 릴리즈 담당자 판단이 필요합니다
- Vanilla 의 `0 0 0 3px` 포커스 링은 **의도적으로 React 로 옮기지 않았습니다.** React 폼 컨트롤(TextField outline · Dropdown)은 컨테이너에 링을 쓰지 않고 `border-color` 로만 포커스를 표현하는데, filled 에만 링을 붙이면 같은 컴포넌트의 두 variant 가 서로 다른 포커스 언어를 쓰게 됩니다. 반대로 Vanilla 쪽에서 링을 걷어내 맞추는 방향도 가능하니 별도 논의 대상입니다
- `Textarea` 는 TextField 와 동일한 시각 토큰을 공유하는데 이번 PR 범위에서 제외했습니다. `variant`/`success` 를 Textarea 에도 확장할지 후속 검토 필요
- Dropdown 의 나머지 deprecated no-op prop (`fullWidth`, `textAlign`) 은 그대로 뒀습니다
