### PR TITLE
ci: claude-review 모델 Haiku 4.5 고정

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -256,6 +256,7 @@ jobs:
           # gh api 는 아예 주지 않는다 - 리뷰는 위 도구로 충분하고, 프롬프트 인젝션 시
           # 임의 REST 호출로 번지는 경로를 원천 차단한다. Edit/Write 계열도 없어 파일 수정 불가.
           claude_args: |
+            --model claude-haiku-4-5
             --max-turns 50
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git show:*),Bash(git log:*)"
 
@@ -294,6 +295,7 @@ jobs:
           # 읽기 전용 도구만. 게시/gh/gh api/Write 전부 없음 -> 부작용 원천 차단.
           # 답변은 --json-schema 로 structured_output 에 담고, 게시는 다음 고정 단계가 수행.
           claude_args: |
+            --model claude-haiku-4-5
             --max-turns 20
             --json-schema '{"type":"object","additionalProperties":false,"properties":{"answered":{"type":"boolean"},"reply":{"type":"string"}},"required":["answered","reply"]}'
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git log:*)"


### PR DESCRIPTION
## 배경
`claude-review` 워크플로우가 모델 미지정 상태여서 액션 기본값인 `claude-sonnet-5` 로 붙었고, 구독 시트 기반 OAuth 토큰(`sk-ant-oat`)은 Sonnet·Opus 에서 플랜 게이트로 막혀 잡이 즉시 실패했습니다.

로그 근거 (insight-app 실행 31584684614):
```
"subtype": "success", "is_error": true,
"duration_ms": 1982, "num_turns": 1, "total_cost_usd": 0,
"model": "claude-sonnet-5"
```
1턴·2초·비용 0 — 모델 호출이 시작도 못 하고 거부됐습니다.

## 변경
`claude_args` 의 모든 블록에 `--model claude-haiku-4-5` 를 추가해 Haiku 4.5 로 고정합니다. v1 액션에는 `model` 입력이 없어 `claude_args` 가 유일한 지정 경로입니다.

## 참고
Haiku 고정은 시트 토큰으로 파이프라인을 되살리기 위한 조치이며, 리뷰 품질을 유지하려면 조직 API 키(`anthropic_api_key`) 전환이 필요합니다. 별건으로 검토 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 자동화된 코드 리뷰와 인라인 답글 처리에 최신 AI 모델이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->