### PR TITLE
feat/vanilla-dropdown-card-parity

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -477,6 +477,8 @@ Class names and JS option names mirror the React API exactly - there are no depr
 JS API (auto-init on DOMContentLoaded, or manual):
 ```js
 const dropdown = Bigtablet.Dropdown("#my-dropdown", { options, onValueChange });
+// React 와 동일한 이름의 multiple / searchable 도 지원 (data-multiple / data-searchable 로도 가능)
+Bigtablet.Dropdown("#multi", { multiple: true, searchable: true, selectedSummary: (n) => `${n}개 선택` });
 const modal = Bigtablet.Modal("#my-modal", { onOpen, onClose });
 Bigtablet.Alert({ title, message, showCancel: true, onConfirm });
 ```

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1015,6 +1015,8 @@ import { Spinner } from '@bigtablet/design-system';
 |------|------|---------|-------------|
 | `size` | `number` | `24` | 스피너 크기 (px) |
 
+> ℹ️ React 는 12개 bar 가 순차 페이드하는 iOS 스타일이고, `prefers-reduced-motion: reduce` 에서는 애니메이션을 완전히 정지시킨다(멈춰 있어도 12개 spoke 형태가 로딩 위젯으로 읽히기 때문). Vanilla `.bt-spinner` 는 서버 템플릿의 마크업 단순성(빈 요소 하나)을 위해 단일 border ring 이고, 정지 대신 회전을 늦춘다(0.8s → 2.4s). **의도된 차이이며 통일 계획은 없다** - 자세한 근거는 [VANILLA.md#spinner](./VANILLA.md#spinner).
+
 ---
 
 ### TopLoading

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -94,7 +94,7 @@ React 컴포넌트 이름이 `Dropdown` 이므로 블록 이름·data 속성·JS
 
 `.is-open` / `.is-selected` / `.is-active` / `.is-disabled` 상태 클래스와 인스턴스 API(`getValue` / `setValue` / `open` / `close` / `toggle` / `setDisabled` / `destroy`)는 그대로입니다.
 
-> **남은 격차**: React `Dropdown` 의 `multiple`(다중 선택)·`searchable`(검색 필터)은 Vanilla 에 아직 없습니다. 이름만 맞췄을 뿐 기능까지 동등하지는 않으니, 두 기능이 필요하면 React 쪽을 쓰세요.
+> React `Dropdown` 의 `multiple`(다중 선택)·`searchable`(검색 필터)도 Vanilla 에서 지원합니다 (JS 옵션 또는 `data-multiple` / `data-searchable`). 사용법은 [VANILLA.md#dropdown](./VANILLA.md#dropdown) 참고.
 
 ### 5. Spinner - size enum → px 커스텀 프로퍼티
 

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -452,6 +452,22 @@ React 와 동일하게 `multiple`(다중 선택) / `searchable`(검색)을 지�
 </div>
 ```
 
+> **`__list` 에 커스텀 클래스를 붙였다면 주의**
+> 평면 `<ul class="bt-dropdown__list">` 마크업 + `searchable` 조합이면, `<ul>` 안에는 `<li>`
+> 밖에 못 오므로 JS 가 새 `<div class="bt-dropdown__list">` 를 만들어 그 `<ul>` 을 감싸 올리고,
+> 원래 `<ul>` 은 `.bt-dropdown__options`(스크롤 컨테이너)가 됩니다. 이때 `bt-dropdown__list`
+> 로 시작하지 않는 커스텀 클래스는 **원래 붙어 있던 `<ul>` 에 그대로 남습니다** — 즉 패널
+> wrapper 가 아니라 안쪽 스크롤 컨테이너를 가리키게 됩니다.
+>
+> 패널 wrapper 를 직접 스타일링해야 하면 승격에 맡기지 말고 최종 구조를 그대로 렌더링하세요.
+> `__options` 컨테이너가 이미 있으면 JS 는 승격을 건너뛰므로 클래스가 의도한 자리에 남습니다:
+>
+> ```html
+> <div class="bt-dropdown__list my-panel">
+>   <ul class="bt-dropdown__options" role="listbox">…</ul>
+> </div>
+> ```
+
 `searchable` 일 때는 React 와 동일하게 **`role="combobox"` 가 검색 입력으로 옮겨가고**
 (`aria-autocomplete` / `aria-expanded` / `aria-controls` / `aria-activedescendant` 포함),
 트리거 버튼에는 `aria-haspopup="listbox"` + `aria-expanded` 만 남습니다.

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -341,13 +341,14 @@ npm install @bigtablet/design-system
 
 ### Dropdown
 
-React `<Dropdown>` 의 Vanilla 대응입니다. 단일 선택 전용이며,
-React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
+React `<Dropdown>` 의 Vanilla 대응입니다. 기본은 단일 선택이고,
+React 와 동일하게 `multiple`(다중 선택) / `searchable`(검색)을 지원합니다.
 
 ```html
 <div class="bt-dropdown" data-bt-dropdown style="width: 300px;">
-  <label class="bt-dropdown__label">과일 선택</label>
-  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+  <!-- 라벨은 React 처럼 트리거 버튼과 연결하세요 (button 은 labelable 요소입니다) -->
+  <label class="bt-dropdown__label" for="fruit-control">과일 선택</label>
+  <button type="button" id="fruit-control" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
     <span class="bt-dropdown__placeholder">선택하세요...</span>
     <span class="bt-dropdown__icon">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -390,6 +391,96 @@ React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
 - `.bt-dropdown__control--md`
 - `.bt-dropdown__control--lg`
 
+**다중 선택 (`multiple`):**
+
+`data-multiple` 또는 JS `multiple: true` 를 주면 React `<Dropdown multiple>` 과 같게 동작합니다.
+옵션을 클릭하면 **토글되고 패널은 열린 채로 유지**되며, 선택된 옵션 왼쪽에 체크
+슬롯(`.bt-dropdown__option-check`)이 표시됩니다. 트리거에는 chip 이 아니라
+`N개 선택` 요약 문자열이 들어가고(`selectedSummary` 로 변경), listbox 에는
+`aria-multiselectable="true"` 가 붙습니다.
+
+값 타입도 React `value` prop 규칙 그대로입니다 - 단일은 `string | null`, 다중은 `string[]`.
+`getValue()` / `setValue()` / `onValueChange` 가 모두 이 규칙을 따릅니다.
+
+폼 제출은 **같은 `name` 의 hidden input 을 선택 개수만큼 반복**해 담습니다
+(React 가 `selectedValues.map(...)` 로 hidden input 을 반복 렌더하는 것과 동일).
+선택이 0개면 hidden input 도 0개입니다.
+
+```html
+<div class="bt-dropdown" data-bt-dropdown data-multiple data-name="topping">
+  <label class="bt-dropdown__label">토핑</label>
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">토핑을 고르세요...</span>
+    <span class="bt-dropdown__icon">▼</span>
+  </button>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="cheese">치즈</li>
+    <li class="bt-dropdown__option" data-value="bacon">베이컨</li>
+    <li class="bt-dropdown__option is-disabled" data-value="pineapple">파인애플 (품절)</li>
+  </ul>
+</div>
+
+<!-- 선택 2개 → 서버에는 topping=cheese&topping=bacon 으로 전송됩니다.
+     Spring MVC 라면 List<String> topping 으로 바인딩됩니다. -->
+```
+
+**검색 (`searchable`):**
+
+`data-searchable` 또는 JS `searchable: true` 를 주면 패널 상단에 검색 행이 생깁니다.
+필터는 옵션 `label` 부분 일치이고 **대소문자·공백을 무시**합니다 (React `normalizeForSearch` 와 동일).
+패널을 열면 검색 입력에 포커스가 가고, 닫으면 검색어가 초기화됩니다.
+결과가 0개면 `emptyText`(기본 `결과 없음`)가 표시됩니다.
+
+> **한글 IME**: 조합 중(`compositionstart` ~ `compositionend`)에는 필터를 갱신하지 않습니다.
+> 입력 표시는 즉시 반영되지만 중간 자모(`ㅍ`, `포`)로 목록이 튀지 않고, 조합이 확정된 뒤에만
+> 필터가 적용됩니다. 조합 중 Enter 도 조합 확정용이라 선택/닫기를 트리거하지 않습니다.
+> (React 가 `searchText` / `committedQuery` 를 분리한 것과 같은 동작)
+
+검색 행·스크롤 컨테이너·빈 결과 안내는 JS 가 자동으로 만들어 넣으므로 마크업은 그대로 둡니다.
+결과 DOM 은 React 와 같은 구조입니다:
+
+```html
+<div class="bt-dropdown__list">          <!-- 패널 (스크롤 없음) -->
+  <div class="bt-dropdown__search">
+    <span class="bt-dropdown__search-icon">…</span>
+    <input class="bt-dropdown__search-input" role="combobox" aria-autocomplete="list" …>
+  </div>
+  <ul class="bt-dropdown__options" role="listbox">   <!-- 스크롤 컨테이너 -->
+    <li class="bt-dropdown__option" …>…</li>
+    <li class="bt-dropdown__empty" hidden>결과 없음</li>
+  </ul>
+</div>
+```
+
+`searchable` 일 때는 React 와 동일하게 **`role="combobox"` 가 검색 입력으로 옮겨가고**
+(`aria-autocomplete` / `aria-expanded` / `aria-controls` / `aria-activedescendant` 포함),
+트리거 버튼에는 `aria-haspopup="listbox"` + `aria-expanded` 만 남습니다.
+
+**키보드 (WAI-ARIA APG Combobox):**
+
+| 키 | 동작 |
+|----|------|
+| `Enter` / `Space` | 닫힘이면 열기, 열림이면 활성 옵션 확정 (다중은 토글 후 유지) |
+| `↑` / `↓` | **검색 필터를 통과한 옵션 목록** 위에서 이동 (비활성 건너뜀, 순환) |
+| `Home` / `End` | 첫/마지막 활성 가능 옵션 (검색 입력 안에서는 커서 이동에 양보) |
+| `Esc` | 닫기 (searchable 이면 트리거로 포커스 복귀) |
+| `Tab` | 리스트를 닫고 기본 포커스 이동을 그대로 진행 |
+
+**data-\* 속성:**
+
+| 속성 | 대응 JS 옵션 |
+|------|-------------|
+| `data-multiple` | `multiple` |
+| `data-searchable` | `searchable` |
+| `data-search-placeholder` | `searchPlaceholder` |
+| `data-empty-text` | `emptyText` |
+| `data-placeholder` | `placeholder` (미지정 시 `.bt-dropdown__placeholder` 의 마크업 텍스트를 이어받음) |
+| `data-options` | `options` (JSON 배열) |
+| `data-name` | `name` |
+
+> boolean 속성은 값을 생략해도 되고(`data-multiple`), 끄려면 `data-multiple="false"` 로 명시합니다.
+> `selectedSummary` 는 함수라 JS 옵션으로만 지정할 수 있습니다.
+
 **JavaScript 연동:**
 
 ```html
@@ -410,14 +501,35 @@ React 의 `multiple` / `searchable` 은 아직 지원하지 않습니다.
     }
   });
 
+  // 다중 + 검색 (옵션 이름은 React Dropdown prop 과 동일)
+  const cityDropdown = Bigtablet.Dropdown('#city-dropdown', {
+    multiple: true,
+    searchable: true,
+    searchPlaceholder: '도시 검색…',
+    emptyText: '일치하는 도시가 없습니다',
+    selectedSummary: (count) => `도시 ${count}곳`,
+    options: [
+      { value: 'seoul', label: '서울 Seoul' },
+      { value: 'busan', label: '부산 Busan' },
+    ],
+    // multiple 이면 (values, options) 로 호출됩니다
+    onValueChange: (values, options) => console.log(values, options),
+  });
+
   // API
-  myDropdown.getValue();       // 현재 값
-  myDropdown.setValue('apple'); // 값 설정
+  myDropdown.getValue();       // 단일 → string | null / 다중 → string[]
+  myDropdown.setValue('apple'); // 값 설정 (다중은 배열도 가능: setValue(['a', 'b']))
   myDropdown.open();           // 드롭다운 열기
   myDropdown.close();          // 드롭다운 닫기
+  myDropdown.toggle();         // 열림/닫힘 토글
   myDropdown.setDisabled(true); // 비활성화
+  myDropdown.destroy();        // 바인딩한 이벤트 리스너 해제
 </script>
 ```
+
+> `options` / `data-options` 만 주고 `<li class="bt-dropdown__option">` 마크업을 두지 않으면
+> 옵션 DOM 을 JS 가 대신 생성합니다 (라벨은 `textContent` 로 넣으므로 XSS 위험 없음).
+> 서버가 `<li>` 를 렌더링한 경우에는 그 DOM 을 그대로 씁니다.
 
 ---
 
@@ -531,11 +643,22 @@ Alert는 JavaScript로만 사용합니다.
 ### Card
 
 ```html
-<!-- 기본 -->
+<!-- 기본 - title / body / footer 3단 구성 (React Card 의 heading / children / footer 와 동일) -->
 <div class="bt-card bt-card--bordered bt-card--p-md">
-  <div class="bt-card__title">카드 제목</div>
-  <p>카드 내용입니다.</p>
+  <h3 class="bt-card__title">카드 제목</h3>
+  <div class="bt-card__body">
+    <p>카드 내용입니다.</p>
+  </div>
+  <div class="bt-card__footer">
+    <button class="bt-button bt-button--sm bt-button--text">취소</button>
+    <button class="bt-button bt-button--sm bt-button--filled">저장</button>
+  </div>
 </div>
+
+<!-- Footer 정렬 (React footerAlign prop 과 동일, 기본 end) -->
+<div class="bt-card__footer bt-card__footer--start">...</div>
+<div class="bt-card__footer bt-card__footer--between">...</div>
+<div class="bt-card__footer bt-card__footer--end">...</div>
 
 <!-- Shadow (React Card shadow prop 과 동일) -->
 <div class="bt-card bt-card--shadow-none bt-card--p-md">내용</div>
@@ -566,6 +689,14 @@ Alert는 JavaScript로만 사용합니다.
 - `.bt-card--{accent|outlined|glass}` (선택) - variant. 미지정 시 `default`
 - `.bt-card--interactive` (선택)
 
+**내부 요소:**
+- `.bt-card__title` - 제목. React `headingAs`(기본 `h3`)와 맞춰 **`<h2>`~`<h6>` 시맨틱 헤딩**을 쓰세요
+  (`<div>` 로 쓰면 스크린리더 문서 개요에서 빠집니다)
+- `.bt-card__body` - 본문 영역
+- `.bt-card__footer` - 하단 액션 영역. 위에 구분선(`border-top`)이 붙고,
+  `--start` / `--between` / `--end`(기본) 로 정렬을 바꿉니다.
+  `--accent` / `--glass` 카드에서는 구분선이 반투명 흰색으로 자동 전환됩니다 (React 와 동일)
+
 > `.bt-card` 는 클래스를 하나도 더 붙이지 않아도 React `<Card>` 기본값과 같은
 > 그림자(sm)·여백(md)을 갖습니다. 없애려면 `--shadow-none` / `--p-none` 을 명시하세요.
 
@@ -589,8 +720,19 @@ React `<Spinner size>` 가 px 숫자를 그대로 받는 것과 맞춰, 크기�
 > `role="status"` + `aria-label` 을 직접 붙이세요 - React `<Spinner>` 는 이 둘을 자동으로
 > 렌더링하지만 Vanilla 는 CSS 만 제공하므로 마크업에서 지정해야 스크린리더에 로딩 상태가 전달됩니다.
 >
-> 회전 모양은 React 와 다릅니다 - React 는 12개 bar 가 페이드하는 iOS 스타일이고
-> Vanilla 는 단일 border spinner 입니다 (CSS 만으로 동일 렌더 불가 - 의도된 차이).
+> **회전 모양은 React 와 다릅니다 (의도된 차이, 통일 계획 없음).**
+> React `<Spinner>` 는 12개 bar 가 순차적으로 페이드하는 iOS 스타일이고, Vanilla 는 단일 border ring 입니다.
+> React 는 컴포넌트가 12개 `<span>` 을 직접 렌더링하지만, Vanilla 는 Thymeleaf/JSP 같은
+> 서버 템플릿에서 **빈 요소 하나(`<span class="bt-spinner">`)만 찍으면 되는 마크업 단순성**을
+> 우선했습니다. 12개 bar 를 CSS 만으로(추가 DOM 없이) 만들 수 없으므로 형태를 맞추려면
+> 템플릿마다 12개 자식을 반복해야 하고, 그 비용이 시각적 일치보다 크다고 판단했습니다.
+>
+> **reduced motion 대응도 이 형태 차이 때문에 갈립니다 (역시 의도된 차이).**
+> React 는 `prefers-reduced-motion: reduce` 에서 애니메이션을 완전히 정지시킵니다
+> (`animation: none; opacity: .5`) - 12개 spoke 는 멈춰 있어도 "로딩 위젯"으로 읽히기 때문입니다.
+> Vanilla 의 단일 ring 은 멈추면 그냥 원 하나라 상태 정보가 사라지므로, 정지 대신
+> 회전을 크게 늦춥니다(0.8s → 2.4s). 둘 다 "모션은 줄이되 로딩 상태는 유지"라는 같은 원칙의
+> 서로 다른 구현입니다.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
 		},
 		{
 			"path": "dist/vanilla/bigtablet.min.js",
-			"limit": "5 kB"
+			"limit": "7 kB",
+			"message": "Raised 5 kB -> 7 kB on 2026-08-06: Dropdown multiple/searchable pushed the baseline from 4.13 kB to 5.6 kB, 0.6 kB over the old limit. The current limit leaves 1.4 kB. Re-measure before raising again."
 		},
 		{
 			"path": "dist/index.css",

--- a/src/vanilla/CLAUDE.md
+++ b/src/vanilla/CLAUDE.md
@@ -40,9 +40,15 @@ dist/vanilla/
 | Dropdown | `.bt-dropdown` | | |
 | Dropdown Control | `.bt-dropdown__control` | `--outline/filled`, `--sm/md/lg` | `.is-open`, `.is-disabled` |
 | Dropdown List | `.bt-dropdown__list` | `--up` (opens upward) | |
-| Dropdown Option | `.bt-dropdown__option` | | `.is-selected`, `.is-active`, `.is-disabled` |
+| Dropdown Search | `.bt-dropdown__search` (+ `__search-icon`, `__search-input`) | | |
+| Dropdown Options | `.bt-dropdown__options` (role=listbox 스크롤 컨테이너) | | |
+| Dropdown Option | `.bt-dropdown__option` | | `.is-selected`, `.is-active`, `.is-disabled`, `[hidden]`(필터로 숨김) |
+| Dropdown Option Check | `.bt-dropdown__option-check` (multiple 전용 좌측 체크 슬롯) | | |
+| Dropdown Empty | `.bt-dropdown__empty` (검색 결과 0개) | | |
 | Modal | `.bt-modal` | | `.is-open` |
 | Card | `.bt-card` | `--bordered`, `--shadow-none/sm/md/lg`(기본 sm), `--p-none/sm/md/lg`(기본 md), `--accent/glass/outlined`, `--interactive` | |
+| Card Title / Body | `.bt-card__title`(h2~h6), `.bt-card__body` | | |
+| Card Footer | `.bt-card__footer` | `--start/between/end`(기본 end) | |
 | Spinner | `.bt-spinner` | 없음 - 크기는 `--bt-spinner-size` (기본 24px) | |
 | Pagination | `.bt-pagination` | | |
 | DatePicker | `.bt-date-picker` | `--full-width` | |
@@ -120,6 +126,30 @@ dist/vanilla/
 </div>
 ```
 
+React 와 동일하게 `multiple` / `searchable` 을 지원한다. 마크업은 그대로 두고
+`data-multiple` / `data-searchable` 만 붙이면 되고, 검색 행(`__search`)·스크롤 컨테이너
+(`__options`)·빈 결과(`__empty`)·체크 슬롯(`__option-check`)은 JS 가 만들어 넣는다.
+
+```html
+<!-- 다중 선택 - 옵션 토글 시 패널 유지, 트리거는 "N개 선택" 요약, hidden input 은 같은 name 반복 -->
+<div class="bt-dropdown" data-bt-dropdown data-multiple data-name="topping">
+  <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+    <span class="bt-dropdown__placeholder">토핑을 고르세요...</span>
+    <span class="bt-dropdown__icon">▼</span>
+  </button>
+  <ul class="bt-dropdown__list">
+    <li class="bt-dropdown__option" data-value="cheese">치즈</li>
+    <li class="bt-dropdown__option" data-value="bacon">베이컨</li>
+  </ul>
+</div>
+
+<!-- 검색 - 대소문자·공백 무시 부분 일치. 한글 IME 조합 중에는 필터를 보류한다. -->
+<div class="bt-dropdown" data-bt-dropdown data-searchable
+     data-search-placeholder="검색…" data-empty-text="결과 없음">
+  ...
+</div>
+```
+
 #### Modal
 ```html
 <button data-bt-modal-open="my-modal">Open</button>
@@ -141,9 +171,17 @@ dist/vanilla/
 
 #### Card
 ```html
+<!-- title / body / footer 3단 구성 (React Card 의 heading / children / footer 와 동일).
+     제목은 React `headingAs`(기본 h3)와 맞춰 시맨틱 헤딩 태그를 쓴다. -->
 <div class="bt-card bt-card--bordered bt-card--p-md">
-  <div class="bt-card__title">Title</div>
-  <p>Content</p>
+  <h3 class="bt-card__title">Title</h3>
+  <div class="bt-card__body">
+    <p>Content</p>
+  </div>
+  <div class="bt-card__footer">  <!-- --start / --between / --end (기본 end) -->
+    <button class="bt-button bt-button--sm bt-button--text">Cancel</button>
+    <button class="bt-button bt-button--sm bt-button--filled">Save</button>
+  </div>
 </div>
 
 <div class="bt-card bt-card--shadow-md bt-card--p-lg">
@@ -175,15 +213,26 @@ dist/vanilla/
 ```javascript
 // Auto-init: elements with data-bt-* are initialized on DOMContentLoaded
 
-// Manual initialization
+// Manual initialization - 옵션 이름은 React Dropdown prop 과 동일 (별칭 없음)
 const dropdown = Bigtablet.Dropdown('#my-dropdown', {
   options: [{ value: '1', label: 'One' }],
+  placeholder: 'Select...',
+  name: 'field',            // hidden input 으로 폼 제출 참여 (multiple 은 같은 name 반복)
+  multiple: false,          // true 면 값이 string[] 이고 선택해도 패널이 닫히지 않는다
+  searchable: false,        // true 면 패널 상단 검색 입력 (대소문자·공백 무시, IME 조합 중 필터 보류)
+  searchPlaceholder: '검색…',
+  emptyText: '결과 없음',
+  selectedSummary: (count) => `${count}개 선택`,  // multiple 트리거 요약 문구
   onValueChange: (value, option) => console.log(value)
+  // multiple 이면 (values: string[], options: Option[]) 로 호출된다
 });
-dropdown.getValue();
-dropdown.setValue('1');
+dropdown.getValue();        // 단일 → string | null / 다중 → string[]
+dropdown.setValue('1');     // 다중 모드는 배열도 받는다: setValue(['1', '2'])
 dropdown.open();
 dropdown.close();
+dropdown.toggle();
+dropdown.setDisabled(true);
+dropdown.destroy();         // 바인딩한 리스너 해제
 
 const modal = Bigtablet.Modal('#my-modal', {
   closeOnOverlay: true,

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -223,6 +223,11 @@
 		if (!listbox) {
 			if (searchable) {
 				const inner = panel;
+				// `bt-dropdown__list*` 만 새 패널로 옮긴다. 소비자가 붙인 커스텀 클래스는 원래
+				// 붙어 있던 요소(= 이제 `__options` 스크롤 컨테이너)에 그대로 둔다 - 클래스가
+				// 노드를 따라가야 리스트 내부를 겨냥한 셀렉터가 유지된다. 패널 wrapper 를
+				// 직접 스타일링하려면 `__options` 를 포함한 최종 구조를 마크업에 직접 쓰면
+				// 이 승격 자체를 건너뛴다 (docs/VANILLA.md 의 주의 박스 참고).
 				const listClasses = Array.from(inner.classList).filter((c) =>
 					c.startsWith("bt-dropdown__list"),
 				);

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -104,10 +104,37 @@
      Dropdown Component
      ======================================== */
 
+	/** 검색 매칭용 정규화 - 대소문자·공백 무시 (React `normalizeForSearch` 와 동일 규칙) */
+	function normalizeForSearch(str) {
+		return String(str).toLowerCase().replace(/\s+/g, "");
+	}
+
+	/**
+	 * data-* boolean 속성 파싱 - 속성이 없으면 undefined(=설정 안 함),
+	 * 있으면 `"false"` 만 false 로 보고 나머지(빈 문자열 포함)는 true.
+	 */
+	function parseBoolAttr(value) {
+		if (value === undefined) return undefined;
+		return value !== "false";
+	}
+
+	/** 검색 행 아이콘 (lucide `Search` 와 동일한 path - React Dropdown 이 쓰는 아이콘) */
+	const SEARCH_ICON_SVG =
+		'<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+		'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+		'<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>';
+
+	/** 다중 선택 체크 아이콘 (lucide `Check`) - 선택 여부는 CSS 가 토글한다 */
+	const CHECK_ICON_SVG =
+		'<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+		'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+		'<path d="M20 6 9 17l-5-5"/></svg>';
+
 	/**
 	 * Initialize Dropdown component (React `<Dropdown>` 의 Vanilla 대응)
 	 *
-	 * React 의 `multiple` / `searchable` 은 아직 지원하지 않는다 - 단일 선택 전용.
+	 * React 와 동일하게 단일 선택(기본), `multiple`(다중 선택), `searchable`(검색)을 지원한다.
+	 * 값 타입도 React `value` prop 과 같은 규칙 - 단일은 `string | null`, 다중은 `string[]`.
 	 * @param {HTMLElement|string} element - Dropdown wrapper element or selector
 	 * @param {Object} options - Configuration options
 	 */
@@ -118,30 +145,100 @@
 		const config = {
 			placeholder: "Select...",
 			disabled: false,
+			// React Dropdown 과 동일한 이름의 옵션들 (별칭 없음).
+			multiple: false,
+			searchable: false,
+			searchPlaceholder: "검색…",
+			emptyText: "결과 없음",
+			selectedSummary: (count) => `${count}개 선택`,
 			// React Dropdown 과 동일한 값 변경 콜백.
 			onValueChange: null,
 			...options,
 		};
 
+		// data-* 폴백 - data-options / data-name 과 같은 기존 규칙의 연장.
+		// JS 로 명시한 값이 항상 우선하고, 속성은 서버 템플릿 전용 진입점이다.
+		if (options.multiple === undefined) {
+			const attr = parseBoolAttr(wrapper.dataset.multiple);
+			if (attr !== undefined) config.multiple = attr;
+		}
+		if (options.searchable === undefined) {
+			const attr = parseBoolAttr(wrapper.dataset.searchable);
+			if (attr !== undefined) config.searchable = attr;
+		}
+		if (options.searchPlaceholder === undefined && wrapper.dataset.searchPlaceholder) {
+			config.searchPlaceholder = wrapper.dataset.searchPlaceholder;
+		}
+		if (options.emptyText === undefined && wrapper.dataset.emptyText) {
+			config.emptyText = wrapper.dataset.emptyText;
+		}
+		if (options.placeholder === undefined && wrapper.dataset.placeholder) {
+			config.placeholder = wrapper.dataset.placeholder;
+		} else if (options.placeholder === undefined) {
+			// 서버 마크업의 `.bt-dropdown__placeholder` 텍스트를 기본 placeholder 로 이어받는다.
+			// (없으면 값을 지웠을 때 마크업에 쓴 문구 대신 라이브러리 기본값이 튀어나온다.)
+			const markupPlaceholder = wrapper
+				.querySelector(".bt-dropdown__placeholder")
+				?.textContent.trim();
+			if (markupPlaceholder) config.placeholder = markupPlaceholder;
+		}
+
+		const multiple = config.multiple === true;
+		const searchable = config.searchable === true;
+
 		const state = {
 			isOpen: false,
-			value: config.defaultValue || null,
+			// 단일 모드 값 (string | null) / 다중 모드 값 목록 (string[]) - 모드에 따라 하나만 쓴다.
+			value: null,
+			values: [],
 			activeIndex: -1,
 			options: [],
+			// 검색 필터를 통과한 옵션들의 raw index 목록 (searchable 아니면 전체)
+			visible: [],
+			// searchText 는 표시용(IME 조합 중에도 즉시 반영), committedQuery 는 필터용(조합 완료 시 반영)
+			committedQuery: "",
 		};
+		let isComposing = false;
 
 		// Create DOM structure
 		const controlId = wrapper.id || generateId("dropdown");
-		const _listId = `${controlId}_listbox`;
 
 		const control = wrapper.querySelector(".bt-dropdown__control");
-		const list = wrapper.querySelector(".bt-dropdown__list");
+		let panel = wrapper.querySelector(".bt-dropdown__list");
 
-		if (!control || !list) {
+		if (!control || !panel) {
 			console.warn(
 				"Dropdown: Missing required elements (.bt-dropdown__control, .bt-dropdown__list)",
 			);
 			return null;
+		}
+
+		// 패널 구조 정규화 - React 는 `__list`(패널) > [`__search`] + `__options`(role=listbox, 스크롤)다.
+		// Vanilla 는 `<ul class="bt-dropdown__list">` 에 `<li>` 를 직접 두는 평면 마크업을 계속
+		// 지원해야 하므로, `__options` 컨테이너가 없으면 `__list` 자체를 listbox 로 쓴다.
+		// 단 searchable 은 검색 행이 패널 안에 들어가야 하는데 `<ul>` 의 자식은 `<li>` 만 유효하다.
+		// 그래서 평면 마크업 + searchable 이면 여기서 패널 `<div>` 로 감싸 올린다
+		// (서버 템플릿을 고치지 않아도 검색이 동작하도록).
+		let listbox = panel.querySelector(".bt-dropdown__options");
+		if (!listbox) {
+			if (searchable) {
+				const inner = panel;
+				const listClasses = Array.from(inner.classList).filter((c) =>
+					c.startsWith("bt-dropdown__list"),
+				);
+				const newPanel = document.createElement("div");
+				newPanel.className = listClasses.join(" ");
+				inner.classList.remove(...listClasses);
+				inner.classList.add("bt-dropdown__options");
+				// 마크업이 FOUC 방지용으로 걸어둔 inline display:none 은 패널로 넘긴다.
+				inner.style.display = "";
+				inner.parentNode.insertBefore(newPanel, inner);
+				newPanel.appendChild(inner);
+				listbox = inner;
+				panel = newPanel;
+			} else {
+				listbox = panel;
+			}
 		}
 
 		// 초기 비활성 상태 흡수 - 서버가 native `disabled` 또는 `is-disabled` 로 렌더링했으면 config 에 반영.
@@ -156,7 +253,7 @@
 		// 지원해야 하므로 DOM 파싱이 반드시 필요하다.
 		// data-options 는 잘못된 JSON(작은따옴표 등)이면 스크립트 전체가 크래시하므로 방어적 파싱.
 		const parseDomOptions = () =>
-			$$(".bt-dropdown__option", list).map((el) => ({
+			$$(".bt-dropdown__option", listbox).map((el) => ({
 				value: el.dataset.value !== undefined ? el.dataset.value : el.textContent.trim(),
 				label: el.textContent.trim(),
 				disabled: el.classList.contains("is-disabled"),
@@ -182,68 +279,244 @@
 
 		state.options = optionsData;
 
-		// Combobox ARIA (WAI-ARIA APG select-only combobox) - React Dropdown 과 패리티
-		list.id = list.id || _listId;
-		list.setAttribute("role", "listbox");
-		control.setAttribute("role", "combobox");
+		// 옵션 DOM. 데이터만 넘기고 `<li>` 를 서버가 렌더링하지 않은 경우(data-options / config.options
+		// 단독 사용)에는 여기서 생성한다 - 그래야 데이터와 DOM 인덱스가 항상 1:1 로 맞는다.
+		let optionEls = $$(".bt-dropdown__option", listbox);
+		if (optionEls.length === 0 && state.options.length > 0) {
+			const itemTag = listbox.tagName === "UL" || listbox.tagName === "OL" ? "li" : "div";
+			state.options.forEach((opt) => {
+				const el = document.createElement(itemTag);
+				el.className = "bt-dropdown__option";
+				if (opt.disabled) el.classList.add("is-disabled");
+				el.dataset.value = opt.value;
+				// textContent - 라벨은 소비자 데이터라 innerHTML 금지 (XSS)
+				el.textContent = opt.label;
+				listbox.appendChild(el);
+			});
+			optionEls = $$(".bt-dropdown__option", listbox);
+		}
+
+		// Combobox ARIA (WAI-ARIA APG combobox) - React Dropdown 과 패리티.
+		// searchable 이면 React 처럼 combobox 역할을 검색 입력이 갖고, 트리거는 팝업 버튼으로 남는다.
+		listbox.id = listbox.id || `${controlId}_listbox`;
+		listbox.setAttribute("role", "listbox");
+		if (multiple) listbox.setAttribute("aria-multiselectable", "true");
 		control.setAttribute("aria-haspopup", "listbox");
 		control.setAttribute("aria-expanded", "false");
-		control.setAttribute("aria-controls", list.id);
-		$$(".bt-dropdown__option", list).forEach((el, i) => {
+		control.setAttribute("aria-controls", listbox.id);
+		if (searchable) control.removeAttribute("role");
+		else control.setAttribute("role", "combobox");
+
+		optionEls.forEach((el, i) => {
 			el.id = el.id || `${controlId}_option_${i}`;
 			el.setAttribute("role", "option");
 			el.setAttribute("aria-selected", "false");
 			if (state.options[i]?.disabled) el.setAttribute("aria-disabled", "true");
+			// 다중 선택: 왼쪽 체크 슬롯. 미선택 시에도 폭을 유지해 라벨 정렬이 흔들리지 않는다.
+			if (multiple && !el.querySelector(".bt-dropdown__option-check")) {
+				const check = document.createElement("span");
+				check.className = "bt-dropdown__option-check";
+				check.setAttribute("aria-hidden", "true");
+				check.innerHTML = CHECK_ICON_SVG; // 정적 문자열 - 소비자 데이터 아님
+				el.insertBefore(check, el.firstChild);
+			}
 		});
 
-		// 폼 제출 참여: name(설정 또는 data-name)이 있으면 hidden input 으로 값을 노출한다.
-		// 서버 템플릿(th:field 등)이 미리 렌더링한 hidden input 이 있으면 그대로 재사용 -
-		// name/초기값을 서버 바인딩에서 이어받는다.
-		let hiddenInput = wrapper.querySelector('input[type="hidden"]');
-		const fieldName = config.name || wrapper.dataset.name || null;
-		if (!hiddenInput && fieldName) {
-			hiddenInput = document.createElement("input");
-			hiddenInput.type = "hidden";
-			hiddenInput.name = fieldName;
-			wrapper.appendChild(hiddenInput);
+		// 검색 행 (searchable) - React `.dropdown_search` 구조와 동일.
+		let searchInput = null;
+		let emptyEl = null;
+		if (searchable) {
+			let searchRow = panel.querySelector(".bt-dropdown__search");
+			if (!searchRow) {
+				searchRow = document.createElement("div");
+				searchRow.className = "bt-dropdown__search";
+				const icon = document.createElement("span");
+				icon.className = "bt-dropdown__search-icon";
+				icon.setAttribute("aria-hidden", "true");
+				icon.innerHTML = SEARCH_ICON_SVG; // 정적 문자열 - 소비자 데이터 아님
+				searchRow.appendChild(icon);
+				panel.insertBefore(searchRow, panel.firstChild);
+			}
+			searchInput = searchRow.querySelector(".bt-dropdown__search-input");
+			if (!searchInput) {
+				searchInput = document.createElement("input");
+				searchInput.type = "text";
+				searchInput.className = "bt-dropdown__search-input";
+				searchInput.autocomplete = "off";
+				searchRow.appendChild(searchInput);
+			}
+			searchInput.placeholder = config.searchPlaceholder;
+			searchInput.setAttribute("aria-label", config.searchPlaceholder);
+			searchInput.setAttribute("role", "combobox");
+			searchInput.setAttribute("aria-autocomplete", "list");
+			searchInput.setAttribute("aria-expanded", "false");
+			searchInput.setAttribute("aria-controls", listbox.id);
+
+			// 필터 결과 0개 안내 (React `.dropdown_empty`)
+			emptyEl = listbox.querySelector(".bt-dropdown__empty");
+			if (!emptyEl) {
+				const emptyTag = listbox.tagName === "UL" || listbox.tagName === "OL" ? "li" : "div";
+				emptyEl = document.createElement(emptyTag);
+				emptyEl.className = "bt-dropdown__empty";
+				listbox.appendChild(emptyEl);
+			}
+			emptyEl.textContent = config.emptyText;
+			emptyEl.hidden = true;
 		}
 
-		// State management
-		function setValue(newValue) {
-			state.value = newValue;
-			// String 비교 - 서버 hidden input 초기값(항상 문자열)과 JS config 의 숫자 value 가
-			// 섞여도 매칭되도록 (엄격 === 이면 조용히 placeholder 로 남던 문제 방지).
-			const option = state.options.find((o) => String(o.value) === String(newValue));
+		/** aria-activedescendant 를 갖는 요소 - searchable 이면 검색 입력, 아니면 트리거 */
+		const activeDescendantHost = () => (searchable ? searchInput : control);
 
-			// 폼 제출용 hidden input 동기화
-			if (hiddenInput) {
-				hiddenInput.value = newValue == null ? "" : newValue;
+		// 폼 제출 참여: name(설정 또는 data-name, 서버가 미리 렌더링한 hidden input 의 name)이 있으면
+		// 값을 hidden input 으로 노출한다. 다중 모드는 React 와 동일하게 **같은 name 의 input 을 반복**한다.
+		// 서버 템플릿(th:field 등)이 미리 렌더링한 hidden input 이 있으면 그대로 재사용한다.
+		const hiddenEls = $$('input[type="hidden"]', wrapper);
+		const hiddenName = config.name || wrapper.dataset.name || hiddenEls[0]?.name || null;
+		if (hiddenEls.length === 0 && hiddenName) {
+			const el = document.createElement("input");
+			el.type = "hidden";
+			el.name = hiddenName;
+			wrapper.appendChild(el);
+			hiddenEls.push(el);
+		}
+
+		function syncHiddenInputs() {
+			if (!hiddenName) return;
+			// 단일: 항상 1개 유지(빈 값이라도 전송 - 기존 동작). 다중: 선택 개수만큼 반복, 0개면 없음(React 와 동일).
+			const values = multiple
+				? state.values.map((v) => (v == null ? "" : String(v)))
+				: [state.value == null ? "" : String(state.value)];
+			while (hiddenEls.length > values.length) {
+				hiddenEls.pop().remove();
 			}
+			while (hiddenEls.length < values.length) {
+				const el = document.createElement("input");
+				el.type = "hidden";
+				el.name = hiddenName;
+				wrapper.appendChild(el);
+				hiddenEls.push(el);
+			}
+			hiddenEls.forEach((el, i) => {
+				el.value = values[i];
+			});
+		}
 
+		// String 비교 - 서버 hidden input 초기값(항상 문자열)과 JS config 의 숫자 value 가
+		// 섞여도 매칭되도록 (엄격 === 이면 조용히 placeholder 로 남던 문제 방지).
+		function findOption(value) {
+			return state.options.find((o) => String(o.value) === String(value));
+		}
+
+		function isSelected(value) {
+			if (value === undefined) return false;
+			return multiple
+				? state.values.some((v) => String(v) === String(value))
+				: state.value != null && String(state.value) === String(value);
+		}
+
+		function selectedOptions() {
+			return state.values.map(findOption).filter(Boolean);
+		}
+
+		/** 트리거 텍스트 + 옵션 selected 상태 + hidden input 을 현재 값에 맞춰 갱신 */
+		function renderSelection() {
 			const valueEl = control.querySelector(".bt-dropdown__value, .bt-dropdown__placeholder");
 			if (valueEl) {
-				if (option) {
-					valueEl.textContent = option.label;
-					valueEl.classList.remove("bt-dropdown__placeholder");
-					valueEl.classList.add("bt-dropdown__value");
+				let text = config.placeholder;
+				let hasValue = false;
+				if (multiple) {
+					// React 와 동일하게 chip 이 아니라 "N개 선택" 요약 문자열을 보여준다.
+					hasValue = state.values.length > 0;
+					if (hasValue) text = config.selectedSummary(state.values.length);
 				} else {
-					valueEl.textContent = config.placeholder;
-					valueEl.classList.remove("bt-dropdown__value");
-					valueEl.classList.add("bt-dropdown__placeholder");
+					const option = findOption(state.value);
+					hasValue = Boolean(option);
+					if (option) text = option.label;
 				}
+				valueEl.textContent = text;
+				valueEl.classList.toggle("bt-dropdown__value", hasValue);
+				valueEl.classList.toggle("bt-dropdown__placeholder", !hasValue);
 			}
 
-			// Update selected state in list
-			$$(".bt-dropdown__option", list).forEach((el, i) => {
-				// String 비교(#374: 숫자 value vs 문자열 hidden 초기값) + aria-selected(#379: AT 노출)
-				const selected = String(state.options[i]?.value) === String(newValue);
+			optionEls.forEach((el, i) => {
+				const selected = isSelected(state.options[i]?.value);
 				el.classList.toggle("is-selected", selected);
 				el.setAttribute("aria-selected", selected ? "true" : "false");
 			});
 
-			if (config.onValueChange) {
-				config.onValueChange(newValue, option);
+			syncHiddenInputs();
+		}
+
+		/**
+		 * 값 설정. React `value` prop 과 같은 타입 규칙 -
+		 * 단일 모드는 `string | null`, 다중 모드는 `string[]`(단일 값을 주면 1개짜리로 승격).
+		 */
+		function setValue(newValue) {
+			if (multiple) {
+				state.values =
+					newValue == null ? [] : Array.isArray(newValue) ? newValue.slice() : [newValue];
+				renderSelection();
+				if (config.onValueChange) config.onValueChange(state.values.slice(), selectedOptions());
+			} else {
+				state.value = Array.isArray(newValue) ? (newValue[0] ?? null) : newValue;
+				renderSelection();
+				if (config.onValueChange)
+					config.onValueChange(state.value, findOption(state.value) ?? null);
 			}
+		}
+
+		/** 다중 모드 토글 - React `toggleMultiple` 과 동일하게 선택 순서를 유지한다 */
+		function toggleValue(option) {
+			const next = isSelected(option.value)
+				? state.values.filter((v) => String(v) !== String(option.value))
+				: [...state.values, option.value];
+			setValue(next);
+		}
+
+		function updateActiveOption() {
+			let activeId = null;
+			optionEls.forEach((el, i) => {
+				const active = i === state.activeIndex;
+				el.classList.toggle("is-active", active);
+				if (active) activeId = el.id;
+			});
+			// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음).
+			// 활성 옵션이 없으면(activeIndex=-1 등) 잘못된 참조가 남지 않게 속성을 제거.
+			const host = activeDescendantHost();
+			if (!host) return;
+			if (activeId) {
+				host.setAttribute("aria-activedescendant", activeId);
+			} else {
+				host.removeAttribute("aria-activedescendant");
+			}
+		}
+
+		/** 필터를 통과하고 비활성이 아닌 첫 옵션의 raw index (없으면 -1) */
+		function firstEnabledVisible() {
+			return state.visible.find((i) => !state.options[i]?.disabled) ?? -1;
+		}
+
+		/**
+		 * 검색어 기준으로 옵션 표시/숨김을 갱신한다.
+		 * 키보드 탐색·Enter 선택은 모두 여기서 만든 `state.visible`(필터된 목록) 위에서 동작한다.
+		 */
+		function applyFilter() {
+			const query = searchable ? normalizeForSearch(state.committedQuery) : "";
+			state.visible = [];
+			optionEls.forEach((el, i) => {
+				const label = state.options[i]?.label ?? el.textContent;
+				const match = query === "" || normalizeForSearch(label).includes(query);
+				el.hidden = !match;
+				if (match) state.visible.push(i);
+			});
+			if (emptyEl) emptyEl.hidden = state.visible.length > 0;
+			if (!state.isOpen) {
+				state.activeIndex = -1;
+			} else if (!state.visible.includes(state.activeIndex)) {
+				// 활성 옵션이 필터로 사라졌으면 첫 후보로 되돌린다
+				state.activeIndex = firstEnabledVisible();
+			}
+			updateActiveOption();
 		}
 
 		function open() {
@@ -252,7 +525,8 @@
 			state.isOpen = true;
 			control.classList.add("is-open");
 			control.setAttribute("aria-expanded", "true");
-			list.style.display = "block";
+			panel.style.display = "block";
+			if (searchInput) searchInput.setAttribute("aria-expanded", "true");
 
 			// Calculate position (auto-flip)
 			const rect = control.getBoundingClientRect();
@@ -261,15 +535,17 @@
 			const spaceAbove = rect.top;
 
 			if (spaceBelow < listHeight && spaceAbove > spaceBelow) {
-				list.classList.add("bt-dropdown__list--up");
+				panel.classList.add("bt-dropdown__list--up");
 			} else {
-				list.classList.remove("bt-dropdown__list--up");
+				panel.classList.remove("bt-dropdown__list--up");
 			}
 
-			// Set active index
-			const selectedIndex = state.options.findIndex((o) => o.value === state.value);
-			state.activeIndex = selectedIndex >= 0 ? selectedIndex : 0;
-			updateActiveOption();
+			// Set active index - 선택된 항목이 있으면 그쪽, 없으면 첫 후보 (React 와 동일).
+			// applyFilter 가 필터 밖(=-1 포함)이면 첫 후보로 보정한다.
+			state.activeIndex = state.options.findIndex((o) => isSelected(o.value) && !o.disabled);
+			applyFilter();
+
+			if (searchInput) searchInput.focus();
 
 			// Rotate icon
 			const icon = control.querySelector(".bt-dropdown__icon");
@@ -281,10 +557,28 @@
 			control.classList.remove("is-open");
 			control.setAttribute("aria-expanded", "false");
 			control.removeAttribute("aria-activedescendant");
-			list.style.display = "none";
+			panel.style.display = "none";
+
+			// 패널을 닫으면 검색 상태 초기화 (다음 열림 시 fresh - React 와 동일)
+			if (searchInput) {
+				searchInput.value = "";
+				searchInput.setAttribute("aria-expanded", "false");
+				searchInput.removeAttribute("aria-activedescendant");
+			}
+			state.committedQuery = "";
+			isComposing = false;
+			state.activeIndex = -1;
+			applyFilter();
 
 			const icon = control.querySelector(".bt-dropdown__icon");
 			if (icon) icon.classList.remove("is-open");
+		}
+
+		/** searchable 은 포커스가 검색 입력에 있으므로 닫을 때 트리거로 되돌린다 (React `closePanel`) */
+		function closePanel() {
+			const wasOpen = state.isOpen;
+			close();
+			if (wasOpen && searchable) control.focus();
 		}
 
 		function toggle() {
@@ -295,42 +589,35 @@
 			}
 		}
 
-		function updateActiveOption() {
-			let activeId = null;
-			$$(".bt-dropdown__option", list).forEach((el, i) => {
-				const active = i === state.activeIndex;
-				el.classList.toggle("is-active", active);
-				if (active) activeId = el.id;
-			});
-			// 키보드 탐색 중 활성 옵션을 AT 에 전달 (없으면 화살표 탐색이 스크린리더에 무음).
-			// 활성 옵션이 없으면(activeIndex=-1 등) 잘못된 참조가 남지 않게 속성을 제거.
-			if (activeId) {
-				control.setAttribute("aria-activedescendant", activeId);
-			} else {
-				control.removeAttribute("aria-activedescendant");
-			}
+		/** 필터된 목록 위에서 활성 항목을 이동한다 (비활성 옵션은 건너뛰고 순환) */
+		function moveActive(dir) {
+			const candidates = state.visible.filter((i) => !state.options[i]?.disabled);
+			if (candidates.length === 0) return;
+			const pos = candidates.indexOf(state.activeIndex);
+			state.activeIndex =
+				pos === -1
+					? dir === 1
+						? candidates[0]
+						: candidates[candidates.length - 1]
+					: candidates[(pos + dir + candidates.length) % candidates.length];
+			updateActiveOption();
 		}
 
-		function moveActive(dir) {
-			const len = state.options.length;
-			let i = state.activeIndex;
-
-			for (let step = 0; step < len; step++) {
-				i = (i + dir + len) % len;
-				if (!state.options[i].disabled) {
-					state.activeIndex = i;
-					updateActiveOption();
-					break;
-				}
+		/** 옵션 확정 - 단일은 선택 후 닫고, 다중은 토글만 하고 패널을 유지한다 (React 와 동일) */
+		function selectOption(index) {
+			const option = state.options[index];
+			if (!option || option.disabled) return;
+			if (multiple) {
+				toggleValue(option);
+			} else {
+				setValue(option.value);
+				closePanel();
 			}
 		}
 
 		function selectActive() {
-			const option = state.options[state.activeIndex];
-			if (option && !option.disabled) {
-				setValue(option.value);
-				close();
-			}
+			if (!state.visible.includes(state.activeIndex)) return;
+			selectOption(state.activeIndex);
 		}
 
 		// Event handlers
@@ -371,15 +658,15 @@
 				case "Home":
 					e.preventDefault();
 					open();
-					state.activeIndex = state.options.findIndex((o) => !o.disabled);
+					state.activeIndex = firstEnabledVisible();
 					updateActiveOption();
 					break;
 				case "End":
 					e.preventDefault();
 					open();
-					for (let i = state.options.length - 1; i >= 0; i--) {
-						if (!state.options[i].disabled) {
-							state.activeIndex = i;
+					for (let i = state.visible.length - 1; i >= 0; i--) {
+						if (!state.options[state.visible[i]]?.disabled) {
+							state.activeIndex = state.visible[i];
 							updateActiveOption();
 							break;
 						}
@@ -388,6 +675,40 @@
 				case "Escape":
 					e.preventDefault();
 					close();
+					break;
+				case "Tab":
+					// APG Combobox: Tab 은 리스트를 닫고 자연스러운 포커스 이동을 허용 (preventDefault 안 함)
+					close();
+					break;
+			}
+		}
+
+		// 검색 입력 내 키보드 - ↑/↓ 이동, Enter 선택/토글, Esc 닫기. Home/End 는 커서 이동에 양보.
+		function onSearchKeyDown(e) {
+			// IME 조합 중 Enter 는 조합 확정용 - 선택/토글·네비게이션·닫기 트리거 금지
+			// (`keyCode === 229` 는 isComposing 을 채우지 않는 구형 브라우저 폴백)
+			if (e.isComposing || e.keyCode === 229) return;
+			switch (e.key) {
+				case "ArrowDown":
+					e.preventDefault();
+					moveActive(1);
+					break;
+				case "ArrowUp":
+					e.preventDefault();
+					moveActive(-1);
+					break;
+				case "Enter":
+					e.preventDefault();
+					selectActive();
+					break;
+				case "Escape":
+					e.preventDefault();
+					closePanel();
+					break;
+				case "Tab":
+					// APG Combobox: Tab 은 리스트를 닫는다. closePanel 이 트리거로 포커스를
+					// 되돌린 뒤 브라우저 기본 Tab 이동이 이어진다 (preventDefault 안 함).
+					closePanel();
 					break;
 			}
 		}
@@ -401,17 +722,13 @@
 		function onOptionClick(index) {
 			return (e) => {
 				e.preventDefault();
-				const option = state.options[index];
-				if (option && !option.disabled) {
-					setValue(option.value);
-					close();
-				}
+				selectOption(index);
 			};
 		}
 
 		function onOptionMouseEnter(index) {
 			return () => {
-				if (!state.options[index].disabled) {
+				if (!state.options[index]?.disabled) {
 					state.activeIndex = index;
 					updateActiveOption();
 				}
@@ -425,23 +742,60 @@
 			on(document, "mousedown", onDocumentClick),
 		];
 
-		$$(".bt-dropdown__option", list).forEach((el, i) => {
+		optionEls.forEach((el, i) => {
 			cleanups.push(on(el, "click", onOptionClick(i)));
 			cleanups.push(on(el, "mouseenter", onOptionMouseEnter(i)));
 		});
 
-		// Initialize
-		list.style.display = "none";
-		if (config.defaultValue) {
+		if (searchInput) {
+			// IME(한글 등) 조합 중에는 필터 갱신을 보류한다 - 조합 중간 자모로 리스트가 튀지 않게.
+			// 표시값은 input 자체가 즉시 반영하고, 필터용 committedQuery 만 조합 완료 시 커밋한다.
+			cleanups.push(
+				on(searchInput, "compositionstart", () => {
+					isComposing = true;
+				}),
+			);
+			cleanups.push(
+				on(searchInput, "compositionend", (e) => {
+					isComposing = false;
+					state.committedQuery = e.target.value;
+					applyFilter();
+				}),
+			);
+			cleanups.push(
+				on(searchInput, "input", (e) => {
+					if (isComposing) return;
+					state.committedQuery = e.target.value;
+					applyFilter();
+				}),
+			);
+			cleanups.push(on(searchInput, "keydown", onSearchKeyDown));
+		}
+
+		// Initialize.
+		// 서버 바인딩(th:field 등) 초기값은 renderSelection 이 hidden input 을 재동기화하기 **전에**
+		// 읽어 둔다 (다중 모드에서 선택 0개 = input 0개라 먼저 렌더하면 초기값이 지워진다).
+		const serverValues = hiddenEls.map((el) => el.value).filter((v) => v !== "");
+		panel.style.display = "none";
+		applyFilter();
+		renderSelection();
+		if (multiple) {
+			const initial = Array.isArray(config.defaultValue)
+				? config.defaultValue
+				: config.defaultValue != null
+					? [config.defaultValue]
+					: serverValues;
+			if (initial.length > 0) setValue(initial);
+		} else if (config.defaultValue) {
 			setValue(config.defaultValue);
-		} else if (hiddenInput && hiddenInput.value) {
-			// 서버 바인딩(th:field 등)이 넣어 둔 초기값을 표시에 반영
-			setValue(hiddenInput.value);
+		} else if (serverValues[0]) {
+			setValue(serverValues[0]);
 		}
 
 		// Public API
 		return {
-			getValue: () => state.value,
+			/** 단일 모드는 `string | null`, 다중 모드는 `string[]` (React `value` prop 과 같은 규칙) */
+			getValue: () => (multiple ? state.values.slice() : state.value),
 			setValue,
 			open,
 			close,

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -54,6 +54,8 @@
 
   /* Colors - State */
   --bt-color-hover: #{token.$color_state_hover_on_light};
+  /* 어두운 표면(Card --accent / --glass) 위의 반투명 흰 hover/divider */
+  --bt-color-hover-on-dark: #{token.$color_state_hover_on_dark};
   --bt-color-pressed: #{token.$color_state_pressed_on_light};
   --bt-color-primary-hover: #{token.$color_base_neutral_800}; // brand_primary lighten 15% 근사 (CSS var와 SCSS color.adjust 호환 X)
 
@@ -704,7 +706,9 @@
    Dropdown
    ========================================
    React `<Dropdown>` 과 같은 블록 이름을 쓴다 (구 Vanilla 이름은 Select 였다).
-   React 의 `multiple` / `searchable` 은 Vanilla 에 아직 없다 - 단일 선택 전용. */
+   React 와 동일하게 `multiple`(다중 선택) / `searchable`(검색)을 지원한다 -
+   패널 구조도 React 와 같은 __list(패널) > [__search] + __options(role=listbox, 스크롤) 다.
+   옵션을 __list 에 직접 두는 평면 마크업도 계속 지원한다(그 경우 __list 가 곧 listbox). */
 .bt-dropdown {
   position: relative;
   display: inline-flex;
@@ -847,6 +851,74 @@
       margin-top: 0;
       margin-bottom: var(--bt-spacing-xs);
     }
+
+    /* __options 를 품은 패널은 스크롤/여백을 그쪽에 넘긴다 -
+       그래야 검색 행이 옵션과 함께 스크롤되지 않고 상단에 고정된다. */
+    &:has(> .bt-dropdown__options) {
+      max-height: none;
+      overflow: hidden;
+      padding: 0;
+    }
+  }
+
+  /* Search (searchable) - React `.dropdown_search` 와 동일 구조: 패널 상단 고정 행 */
+  &__search {
+    display: flex;
+    align-items: center;
+    gap: var(--bt-spacing-sm);
+    padding: var(--bt-spacing-sm) var(--bt-spacing-md);
+    border-bottom: 1px solid var(--bt-color-border);
+  }
+
+  &__search-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: var(--bt-color-text-secondary);
+  }
+
+  &__search-input {
+    flex: 1 1 auto;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: var(--bt-color-text-primary);
+    border-radius: var(--bt-radius-sm);
+    font-family: var(--bt-font-family);
+    font-size: var(--bt-font-size-sm);
+    line-height: var(--bt-line-height-normal);
+    transition: box-shadow var(--bt-transition-fast);
+
+    &::placeholder {
+      color: var(--bt-color-text-tertiary);
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px var(--bt-color-border-light);
+    }
+  }
+
+  /* 옵션 스크롤 컨테이너(role=listbox). React 가 스크롤을 list 에서 이 컨테이너로 옮긴 것과 동일. */
+  &__options {
+    max-height: 18rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: var(--bt-spacing-xs) 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  /* 검색 결과 0개 안내 (React `.dropdown_empty`) */
+  &__empty {
+    padding: var(--bt-spacing-md) var(--bt-spacing-lg);
+    color: var(--bt-color-text-tertiary);
+    font-family: var(--bt-font-family);
+    font-size: var(--bt-font-size-sm);
+    line-height: var(--bt-line-height-normal);
+    text-align: center;
+    list-style: none;
   }
 
   &__option {
@@ -854,7 +926,9 @@
     box-sizing: border-box;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    /* 왼쪽부터 채운다 - 다중 선택 체크 슬롯이 라벨 앞에 오고, 오른쪽으로 밀 요소는
+       React 처럼 `__option-content` 에 flex:1 을 줘서 처리한다 (space-between 대신). */
+    justify-content: flex-start;
     gap: var(--bt-spacing-sm);
     padding: var(--bt-spacing-sm) var(--bt-spacing-lg);
     cursor: pointer;
@@ -863,6 +937,11 @@
     font-family: var(--bt-font-family);
     font-size: var(--bt-font-size-base);
     line-height: var(--bt-line-height-normal);
+
+    /* 검색 필터로 숨긴 옵션 - display:flex 가 UA 의 [hidden] 규칙을 이기므로 명시적으로 끈다 */
+    &[hidden] {
+      display: none;
+    }
 
     &:hover,
     &.is-active {
@@ -877,6 +956,31 @@
       cursor: not-allowed;
       color: var(--bt-color-text-tertiary);
     }
+  }
+
+  /* 라벨/보조 텍스트 래퍼 (선택) - 트레일링 요소를 오른쪽 끝으로 밀 때 쓴다 */
+  &__option-content {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  /* 다중 선택 체크 슬롯 - 미선택 시에도 폭을 유지해 라벨 정렬이 흔들리지 않는다 (React 와 동일) */
+  &__option-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: var(--bt-spacing-lg);
+    color: var(--bt-color-accent);
+
+    svg {
+      opacity: 0;
+      transition: opacity var(--bt-transition-fast);
+    }
+  }
+
+  &__option.is-selected &__option-check svg {
+    opacity: 1;
   }
 }
 
@@ -1063,6 +1167,11 @@
     .bt-card__title {
       color: var(--bt-color-accent-on-surface);
     }
+
+    .bt-card__footer {
+      /* 반전 배경 위에서는 반투명 흰 구분선이 자연스럽다 (React 와 동일) */
+      border-top-color: var(--bt-color-hover-on-dark);
+    }
   }
 
   /* Variant: outlined - 투명 배경 + 테두리만, shadow 무시 (React card_variant_outlined) */
@@ -1080,6 +1189,10 @@
 
     .bt-card__title {
       color: var(--bt-color-on-primary);
+    }
+
+    .bt-card__footer {
+      border-top-color: var(--bt-color-hover-on-dark);
     }
 
     /* 다크 표면 위에서는 밝은 frosted 로 뒤집는다 (React 와 동일) */
@@ -1103,12 +1216,34 @@
     }
   }
 
+  /* title / body / footer 3단 composition - React Card 의 heading / children / footer 와 동일.
+     React 는 `headingAs`(기본 h3)로 시맨틱 헤딩을 렌더하므로 Vanilla 도 h2~h6 를 쓴다. */
   &__title {
     font-size: var(--bt-font-size-xl);
     font-weight: var(--bt-font-weight-semibold);
     line-height: 1.3;
+    margin-top: 0;
     margin-bottom: var(--bt-spacing-md);
     color: var(--bt-color-text-primary);
+  }
+
+  &__body {
+    width: 100%;
+  }
+
+  /* Footer - React Card `footer` / `footerAlign`(기본 end) 과 동일하게 구분선 + 정렬 modifier */
+  &__footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--bt-spacing-sm);
+    margin-top: var(--bt-spacing-lg);
+    padding-top: var(--bt-spacing-lg);
+    border-top: 1px solid var(--bt-color-border);
+
+    &--start { justify-content: flex-start; }
+    &--between { justify-content: space-between; }
+    &--end { justify-content: flex-end; }
   }
 }
 
@@ -1401,7 +1536,12 @@
      animation:none 이면 멈춘 위젯처럼 보여 의미를 잃는다.
      회전을 크게 늦춰(0.8s → 2.4s) 전정기관 자극만 줄인다.
      (Toast progress 를 정적 keyframe 으로 바꿔 타이머를 살려두는 React 쪽과 같은 판단 -
-      모션만 줄이고 기능은 유지) */
+      모션만 줄이고 기능은 유지)
+
+     React Spinner 는 12개 bar 를 `animation: none; opacity: .5` 로 완전히 정지시킨다 -
+     정지해도 12개 spoke 라는 형태 자체가 "로딩 위젯"으로 읽히기 때문이다. Vanilla 의
+     단일 border ring 은 정지하면 그냥 원 하나라 상태 정보가 사라지므로 감속을 택했다.
+     둘의 차이는 렌더 형태 차이에서 나온 의도된 divergence 다 (docs/VANILLA.md#spinner). */
   .bt-spinner {
     animation-duration: 2.4s;
   }

--- a/src/vanilla/examples/index.html
+++ b/src/vanilla/examples/index.html
@@ -260,8 +260,8 @@
       <h2>Dropdown</h2>
       <div class="demo-row">
         <div class="bt-dropdown" data-bt-dropdown style="width: 300px;">
-          <label class="bt-dropdown__label">Select Option</label>
-          <button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+          <label class="bt-dropdown__label" for="basic-dropdown-control">Select Option</label>
+          <button type="button" id="basic-dropdown-control" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
             <span class="bt-dropdown__placeholder">Select...</span>
             <span class="bt-dropdown__icon">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -292,23 +292,180 @@
 &lt;/div&gt;</code></pre>
     </div>
 
+    <!-- Dropdown - searchable -->
+    <div class="section">
+      <h2>Dropdown - searchable</h2>
+      <p style="margin-bottom: 1rem; color: var(--bt-color-text-secondary);">
+        <code>data-searchable</code> 를 붙이면 패널 상단에 검색 입력이 생깁니다.
+        대소문자·공백 무시 부분 일치이고, 한글 IME 조합 중에는 필터를 보류합니다.
+      </p>
+      <div class="demo-row">
+        <div class="bt-dropdown" data-bt-dropdown data-searchable data-search-placeholder="과일 검색…"
+             id="fruit-searchable" style="width: 300px;">
+          <label class="bt-dropdown__label" for="fruit-searchable-control">과일 (검색)</label>
+          <button type="button" id="fruit-searchable-control" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+            <span class="bt-dropdown__placeholder">선택하세요...</span>
+            <span class="bt-dropdown__icon">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M6 9l6 6 6-6"/>
+              </svg>
+            </span>
+          </button>
+          <ul class="bt-dropdown__list" style="display: none;">
+            <li class="bt-dropdown__option" data-value="apple">사과 Apple</li>
+            <li class="bt-dropdown__option" data-value="banana">바나나 Banana</li>
+            <li class="bt-dropdown__option" data-value="cherry">체리 Cherry</li>
+            <li class="bt-dropdown__option is-disabled" data-value="mango">망고 Mango (품절)</li>
+            <li class="bt-dropdown__option" data-value="orange">오렌지 Orange</li>
+            <li class="bt-dropdown__option" data-value="grape">포도 Grape</li>
+          </ul>
+        </div>
+      </div>
+
+      <pre><code>&lt;div class="bt-dropdown" data-bt-dropdown data-searchable data-search-placeholder="과일 검색…"&gt;
+  &lt;label class="bt-dropdown__label"&gt;과일 (검색)&lt;/label&gt;
+  &lt;button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md"&gt;
+    &lt;span class="bt-dropdown__placeholder"&gt;선택하세요...&lt;/span&gt;
+    &lt;span class="bt-dropdown__icon"&gt;▼&lt;/span&gt;
+  &lt;/button&gt;
+  &lt;ul class="bt-dropdown__list"&gt;
+    &lt;li class="bt-dropdown__option" data-value="apple"&gt;사과 Apple&lt;/li&gt;
+    &lt;li class="bt-dropdown__option" data-value="banana"&gt;바나나 Banana&lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+    </div>
+
+    <!-- Dropdown - multiple -->
+    <div class="section">
+      <h2>Dropdown - multiple</h2>
+      <p style="margin-bottom: 1rem; color: var(--bt-color-text-secondary);">
+        <code>data-multiple</code> 는 옵션을 토글하고 패널을 열어 둡니다. 트리거에는
+        <code>N개 선택</code> 요약이 표시되고, <code>data-name</code> 이 있으면 같은 name 의
+        hidden input 이 선택 개수만큼 반복 생성되어 폼 POST 에 담깁니다.
+      </p>
+      <form class="demo-row" id="topping-form" onsubmit="return false;">
+        <div class="bt-dropdown" data-bt-dropdown data-multiple data-name="topping"
+             id="topping-dropdown" style="width: 300px;">
+          <label class="bt-dropdown__label" for="topping-dropdown-control">토핑 (다중)</label>
+          <button type="button" id="topping-dropdown-control" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+            <span class="bt-dropdown__placeholder">토핑을 고르세요...</span>
+            <span class="bt-dropdown__icon">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M6 9l6 6 6-6"/>
+              </svg>
+            </span>
+          </button>
+          <ul class="bt-dropdown__list" style="display: none;">
+            <li class="bt-dropdown__option" data-value="cheese">치즈</li>
+            <li class="bt-dropdown__option" data-value="bacon">베이컨</li>
+            <li class="bt-dropdown__option" data-value="olive">올리브</li>
+            <li class="bt-dropdown__option is-disabled" data-value="pineapple">파인애플 (품절)</li>
+            <li class="bt-dropdown__option" data-value="mushroom">버섯</li>
+          </ul>
+        </div>
+        <output id="topping-output" style="color: var(--bt-color-text-secondary);">선택 없음</output>
+      </form>
+
+      <pre><code>&lt;div class="bt-dropdown" data-bt-dropdown data-multiple data-name="topping"&gt;
+  &lt;label class="bt-dropdown__label"&gt;토핑 (다중)&lt;/label&gt;
+  &lt;button type="button" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md"&gt;
+    &lt;span class="bt-dropdown__placeholder"&gt;토핑을 고르세요...&lt;/span&gt;
+    &lt;span class="bt-dropdown__icon"&gt;▼&lt;/span&gt;
+  &lt;/button&gt;
+  &lt;ul class="bt-dropdown__list"&gt;
+    &lt;li class="bt-dropdown__option" data-value="cheese"&gt;치즈&lt;/li&gt;
+    &lt;li class="bt-dropdown__option" data-value="bacon"&gt;베이컨&lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+    </div>
+
+    <!-- Dropdown - multiple + searchable (JS) -->
+    <div class="section">
+      <h2>Dropdown - multiple + searchable (JS)</h2>
+      <p style="margin-bottom: 1rem; color: var(--bt-color-text-secondary);">
+        옵션을 JS 로 넘기고 <code>selectedSummary</code> 로 요약 문구를 바꾼 예시입니다.
+        수동 초기화라 <code>data-bt-dropdown</code> 은 붙이지 않습니다.
+      </p>
+      <div class="demo-row">
+        <div class="bt-dropdown" id="city-dropdown" style="width: 300px;">
+          <label class="bt-dropdown__label" for="city-dropdown-control">도시 (다중 + 검색)</label>
+          <button type="button" id="city-dropdown-control" class="bt-dropdown__control bt-dropdown__control--outline bt-dropdown__control--md">
+            <span class="bt-dropdown__placeholder">도시를 고르세요...</span>
+            <span class="bt-dropdown__icon">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M6 9l6 6 6-6"/>
+              </svg>
+            </span>
+          </button>
+          <ul class="bt-dropdown__list" style="display: none;"></ul>
+        </div>
+        <output id="city-output" style="color: var(--bt-color-text-secondary);">선택 없음</output>
+      </div>
+
+      <pre><code>Bigtablet.Dropdown('#city-dropdown', {
+  multiple: true,
+  searchable: true,
+  searchPlaceholder: '도시 검색…',
+  emptyText: '일치하는 도시가 없습니다',
+  selectedSummary: (count) =&gt; `도시 ${count}곳`,
+  options: [
+    { value: 'seoul', label: '서울 Seoul' },
+    { value: 'busan', label: '부산 Busan' },
+  ],
+  onValueChange: (values, options) =&gt; console.log(values, options),
+});</code></pre>
+    </div>
+
     <!-- Card -->
     <div class="section">
       <h2>Card</h2>
       <div class="demo-row">
         <div class="bt-card bt-card--bordered bt-card--p-md" style="width: 300px;">
-          <div class="bt-card__title">Card Title</div>
-          <p>This is a card component with bordered style and medium padding.</p>
+          <h3 class="bt-card__title">Card Title</h3>
+          <div class="bt-card__body">
+            <p>This is a card component with bordered style and medium padding.</p>
+          </div>
         </div>
         <div class="bt-card bt-card--shadow-md bt-card--p-md" style="width: 300px;">
-          <div class="bt-card__title">Shadow Card</div>
-          <p>This card uses shadow instead of border.</p>
+          <h3 class="bt-card__title">Shadow Card</h3>
+          <div class="bt-card__body">
+            <p>This card uses shadow instead of border.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="demo-row">
+        <div class="bt-card bt-card--bordered bt-card--p-md" style="width: 300px;">
+          <h3 class="bt-card__title">title / body / footer</h3>
+          <div class="bt-card__body">
+            <p>footer 는 구분선과 함께 하단에 붙습니다 (React <code>footer</code> prop 과 동일).</p>
+          </div>
+          <div class="bt-card__footer">
+            <button type="button" class="bt-button bt-button--sm bt-button--text">취소</button>
+            <button type="button" class="bt-button bt-button--sm bt-button--filled">저장</button>
+          </div>
+        </div>
+        <div class="bt-card bt-card--accent bt-card--p-md" style="width: 300px;">
+          <h3 class="bt-card__title">footer--between</h3>
+          <div class="bt-card__body">
+            <p>accent 카드에서는 구분선이 반투명 흰색으로 바뀝니다.</p>
+          </div>
+          <div class="bt-card__footer bt-card__footer--between">
+            <span>2026-08-06</span>
+            <button type="button" class="bt-button bt-button--sm bt-button--outline">자세히</button>
+          </div>
         </div>
       </div>
 
       <pre><code>&lt;div class="bt-card bt-card--bordered bt-card--p-md"&gt;
-  &lt;div class="bt-card__title"&gt;Card Title&lt;/div&gt;
-  &lt;p&gt;Card content goes here.&lt;/p&gt;
+  &lt;h3 class="bt-card__title"&gt;Card Title&lt;/h3&gt;
+  &lt;div class="bt-card__body"&gt;
+    &lt;p&gt;Card content goes here.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;div class="bt-card__footer"&gt;  &lt;!-- --start / --between / --end (기본 end) --&gt;
+    &lt;button class="bt-button bt-button--sm bt-button--text"&gt;취소&lt;/button&gt;
+    &lt;button class="bt-button bt-button--sm bt-button--filled"&gt;저장&lt;/button&gt;
+  &lt;/div&gt;
 &lt;/div&gt;</code></pre>
     </div>
 
@@ -546,6 +703,47 @@ Bigtablet.Alert({
           }
         });
       }
+
+      // Dropdown - multiple (auto-init). 자동 초기화된 인스턴스는 _btDropdown 으로 재사용한다.
+      const toppingEl = document.getElementById('topping-dropdown');
+      const toppingOutput = document.getElementById('topping-output');
+      if (toppingEl?._btDropdown) {
+        const render = () => {
+          const values = toppingEl._btDropdown.getValue();
+          const hidden = document.querySelectorAll('#topping-form input[name="topping"]');
+          toppingOutput.textContent = values.length
+            ? `getValue() → [${values.join(', ')}] / hidden input ${hidden.length}개`
+            : '선택 없음';
+        };
+        // 자동 초기화라 onValueChange 를 못 넘기므로, 데모에서는 상호작용 후 값을 다시 읽는다.
+        toppingEl.addEventListener('click', () => requestAnimationFrame(render));
+        toppingEl.addEventListener('keyup', () => requestAnimationFrame(render));
+      }
+
+      // Dropdown - multiple + searchable (수동 초기화 + JS options)
+      const cityOutput = document.getElementById('city-output');
+      Bigtablet.Dropdown('#city-dropdown', {
+        multiple: true,
+        searchable: true,
+        searchPlaceholder: '도시 검색…',
+        emptyText: '일치하는 도시가 없습니다',
+        selectedSummary: (count) => `도시 ${count}곳`,
+        options: [
+          { value: 'seoul', label: '서울 Seoul' },
+          { value: 'busan', label: '부산 Busan' },
+          { value: 'incheon', label: '인천 Incheon' },
+          { value: 'daegu', label: '대구 Daegu' },
+          { value: 'daejeon', label: '대전 Daejeon' },
+          { value: 'gwangju', label: '광주 Gwangju', disabled: true },
+          { value: 'ulsan', label: '울산 Ulsan' },
+          { value: 'jeju', label: '제주 Jeju' }
+        ],
+        onValueChange: (values, options) => {
+          cityOutput.textContent = values.length
+            ? `${values.join(', ')} (${options.map((o) => o.label).join(' / ')})`
+            : '선택 없음';
+        }
+      });
 
       // Pagination change handler
       const paginationEl = document.querySelector('[data-bt-pagination]');


### PR DESCRIPTION
## 제목
feat/vanilla-dropdown-card-parity

## 작업한 내용
- [x] Vanilla Dropdown 에 React 와 동일한 `multiple` 추가 - 옵션 토글 시 패널 유지, 트리거는 `selectedSummary`(기본 `N개 선택`) 요약, 좌측 체크 슬롯 `.bt-dropdown__option-check`, listbox `aria-multiselectable`, 폼 제출은 **같은 `name` 의 hidden input 반복**
- [x] Vanilla Dropdown 에 React 와 동일한 `searchable` 추가 - 패널 상단 `.bt-dropdown__search` 행, 대소문자·공백 무시 부분 일치(React `normalizeForSearch` 와 동일), 결과 0개 `.bt-dropdown__empty`(`emptyText`), 열릴 때 자동 포커스·닫힐 때 초기화
- [x] 한글 IME 대응 - `compositionstart` / `compositionend` 로 조합 중에는 필터를 보류(중간 자모로 목록이 튀지 않음)하고 조합 중 Enter 는 선택/닫기를 트리거하지 않음 (React 의 `searchText` / `committedQuery` 분리와 동일 동작)
- [x] ARIA 를 React 와 일치시킴 - `searchable` 이면 `role="combobox"` 가 검색 입력으로 이동(`aria-autocomplete` / `aria-expanded` / `aria-controls` / `aria-activedescendant`), 트리거에는 `aria-haspopup="listbox"` + `aria-expanded` 만 남김
- [x] 키보드 - 화살표 이동이 **검색 필터를 통과한 목록** 위에서만 동작하도록 변경, APG Combobox 의 `Tab`(리스트 닫고 기본 포커스 이동) 케이스 추가, 검색 입력의 Enter 는 활성 옵션 확정
- [x] 값 타입을 React `value` prop 규칙과 동일하게 통일 - 단일 `string | null`, 다중 `string[]`. `getValue()` / `setValue()` / `onValueChange` 모두 같은 규칙 (다중 `setValue` 는 배열도 허용)
- [x] 패널 구조를 React 와 같은 `__list`(패널) > `[__search]` + `__options`(role=listbox, 스크롤) 로 정규화. 기존 평면 `<ul class="bt-dropdown__list">` 마크업은 그대로 지원하고, `<ul>` 안에 `<div>` 를 넣을 수 없는 `searchable` 인 경우에만 JS 가 패널로 승격
- [x] SCSS 에 `__search` / `__search-icon` / `__search-input` / `__options` / `__empty` / `__option-check` / `__option-content` 추가. `__option` 의 `justify-content: space-between` → `flex-start` 로 바꿔 좌측 체크 슬롯 정렬 확보
- [x] Vanilla Card 에 `.bt-card__body` / `.bt-card__footer`(+ `--start` / `--between` / `--end`) 추가. `--accent` / `--glass` 에서는 구분선이 반투명 흰색으로 뒤집히도록 `--bt-color-hover-on-dark` CSS 변수 노출
- [x] Card 예시·문서의 `__title` 을 `<div>` → `<h3>` 시맨틱 헤딩으로 교체 (React `headingAs` 기본값과 일치)
- [x] Spinner 는 **코드 변경 없이 문서만** 정리 - React(12 bar, reduced motion 시 정지) vs Vanilla(border ring, 2.4s 감속) 차이가 서버 템플릿 마크업 단순성에서 나온 의도된 divergence 임을 `docs/VANILLA.md` · `docs/COMPONENTS.md` · SCSS 주석에 일관되게 명시
- [x] `multiple` / `searchable` 이 없다고 적혀 있던 주석·문서 3곳(`bigtablet.js`, `bigtablet.scss`, `docs/VANILLA.md`)과 `docs/MIGRATION.md` 의 stale 한 "남은 격차" 문구 제거
- [x] 문서 갱신 - `docs/VANILLA.md`(옵션·키보드·`data-*` 표), `src/vanilla/CLAUDE.md`(클래스 표 + 예시 + 누락돼 있던 `toggle()` / `setDisabled()` / `destroy()` API), `docs/COMPONENTS.md`, `docs/AGENT_GUIDE.md`
- [x] `src/vanilla/examples/index.html` 에 searchable / multiple / multiple+searchable(JS `options`) 데모와 Card body·footer 데모 추가
- [x] 검증 - `pnpm build`, `pnpm exec stylelint "src/**/*.scss"`, `pnpm exec tsc --noEmit`, `pnpm test`(788 passed) 통과. 실제 Chrome 에서 빌드 산출물(`dist/vanilla/examples/index.html`)로 필터·IME 조합·키보드 순환·다중 토글·`FormData` 반복 name(`topping=cheese&topping=bacon`)·서버 렌더 hidden input 초기값 복원까지 확인

## 전달할 추가 이슈
- `.bt-dropdown__option` 의 `justify-content` 를 `space-between` → `flex-start` 로 바꿨습니다. 옵션 안에 트레일링 요소를 직접 넣어 오른쪽 끝으로 밀고 있던 소비자가 있다면 라벨을 `.bt-dropdown__option-content`(React 와 동일하게 `flex: 1`) 로 감싸야 합니다. 문서화된 마크업에는 트레일링 요소가 없어 영향은 없을 것으로 봅니다.
- 패널이 `__options` 를 품었을 때 스크롤을 넘기는 규칙에 CSS `:has()` 를 썼습니다. Chrome 105+ / Safari 15.4+ / Firefox 121+ 이며, 미지원 브라우저에서는 검색 행이 옵션과 함께 스크롤됩니다(기능은 정상). 더 낮은 버전을 지원해야 하면 JS 가 패널에 modifier 클래스를 붙이는 방식으로 바꿀 수 있습니다.
- React 는 `disabled` 인 Dropdown 의 hidden input 에 `disabled` 를 걸어 FormData 에서 제외합니다. Vanilla 는 기존 단일 선택 동작을 바꾸지 않으려고 이번엔 반영하지 않았습니다 - 별도로 맞출지 결정이 필요합니다.
- Vanilla 번들에는 단위 테스트가 없어 이번 동작도 브라우저 수동 검증으로만 확인했습니다. Dropdown 처럼 로직이 커진 컴포넌트는 jsdom 기반 테스트를 붙일 가치가 있어 보입니다.