### PR TITLE
config/dependabot-grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 updates:
+  # npm 의존성
+  #
+  # 한 PR 로 묶는다. 이 레포는 모든 갱신이 `pnpm-lock.yaml` 한 파일을 건드리기 때문에, 패키지별로
+  # PR 이 갈리면 첫 PR 을 머지한 순간 나머지가 전부 lockfile 충돌로 막힌다(실측: 5건 중 2건이
+  # 즉시 CONFLICTING). 게다가 squash 머지는 각 PR 의 base 시점 lockfile 을 그대로 얹으므로,
+  # 충돌 없이 머지되는 것처럼 보이면서 앞서 머지한 범프를 되돌릴 수 있다 - 과거에 실제로 겪고
+  # `config: re-apply lucide/next/playwright bumps reverted by squash cascade` 로 복구했다.
+  # 묶으면 lockfile 이 한 번만 갱신돼 두 문제가 같이 사라진다.
+  #
+  # 트레이드오프: 한 패키지가 CI 를 깨면 그 주 묶음 전체가 막힌다. 그때는 문제 패키지를 아래
+  # `ignore` 에 추가하거나, 그 항목만 손으로 떼어 올린다.
   - package-ecosystem: npm
     directory: "/"
     schedule:
@@ -14,23 +25,20 @@ updates:
     commit-message:
       prefix: "config"
     groups:
-      # react/react-dom 는 반드시 같은 버전이어야 함 — 한 PR 로 묶어 버전 불일치 방지
-      react:
+      # 하나로 묶는다 - react/react-dom 버전 일치나 @storybook/* 다발 같은 기존 그룹 의도도
+      # 자동으로 충족된다(같은 PR 안에서 함께 올라가므로).
+      npm:
         patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      # Storybook 패키지 다발 — 노이즈 감소 위해 묶음
-      storybook:
-        patterns:
-          - "storybook"
-          - "@storybook/*"
+          - "*"
     ignore:
       # major 버전 업은 수동으로 검토
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  # GitHub Actions
+  #
+  # 같은 이유로 묶는다 - 액션 버전은 워크플로 파일 여러 개에 흩어져 있어 PR 이 갈리면
+  # 같은 파일을 두 PR 이 고치는 경우가 생긴다.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -43,6 +51,10 @@ updates:
       - dependencies
     commit-message:
       prefix: "config"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       # major 버전 업은 수동으로 검토
       - dependency-name: "*"


### PR DESCRIPTION
## 제목
config/dependabot-grouping

## 작업한 내용
- [x] npm 갱신을 한 PR 로 묶음 (`groups: npm: patterns: ["*"]`)
- [x] github-actions 갱신도 동일하게 묶음
- [x] `react` · `storybook` 하위 그룹 제거 — 단일 `*` 그룹이 포함하므로 react/react-dom 동시 이동은 그대로 보장
- [x] 각 결정의 근거를 설정 파일 주석에 기록 (notiiv 웹 설정 방식)

## 전달할 추가 이슈
- **묶는 이유가 이 레포에선 특히 강합니다.** 모든 npm 범프가 `pnpm-lock.yaml` 한 파일을 건드려서, 오늘 5건 중 첫 PR 을 머지한 순간 나머지 2건이 즉시 `CONFLICTING` 이 됐습니다. 더 위험한 건 squash 머지가 각 PR 의 base 시점 lockfile 을 그대로 얹는다는 점입니다 — 충돌 없이 머지되는 것처럼 보이면서 앞 범프를 되돌릴 수 있고, 이 레포는 실제로 겪어서 `config: re-apply lucide/next/playwright bumps reverted by squash cascade` 로 복구한 이력이 있습니다. 묶으면 lockfile 이 한 번만 갱신돼 두 문제가 함께 사라집니다
- **트레이드오프**: 한 패키지가 CI 를 깨면 그 주 묶음 전체가 막힙니다. 그때는 문제 패키지를 `ignore` 에 추가하거나 그 항목만 손으로 떼어 올립니다 (주석에도 적어뒀습니다)
- 라벨은 notiiv 의 `Fix` 대신 이 레포의 기존 `dependencies` 를 유지했습니다 — 봇 PR 을 사람 PR 과 구분하는 데 유용합니다
- notiiv 웹의 catalog 관련 주석(앱 디렉터리 잡을 두지 않는 이유)은 이 레포에 해당 없습니다 — 단일 패키지이고 pnpm catalog 를 쓰지 않습니다
- **오늘 머지한 3건**(#451 storybook 그룹 · #454 stylelint · #455 lucide-react)은 lockfile 에 모두 반영됐음을 확인했습니다(squash cascade 미발생). 남은 #452 vite · #453 tsx 는 lockfile 충돌 상태로, `@dependabot rebase` 요청해뒀습니다 — 이 설정이 머지되면 다음 주기엔 하나로 묶여 올라옵니다