### PR TITLE
merge: release v3.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ permissions:
 jobs:
   # 무엇이 바뀌었는지 한 번만 검사해서 후속 step의 조건으로 사용한다
   changes:
+    # 릴리즈/싱크 PR(develop -> main)은 건너뛴다 - `push: [develop]` 이 이미 같은 트리를 돌렸다.
+    # main 은 develop 의 과거 상태(직전 릴리즈 시점)라 develop 을 main 에 머지한 결과의 트리는
+    # develop tip 과 동일하다. 그래서 develop 에 푸시할 때의 push 실행과 열린 릴리즈 PR 의
+    # pull_request(synchronize) 실행이 같은 SHA·같은 트리를 두 번 검사하게 된다.
+    # 이 조건은 head 가 develop 인 경우만 빼므로, 긴급 hotfix 브랜치 -> main PR 은 그대로 돈다.
+    # `test` 는 `needs: changes` 라 이 job 이 skip 되면 함께 skip 된다.
+    if: >-
+      !(github.event_name == 'pull_request' &&
+        github.event.pull_request.head.ref == 'develop' &&
+        github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.10.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.10.0) - 2026-08-18
+
+- 자동완성(autofill) 입력칸을 DS 가 소유 - 크롬/사파리가 `!important` 로 강제하는 UA 배경(연한 라벤더)·글자색을 DS 표면 토큰으로 덮는다. DS 폼 컨트롤은 배경을 컨테이너가 갖고 입력 요소가 투명해서, 자동완성된 칸만 옆 칸과 다른 색이 되고 다크 테마에선 밝은 상자로 튀던 문제 해소. `style.css` 만 import 하고 있으면 자동 적용되고 소비자가 따로 할 일은 없다
+- 상태별 표면 유지 - `variant="filled"` 는 dim 채움(포커스 시 solid)을, `disabled` 는 비활성 표면·글자색을 그대로 유지한다. 에러 칸은 배경이 아니라 테두리로만 구분된다
+- 둥근 모서리 유지 - UA 배경을 덮는 inset 그림자가 네모라서 컨테이너 모서리를 각지게 만들던 문제를, 자동완성된 칸에서만 컨테이너를 `:has()` 로 클리핑해 해결
+- DS 컴포넌트 밖 native 입력도 커버 - 규칙이 `input`/`textarea`/`select` 요소 셀렉터라 `TextField` 로 감싸지 않은 native 입력에도 적용된다
+- Vanilla 번들에도 동일 적용 - `/vanilla` CSS 는 별도 번들이라 Thymeleaf/JSP 폼도 같은 문제를 겪었다 (입력 요소가 배경·반경을 직접 가져 클리핑 규칙은 불필요)
+
 ## [3.9.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.9.0) - 2026-08-06
 
 - Vanilla Dropdown 다중 선택·검색 지원 - React `<Dropdown multiple searchable>` 과 동등하게 `data-multiple` / `data-searchable`(또는 JS 옵션) 지원. 선택 시 패널 유지·"N개 선택" 요약·좌측 체크 슬롯·같은 `name` 반복 hidden input, 한글 IME 조합 중 필터 보류, 필터된 목록 기준 방향키·`role="combobox"` 이동 등 WAI-ARIA APG Combobox 정합. 기존 평면 `<ul>` 마크업은 그대로 동작

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,6 +232,7 @@ cn(styles.button, styles[`size_${size}`], className);
 // src/index.ts - 컴포넌트·타입·토큰을 명시적 named export 로 나열한다.
 // `export *` 는 쓰지 않는다 - 공개 API 표면이 파일 구조에 따라 조용히 늘어나는 걸 막기 위해서다.
 import "./styles/theme.scss"; // :root / [data-theme="dark"] CSS 변수 (dist/index.css 에 1회 포함)
+import "./styles/autofill.scss"; // 자동완성 칸의 UA 배경/글자색 무력화 (전역 요소 규칙)
 
 export { cn, useFocusTrap, useReducedMotion, useSpringHover, useSpringPresence } from "./utils";
 
@@ -441,12 +442,13 @@ describe("Button", () => {
 - `pull_request` → `develop`, `main`
 - `push` → `develop`
 - 양쪽 모두 `paths-ignore` 로 `**.md` · `docs/**` · `.github/ISSUE_TEMPLATE/**` · `LICENSE` 는 제외 (docs-only PR 은 CI 를 돌리지 않는다)
+- **릴리즈/싱크 PR(`develop` → `main`)은 `changes` job 의 `if:` 로 제외** - `push: develop` 이 이미 같은 트리를 검사했다. main 은 develop 의 과거 상태라 머지 결과 트리가 develop tip 과 같아서, develop 에 푸시하면 `push` 실행과 열린 릴리즈 PR 의 `pull_request(synchronize)` 실행이 같은 SHA 를 두 번 돌게 된다. head 가 `develop` 인 경우만 빼므로 hotfix 브랜치 → `main` PR 은 그대로 돈다
 
 **job 구성**
 
 | Job | 역할 |
 |------|------|
-| `changes` | `dorny/paths-filter` 로 `code` / `stories` / `deps` / `vanilla` 변경 여부를 한 번만 판정해 후속 step 의 조건으로 넘긴다 |
+| `changes` | `dorny/paths-filter` 로 `code` / `stories` / `deps` / `vanilla` 변경 여부를 한 번만 판정해 후속 step 의 조건으로 넘긴다. 릴리즈/싱크 PR(`develop` → `main`)에서는 skip 되고, `test` 도 `needs: changes` 라 함께 skip 된다 |
 | `test` | 위 4개 중 하나라도 변경됐을 때만 실행 |
 
 **`test` job 의 step (실행 조건 포함)**

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -220,7 +220,7 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 
 > UA 배경은 일반 `background-color` 로 이길 수 없어 큰 inset `box-shadow` 로 덮는다. 그 그림자는
 > 네모라서 TextField/Textarea 는 자동완성된 칸에서만 컨테이너에 `overflow: hidden` 을 걸어
-> 컨테이너 반경으로 자른다(`:has()`). Vanilla(`/vanilla/style.css`)는 입력 요소가 배경과
+> 컨테이너 반경으로 자른다(`:has()`). Vanilla(`@bigtablet/design-system/vanilla/style.min.css`)는 입력 요소가 배경과
 > `border-radius` 를 직접 갖고 있어 클리핑이 필요 없고, 색 규칙만 동일하게 적용된다.
 
 ## Storybook

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -13,6 +13,7 @@ Bigtablet Design System의 라이트/다크 테마 시스템 가이드입니다.
   - [React](#react)
   - [SCSS 소비자](#scss-소비자)
   - [CSS 변수 직접 사용](#css-변수-직접-사용)
+- [자동완성(autofill) 입력칸](#자동완성autofill-입력칸)
 - [Storybook](#storybook)
 
 ---
@@ -199,6 +200,28 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 > 참고: Vanilla JS 패키지(`@bigtablet/design-system/vanilla`)는 `src/vanilla/bigtablet.scss` 에서 동일 토큰을 기반으로 하지만 이름이 다른 자체 `--bt-color-*` 변수 세트를 사용하며(예: `--bt-color-primary`, `--bt-color-background`), 현재 `data-theme`/`prefers-color-scheme` 다크 모드 오버라이드가 없습니다. Vanilla 환경과 React 환경의 CSS 변수는 서로 호환되지 않으니 섞어 쓰지 마세요.
 
 ---
+
+## 자동완성(autofill) 입력칸
+
+크롬/사파리는 자동완성으로 채운 칸에 자체 배경(연한 라벤더)과 글자색을 `!important` 로 강제한다.
+그대로 두면 그 칸만 옆 칸과 다른 색이 되고, 다크 테마에서는 밝은 상자로 튄다.
+
+`style.css` 가 이걸 대신 막는다 (`src/styles/autofill.scss`). **소비자가 따로 할 일은 없다** -
+`@bigtablet/design-system/style.css` 를 이미 import 하고 있으면 자동 적용된다.
+
+| 상태 | 배경 | 글자 |
+|---|---|---|
+| 기본 | `--bt-color-bg-solid` | `--bt-color-text-heading` |
+| `variant="filled"` | `--bt-color-bg-solid-dim` (포커스 시 `bg-solid`) | 동일 |
+| `disabled` | `--bt-color-bg-solid-dim` | `--bt-color-text-disabled` |
+
+전부 테마 CSS 변수라 라이트/다크가 자동으로 따라온다. 규칙이 `input` / `textarea` / `select`
+요소 셀렉터라 **DS 컴포넌트로 감싸지 않은 native 입력에도 적용된다**.
+
+> UA 배경은 일반 `background-color` 로 이길 수 없어 큰 inset `box-shadow` 로 덮는다. 그 그림자는
+> 네모라서 TextField/Textarea 는 자동완성된 칸에서만 컨테이너에 `overflow: hidden` 을 걸어
+> 컨테이너 반경으로 자른다(`:has()`). Vanilla(`/vanilla/style.css`)는 입력 요소가 배경과
+> `border-radius` 를 직접 갖고 있어 클리핑이 필요 없고, 색 규칙만 동일하게 적용된다.
 
 ## Storybook
 

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -54,14 +54,10 @@ npm install @bigtablet/design-system
 @import '@bigtablet/design-system/vanilla/style.min.css';
 ```
 
-### 직접 다운로드
-
-[GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases)에서 다운로드:
-
-- `bigtablet.css` - 비압축 CSS (~40KB)
-- `bigtablet.min.css` - 압축 CSS (~31KB)
-- `bigtablet.js` - 비압축 JS (~30KB)
-- `bigtablet.min.js` - 압축 JS (~13KB)
+> 배포 패키지에 들어가는 Vanilla 산출물은 **압축본 2개뿐**입니다 - `bigtablet.min.css`(약 38KB),
+> `bigtablet.min.js`(약 19KB). 비압축본(`bigtablet.css` / `bigtablet.js`)은 `package.json` 의
+> `files` 에서 제외돼 npm·CDN 어느 쪽에도 없습니다. 소스를 읽어야 하면 저장소의
+> `src/vanilla/bigtablet.scss` · `src/vanilla/bigtablet.js` 를 보세요.
 
 ---
 

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -158,6 +158,11 @@ npm install @bigtablet/design-system
 
 ### TextField
 
+> 자동완성(autofill)으로 채운 칸은 크롬/사파리가 UA 배경(연한 라벤더)을 `!important` 로
+> 강제하는데, `bigtablet.css` 가 이를 DS 표면색으로 덮는다. `input`/`textarea`/`select`
+> 요소 셀렉터라 DS 클래스를 안 붙인 native 입력에도 적용되고, 비활성 칸은 비활성 표면·
+> 글자색을 유지한다. 소비자가 따로 할 일은 없다.
+
 ```html
 <!-- 기본 -->
 <div class="bt-text-field">

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -51,7 +51,7 @@ npm install @bigtablet/design-system
 <link rel="stylesheet" href="node_modules/@bigtablet/design-system/dist/vanilla/bigtablet.min.css">
 
 <!-- 또는 빌드 도구 사용 시 -->
-@import '@bigtablet/design-system/dist/vanilla/bigtablet.css';
+@import '@bigtablet/design-system/vanilla/style.min.css';
 ```
 
 ### 직접 다운로드
@@ -159,7 +159,7 @@ npm install @bigtablet/design-system
 ### TextField
 
 > 자동완성(autofill)으로 채운 칸은 크롬/사파리가 UA 배경(연한 라벤더)을 `!important` 로
-> 강제하는데, `bigtablet.css` 가 이를 DS 표면색으로 덮는다. `input`/`textarea`/`select`
+> 강제하는데, Vanilla CSS(`@bigtablet/design-system/vanilla/style.min.css`)가 이를 DS 표면색으로 덮는다. `input`/`textarea`/`select`
 > 요소 셀렉터라 DS 클래스를 안 붙인 native 입력에도 적용되고, 비활성 칸은 비활성 표면·
 > 글자색을 유지한다. 소비자가 따로 할 일은 없다.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.9.0",
+	"version": "3.10.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 // 컴포넌트 번들(dist/index.css = style.css)에 1회 포함시킨다.
 // scss/token 진입점에서 분리되어 있어 소비자 module.scss 로는 새지 않는다.
 import "./styles/theme.scss";
+// 자동완성(autofill) 칸의 UA 배경/글자색 무력화 - 전역 요소 규칙이라 theme.scss 와 분리.
+import "./styles/autofill.scss";
 
 // Hooks / Utils
 

--- a/src/styles/autofill.scss
+++ b/src/styles/autofill.scss
@@ -77,8 +77,10 @@ select:-webkit-autofill:disabled {
 // 표현하고, 아이콘·clear 버튼은 컨테이너 안쪽이며 Textarea 카운터는 컨테이너를
 // 닫은 뒤의 형제(`textarea_footer`)다. 오버레이(Tooltip/Popover/Menu)는 v3.8.0
 // 부터 `body` 로 포탈되므로 컨테이너 overflow 와 무관하다.
+// (`select` 는 여기 없다 - TextField 는 항상 `<input>` 만 렌더하고 `.text_field_container` 안에
+// native select 가 들어가는 곳이 없다. 위 1·2번의 `select` 요소 셀렉터는 컨슈머의 native select
+// 를 덮기 위한 것이라 그대로 남긴다.)
 .text_field_container:has(input:-webkit-autofill),
-.text_field_container:has(select:-webkit-autofill),
 .textarea_container:has(textarea:-webkit-autofill) {
   overflow: hidden;
 }

--- a/src/styles/autofill.scss
+++ b/src/styles/autofill.scss
@@ -1,0 +1,84 @@
+// ════════════════════════════════════════════════════════════════════════
+// 자동완성(autofill) 입력칸 - UA 스타일 무력화.
+//
+// 크롬/사파리는 자동완성으로 채운 칸에 자체 배경(연한 라벤더)과 글자색을
+// `!important` 로 강제한다. DS 폼 컨트롤은 배경을 *컨테이너*가 갖고 입력 요소는
+// 투명하므로, 자동완성이 걸린 칸만 UA 배경으로 칠해져 옆 칸과 달라 보인다
+// (다크 테마에선 그 칸만 밝은 상자로 튄다).
+//
+// 이 파일은 컴포넌트 번들(src/index.ts)이 1회 import → dist/index.css
+// (= `@bigtablet/design-system/style.css`) 에 포함된다. 테마 CSS 변수 정의는
+// `theme.scss` 가 담당하고 여기는 전역 요소 규칙만 둔다 (파일 역할 분리).
+//
+// 요소 셀렉터를 쓰는 이유: DS 컴포넌트로 감싸지 않은 native `<input>`(숫자
+// 스테퍼 등)도 같은 UA 스타일을 받으므로, 컴포넌트 스코프 셀렉터만 두면 그 칸은
+// 여전히 라벤더로 남는다. 컨테이너 클리핑(3번)만 DS 컴포넌트 스코프다.
+// ════════════════════════════════════════════════════════════════════════
+
+@use "./colors/index" as colors;
+
+// ── 1. 색 ───────────────────────────────────────────────────────────────
+// UA 배경은 `!important` 라 일반 `background-color` 로 못 이긴다. 대신 칸을 덮을
+// 만큼 큰 inset 그림자로 가리고, 글자색은 `-webkit-text-fill-color` 로 되돌린다
+// (autofill 상태에서는 `color` 보다 이 속성이 우선한다).
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+  -webkit-text-fill-color: colors.$color_text_heading;
+  caret-color: colors.$color_text_heading;
+}
+
+// ── 1b. filled variant ──────────────────────────────────────────────────
+// TextField `variant="filled"` 은 컨테이너 배경이 dim 이라, 1번(기본 표면)을 그대로 두면
+// 자동완성된 filled 칸만 outline 칸처럼 밝아진다. 컨테이너의 배경 전환을 그대로 따라간다:
+// 평상시 dim, 포커스 시 solid (`_variant_filled &_container:focus-within` 와 동일).
+// Textarea 에는 variant 가 없어 대응 규칙이 필요 없다.
+.text_field_variant_filled input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+}
+
+.text_field_variant_filled input:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid inset;
+}
+
+// ── 2. 비활성 + 자동완성 ─────────────────────────────────────────────────
+// 인증 후 칸을 `disabled` 로 잠그는 흐름에서 자동완성 값이 남는다. 1번만 두면
+// `-webkit-text-fill-color` 가 DS 의 disabled 글자색을 이겨 잠긴 칸이 활성처럼
+// 진해지고, 배경도 비활성 표면이 아니라 기본 표면이 된다.
+input:-webkit-autofill:disabled,
+textarea:-webkit-autofill:disabled,
+select:-webkit-autofill:disabled {
+  -webkit-box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+  box-shadow: 0 0 0 1000px colors.$color_bg_solid_dim inset;
+  -webkit-text-fill-color: colors.$color_text_disabled;
+}
+
+// ── 3. 둥근 모서리 유지 ──────────────────────────────────────────────────
+// 1·2번 그림자는 네모라서 그대로 두면 컨테이너의 둥근 모서리를 덮어 자동완성된
+// 칸만 각져 보인다 (자식은 부모 배경/테두리 위에 그려지고 부모 border-radius 로
+// 잘리지 않는다). 자동완성된 칸에서만 컨테이너를 클리핑 컨텍스트로 만들어
+// 컨테이너 자신의 반경으로 자른다.
+//
+// 입력 요소에 직접 `border-radius` 를 주는 방식은 쓰지 않는다: 앞/뒤 아이콘이
+// 있으면 input 상자가 컨테이너 가장자리에서 밀려 있어(`_inner` flex row) 어떤
+// 반경을 줘도 컨테이너 코너와 맞지 않는다. 클리핑은 아이콘 유무와 무관하게 맞다.
+//
+// `:has()` 지원은 문제되지 않는다 - `:-webkit-autofill` 자체가 Chromium/WebKit
+// 전용이고 두 엔진 모두 `:has()` 를 오래전부터 지원한다.
+//
+// 클리핑 안전성 확인: 포커스는 outset 그림자가 아니라 컨테이너 `border-color` 로
+// 표현하고, 아이콘·clear 버튼은 컨테이너 안쪽이며 Textarea 카운터는 컨테이너를
+// 닫은 뒤의 형제(`textarea_footer`)다. 오버레이(Tooltip/Popover/Menu)는 v3.8.0
+// 부터 `body` 로 포탈되므로 컨테이너 overflow 와 무관하다.
+.text_field_container:has(input:-webkit-autofill),
+.text_field_container:has(select:-webkit-autofill),
+.textarea_container:has(textarea:-webkit-autofill) {
+  overflow: hidden;
+}

--- a/src/vanilla/CLAUDE.md
+++ b/src/vanilla/CLAUDE.md
@@ -8,12 +8,15 @@ For non-React environments (Thymeleaf, JSP, PHP, Django, etc.)
 ### Build Output
 ```
 dist/vanilla/
-├── bigtablet.css       # Full CSS (~40KB)
-├── bigtablet.min.css   # Minified CSS (~31KB)
-├── bigtablet.js        # Full JS (~30KB)
-├── bigtablet.min.js    # Minified JS (~13KB)
-└── examples/           # HTML examples
+├── bigtablet.css       # Full CSS (~55KB)      - 배포 제외
+├── bigtablet.min.css   # Minified CSS (~38KB)  - 배포됨
+├── bigtablet.js        # Full JS (~48KB)       - 배포 제외
+├── bigtablet.min.js    # Minified JS (~19KB)   - 배포됨
+└── examples/           # HTML examples         - 배포 제외
 ```
+
+"배포 제외" 는 `package.json` `files` 의 `!dist/vanilla/...` 로 npm tarball 에서 빠진다는 뜻이다
+(로컬 빌드에는 생성된다). 소비자에게 안내할 경로는 압축본 2개뿐 - `docs/VANILLA.md#설치` 참고.
 
 ### Class Naming Convention (BEM-like)
 ```

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1534,6 +1534,20 @@ select:-webkit-autofill {
   caret-color: var(--bt-color-text-primary);
 }
 
+/* filled variant - `.bt-text-field__input--filled` 는 평상시 배경이 dim 이라, 위 규칙(기본 표면)만
+   두면 자동완성된 filled 칸만 outline 칸처럼 밝아진다. 그 variant 자신의 배경 전환을 따라간다:
+   평상시 dim, `:focus-visible` 에서 solid (`&--filled` 블록과 같은 훅).
+   React 쪽은 배경이 컨테이너에 있어 `.text_field_variant_filled` + `:focus-within` 을 쓴다. */
+.bt-text-field__input--filled:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+}
+
+.bt-text-field__input--filled:-webkit-autofill:focus-visible {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+}
+
 /* 비활성 + 자동완성 - 인증 후 칸을 잠그는 흐름에서 값이 남는다. 위 규칙만 두면
    `-webkit-text-fill-color` 가 disabled 글자색을 이겨 잠긴 칸이 활성처럼 진해진다. */
 input:-webkit-autofill:disabled,

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1511,6 +1511,39 @@
    DatePicker / FileInput 의 transition 은 전부 --bt-transition-* 를 경유하므로,
    선택자를 나열하는 대신 토큰 자체를 0s 로 눌러 일괄 무효화한다.
    (이후 추가되는 규칙과, 같은 var 를 쓰는 소비자 커스텀 스타일까지 자동으로 커버된다.) */
+/* ========================================
+   Autofill (자동완성) 입력칸 - UA 스타일 무력화
+   ======================================== */
+
+/* 크롬/사파리는 자동완성으로 채운 칸에 자체 배경(연한 라벤더)과 글자색을 `!important` 로
+   강제한다. 일반 `background-color` 로는 못 이기므로 칸을 덮을 만큼 큰 inset 그림자로 가리고
+   글자색은 `-webkit-text-fill-color` 로 되돌린다.
+
+   React 쪽(`style.css`)과 달리 컨테이너 클리핑 규칙이 없어도 된다 - Vanilla 는
+   `.bt-text-field__input` 자체가 배경과 `border-radius` 를 갖고 있어 inset 그림자가
+   input 자신의 반경으로 잘린다. React 는 배경이 컨테이너에 있어 별도 클리핑이 필요하다. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background) inset;
+  -webkit-text-fill-color: var(--bt-color-text-primary);
+  caret-color: var(--bt-color-text-primary);
+}
+
+/* 비활성 + 자동완성 - 인증 후 칸을 잠그는 흐름에서 값이 남는다. 위 규칙만 두면
+   `-webkit-text-fill-color` 가 disabled 글자색을 이겨 잠긴 칸이 활성처럼 진해진다. */
+input:-webkit-autofill:disabled,
+textarea:-webkit-autofill:disabled,
+select:-webkit-autofill:disabled {
+  -webkit-box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+  box-shadow: 0 0 0 1000px var(--bt-color-background-secondary) inset;
+  -webkit-text-fill-color: var(--bt-color-text-tertiary);
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root {
     --bt-transition-fast: 0s;


### PR DESCRIPTION
## 제목
merge: release v3.10.0

## 작업한 내용
- [x] 자동완성(autofill) 입력칸을 DS 가 소유 — 크롬/사파리가 `!important` 로 강제하는 UA 배경(연한 라벤더)·글자색을 DS 표면 토큰으로 덮는다. `src/styles/autofill.scss` 신설 → `style.css` 포함
- [x] 상태별 표면 유지 — `variant="filled"` 는 dim 채움(포커스 시 solid), `disabled` 는 비활성 표면·글자색. 에러 칸은 테두리로만 구분
- [x] 둥근 모서리 유지 — inset 그림자가 네모라 컨테이너 모서리를 각지게 만들던 문제를 자동완성된 칸에서만 `:has()` 클리핑으로 해결
- [x] DS 밖 native 입력도 커버 — `input`/`textarea`/`select` 요소 셀렉터
- [x] Vanilla 번들에도 동일 적용 (별도 번들이라 Thymeleaf/JSP 폼도 같은 문제였음)
- [x] `docs/THEMING.md` 절 추가(상태별 토큰 표 + 원리), `docs/VANILLA.md` 안내
- [x] `docs/VANILLA.md` "직접 다운로드" 절 제거 → CDN/npm 안내로 정리. `release.yml` 이 자산을 첨부하지 않아 받을 수 없는 경로였고, 안내된 두 파일은 `package.json` `files` 로 tarball 에서도 제외돼 있었습니다. 실제 배포되는 산출물(압축본 2개, 실측 38KB/19KB)과 소스 위치를 대신 명시. `src/vanilla/CLAUDE.md` 의 낡은 크기 표기도 실측으로 갱신 + 배포 포함 여부 표시
- [x] `package.json` 3.9.0 → 3.10.0, CHANGELOG 3.10.0 섹션

## 전달할 추가 이슈
- **전역 CSS 규칙 추가라 minor** — breaking 없음. 기존 호출부·마크업 변경 불필요하고, `style.css` 를 이미 import 하는 소비자는 자동 적용됩니다
- **릴리스 후 컨슈머 정리**: notiiv 웹에서 `packages/styles/autofill.css` + 3개 layout import + `package.json` export 삭제 (남기면 knip `Dead code` 가 잡습니다). 그 앱들은 DS `style.css` 를 이미 import 하고 있어 추가 import 는 필요 없습니다
- **남은 미확인 1건**: 실제 크롬 autofill 팝업으로 채운 상태는 사람이 한 번 봐주시면 좋겠습니다. CSS 캐스케이드는 빌드 산출물의 `:-webkit-autofill` 을 동일 특이도 클래스로 치환해 React 11케이스 · Vanilla 7케이스를 라이트/다크 각각 계산값으로 검증했지만(전부 `그림자색 == 컨테이너 배경`), UA 가 `!important` 를 붙이는 실제 속성 집합이 브라우저 버전에 따라 다를 여지는 남습니다
- **자동 리뷰가 붙지 않았습니다** — `claude[bot]` 은 조직 월 코드리뷰 예산 초과, CodeRabbit 은 플랜 rate limit, 우리 `claude-review.yml` 은 이번에 넣은 릴리즈 PR 제외 규칙으로 의도적 skip. 리뷰가 필요하면 `@claude review`(수동 호출은 제외 규칙과 무관하게 동작) 또는 한도 리셋 후 `@coderabbitai review`
- 열려 있는 dependabot PR 5건(#451~#455)은 dev 의존성이라 이 릴리스에 포함되지 않았습니다

## 배포 절차
머지 후 `main` 에서 `git tag -a v3.10.0 -m "v3.10.0"` → `git push origin v3.10.0` → `release.yml` 자동 publish