### PR TITLE
feat/vanilla-tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -108,6 +108,30 @@ src/ui/general/button/
 └── Button.test.tsx    # 테스트 파일
 ```
 
+### Vanilla 번들 테스트
+
+`src/vanilla/bigtablet.test.ts` 가 Vanilla 번들(`Dropdown` / `Modal` / `Toggle` / `Alert`)을 덮는다.
+React 쪽 `unit` 프로젝트에 그대로 포함되므로 `pnpm test` 로 함께 돈다.
+
+```ts
+// UMD 번들이지만 Vite 가 named export 로 노출해준다. 소비자는 `<script>` + 전역 `Bigtablet`
+// 로 쓰지만 부착 경로만 다르고 검사 대상 로직은 같다. 빌드 산출물이 아니라 소스를 import 해서
+// 소스 변경이 곧 테스트에 걸리게 한다.
+import { Alert, Dropdown, Modal, Toggle } from "./bigtablet.js";
+```
+
+주의할 점:
+
+- **jsdom 은 레이아웃을 하지 않는다.** 스크롤바 폭(`innerWidth - documentElement.clientWidth`)은 항상 0
+  이므로, 스크롤 잠금 보정을 검사하려면 두 값을 직접 세워야 한다 (`setScrollbarWidth` 헬퍼 참고).
+- **내부 함수는 export 되지 않는다.** `lockScroll` / `unlockScroll` 는 `Modal` · `Alert` 를 열고
+  닫으며 간접 검사한다 - 통합 경로를 함께 보게 되어 오히려 낫다.
+- **문서화된 마크업으로 시작한다.** 서버 템플릿이 렌더하는 형태(평면 `<ul>`, 서버가 심어둔 hidden
+  input 등)를 그대로 세워야 실제 회귀를 잡는다 - 실제로 그 두 경로에서 버그가 나왔다.
+
+> 커버리지 집계(`vitest.config.ts` 의 `coverage.include`)는 아직 `src/ui/**` · `src/utils/**` 만
+> 본다. Vanilla 를 넣으면 전체 수치가 크게 떨어지므로 별건으로 다룬다 - 테스트 자체는 이미 돈다.
+
 ### 기본 구조
 
 ```tsx

--- a/src/vanilla/CLAUDE.md
+++ b/src/vanilla/CLAUDE.md
@@ -18,6 +18,14 @@ dist/vanilla/
 "배포 제외" 는 `package.json` `files` 의 `!dist/vanilla/...` 로 npm tarball 에서 빠진다는 뜻이다
 (로컬 빌드에는 생성된다). 소비자에게 안내할 경로는 압축본 2개뿐 - `docs/VANILLA.md#설치` 참고.
 
+### 테스트
+
+`bigtablet.test.ts` 가 이 번들을 덮는다 (`pnpm test` 에 포함). 소스를 직접 import 하므로
+여기 코드를 고치면 테스트가 먼저 걸린다. 새 동작을 추가하면 같은 파일에 케이스를 더한다.
+
+jsdom 은 레이아웃을 하지 않으니 스크롤바 폭 같은 값은 직접 세워야 한다. 자세한 주의점은
+[docs/TESTING.md](../../docs/TESTING.md#vanilla-번들-테스트) 참고.
+
 ### Class Naming Convention (BEM-like)
 ```
 .bt-{component}

--- a/src/vanilla/bigtablet.test.ts
+++ b/src/vanilla/bigtablet.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// Vanilla 번들은 UMD 다. 소비자는 `<script>` 로 읽어 전역 `Bigtablet` 을 쓰지만, 여기서는
+// Vite 가 노출하는 named export 로 같은 팩토리를 직접 부른다 - 부착 경로만 다르고 검사 대상
+// 로직은 동일하다. 빌드 산출물이 아니라 소스를 import 해서, 소스 변경이 곧 테스트에 걸린다.
+import { Alert, Dropdown, Modal, Toggle } from "./bigtablet.js";
+
+/** jsdom 은 레이아웃을 하지 않아 스크롤바 폭이 항상 0 이다. 있는 상황을 직접 세운다. */
+const setScrollbarWidth = (width: number) => {
+	Object.defineProperty(window, "innerWidth", { value: 1280, configurable: true, writable: true });
+	vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280 - width);
+};
+
+const pressEscape = () =>
+	document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+/** 문서화된 기본 Dropdown 마크업 (평면 `<ul>`). */
+const dropdownMarkup = (opts: { multiple?: boolean; name?: string; placeholder?: string } = {}) => {
+	const wrap = document.createElement("div");
+	wrap.className = "bt-dropdown";
+	wrap.id = "dd";
+	if (opts.multiple) wrap.dataset.multiple = "";
+	if (opts.name) wrap.dataset.name = opts.name;
+	wrap.innerHTML = `
+		<button type="button" class="bt-dropdown__control">
+			<span class="bt-dropdown__placeholder">${opts.placeholder ?? "선택하세요"}</span>
+		</button>
+		<ul class="bt-dropdown__list">
+			<li class="bt-dropdown__option" data-value="apple">사과 Apple</li>
+			<li class="bt-dropdown__option" data-value="grape">포도</li>
+			<li class="bt-dropdown__option is-disabled" data-value="melon">멜론 (품절)</li>
+		</ul>`;
+	document.body.appendChild(wrap);
+	return wrap;
+};
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	document.body.style.cssText = "";
+	document.documentElement.style.cssText = "";
+	for (const k of Object.keys(document.body.dataset)) delete document.body.dataset[k];
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Dropdown - 초기화", () => {
+	it("마크업의 placeholder 문구를 라이브러리 기본값으로 덮어쓰지 않는다", () => {
+		// 회귀: renderSelection() 이 init 시점에 "Select..." 로 덮어써서 서버 템플릿 문구가 사라졌다.
+		const wrap = dropdownMarkup({ placeholder: "과일을 고르세요" });
+		Dropdown(wrap);
+
+		expect(wrap.querySelector(".bt-dropdown__placeholder")?.textContent).toBe("과일을 고르세요");
+	});
+
+	it("서버가 렌더한 hidden input 값을 읽어 초기 선택으로 쓴다 (다중)", () => {
+		// 회귀: 다중 모드에서 값을 읽기 전에 기존 hidden input 을 지워 th:field 값이 유실됐다.
+		const wrap = dropdownMarkup({ multiple: true, name: "fruit" });
+		for (const v of ["apple", "grape"]) {
+			const input = document.createElement("input");
+			input.type = "hidden";
+			input.name = "fruit";
+			input.value = v;
+			wrap.appendChild(input);
+		}
+
+		const dd = Dropdown(wrap);
+
+		expect(dd?.getValue()).toEqual(["apple", "grape"]);
+	});
+
+	it("native disabled 를 config·aria·클래스와 함께 동기화한다", () => {
+		const wrap = dropdownMarkup();
+		const control = wrap.querySelector(".bt-dropdown__control") as HTMLButtonElement;
+		control.disabled = true;
+
+		const dd = Dropdown(wrap);
+
+		expect(control.getAttribute("aria-disabled")).toBe("true");
+		expect(control.classList.contains("is-disabled")).toBe(true);
+
+		dd?.open();
+		expect(wrap.querySelector(".bt-dropdown__list")?.getAttribute("style")).not.toContain("block");
+	});
+
+	it("setDisabled 가 native disabled 까지 반영한다", () => {
+		const wrap = dropdownMarkup();
+		const control = wrap.querySelector(".bt-dropdown__control") as HTMLButtonElement;
+		const dd = Dropdown(wrap);
+
+		dd?.setDisabled(true);
+		expect(control.disabled).toBe(true);
+		expect(control.getAttribute("aria-disabled")).toBe("true");
+
+		dd?.setDisabled(false);
+		expect(control.disabled).toBe(false);
+	});
+});
+
+describe("Dropdown - 다중 선택", () => {
+	it("옵션을 토글해도 패널이 닫히지 않는다", () => {
+		const wrap = dropdownMarkup({ multiple: true });
+		const dd = Dropdown(wrap);
+		dd?.open();
+
+		(wrap.querySelector('[data-value="apple"]') as HTMLElement).click();
+
+		expect(dd?.getValue()).toEqual(["apple"]);
+		expect(wrap.querySelector(".bt-dropdown__control")?.getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("트리거에 선택 개수 요약을 쓴다", () => {
+		const wrap = dropdownMarkup({ multiple: true });
+		const dd = Dropdown(wrap);
+		dd?.setValue(["apple", "grape"]);
+
+		expect(wrap.querySelector(".bt-dropdown__value")?.textContent).toBe("2개 선택");
+	});
+
+	it("같은 name 의 hidden input 을 선택 개수만큼 반복해 만든다", () => {
+		const wrap = dropdownMarkup({ multiple: true, name: "fruit" });
+		const dd = Dropdown(wrap);
+		dd?.setValue(["apple", "grape"]);
+
+		const values = [
+			...wrap.querySelectorAll<HTMLInputElement>('input[type="hidden"][name="fruit"]'),
+		].map((i) => i.value);
+		expect(values).toEqual(["apple", "grape"]);
+	});
+
+	it("선택이 0개면 hidden input 도 0개다", () => {
+		const wrap = dropdownMarkup({ multiple: true, name: "fruit" });
+		const dd = Dropdown(wrap);
+		dd?.setValue([]);
+
+		expect(wrap.querySelectorAll('input[type="hidden"][name="fruit"]')).toHaveLength(0);
+	});
+
+	it("listbox 에 aria-multiselectable 을 붙인다", () => {
+		const wrap = dropdownMarkup({ multiple: true });
+		Dropdown(wrap);
+
+		expect(wrap.querySelector('[role="listbox"]')?.getAttribute("aria-multiselectable")).toBe(
+			"true",
+		);
+	});
+});
+
+describe("Dropdown - 검색", () => {
+	const searchableMarkup = () => {
+		const wrap = dropdownMarkup();
+		wrap.dataset.searchable = "";
+		return wrap;
+	};
+
+	const visibleLabels = (wrap: HTMLElement) =>
+		[...wrap.querySelectorAll<HTMLElement>(".bt-dropdown__option")]
+			.filter((el) => !el.hidden)
+			.map((el) => el.textContent?.trim());
+
+	it("평면 `<ul>` 마크업을 패널로 승격하고 검색 행을 넣는다", () => {
+		const wrap = searchableMarkup();
+		Dropdown(wrap);
+
+		expect(wrap.querySelector(".bt-dropdown__search-input")).not.toBeNull();
+		// 원래 `<ul>` 은 스크롤 컨테이너(`__options`)가 되고 새 `<div>` 패널이 그것을 감싼다.
+		expect(wrap.querySelector("div.bt-dropdown__list > ul.bt-dropdown__options")).not.toBeNull();
+	});
+
+	it("대소문자·공백을 무시하고 부분 일치로 걸러낸다", () => {
+		const wrap = searchableMarkup();
+		const dd = Dropdown(wrap);
+		dd?.open();
+
+		const input = wrap.querySelector(".bt-dropdown__search-input") as HTMLInputElement;
+		input.value = "  aPP le ";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+
+		expect(visibleLabels(wrap)).toEqual(["사과 Apple"]);
+	});
+
+	it("결과가 없으면 안내 문구를 보여준다", () => {
+		const wrap = searchableMarkup();
+		const dd = Dropdown(wrap);
+		dd?.open();
+
+		const input = wrap.querySelector(".bt-dropdown__search-input") as HTMLInputElement;
+		input.value = "존재하지않는과일";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+
+		const empty = wrap.querySelector(".bt-dropdown__empty") as HTMLElement;
+		expect(empty.hidden).toBe(false);
+		expect(empty.textContent).toBe("결과 없음");
+	});
+
+	it("한글 IME 조합 중에는 필터를 보류한다", () => {
+		const wrap = searchableMarkup();
+		const dd = Dropdown(wrap);
+		dd?.open();
+
+		const input = wrap.querySelector(".bt-dropdown__search-input") as HTMLInputElement;
+		input.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+		input.value = "포";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+
+		// 조합 중 - 아직 아무것도 걸러지지 않았다.
+		expect(visibleLabels(wrap)).toHaveLength(3);
+
+		input.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true, data: "포" }));
+
+		expect(visibleLabels(wrap)).toEqual(["포도"]);
+	});
+});
+
+describe("Toggle", () => {
+	const toggleMarkup = () => {
+		const el = document.createElement("button");
+		el.className = "bt-toggle";
+		el.innerHTML = '<span class="bt-toggle__thumb"></span>';
+		document.body.appendChild(el);
+		return el;
+	};
+
+	it("클릭하면 onCheckedChange 를 부른다", () => {
+		const onCheckedChange = vi.fn();
+		const el = toggleMarkup();
+		Toggle(el, { onCheckedChange });
+
+		el.click();
+
+		expect(onCheckedChange).toHaveBeenCalledWith(true);
+		expect(el.getAttribute("aria-checked")).toBe("true");
+	});
+
+	it("native disabled 면 토글되지 않는다", () => {
+		const onCheckedChange = vi.fn();
+		const el = toggleMarkup();
+		el.disabled = true;
+		Toggle(el, { onCheckedChange });
+
+		el.click();
+
+		expect(onCheckedChange).not.toHaveBeenCalled();
+	});
+
+	it("config.disabled 를 native disabled 로 통일한다", () => {
+		const el = toggleMarkup();
+		Toggle(el, { disabled: true });
+
+		expect(el.disabled).toBe(true);
+	});
+});
+
+describe("Modal - 바디 스크롤 잠금", () => {
+	const modalMarkup = (id = "m1") => {
+		const el = document.createElement("div");
+		el.className = "bt-modal";
+		el.id = id;
+		el.innerHTML = '<div class="bt-modal__panel"><button>닫기</button></div>';
+		document.body.appendChild(el);
+		return el;
+	};
+
+	it("열면 잠그고 닫으면 푼다", () => {
+		setScrollbarWidth(0);
+		const m = Modal(modalMarkup());
+
+		m?.open();
+		expect(document.body.style.overflow).toBe("hidden");
+		expect(document.body.dataset.btOpenModals).toBe("1");
+
+		m?.close();
+		expect(document.body.style.overflow).toBe("");
+		expect(document.body.dataset.btOpenModals).toBeUndefined();
+	});
+
+	it("스크롤바 폭을 보정하고 stable 거터를 놓는다", () => {
+		document.documentElement.style.scrollbarGutter = "stable";
+		setScrollbarWidth(15);
+
+		const m = Modal(modalMarkup());
+		m?.open();
+
+		expect(document.body.style.paddingRight).toBe("15px");
+		expect(document.documentElement.style.scrollbarGutter).toBe("auto");
+		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("15px");
+
+		m?.close();
+
+		expect(document.body.style.paddingRight).toBe("");
+		expect(document.documentElement.style.scrollbarGutter).toBe("stable");
+		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("");
+	});
+
+	it("중첩 오버레이는 마지막 해제까지 잠금을 유지한다", () => {
+		setScrollbarWidth(15);
+		const a = Modal(modalMarkup("m1"));
+		const b = Modal(modalMarkup("m2"));
+
+		a?.open();
+		b?.open();
+		expect(document.body.dataset.btOpenModals).toBe("2");
+
+		b?.close();
+		expect(document.body.style.overflow).toBe("hidden");
+		expect(document.body.style.paddingRight).toBe("15px");
+
+		a?.close();
+		expect(document.body.style.overflow).toBe("");
+	});
+
+	it("이미 열린 모달을 다시 열어도 카운터가 중복 증가하지 않는다", () => {
+		setScrollbarWidth(0);
+		const m = Modal(modalMarkup());
+
+		m?.open();
+		m?.open();
+
+		expect(document.body.dataset.btOpenModals).toBe("1");
+	});
+});
+
+describe("Alert", () => {
+	it("Escape 로 닫으면 onCancel 을 경유한다", () => {
+		setScrollbarWidth(0);
+		const onCancel = vi.fn();
+		Alert({ title: "삭제", message: "정말?", showCancel: true, onCancel });
+
+		pressEscape();
+
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("오버레이 클릭으로 닫아도 onCancel 을 경유한다", () => {
+		setScrollbarWidth(0);
+		const onCancel = vi.fn();
+		Alert({ title: "삭제", message: "정말?", showCancel: true, onCancel });
+
+		const overlay = document.querySelector(".bt-alert__overlay") as HTMLElement;
+		overlay.click();
+
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("closeOnOverlay: false 면 오버레이 클릭으로 닫히지 않는다", () => {
+		setScrollbarWidth(0);
+		const onCancel = vi.fn();
+		Alert({ title: "삭제", message: "정말?", closeOnOverlay: false, onCancel });
+
+		(document.querySelector(".bt-alert__overlay") as HTMLElement).click();
+
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+});

--- a/src/vanilla/bigtablet.test.ts
+++ b/src/vanilla/bigtablet.test.ts
@@ -80,7 +80,7 @@ describe("Dropdown - 초기화", () => {
 		expect(control.classList.contains("is-disabled")).toBe(true);
 
 		dd?.open();
-		expect(wrap.querySelector(".bt-dropdown__list")?.getAttribute("style")).not.toContain("block");
+		expect((wrap.querySelector(".bt-dropdown__list") as HTMLElement).style.display).toBe("none");
 	});
 
 	it("setDisabled 가 native disabled 까지 반영한다", () => {
@@ -317,12 +317,30 @@ describe("Modal - 바디 스크롤 잠금", () => {
 		m?.open();
 
 		expect(document.body.dataset.btOpenModals).toBe("1");
+
+		// 반드시 닫는다. Modal 은 `document` 에 keydown 리스너를 걸고 close() 에서만 떼므로,
+		// 열어둔 채 끝내면 이후 테스트의 Escape 가 이 좀비 모달까지 깨워 그쪽 close() ->
+		// unlockScroll() 이 남의 스크롤 잠금 카운터를 소비해버린다.
+		m?.close();
 	});
 });
 
+// Alert 의 close() 는 퇴출 애니메이션을 기다려 `setTimeout(..., 200)` 안에서 overlay 제거와
+// unlockScroll() 을 한다. 실제 타이머로 두면 그 콜백이 이 테스트가 끝난 뒤 **다른 테스트가 도는
+// 중에** 발화해 남의 스크롤 잠금 상태를 건드린다. fake timer 로 시점을 직접 통제한다.
 describe("Alert", () => {
-	it("Escape 로 닫으면 onCancel 을 경유한다", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
 		setScrollbarWidth(0);
+	});
+
+	afterEach(() => {
+		// 남은 지연 콜백(overlay 제거 + unlockScroll)을 이 테스트 안에서 소진시킨 뒤 되돌린다.
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+	});
+
+	it("Escape 로 닫으면 onCancel 을 경유한다", () => {
 		const onCancel = vi.fn();
 		Alert({ title: "삭제", message: "정말?", showCancel: true, onCancel });
 
@@ -332,23 +350,38 @@ describe("Alert", () => {
 	});
 
 	it("오버레이 클릭으로 닫아도 onCancel 을 경유한다", () => {
-		setScrollbarWidth(0);
 		const onCancel = vi.fn();
 		Alert({ title: "삭제", message: "정말?", showCancel: true, onCancel });
 
-		const overlay = document.querySelector(".bt-alert__overlay") as HTMLElement;
-		overlay.click();
+		(document.querySelector(".bt-alert__overlay") as HTMLElement).click();
 
 		expect(onCancel).toHaveBeenCalledTimes(1);
 	});
 
+	it("닫으면 스크롤 잠금이 풀린다", () => {
+		Alert({ title: "삭제", message: "정말?", showCancel: true });
+		expect(document.body.dataset.btOpenModals).toBe("1");
+
+		pressEscape();
+		// 잠금 해제는 200ms 뒤 - 그 전에는 아직 잠겨 있다.
+		expect(document.body.style.overflow).toBe("hidden");
+
+		vi.advanceTimersByTime(200);
+
+		expect(document.body.style.overflow).toBe("");
+		expect(document.body.dataset.btOpenModals).toBeUndefined();
+	});
+
 	it("closeOnOverlay: false 면 오버레이 클릭으로 닫히지 않는다", () => {
-		setScrollbarWidth(0);
 		const onCancel = vi.fn();
-		Alert({ title: "삭제", message: "정말?", closeOnOverlay: false, onCancel });
+		const alert = Alert({ title: "삭제", message: "정말?", closeOnOverlay: false, onCancel });
 
 		(document.querySelector(".bt-alert__overlay") as HTMLElement).click();
 
 		expect(onCancel).not.toHaveBeenCalled();
+
+		// 이 케이스는 끝까지 열려 있으므로 직접 닫는다 - 안 닫으면 Alert 가 `document` 에 건
+		// keydown 리스너와 스크롤 잠금이 파일 끝까지 남는다.
+		alert?.close();
 	});
 });


### PR DESCRIPTION
## 제목
feat/vanilla-tests

## 작업한 내용
- [x] `src/vanilla/bigtablet.test.ts` 신설 — 23건. 기존 `unit` 프로젝트에 포함되므로 `pnpm test` 로 함께 돈다 (새 vitest 프로젝트 불필요)
- [x] Dropdown 초기화 4건 — 마크업 placeholder 승계, 서버 렌더 hidden input 승계(다중), native disabled 동기화, `setDisabled`
- [x] Dropdown 다중 5건 — 토글 시 패널 유지, `N개 선택` 요약, 같은 name 반복 hidden input, 0개면 0개, `aria-multiselectable`
- [x] Dropdown 검색 4건 — 평면 `<ul>` 패널 승격, 대소문자·공백 무시 필터, `emptyText`, 한글 IME 조합 중 필터 보류
- [x] Toggle 3건 · Modal 스크롤 잠금 4건 · Alert 3건
- [x] `docs/TESTING.md` 절 + `src/vanilla/CLAUDE.md` 안내 추가

## 전달할 추가 이슈
- **테스트가 헛통과하지 않는지 변이 검사했습니다.** 소스에서 (1) 마크업 placeholder 승계와 (2) 스크롤바 폭 보정을 각각 제거해보니 해당 테스트가 정확히 실패했고, 원복 후 23/23 통과했습니다. 오늘 고친 회귀들을 실제로 잡습니다
- **로딩 방식**: UMD 번들이지만 Vite 가 named export 로 노출해줘서 `import { Dropdown, Modal, Toggle, Alert } from "./bigtablet.js"` 로 씁니다. 소비자는 `<script>` + 전역 `Bigtablet` 을 쓰지만 부착 경로만 다르고 검사 대상 로직은 같습니다. **빌드 산출물이 아니라 소스를 import** 하므로 소스 변경이 곧 테스트에 걸립니다
- **`lockScroll` / `unlockScroll` 는 export 되지 않아** Modal 을 열고 닫으며 간접 검사합니다 — 통합 경로를 함께 보게 되어 오히려 낫습니다
- **jsdom 은 레이아웃을 하지 않아** 스크롤바 폭이 항상 0 입니다. `setScrollbarWidth` 헬퍼로 `innerWidth` / `documentElement.clientWidth` 를 직접 세웠습니다 (React `scroll-lock.test.ts` 와 같은 방식)
- **커버리지 집계는 아직 vanilla 를 포함하지 않습니다** (`coverage.include` 가 `src/ui/**` · `src/utils/**`). 넣으면 헤드라인 수치가 크게 움직이므로 별건으로 남겼습니다 — 테스트 자체는 이미 CI 에서 돕니다. 원하시면 후속 PR 로 포함시키겠습니다
- **아직 안 덮은 것**: Pagination, `init()` 자동 초기화 경로, Dropdown 키보드 내비게이션(방향키·Home/End·Tab), FileInput·DatePicker. 오늘 손댄 영역을 우선했습니다

## 검증
`pnpm test` 826 → **849 통과** (57 파일). tsc · biome 통과.