### PR TITLE
merge: sync develop to main (no release)

### DIFF
--- a/.claude/docs/claude-review.md
+++ b/.claude/docs/claude-review.md
@@ -35,10 +35,14 @@ CodeRabbit(`.coderabbit.yaml`) 는 그대로 병행한다 (중복 리뷰 허용)
 | 푸시(synchronize) | **자동 리뷰 안 함**(비용) - 재리뷰는 코멘트로 |
 | PR 재오픈(reopened) | **자동 리뷰 안 함**(비용) - 필요하면 `@claude review` |
 | 릴리즈/싱크 PR(`develop` -> `main`) | **자동 리뷰 안 함**(비용) - 필요하면 `@claude review` |
+| dependabot PR | **자동 리뷰 안 함** - secret 이 안 넘어와 리뷰 자체가 불가 |
 
 - draft PR / 포크 PR 은 자동 경로에서 제외.
 - 릴리즈 PR 을 빼는 이유: 그 diff 는 피처 PR 단계에서 이미 리뷰한 것의 누적본이라 같은 코드를
   두 번 보는 셈이고, 누적이라 건당 토큰 소모도 가장 크다. 재오픈도 같은 diff 를 다시 과금한다.
+- dependabot 을 빼는 이유: GitHub 이 dependabot 트리거 run 에 레포 secret 을 넘기지 않아
+  `CLAUDE_CODE_REVIEW_API_KEY` 가 빈 값이 된다. "Check review token" 가드가 이를 잡아 실패로
+  찍히진 않지만(실측 ~10초 success), 어차피 리뷰가 불가능하니 job 진입 자체를 막는다.
 - 코멘트 트리거는 author_association(OWNER/MEMBER/COLLABORATOR) 로 제한 - 외부 트리거 차단.
 - `issue_comment`(멘션 재리뷰)는 GitHub 제약상 **워크플로가 기본 브랜치(main)에 올라간 뒤**부터 동작한다.
   PR-open 자동 리뷰는 워크플로가 그 PR 브랜치에 있으면 바로 동작.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,7 @@ name: Claude PR Review
 #    필요하면 그 PR 에 `@claude review` 를 남겨 수동으로 돌린다.
 #  - `reopened` 는 트리거에서 뺐다 - 닫았다 다시 열 때마다 풀 리뷰가 재실행돼 같은 diff 를
 #    중복 과금한다. 재오픈 후 리뷰가 필요하면 `@claude review` 로 부른다.
+#  - dependabot PR 도 자동 리뷰에서 제외한다 - secret 이 안 넘어와 애초에 리뷰가 불가능하다.
 #  - 이후 재리뷰는 PR 코멘트에 `@claude review` / `@claude re-review` 를 남길 때만 실행 [리뷰 모드]
 #  - 인라인 리뷰 스레드에 `@claude` 를 멘션하면 그 스레드 맥락(파일/라인/diff)으로 답글만 단다
 #    [대화형 답글 모드] - 전체 리뷰/판정은 다시 돌리지 않는다
@@ -43,8 +44,13 @@ concurrency:
 jobs:
   review:
     # 실행 조건:
-    #  - pull_request: 같은 저장소(포크 아님) + draft 아님 + 릴리즈/싱크 PR(develop -> main) 아님
-    #    -> 최초/ready 자동 리뷰
+    #  - pull_request: 같은 저장소(포크 아님) + draft 아님 + dependabot 아님
+    #    + 릴리즈/싱크 PR(develop -> main) 아님 -> 최초/ready 자동 리뷰
+    #    dependabot 을 빼는 이유: GitHub 이 dependabot 트리거 run 에는 레포 secret 을 넘기지
+    #    않아 CLAUDE_CODE_REVIEW_API_KEY 가 빈 값이 된다. 이 레포는 "Check review token"
+    #    가드가 그걸 잡아 리뷰 스텝을 skip 하므로 실패로 찍히진 않지만(2026-08-10 실측 5건 모두
+    #    ~10초 success), 어차피 리뷰가 불가능한 run 이라 job 진입 자체를 막아 러너 시간을 아낀다.
+    #    (가드가 없는 레포에서는 같은 상황이 그냥 실패로 쌓인다 - insight-app 실패 24건 중 19건)
     #  - issue_comment: PR 에 달린 코멘트 + 봇 아님 + author_association 신뢰 + 본문에 트리거 문구
     #    (`@claude review` / `@claude re-review`) 포함 -> 재리뷰 [리뷰 모드]
     #  - pull_request_review_comment: 인라인 리뷰 스레드 답글 + 봇 아님 + author_association 신뢰
@@ -53,6 +59,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        !github.event.pull_request.draft &&
+       github.event.pull_request.user.login != 'dependabot[bot]' &&
        !(github.event.pull_request.head.ref == 'develop' &&
          github.event.pull_request.base.ref == 'main'))
       ||


### PR DESCRIPTION
## 제목
merge: sync develop to main (no release)

## 작업한 내용
- [x] Claude 자동 리뷰에서 dependabot PR 제외 — `github.event.pull_request.user.login != 'dependabot[bot]'`
- [x] 워크플로 헤더 주석·`.claude/docs/claude-review.md` 트리거 표에 근거 반영

## 전달할 추가 이슈
- **이 레포에서 dependabot 은 실패가 아니라 클린 종료였습니다.** GitHub 이 dependabot run 에 레포 secret 을 안 넘겨 `CLAUDE_CODE_REVIEW_API_KEY` 가 빈 값이 되는데, "Check review token" 가드가 이를 잡아 리뷰 스텝을 skip 합니다 (2026-08-10 실측 5건 전부 ~10초 `success`). 그래서 이번 변경은 실패를 고치는 게 아니라, **어차피 끝낼 수 없는 job 의 진입 자체를 막아 러너 시간을 아끼는 것**입니다
- 원본 스니펫 주석의 "이 레포엔 아직 dependabot 이 없어 예방 목적 / 켜는 순간 반드시 즉시 실패"는 가드가 없는 레포(insight-app 실패 24건 중 19건) 기준이라, DS 실측에 맞게 주석을 다시 썼습니다
- **버전 범프·CHANGELOG 없음** — `dist` 무변화. 머지 후 태그 붙이지 마세요