### PR TITLE
feat/autofill-styles

### DIFF
--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -220,7 +220,7 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 
 > UA 배경은 일반 `background-color` 로 이길 수 없어 큰 inset `box-shadow` 로 덮는다. 그 그림자는
 > 네모라서 TextField/Textarea 는 자동완성된 칸에서만 컨테이너에 `overflow: hidden` 을 걸어
-> 컨테이너 반경으로 자른다(`:has()`). Vanilla(`/vanilla/style.css`)는 입력 요소가 배경과
+> 컨테이너 반경으로 자른다(`:has()`). Vanilla(`@bigtablet/design-system/vanilla/style.min.css`)는 입력 요소가 배경과
 > `border-radius` 를 직접 갖고 있어 클리핑이 필요 없고, 색 규칙만 동일하게 적용된다.
 
 ## Storybook

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -13,6 +13,7 @@ Bigtablet Design System의 라이트/다크 테마 시스템 가이드입니다.
   - [React](#react)
   - [SCSS 소비자](#scss-소비자)
   - [CSS 변수 직접 사용](#css-변수-직접-사용)
+- [자동완성(autofill) 입력칸](#자동완성autofill-입력칸)
 - [Storybook](#storybook)
 
 ---
@@ -199,6 +200,28 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 > 참고: Vanilla JS 패키지(`@bigtablet/design-system/vanilla`)는 `src/vanilla/bigtablet.scss` 에서 동일 토큰을 기반으로 하지만 이름이 다른 자체 `--bt-color-*` 변수 세트를 사용하며(예: `--bt-color-primary`, `--bt-color-background`), 현재 `data-theme`/`prefers-color-scheme` 다크 모드 오버라이드가 없습니다. Vanilla 환경과 React 환경의 CSS 변수는 서로 호환되지 않으니 섞어 쓰지 마세요.
 
 ---
+
+## 자동완성(autofill) 입력칸
+
+크롬/사파리는 자동완성으로 채운 칸에 자체 배경(연한 라벤더)과 글자색을 `!important` 로 강제한다.
+그대로 두면 그 칸만 옆 칸과 다른 색이 되고, 다크 테마에서는 밝은 상자로 튄다.
+
+`style.css` 가 이걸 대신 막는다 (`src/styles/autofill.scss`). **소비자가 따로 할 일은 없다** -
+`@bigtablet/design-system/style.css` 를 이미 import 하고 있으면 자동 적용된다.
+
+| 상태 | 배경 | 글자 |
+|---|---|---|
+| 기본 | `--bt-color-bg-solid` | `--bt-color-text-heading` |
+| `variant="filled"` | `--bt-color-bg-solid-dim` (포커스 시 `bg-solid`) | 동일 |
+| `disabled` | `--bt-color-bg-solid-dim` | `--bt-color-text-disabled` |
+
+전부 테마 CSS 변수라 라이트/다크가 자동으로 따라온다. 규칙이 `input` / `textarea` / `select`
+요소 셀렉터라 **DS 컴포넌트로 감싸지 않은 native 입력에도 적용된다**.
+
+> UA 배경은 일반 `background-color` 로 이길 수 없어 큰 inset `box-shadow` 로 덮는다. 그 그림자는
+> 네모라서 TextField/Textarea 는 자동완성된 칸에서만 컨테이너에 `overflow: hidden` 을 걸어
+> 컨테이너 반경으로 자른다(`:has()`). Vanilla(`/vanilla/style.css`)는 입력 요소가 배경과
+> `border-radius` 를 직접 갖고 있어 클리핑이 필요 없고, 색 규칙만 동일하게 적용된다.
 
 ## Storybook
 

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -158,6 +158,11 @@ npm install @bigtablet/design-system
 
 ### TextField
 
+> 자동완성(autofill)으로 채운 칸은 크롬/사파리가 UA 배경(연한 라벤더)을 `!important` 로
+> 강제하는데, `bigtablet.css` 가 이를 DS 표면색으로 덮는다. `input`/`textarea`/`select`
+> 요소 셀렉터라 DS 클래스를 안 붙인 native 입력에도 적용되고, 비활성 칸은 비활성 표면·
+> 글자색을 유지한다. 소비자가 따로 할 일은 없다.
+
 ```html
 <!-- 기본 -->
 <div class="bt-text-field">

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -51,7 +51,7 @@ npm install @bigtablet/design-system
 <link rel="stylesheet" href="node_modules/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 
 <!-- 또는 빌드 도구 사용 시 -->
-@import '@bigtablet/design-system/dist/vanilla/bigtablet.css';
+@import '@bigtablet/design-system/vanilla/style.min.css';
 ```
 
 ### 직접 다운로드
@@ -159,7 +159,7 @@ npm install @bigtablet/design-system
 ### TextField
 
 > 자동완성(autofill)으로 채운 칸은 크롬/사파리가 UA 배경(연한 라벤더)을 `!important` 로
-> 강제하는데, `bigtablet.css` 가 이를 DS 표면색으로 덮는다. `input`/`textarea`/`select`
+> 강제하는데, Vanilla CSS(`@bigtablet/design-system/vanilla/style.min.css`)가 이를 DS 표면색으로 덮는다. `input`/`textarea`/`select`
 > 요소 셀렉터라 DS 클래스를 안 붙인 native 입력에도 적용되고, 비활성 칸은 비활성 표면·
 > 글자색을 유지한다. 소비자가 따로 할 일은 없다.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 // 컴포넌트 번들(dist/index.css = style.css)에 1회 포함시킨다.
 // scss/token 진입점에서 분리되어 있어 소비자 module.scss 로는 새지 않는다.
 import "./styles/theme.scss";
+// 자동완성(autofill) 칸의 UA 배경/글자색 무력화 - 전역 요소 규칙이라 theme.scss 와 분리.
+import "./styles/autofill.scss";
 
 // Hooks / Utils
 

--- a/src/styles/autofill.scss
+++ b/src/styles/autofill.scss
@@ -77,8 +77,10 @@ select:-webkit-autofill:disabled {
 // 표현하고, 아이콘·clear 버튼은 컨테이너 안쪽이며 Textarea 카운터는 컨테이너를
 // 닫은 뒤의 형제(`textarea_footer`)다. 오버레이(Tooltip/Popover/Menu)는 v3.8.0
 // 부터 `body` 로 포탈되므로 컨테이너 overflow 와 무관하다.
+// (`select` 는 여기 없다 - TextField 는 항상 `<input>` 만 렌더하고 `.text_field_container` 안에
+// native select 가 들어가는 곳이 없다. 위 1·2번의 `select` 요소 셀렉터는 컨슈머의 native select
+// 를 덮기 위한 것이라 그대로 남긴다.)
 .text_field_container:has(input:-webkit-autofill),
-.text_field_container:has(select:-webkit-autofill),
 .textarea_container:has(textarea:-webkit-autofill) {
   overflow: hidden;
 }

--- a/src/styles/autofill.scss
+++ b/src/styles/autofill.scss
@@ -1,0 +1,84 @@
+// ════════════════════════════════════════════════════════════════════════
+// 자동완성(autofill) 입력칸 - UA 스타일 무력화.
+//
+// 크롬/사파리는 자동완성으로 채운 칸에 자체 배경(연한 라벤더)과 글자색을
+// `!important` 로 강제한다. DS 폼 컨트롤은 배경을 *컨테이너*가 갖고 입력 요소는
+// 투명하므로, 자동완성이 걸린 칸만 UA 배경으로 칠해져 옆 칸과 달라 보인다
+// (다크 테마에선 그 칸만 밝은 상자로 튄다).
+//
+// 이 파일은 컴포넌트 번들(src/index.ts)이 1회 import → dist/index.css
+// (= `@bigtablet/design-system/style.css`) 에 포함된다. 테마 CSS 변수 정의는
+// `theme.scss` 가 담당하고 여기는 전역 요소 규칙만 둔다 (파일 역할 분리).
+//
+// 요소 셀렉터를 쓰는 이유: DS 컴포넌트로 감싸지 않은 native `<input>`(숫자
+// 스테퍼 등)도 같은 UA 스타일을 받으므로, 컴포넌트 스코프 셀렉터만 두면 그 칸은
+// 여전히 라벤더로 남는다. 컨테이너 클리핑(3번)만 DS 컴포넌트 스코프다.
+// ════════════════════════════════════════════════════════════════════════
+
+@use "./colors/index" as colors;
+
+// ── 1. 색 ───────────────────────────────────────────────────────────────
+// UA 배경은 `!important` 라 일반 `background-color` 로 못 이긴다. 대신 칸을 덮을
+// 만큼 큰 inset 그림자로 가리고, 글자색은 `-webkit-text-fill-color` 로 되돌린다
+// (autofill 상태에서는 `color` 보다 이 속성이 우선한다).
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+  -webkit-text-fill-color: colors.$color_text_heading;
+  caret-color: colors.$color_text_heading;
+}
+
+// ── 1b. filled variant ──────────────────────────────────────────────────
+// TextField `variant="filled"` 은 컨테이너 배경이 dim 이라, 1번(기본 표면)을 그대로 두면
+// 자동완성된 filled 칸만 outline 칸처럼 밝아진다. 컨테이너의 배경 전환을 그대로 따라간다:
+// 평상시 dim, 포커스 시 solid (`_variant_filled &_container:focus-within` 와 동일).
+// Textarea 에는 variant 가 없어 대응 규칙이 필요 없다.
+.text_field_variant_filled input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+}
+
+.text_field_variant_filled input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+}
+
+// ── 2. 비활성 + 자동완성 ─────────────────────────────────────────────────
+// 인증 후 칸을 `disabled` 로 잠그는 흐름에서 자동완성 값이 남는다. 1번만 두면
+// `-webkit-text-fill-color` 가 DS 의 disabled 글자색을 이겨 잠긴 칸이 활성처럼
+// 진해지고, 배경도 비활성 표면이 아니라 기본 표면이 된다.
+input:-webkit-autofill:disabled,
+textarea:-webkit-autofill:disabled,
+select:-webkit-autofill:disabled {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+  -webkit-text-fill-color: colors.$color_text_disabled;
+}
+
+// ── 3. 둥근 모서리 유지 ──────────────────────────────────────────────────
+// 1·2번 그림자는 네모라서 그대로 두면 컨테이너의 둥근 모서리를 덮어 자동완성된
+// 칸만 각져 보인다 (자식은 부모 배경/테두리 위에 그려지고 부모 border-radius 로
+// 잘리지 않는다). 자동완성된 칸에서만 컨테이너를 클리핑 컨텍스트로 만들어
+// 컨테이너 자신의 반경으로 자른다.
+//
+// 입력 요소에 직접 `border-radius` 를 주는 방식은 쓰지 않는다: 앞/뒤 아이콘이
+// 있으면 input 상자가 컨테이너 가장자리에서 밀려 있어(`_inner` flex row) 어떤
+// 반경을 줘도 컨테이너 코너와 맞지 않는다. 클리핑은 아이콘 유무와 무관하게 맞다.
+//
+// `:has()` 지원은 문제되지 않는다 - `:-webkit-autofill` 자체가 Chromium/WebKit
+// 전용이고 두 엔진 모두 `:has()` 를 오래전부터 지원한다.
+//
+// 클리핑 안전성 확인: 포커스는 outset 그림자가 아니라 컨테이너 `border-color` 로
+// 표현하고, 아이콘·clear 버튼은 컨테이너 안쪽이며 Textarea 카운터는 컨테이너를
+// 닫은 뒤의 형제(`textarea_footer`)다. 오버레이(Tooltip/Popover/Menu)는 v3.8.0
+// 부터 `body` 로 포탈되므로 컨테이너 overflow 와 무관하다.
+.text_field_container:has(input:-webkit-autofill),
+.text_field_container:has(select:-webkit-autofill),
+.textarea_container:has(textarea:-webkit-autofill) {
+  overflow: hidden;
+}

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1534,6 +1534,20 @@ select:-webkit-autofill {
   caret-color: var(--bt-color-text-primary);
 }
 
+/* filled variant - `.bt-text-field__input--filled` 는 평상시 배경이 dim 이라, 위 규칙(기본 표면)만
+   두면 자동완성된 filled 칸만 outline 칸처럼 밝아진다. 그 variant 자신의 배경 전환을 따라간다:
+   평상시 dim, `:focus-visible` 에서 solid (`&--filled` 블록과 같은 훅).
+   React 쪽은 배경이 컨테이너에 있어 `.text_field_variant_filled` + `:focus-within` 을 쓴다. */
+.bt-text-field__input--filled:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+}
+
+.bt-text-field__input--filled:-webkit-autofill:focus-visible {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+}
+
 /* 비활성 + 자동완성 - 인증 후 칸을 잠그는 흐름에서 값이 남는다. 위 규칙만 두면
    `-webkit-text-fill-color` 가 disabled 글자색을 이겨 잠긴 칸이 활성처럼 진해진다. */
 input:-webkit-autofill:disabled,

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1511,6 +1511,39 @@
    DatePicker / FileInput 의 transition 은 전부 --bt-transition-* 를 경유하므로,
    선택자를 나열하는 대신 토큰 자체를 0s 로 눌러 일괄 무효화한다.
    (이후 추가되는 규칙과, 같은 var 를 쓰는 소비자 커스텀 스타일까지 자동으로 커버된다.) */
+/* ========================================
+   Autofill (자동완성) 입력칸 - UA 스타일 무력화
+   ======================================== */
+
+/* 크롬/사파리는 자동완성으로 채운 칸에 자체 배경(연한 라벤더)과 글자색을 `!important` 로
+   강제한다. 일반 `background-color` 로는 못 이기므로 칸을 덮을 만큼 큰 inset 그림자로 가리고
+   글자색은 `-webkit-text-fill-color` 로 되돌린다.
+
+   React 쪽(`style.css`)과 달리 컨테이너 클리핑 규칙이 없어도 된다 - Vanilla 는
+   `.bt-text-field__input` 자체가 배경과 `border-radius` 를 갖고 있어 inset 그림자가
+   input 자신의 반경으로 잘린다. React 는 배경이 컨테이너에 있어 별도 클리핑이 필요하다. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+  -webkit-text-fill-color: var(--bt-color-text-primary);
+  caret-color: var(--bt-color-text-primary);
+}
+
+/* 비활성 + 자동완성 - 인증 후 칸을 잠그는 흐름에서 값이 남는다. 위 규칙만 두면
+   `-webkit-text-fill-color` 가 disabled 글자색을 이겨 잠긴 칸이 활성처럼 진해진다. */
+input:-webkit-autofill:disabled,
+textarea:-webkit-autofill:disabled,
+select:-webkit-autofill:disabled {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+  -webkit-text-fill-color: var(--bt-color-text-tertiary);
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root {
     --bt-transition-fast: 0s;


### PR DESCRIPTION
## 제목
feat/autofill-styles

## 작업한 내용
- [x] `src/styles/autofill.scss` 신설 + `src/index.ts` 에서 import → `style.css` 에 포함. `theme.scss` 는 CSS 변수 정의 전용이라 전역 요소 규칙은 파일을 분리
- [x] 색 규칙 — UA 배경을 `0 0 0 1000px <표면토큰> inset` 그림자로 덮고 `-webkit-text-fill-color` 로 글자색 복구. `input`/`textarea`/`select` 요소 셀렉터라 DS 로 감싸지 않은 native 입력도 커버
- [x] 비활성 규칙 — 잠긴 칸이 비활성 표면 + 비활성 글자색 유지 (`-webkit-text-fill-color` 가 `color` 를 이기므로 별도 필요)
- [x] **filled variant 규칙 추가** — 검증 중 발견한 실제 갭. filled 컨테이너 배경이 dim 인데 기본 규칙(solid)만 두면 자동완성된 filled 칸만 outline 칸처럼 밝아짐. 컨테이너 전환을 그대로 따라가게 함(평상시 dim, 포커스 시 solid)
- [x] `:has()` + `overflow: hidden` 으로 컨테이너 반경 클리핑 (자동완성된 칸에만)
- [x] Vanilla(`bigtablet.scss`)에도 색 규칙 — 별도 번들이라 Thymeleaf 폼은 `style.css` 를 안 받음
- [x] `docs/THEMING.md` 절 추가(상태별 토큰 표 + 원리), `docs/VANILLA.md` TextField 절에 안내

## 전달할 추가 이슈
- **버전**: 전역 규칙 추가라 minor — 제안대로 `3.10.0`. 관례상 범프·CHANGELOG 는 `merge: release` PR 에서 하므로 이 PR 에는 없습니다
- **`:has()` 대신 입력 요소에 `border-radius` 를 주는 방식은 택하지 않았습니다.** 앞/뒤 아이콘이 있으면 input 상자가 `_inner` flex row 안에서 컨테이너 가장자리로부터 밀려 있어, 어떤 반경을 줘도 컨테이너 코너와 맞지 않습니다. 클리핑은 아이콘 유무와 무관하게 맞습니다. `:has()` 지원도 문제되지 않습니다 — `:-webkit-autofill` 자체가 Chromium/WebKit 전용이고 두 엔진 모두 `:has()` 를 오래 전부터 지원합니다. 반경을 CSS 변수로 빼는 건 별건으로 다룰 수 있습니다
- **클리핑 안전성 확인 완료** — `.text_field_container`/`.textarea_container` 는 TextField·Textarea 전용(다른 컴포넌트가 재사용하지 않음), 포커스는 outset 그림자가 아니라 `border-color`, 아이콘·clear 는 컨테이너 안쪽, Textarea 카운터는 컨테이너를 닫은 뒤의 형제(`textarea_footer`)입니다. DatePicker 는 Dropdown 조합이고 native input 이 없어 무관하며, Tooltip/Popover/Menu 는 v3.8.0 부터 `body` 포탈이라 컨테이너 `overflow` 와 무관합니다
- **검증 방법**: 크롬 autofill 은 코드로 띄울 수 없어, 빌드된 `dist/index.css` 의 `:-webkit-autofill` 을 `.af` 클래스로 치환해(클래스와 의사클래스는 특이도 동일 → 캐스케이드·순서 보존) 11개 케이스를 실제 규칙으로 렌더했습니다. 라이트/다크 각각에서 `그림자색 == 컨테이너 배경`, `radius 12px`, `overflow hidden` 을 계산값으로 확인 — 요청하신 6항목 + filled·filled×disabled 포함 전부 통과
- 남은 미확인: **실제 크롬 autofill 팝업으로 채운 상태**는 사람이 한 번 봐주시면 좋겠습니다. CSS 캐스케이드는 위 방식으로 동등하게 검증됐지만, UA 가 `!important` 를 붙이는 실제 속성 집합이 브라우저 버전에 따라 다를 여지는 남습니다
- 릴리스 후 notiiv 웹에서 `packages/styles/autofill.css` + 3개 layout import + `package.json` export 제거 (knip Dead code 대상)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 브라우저 자동완성 입력에 디자인 시스템의 배경색, 글자색, 커서 색상이 적용됩니다.
  * 기본, 입력 완료, 비활성 상태별 스타일을 지원합니다.
  * 자동완성된 TextField와 Textarea에서도 둥근 모서리가 자연스럽게 유지됩니다.

* **문서**
  * 테마 및 Vanilla 스타일 가이드에 자동완성 입력 스타일 적용 기준과 동작 방식이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->