### PR TITLE
merge: sync develop to main (no release)

### DIFF
--- a/.claude/docs/claude-review.md
+++ b/.claude/docs/claude-review.md
@@ -29,12 +29,16 @@ CodeRabbit(`.coderabbit.yaml`) 는 그대로 병행한다 (중복 리뷰 허용)
 
 | 상황 | 동작 |
 | --- | --- |
-| PR 열림 / 재오픈 / draft->ready | 자동 리뷰 1회 |
+| PR 열림 / draft->ready | 자동 리뷰 1회 |
 | PR 코멘트에 `@claude review` / `@claude re-review` | 재리뷰 |
 | 인라인 리뷰 스레드에 `@claude` 멘션 | 그 스레드에만 답글 (전체 리뷰 X) |
 | 푸시(synchronize) | **자동 리뷰 안 함**(비용) - 재리뷰는 코멘트로 |
+| PR 재오픈(reopened) | **자동 리뷰 안 함**(비용) - 필요하면 `@claude review` |
+| 릴리즈/싱크 PR(`develop` -> `main`) | **자동 리뷰 안 함**(비용) - 필요하면 `@claude review` |
 
 - draft PR / 포크 PR 은 자동 경로에서 제외.
+- 릴리즈 PR 을 빼는 이유: 그 diff 는 피처 PR 단계에서 이미 리뷰한 것의 누적본이라 같은 코드를
+  두 번 보는 셈이고, 누적이라 건당 토큰 소모도 가장 크다. 재오픈도 같은 diff 를 다시 과금한다.
 - 코멘트 트리거는 author_association(OWNER/MEMBER/COLLABORATOR) 로 제한 - 외부 트리거 차단.
 - `issue_comment`(멘션 재리뷰)는 GitHub 제약상 **워크플로가 기본 브랜치(main)에 올라간 뒤**부터 동작한다.
   PR-open 자동 리뷰는 워크플로가 그 PR 브랜치에 있으면 바로 동작.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,12 @@
 name: Claude PR Review
 
 # 트리거 모델 (비용 절감):
-#  - PR 최초 열림/재오픈/ready 전환 시 1회 자동 리뷰
+#  - PR 최초 열림/ready 전환 시 1회 자동 리뷰
+#  - 릴리즈/싱크 PR(develop -> main)은 자동 리뷰에서 제외한다. 그 diff 는 이미 피처 PR 단계에서
+#    리뷰된 것의 누적본이라 같은 코드를 두 번 보는 셈이고, 누적이라 건당 토큰도 가장 크다.
+#    필요하면 그 PR 에 `@claude review` 를 남겨 수동으로 돌린다.
+#  - `reopened` 는 트리거에서 뺐다 - 닫았다 다시 열 때마다 풀 리뷰가 재실행돼 같은 diff 를
+#    중복 과금한다. 재오픈 후 리뷰가 필요하면 `@claude review` 로 부른다.
 #  - 이후 재리뷰는 PR 코멘트에 `@claude review` / `@claude re-review` 를 남길 때만 실행 [리뷰 모드]
 #  - 인라인 리뷰 스레드에 `@claude` 를 멘션하면 그 스레드 맥락(파일/라인/diff)으로 답글만 단다
 #    [대화형 답글 모드] - 전체 리뷰/판정은 다시 돌리지 않는다
@@ -12,7 +17,7 @@ name: Claude PR Review
 # CodeRabbit(.coderabbit.yaml) 는 그대로 병행한다 (중복 리뷰 허용).
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -38,7 +43,8 @@ concurrency:
 jobs:
   review:
     # 실행 조건:
-    #  - pull_request: 같은 저장소(포크 아님) + draft 아님 -> 최초/재오픈/ready 자동 리뷰
+    #  - pull_request: 같은 저장소(포크 아님) + draft 아님 + 릴리즈/싱크 PR(develop -> main) 아님
+    #    -> 최초/ready 자동 리뷰
     #  - issue_comment: PR 에 달린 코멘트 + 봇 아님 + author_association 신뢰 + 본문에 트리거 문구
     #    (`@claude review` / `@claude re-review`) 포함 -> 재리뷰 [리뷰 모드]
     #  - pull_request_review_comment: 인라인 리뷰 스레드 답글 + 봇 아님 + author_association 신뢰
@@ -46,7 +52,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
-       !github.event.pull_request.draft)
+       !github.event.pull_request.draft &&
+       !(github.event.pull_request.head.ref == 'develop' &&
+         github.event.pull_request.base.ref == 'main'))
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&


### PR DESCRIPTION
## 제목
merge: sync develop to main (no release)

## 작업한 내용
- [x] Claude 자동 리뷰에서 릴리즈/싱크 PR(`develop` -> `main`) 제외 — 피처 PR 에서 이미 리뷰한 diff 의 누적본이라 같은 코드를 두 번 보는 셈이고, 누적이라 건당 토큰도 가장 큼
- [x] 트리거 `types` 에서 `reopened` 제거 — 닫았다 다시 열 때마다 같은 diff 를 재과금
- [x] `.claude/docs/claude-review.md` 트리거 표에 두 예외 + 이유 반영

## 전달할 추가 이슈
- 조직 리뷰 소진 감사 결과 중 **DS 에 해당하는 항목만** 반영했습니다. 나머지는 무관: `@gemini review` 트리거 없음, dependabot PR 은 이미 토큰 가드로 ~10초 클린 종료(리포트가 DS 를 레퍼런스 패턴으로 지목), 실패 run 토큰 소모는 설정으로 막을 수 없음
- 두 경로 모두 **수동 `@claude review` 로는 그대로 호출 가능**합니다. 릴리즈 PR 을 꼭 리뷰하고 싶으면 코멘트로 부르면 됩니다
- 이 PR 자체가 `develop` -> `main` 이라 새 규칙의 첫 적용 대상입니다 — Claude 자동 리뷰가 안 붙는 게 정상입니다 (CodeRabbit 은 그대로 돕니다)
- **버전 범프·CHANGELOG 없음** — `dist` 무변화. 머지 후 태그 붙이지 마세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * PR이 다시 열릴 때 자동 리뷰가 실행되지 않도록 변경했습니다.
  * `develop`에서 `main`으로 향하는 릴리즈 및 동기화 PR은 자동 리뷰 대상에서 제외됩니다.
  * 해당 PR은 필요할 때 수동 리뷰를 요청할 수 있습니다.

* **문서**
  * 자동 리뷰 대상과 수동 리뷰 요청 방법에 대한 안내를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->