### PR TITLE
ci: claude-review 모델을 Haiku 로 고정 (구독 토큰 플랜 게이트 회피)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -255,7 +255,10 @@ jobs:
           # 요약/보조 코멘트(gh pr comment) + 인라인 코멘트 MCP 툴.
           # gh api 는 아예 주지 않는다 - 리뷰는 위 도구로 충분하고, 프롬프트 인젝션 시
           # 임의 REST 호출로 번지는 경로를 원천 차단한다. Edit/Write 계열도 없어 파일 수정 불가.
+          # 구독 시트 OAuth 토큰은 Opus/Sonnet 요청이 플랜 게이트에 즉시 거부된다
+          # (1턴 · cost $0 · is_error:true). 이 토큰으로 성립하는 모델은 Haiku 뿐이라 명시 고정.
           claude_args: |
+            --model claude-haiku-4-5-20251001
             --max-turns 50
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git show:*),Bash(git log:*)"
 
@@ -294,6 +297,7 @@ jobs:
           # 읽기 전용 도구만. 게시/gh/gh api/Write 전부 없음 -> 부작용 원천 차단.
           # 답변은 --json-schema 로 structured_output 에 담고, 게시는 다음 고정 단계가 수행.
           claude_args: |
+            --model claude-haiku-4-5-20251001
             --max-turns 20
             --json-schema '{"type":"object","additionalProperties":false,"properties":{"answered":{"type":"boolean"},"reply":{"type":"string"}},"required":["answered","reply"]}'
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git log:*)"


### PR DESCRIPTION
## 배경 — org 전반 claude-review 잡 실패 (CI 빨간불 노이즈)

Bigtablet org 의 claude-review 계열 워크플로가 전면 실패 중이라 원 로그를 뜯어 원인을 확정했다 (상세 실증은 [homepage-server PR #183](https://github.com/Bigtablet/bigtablet-homepage-server/pull/183) 참고). 원인은 두 겹:

1. **토큰 무효 (401)** — `CLAUDE_CODE_REVIEW_API_KEY` 구 토큰은 7/12 회수됐고, 오늘(8/12) 09:50~10:02Z 일괄 교체된 새 토큰도 디버그 실행 결과 `Failed to authenticate. API Error: 401 OAuth access token is invalid`. **담당자가 `claude setup-token` 으로 유효 토큰을 재발급해 시크릿을 다시 채워야 한다** (같은 계정 재로그인/재발급 시 기존 토큰이 회수되는 패턴 주의).
2. **플랜 게이트 (이 PR 가 고치는 것)** — 이 시크릿은 구독 시트 OAuth 토큰(sk-ant-oat)이라 Opus/Sonnet 요청이 플랜 게이트에서 즉시 429 거부(retry-after 없음)되고 Haiku 만 성립한다. 액션은 model 미지정 시 Sonnet 5 를 쓰므로, 유효 토큰이 들어와도 리뷰가 다시 죽는다.

## 변경

claude-code-action / claude CLI 호출에 `--model claude-haiku-4-5-20251001` 명시. (이 레포의 claude 호출 스텝 전부에 적용)

## 검증

유효한 토큰이 시크릿에 들어간 뒤, 이 PR 에 `@claude review` 코멘트를 남겨 review 잡 초록불 + 리뷰 코멘트 게시를 확인하면 된다. 토큰 교체 전에는 이 PR 의 review 잡도 401 로 빨간불이 뜬다 (기존과 동일).

머지는 레포 담당자가 판단해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * AI 기반 리뷰 및 인라인 답글 생성에 최신 모델이 명시적으로 적용됩니다.
  * 기존 리뷰 동작과 출력 형식, 사용 가능한 도구 설정은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->