### PR TITLE
fix/modal-docs-stories

### DIFF
--- a/src/ui/overlay/modal/modal.stories.tsx
+++ b/src/ui/overlay/modal/modal.stories.tsx
@@ -49,8 +49,12 @@ export const CreateToken: Story = {
 			},
 		},
 	},
-	render: () => {
-		const [open, setOpen] = useState(true);
+	// Docs 뷰는 모든 스토리를 한 페이지에 렌더하고 첫 스토리를 primary 프리뷰로 한 번 더 그린다.
+	// 그래서 마운트 즉시 열면 모달이 겹쳐 쌓이고, 스크롤 잠금 카운터가 그 수만큼 올라가
+	// Docs 페이지 자체가 `overflow: hidden` 으로 잠긴다. 격리된 story 뷰(Chromatic 스냅샷 포함)
+	// 에서만 자동으로 열고, Docs 에서는 버튼으로 연다.
+	render: (_args, { viewMode }) => {
+		const [open, setOpen] = useState(viewMode === "story");
 		return (
 			<div style={{ padding: 24 }}>
 				<Button onClick={() => setOpen(true)}>모달 열기</Button>
@@ -88,8 +92,12 @@ export const DestructiveAction: Story = {
 			},
 		},
 	},
-	render: () => {
-		const [open, setOpen] = useState(true);
+	// Docs 뷰는 모든 스토리를 한 페이지에 렌더하고 첫 스토리를 primary 프리뷰로 한 번 더 그린다.
+	// 그래서 마운트 즉시 열면 모달이 겹쳐 쌓이고, 스크롤 잠금 카운터가 그 수만큼 올라가
+	// Docs 페이지 자체가 `overflow: hidden` 으로 잠긴다. 격리된 story 뷰(Chromatic 스냅샷 포함)
+	// 에서만 자동으로 열고, Docs 에서는 버튼으로 연다.
+	render: (_args, { viewMode }) => {
+		const [open, setOpen] = useState(viewMode === "story");
 		return (
 			<div style={{ padding: 24 }}>
 				<Button danger onClick={() => setOpen(true)}>


### PR DESCRIPTION
## 제목
fix/modal-docs-stories

## 작업한 내용
- [x] Modal Docs 페이지에서 모달 3개가 동시에 열리던 문제 수정 — 초기 open 을 `viewMode === "story"` 로 게이트
- [x] 격리 story 뷰(Chromatic 스냅샷 포함)는 그대로 마운트 즉시 열림 유지

## 전달할 추가 이슈
- **증상이 시각 문제만이 아니었습니다.** Docs 뷰는 모든 스토리를 한 페이지에 렌더하고 첫 스토리를 primary 프리뷰로 한 번 더 그립니다. `CreateToken` · `DestructiveAction` 이 `useState(true)` 였어서 모달 3개가 쌓이고 **스크롤 잠금 카운터가 3 까지 올라가 Docs 페이지 자체가 `overflow: hidden`** 으로 잠겼습니다 (모달 더미 뒤 페이지를 스크롤할 수 없음)
- 두 스토리 모두 이미 "모달 열기" 트리거 버튼을 렌더하고 있어서, Docs 에서는 그 버튼으로 열면 됩니다 — 문서 가치 손실 없음
- 오버레이 스토리 전수 확인했고 이 2건 외에는 없습니다. `useState(true)` 를 쓰는 다른 스토리(Toggle on 상태, 로딩 스피너, 체크박스 기본 체크 등)는 스크롤락과 무관합니다

## 검증
Storybook 실측:

| | 수정 전 | 수정 후 |
|---|---|---|
| Docs 뷰 열린 모달 | **3** | **0** |
| Docs 뷰 스크롤락 카운터 | **3** | 없음 |
| Docs 뷰 `body overflow` | **hidden** (스크롤 불가) | 없음 |
| 격리 story 뷰 | 자동 열림 | 자동 열림 (카운터 1) |

유닛 826 통과 / tsc · biome 통과.