### PR TITLE
merge: release v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.11.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.11.0) - 2026-08-20
+
+- `TextField` 에 조작 슬롯 `leadingAction` · `trailingAction` 추가 - 아이콘 슬롯(`leadingIcon`·`trailingIcon`)은 장식 전용이라 `aria-hidden` 을 유지하고, 포커스 가능한 요소는 이 새 슬롯에 넣는다. 아이콘 칸의 위치·크기 CSS 를 그대로 재사용하고 넘긴 요소가 40x40 히트 영역을 채운다
+- 아이콘 슬롯에 버튼을 넣으면 발생하던 접근성 위반 해소 - `aria-hidden` 조상 때문에 포커스는 가는데 보조기기엔 존재하지 않는 요소가 되어 WCAG 4.1.2(Name/Role/Value) 위반이었고, Chrome 은 `Blocked aria-hidden on an element because its descendant retained focus` 를 남기며 `aria-hidden` 적용을 거부했다
+- `TextField` 에 비밀번호 표시/숨기기 토글 내장 - `showPasswordToggle` 로 켜고, 문구는 i18n 때문에 `passwordToggleLabels` 로 앱이 주입한다(기본값 영문). 오른쪽 칸 우선순위는 `showPasswordToggle` > `clearable` > `trailingAction` > `trailingIcon`
+- `TextField` 내장 버튼이 `disabled` 를 따르도록 수정 - 비밀번호 토글과 지우기(X) 버튼이 비활성 필드에서도 포커스·클릭됐다(비활성 입력의 비밀번호를 드러낼 수 있었음). 비활성 스타일은 `opacity` 만 걸고 `pointer-events` 는 건드리지 않는다
+- `EmptyState.illustration` · `ErrorState.icon` 의 장식 슬롯 계약 명시 - 두 슬롯은 `aria-hidden` 으로 접근성 트리에서 제외되고, 조작 요소는 기존 `action` 슬롯을 쓴다. `ErrorState` 의 래퍼는 필수다(기본 아이콘이 이름 없는 svg 라서 빼면 `role="alert"` 이 이름 없는 그래픽까지 읽는다)
+- `TextField` 아이콘·조작 칸 치수를 `$tap_target_compact` 토큰으로 교체 (하드코딩 40px 제거, 값 동일)
+
 ## [3.10.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.10.1) - 2026-08-18
 
 - 오버레이 스크롤 잠금이 스크롤바 폭을 보정 - Modal · Drawer · Alert 가 열릴 때 사라지는 스크롤바 폭을 재서 `body` `padding-right` 로 되돌린다. 잠금 시 배경 콘텐츠가 그 폭만큼 튀던 문제 해소. 소비자가 이미 준 `padding-right` 에 더하므로 기존 여백은 유지된다

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -194,7 +194,7 @@ Organized by category. **Always** import from the package root (`@bigtablet/desi
 |-----------|---------|-----------|
 | `Button` | Primary action button. | `variant` (filled/outline/tonal/text), `size` (sm/md/lg/xl), `danger`, `radius`, `leadingIcon`, `trailingIcon`, `fullWidth` |
 | `IconButton` | Icon-only button. | `variant` (standard/filled/tonal/outlined), `size` (sm/md), `icon`, `aria-label` (required) |
-| `TextField` | Single-line text input with label. | `label`, `placeholder`, `supportingText`, `error`, `size`, `leadingIcon`, `clearable`, `onChangeAction` (value callback), `imeStrategy` (delayed/immediate - use `immediate` for live search w/ Korean IME) |
+| `TextField` | Single-line text input with label. | `label`, `placeholder`, `supportingText`, `error`, `size`, `leadingIcon`/`trailingIcon` (decorative only - `aria-hidden`), `leadingAction`/`trailingAction` (focusable content), `showPasswordToggle`, `clearable`, `onValueChange`, `imeStrategy` (delayed/immediate - use `immediate` for live search w/ Korean IME) |
 | `Textarea` | Multi-line text input. | `label`, `placeholder`, `supportingText`, `error`, `size`, `rows`, `minRows`/`maxRows` (auto-grow), `maxLength` + `showCounter`, `resize` (none/vertical/both), `onChangeAction`, `imeStrategy`. Same tokens/visuals as TextField. |
 | `Checkbox` | Boolean selection. | `checked`, `indeterminate`, `disabled`, `error`, `label` |
 | `Radio` | Single choice. | `value`, `checked`, `name`, `size`, `label`. Standalone, or auto-wired inside `RadioGroup`. |

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -194,7 +194,7 @@ Organized by category. **Always** import from the package root (`@bigtablet/desi
 |-----------|---------|-----------|
 | `Button` | Primary action button. | `variant` (filled/outline/tonal/text), `size` (sm/md/lg/xl), `danger`, `radius`, `leadingIcon`, `trailingIcon`, `fullWidth` |
 | `IconButton` | Icon-only button. | `variant` (standard/filled/tonal/outlined), `size` (sm/md), `icon`, `aria-label` (required) |
-| `TextField` | Single-line text input with label. | `label`, `placeholder`, `supportingText`, `error`, `size`, `leadingIcon`/`trailingIcon` (decorative only - `aria-hidden`), `leadingAction`/`trailingAction` (focusable content), `showPasswordToggle`, `clearable`, `onValueChange`, `imeStrategy` (delayed/immediate - use `immediate` for live search w/ Korean IME) |
+| `TextField` | Single-line text input with label. | `label`, `placeholder`, `supportingText`, `error`, `size`, `leadingIcon`/`trailingIcon` (decorative only - `aria-hidden`), `leadingAction`/`trailingAction` (focusable content), `showPasswordToggle` + `passwordToggleLabels` (app-injected i18n), `clearable`, `onValueChange`, `imeStrategy` (delayed/immediate - use `immediate` for live search w/ Korean IME) |
 | `Textarea` | Multi-line text input. | `label`, `placeholder`, `supportingText`, `error`, `size`, `rows`, `minRows`/`maxRows` (auto-grow), `maxLength` + `showCounter`, `resize` (none/vertical/both), `onChangeAction`, `imeStrategy`. Same tokens/visuals as TextField. |
 | `Checkbox` | Boolean selection. | `checked`, `indeterminate`, `disabled`, `error`, `label` |
 | `Radio` | Single choice. | `value`, `checked`, `name`, `size`, `label`. Standalone, or auto-wired inside `RadioGroup`. |

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -389,10 +389,27 @@ import { TextField } from '@bigtablet/design-system';
 // 상태 표시
 <TextField label="이메일" error supportingText="유효하지 않은 이메일입니다" />
 
-// 아이콘
-import { Search, Eye } from 'lucide-react';
+// 장식 아이콘 - aria-hidden 으로 접근성 트리에서 제외된다
+import { Search, X } from 'lucide-react';
 <TextField leadingIcon={<Search size={16} />} placeholder="검색..." />
-<TextField trailingIcon={<Eye size={16} />} type="password" />
+
+// 조작 요소 - aria-hidden 을 붙이지 않는다. 버튼은 반드시 이 슬롯에
+<TextField
+  label="검색"
+  trailingAction={
+    <button type="button" aria-label="검색어 지우기" onClick={reset}>
+      <X size={20} aria-hidden="true" />
+    </button>
+  }
+/>
+
+// 비밀번호 표시/숨기기 - 내장 토글 (문구는 i18n 때문에 앱이 주입)
+<TextField
+  label="비밀번호"
+  type="password"
+  showPasswordToggle
+  passwordToggleLabels={{ show: '비밀번호 보기', hide: '비밀번호 숨기기' }}
+/>
 
 // 지우기 버튼
 <TextField label="검색어" clearable onValueChange={(v) => setQuery(v)} />
@@ -420,8 +437,12 @@ import { Search, Eye } from 'lucide-react';
 | `success` | `boolean` | `false` | 성공(검증 통과) 상태. `error` 가 true 면 무시됨 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
 | `variant` | `'outline' \| 'filled'` | `'outline'` | 시각 변형. `filled` 는 테두리 대신 dim 배경으로 채우고, 포커스 시 테두리가 드러남 |
-| `leadingIcon` | `ReactNode` | - | 왼쪽 아이콘 |
-| `trailingIcon` | `ReactNode` | - | 오른쪽 아이콘 |
+| `leadingIcon` | `ReactNode` | - | 왼쪽 **장식** 아이콘 (`aria-hidden`) |
+| `trailingIcon` | `ReactNode` | - | 오른쪽 **장식** 아이콘 (`aria-hidden`) |
+| `leadingAction` | `ReactNode` | - | 왼쪽 조작 요소 (v3.11, `aria-hidden` 없음) |
+| `trailingAction` | `ReactNode` | - | 오른쪽 조작 요소 (v3.11, `aria-hidden` 없음) |
+| `showPasswordToggle` | `boolean` | `false` | 비밀번호 표시/숨기기 토글 내장 (v3.11) |
+| `passwordToggleLabels` | `{ show: string; hide: string }` | 영문 | 토글 버튼 `aria-label` |
 | `clearable` | `boolean` | `false` | 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
 | `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 (호출 시점은 `imeStrategy` 에 따름) |
@@ -436,6 +457,10 @@ import { Search, Eye } from 'lucide-react';
 > **v3.0 변경**: 내부 마크업이 `<fieldset>` + `<legend>` 구조에서 standalone `<label htmlFor>` 구조로 변경되었습니다. 공개 props는 동일하지만, 커스텀 SCSS에서 `.text_field_legend` 같은 내부 셀렉터를 오버라이드했다면 점검이 필요합니다.
 >
 > **v3.1 추가**: `imeStrategy` prop - 한글 IME 조합 중 콜백 전략. 기본 `"delayed"` (조합 완료 후 `onValueChange`), 실시간 검색/필터엔 `"immediate"` (조합 중에도 즉시 호출).
+>
+> **v3.11 추가 - 아이콘 슬롯 vs 조작 슬롯**: `leadingIcon` · `trailingIcon` 은 장식 전용이라 `aria-hidden="true"` 래퍼를 유지한다. 여기에 `<button>` 같은 포커스 가능한 요소를 넣으면 **포커스는 가는데 보조기기에는 존재하지 않는 요소**가 되어 WCAG 4.1.2 (Name/Role/Value) 위반이고, Chrome 은 `Blocked aria-hidden on an element because its descendant retained focus` 를 남기며 `aria-hidden` 적용을 거부한다. 조작 요소는 `leadingAction` · `trailingAction` 에 넣을 것 - 아이콘 칸의 위치·크기 CSS 를 그대로 재사용하고 `aria-hidden` 만 빠지며, 넘긴 요소가 40x40 히트 영역을 채운다 (WCAG 2.5.8).
+>
+> 오른쪽 칸은 하나뿐이라 우선순위가 있다: `showPasswordToggle` > `clearable`(값 있을 때) > `trailingAction` > `trailingIcon`. 토글을 켜면 값이 차 있어도 계속 보인다 - 비밀번호 칸에서 토글이 사라지면 쓸 수 없기 때문. 왼쪽은 `leadingAction` > `leadingIcon`.
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -2893,7 +2893,7 @@ action={
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `illustration` | `ReactNode` | - | 일러스트 영역 (Lucide 아이콘, SVG, 이미지). 내부에 `aria-hidden="true"` 자동 적용 |
+| `illustration` | `ReactNode` | - | 일러스트 영역 (Lucide 아이콘, SVG, 이미지). **장식 전용** - 내부에 `aria-hidden="true"` 자동 적용 |
 | `title` | `ReactNode` | - | 제목 (h3) |
 | `description` | `ReactNode` | - | 보조 설명 (p, max-width 480) |
 | `action` | `ReactNode` | - | 액션 영역 (Button 등) |
@@ -2906,6 +2906,7 @@ action={
   - 검색 결과가 동적으로 바뀐다면 `role="status"`로 SR이 변경을 announce하도록
 - 제목은 `<h3>` 고정 - 페이지 위계와 다르면 wrap해서 시각만 가져가거나, 향후 `titleAs` prop 추가 검토
 - `illustration`은 `aria-hidden="true"` 자동 적용 - 일러스트가 의미 전달용이면 title/description에 텍스트로 동일 의미 포함시키세요
+- **`illustration` 에 포커스 가능한 요소(버튼/링크 등)를 넣지 마세요.** `aria-hidden` 조상 때문에 포커스는 가는데 보조기기엔 존재하지 않는 요소가 되어 WCAG 4.1.2 (Name/Role/Value) 위반이고, Chrome 은 `Blocked aria-hidden on an element because its descendant retained focus` 를 남기며 `aria-hidden` 적용을 거부합니다. 조작 요소는 `action` 슬롯으로 - 여기엔 `aria-hidden` 이 붙지 않습니다
 - 색상은 caption tone - 너무 흐리지 않도록 description 길이는 1-2줄로 유지
 
 #### DOM 구조 (SCSS override 시 참고)
@@ -2993,13 +2994,15 @@ import { Inbox, Search } from "lucide-react";
 
 미지정 시 기본 경고 아이콘(`TriangleAlert`). `icon` prop 으로 교체, `icon={null}` 로 숨김.
 
+> **`icon` 은 장식 전용입니다.** 래퍼의 `aria-hidden="true"` 는 필수입니다 - 기본 아이콘이 이름 없는 bare lucide svg 라서 래퍼를 빼면 `role="alert"` 이 이름 없는 그래픽까지 읽습니다. 포커스 가능한 요소는 `action` 슬롯으로 (WCAG 4.1.2). `EmptyState.illustration` 과 같은 계약입니다.
+
 **Props**
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `title` | `ReactNode` | `"문제가 발생했습니다"` | 제목 (h3) |
 | `description` | `ReactNode` | - | 보조 설명 |
-| `icon` | `ReactNode` | 경고 아이콘 | 아이콘/일러스트. `null` 로 숨김 |
+| `icon` | `ReactNode` | 경고 아이콘 | 아이콘/일러스트. **장식 전용** - `aria-hidden="true"` 래퍼 적용. `null` 로 숨김 |
 | `action` | `ReactNode` | - | 액션 영역 (재시도 버튼 등) |
 | `variant` | `'page' \| 'widget'` | `'page'` | 레이아웃 모드 |
 | `...rest` | `HTMLAttributes<HTMLDivElement>` | - | `aria-*` 등 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.10.1",
+	"version": "3.11.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/src/ui/feedback/empty-state/EmptyState.test.tsx
+++ b/src/ui/feedback/empty-state/EmptyState.test.tsx
@@ -28,4 +28,22 @@ describe("EmptyState", () => {
 		const { container } = render(<EmptyState size="lg" title="t" />);
 		expect(container.firstChild).toHaveClass("empty_state_size_lg");
 	});
+
+	// ── 슬롯 접근성 계약 ────────────────────────────────────────────────────
+	// illustration 은 장식 전용이라 aria-hidden 을 유지하고, action 은 노출한다.
+	// 이 짝을 고정해 두는 이유는 두 방향 모두 조용히 깨지기 때문이다.
+	//  - illustration 에서 aria-hidden 이 빠지면 이름 없는 그래픽이 트리에 노출된다 (axe 는 못 잡는다).
+	//  - action 에 aria-hidden 이 붙으면 포커스는 가는데 보조기기엔 없는 버튼이 된다 (WCAG 4.1.2).
+	it("keeps the illustration slot out of the accessibility tree", () => {
+		render(<EmptyState illustration={<svg data-testid="ill" />} title="t" />);
+		expect(screen.getByTestId("ill").closest("[aria-hidden]")).toHaveAttribute(
+			"aria-hidden",
+			"true",
+		);
+	});
+
+	it("exposes the action slot to the accessibility tree", () => {
+		render(<EmptyState title="t" action={<button type="button">Add</button>} />);
+		expect(screen.getByRole("button", { name: "Add" }).closest("[aria-hidden]")).toBeNull();
+	});
 });

--- a/src/ui/feedback/empty-state/index.tsx
+++ b/src/ui/feedback/empty-state/index.tsx
@@ -5,13 +5,17 @@ import { cn } from "../../../utils";
 import "./style.scss";
 
 export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
-	/** 일러스트 영역 (아이콘/이미지 등) */
+	/**
+	 * 일러스트 영역 (아이콘/이미지 등). **장식 전용** - `aria-hidden="true"` 래퍼로 접근성 트리에서
+	 * 제외된다. 포커스 가능한 요소(버튼/링크 등)를 넣으면 포커스는 가는데 보조기기엔 없는 요소가
+	 * 되므로(WCAG 4.1.2) `action` 을 쓸 것.
+	 */
 	illustration?: React.ReactNode;
 	/** 제목 */
 	title?: React.ReactNode;
 	/** 보조 설명 */
 	description?: React.ReactNode;
-	/** 액션 영역 (Button 등) */
+	/** 액션 영역 (Button 등). `aria-hidden` 을 붙이지 않아 보조기기에 그대로 노출된다. */
 	action?: React.ReactNode;
 	/** 크기 (기본 "md") */
 	size?: "sm" | "md" | "lg";

--- a/src/ui/feedback/error-state/ErrorState.test.tsx
+++ b/src/ui/feedback/error-state/ErrorState.test.tsx
@@ -53,4 +53,27 @@ describe("ErrorState", () => {
 		const { container } = render(<ErrorState title="에러" className="custom" />);
 		expect(container.firstChild).toHaveClass("error_state", "custom");
 	});
+
+	// ── 슬롯 접근성 계약 ────────────────────────────────────────────────────
+	// 아이콘 래퍼의 aria-hidden 은 필수다. 기본 아이콘이 이름 없는 bare lucide svg 라서
+	// 래퍼를 빼면 role="alert" 이 이름 없는 그래픽까지 읽는다. axe 는 이걸 못 잡으니 테스트로 고정한다.
+	it("keeps the default icon out of the accessibility tree", () => {
+		const { container } = render(<ErrorState title="에러" />);
+		const wrap = container.querySelector(".error_state_icon");
+		expect(wrap).toHaveAttribute("aria-hidden", "true");
+		expect(wrap?.querySelector("svg")).toBeInTheDocument();
+	});
+
+	it("keeps a custom icon out of the accessibility tree", () => {
+		render(<ErrorState title="에러" icon={<svg data-testid="ic" />} />);
+		expect(screen.getByTestId("ic").closest("[aria-hidden]")).toHaveAttribute(
+			"aria-hidden",
+			"true",
+		);
+	});
+
+	it("exposes the action slot to the accessibility tree", () => {
+		render(<ErrorState title="에러" action={<button type="button">재시도</button>} />);
+		expect(screen.getByRole("button", { name: "재시도" }).closest("[aria-hidden]")).toBeNull();
+	});
 });

--- a/src/ui/feedback/error-state/index.tsx
+++ b/src/ui/feedback/error-state/index.tsx
@@ -12,9 +12,14 @@ export interface ErrorStateProps extends Omit<React.HTMLAttributes<HTMLDivElemen
 	title?: React.ReactNode;
 	/** 보조 설명 */
 	description?: React.ReactNode;
-	/** 아이콘/일러스트 (미지정 시 기본 경고 아이콘. `null` 로 숨김) */
+	/**
+	 * 아이콘/일러스트 (미지정 시 기본 경고 아이콘. `null` 로 숨김). **장식 전용** -
+	 * `aria-hidden="true"` 래퍼로 접근성 트리에서 제외된다. 래퍼는 필수다: 기본 아이콘이
+	 * 이름 없는 bare lucide svg 라서, 빼면 `role="alert"` 이 이름 없는 그래픽까지 읽는다.
+	 * 포커스 가능한 요소는 `action` 을 쓸 것 (WCAG 4.1.2).
+	 */
 	icon?: React.ReactNode;
-	/** 액션 영역 (재시도 버튼 등) */
+	/** 액션 영역 (재시도 버튼 등). `aria-hidden` 을 붙이지 않아 보조기기에 그대로 노출된다. */
 	action?: React.ReactNode;
 	/**
 	 * 레이아웃 모드 (기본 "page").

--- a/src/ui/forms/textfield/TextField.test.tsx
+++ b/src/ui/forms/textfield/TextField.test.tsx
@@ -331,4 +331,42 @@ describe("TextField", () => {
 		expect(screen.getByLabelText("Password")).toHaveAttribute("type", "password");
 		expect(screen.queryByRole("button")).not.toBeInTheDocument();
 	});
+
+	// disabled 는 컨테이너 자식에 opacity 0.38 만 걸고 pointer-events 는 건드리지 않으므로,
+	// 내장 버튼은 disabled 속성을 직접 받아야 한다. 없으면 비활성 필드의 비밀번호가 드러난다.
+	it("disables the built-in password toggle with the field", () => {
+		render(<TextField label="Password" type="password" showPasswordToggle disabled />);
+		const toggle = screen.getByRole("button", { name: "Show password" });
+		expect(toggle).toBeDisabled();
+
+		fireEvent.click(toggle);
+		expect(screen.getByLabelText("Password")).toHaveAttribute("type", "password");
+	});
+
+	it("disables the built-in clear button with the field", () => {
+		const handleChange = vi.fn();
+		render(<TextField clearable defaultValue="text" disabled onValueChange={handleChange} />);
+		const clear = screen.getByRole("button", { name: "Clear" });
+		expect(clear).toBeDisabled();
+
+		fireEvent.click(clear);
+		expect(handleChange).not.toHaveBeenCalled();
+		expect(screen.getByRole("textbox")).toHaveValue("text");
+	});
+
+	// showPasswordToggle 과 type 은 별개 prop 이라 type 을 빠뜨리기 쉽다. 보정이 없으면
+	// 값이 이미 평문인데 눈 아이콘만 달린, 아무 효과 없는 버튼이 된다.
+	it("falls back to a password input when the toggle is on without a type", () => {
+		render(<TextField label="Password" showPasswordToggle />);
+		const input = screen.getByLabelText("Password");
+		expect(input).toHaveAttribute("type", "password");
+
+		fireEvent.click(screen.getByRole("button", { name: "Show password" }));
+		expect(input).toHaveAttribute("type", "text");
+	});
+
+	it("does not force a password type when the toggle is off", () => {
+		render(<TextField label="Name" />);
+		expect(screen.getByLabelText("Name")).not.toHaveAttribute("type", "password");
+	});
 });

--- a/src/ui/forms/textfield/TextField.test.tsx
+++ b/src/ui/forms/textfield/TextField.test.tsx
@@ -222,4 +222,113 @@ describe("TextField", () => {
 		const root = screen.getByRole("textbox").closest(".text_field");
 		expect(root).toHaveClass("text_field_variant_filled", "text_field_disabled");
 	});
+
+	// ── Action slots (aria-hidden 회귀 방지) ─────────────────────────────────
+	// 장식 슬롯은 aria-hidden 을 유지하고 조작 슬롯은 붙이지 않는다. 이 두 짝이 어긋나면
+	// 포커스는 가는데 보조기기에 없는 요소(WCAG 4.1.2 위반)가 되고 Chrome 이 aria-hidden 적용을
+	// 거부한다 — 조작 요소를 trailingIcon 에 넣던 앱들이 실제로 밟은 버그.
+	it("keeps decorative icon slots hidden from the accessibility tree", () => {
+		render(
+			<TextField
+				leadingIcon={<span data-testid="lead">Q</span>}
+				trailingIcon={<span data-testid="trail">X</span>}
+			/>,
+		);
+		expect(screen.getByTestId("lead").closest("[aria-hidden]")).toHaveAttribute(
+			"aria-hidden",
+			"true",
+		);
+		expect(screen.getByTestId("trail").closest("[aria-hidden]")).toHaveAttribute(
+			"aria-hidden",
+			"true",
+		);
+	});
+
+	it("exposes action slots to the accessibility tree", () => {
+		render(
+			<TextField
+				leadingAction={
+					<button type="button" aria-label="Search">
+						Q
+					</button>
+				}
+				trailingAction={
+					<button type="button" aria-label="Toggle">
+						X
+					</button>
+				}
+			/>,
+		);
+		const search = screen.getByRole("button", { name: "Search" });
+		const toggle = screen.getByRole("button", { name: "Toggle" });
+		expect(search.closest("[aria-hidden]")).toBeNull();
+		expect(toggle.closest("[aria-hidden]")).toBeNull();
+		expect(search.parentElement).toHaveClass("text_field_icon", "text_field_action");
+		expect(toggle.parentElement).toHaveClass("text_field_icon", "text_field_action");
+	});
+
+	it("lets the action slot win over the icon slot on the same side", () => {
+		render(
+			<TextField
+				leadingIcon={<span data-testid="lead">Q</span>}
+				leadingAction={
+					<button type="button" aria-label="Search">
+						Q
+					</button>
+				}
+				trailingIcon={<span data-testid="trail">X</span>}
+				trailingAction={
+					<button type="button" aria-label="Toggle">
+						X
+					</button>
+				}
+			/>,
+		);
+		expect(screen.queryByTestId("lead")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("trail")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Toggle" })).toBeInTheDocument();
+	});
+
+	// ── Password toggle ────────────────────────────────────────────────────
+	it("toggles the password input type and swaps the accessible label", () => {
+		render(<TextField label="Password" type="password" showPasswordToggle />);
+		const input = screen.getByLabelText("Password");
+		expect(input).toHaveAttribute("type", "password");
+
+		const toggle = screen.getByRole("button", { name: "Show password" });
+		expect(toggle.closest("[aria-hidden]")).toBeNull();
+
+		fireEvent.click(toggle);
+		expect(input).toHaveAttribute("type", "text");
+		expect(screen.getByRole("button", { name: "Hide password" })).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Hide password" }));
+		expect(input).toHaveAttribute("type", "password");
+	});
+
+	it("uses injected password toggle labels", () => {
+		render(
+			<TextField
+				type="password"
+				showPasswordToggle
+				passwordToggleLabels={{ show: "비밀번호 보기", hide: "비밀번호 숨기기" }}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: "비밀번호 보기" }));
+		expect(screen.getByRole("button", { name: "비밀번호 숨기기" })).toBeInTheDocument();
+	});
+
+	// 토글은 clear 를 이긴다 - 값이 찬 비밀번호 칸에서 토글이 사라지면 쓸 수 없다.
+	it("keeps the password toggle visible when clearable also has a value", () => {
+		render(<TextField type="password" showPasswordToggle clearable defaultValue="secret" />);
+		expect(screen.getByRole("button", { name: "Show password" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument();
+	});
+
+	it("leaves the input type untouched when the toggle is off", () => {
+		render(<TextField label="Password" type="password" />);
+		expect(screen.getByLabelText("Password")).toHaveAttribute("type", "password");
+		expect(screen.queryByRole("button")).not.toBeInTheDocument();
+	});
 });

--- a/src/ui/forms/textfield/index.tsx
+++ b/src/ui/forms/textfield/index.tsx
@@ -178,7 +178,12 @@ export const TextField = ({
 	const togglePassword = useCallback(() => {
 		setPasswordRevealed((revealed) => !revealed);
 	}, []);
-	const resolvedType = showPasswordToggle && passwordRevealed ? "text" : type;
+	// showPasswordToggle 과 type 은 별개 prop 이라 type 을 빠뜨리기 쉽다. 보정이 없으면 값이 이미
+	// 평문인데 눈 아이콘만 달린, 아무 효과 없는 버튼이 된다 - 토글을 켰으면 password 가 기본이다.
+	let resolvedType = type;
+	if (showPasswordToggle) {
+		resolvedType = passwordRevealed ? "text" : (type ?? "password");
+	}
 
 	// error 가 success 를 이긴다 - 둘 다 켜진 건 대개 검증 상태 전환 중인 순간이고,
 	// 그때 실패를 성공처럼 보여주면 사용자가 잘못된 값을 그대로 제출하게 된다.
@@ -197,6 +202,9 @@ export const TextField = ({
 		className,
 	);
 
+	// 내장 버튼(토글·clear)에는 disabled 를 직접 넘긴다 - `_disabled` 스타일은 컨테이너 자식에
+	// opacity 만 걸고 pointer-events 는 건드리지 않아, 없으면 비활성 필드에서도 포커스·클릭이 된다.
+	// leadingAction/trailingAction 은 앱이 넘긴 임의 요소라 강제하지 않는다(앱 책임).
 	// 오른쪽 칸은 하나뿐이라 우선순위가 필요하다. 토글이 최우선 - 켠 쪽은 값이 있을 때도 계속 보여야 하고,
 	// 비밀번호 칸의 clear 는 잃어도 무해하다. 그 아래는 clear > trailingAction > trailingIcon.
 	const passwordToggleLabel = passwordRevealed
@@ -205,7 +213,12 @@ export const TextField = ({
 
 	const resolvedTrailing = showPasswordToggle ? (
 		<span className="text_field_icon text_field_action">
-			<button type="button" onClick={togglePassword} aria-label={passwordToggleLabel}>
+			<button
+				type="button"
+				onClick={togglePassword}
+				aria-label={passwordToggleLabel}
+				disabled={props.disabled}
+			>
 				{passwordRevealed ? (
 					<EyeOff size={iconSize.lg} aria-hidden="true" />
 				) : (
@@ -214,7 +227,13 @@ export const TextField = ({
 			</button>
 		</span>
 	) : clearable && innerValue ? (
-		<button type="button" className="text_field_clear" onClick={handleClear} aria-label="Clear">
+		<button
+			type="button"
+			className="text_field_clear"
+			onClick={handleClear}
+			aria-label="Clear"
+			disabled={props.disabled}
+		>
 			<ClearIcon />
 		</button>
 	) : trailingAction ? (

--- a/src/ui/forms/textfield/index.tsx
+++ b/src/ui/forms/textfield/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { X } from "lucide-react";
-import * as React from "react";
+import { Eye, EyeOff, X } from "lucide-react";
+import type * as React from "react";
 import { useCallback, useId, useRef, useState } from "react";
 import { iconSize } from "../../../styles/icon";
 import { cn } from "../../../utils";
@@ -42,10 +42,33 @@ export interface TextFieldProps
 	error?: boolean;
 	/** 성공(검증 통과) 상태 여부. `error` 가 true 면 무시된다. */
 	success?: boolean;
-	/** 입력 필드 왼쪽에 표시할 아이콘 */
+	/**
+	 * 입력 필드 왼쪽에 표시할 **장식** 아이콘. `aria-hidden` 으로 접근성 트리에서 제외된다.
+	 * 포커스 가능한 요소(버튼 등)를 넣어야 하면 `leadingAction` 을 쓸 것.
+	 */
 	leadingIcon?: React.ReactNode;
-	/** 입력 필드 오른쪽에 표시할 아이콘 */
+	/**
+	 * 입력 필드 오른쪽에 표시할 **장식** 아이콘. `aria-hidden` 으로 접근성 트리에서 제외된다.
+	 * 포커스 가능한 요소(버튼 등)를 넣어야 하면 `trailingAction` 을 쓸 것.
+	 */
 	trailingIcon?: React.ReactNode;
+	/**
+	 * 입력 필드 왼쪽 조작 요소(버튼 등). `aria-hidden` 을 붙이지 않아 보조기기에 그대로 노출된다.
+	 * 아이콘 칸의 위치·크기 CSS 를 재사용하고, 넘긴 요소가 40x40 히트 영역을 채운다(WCAG 2.5.8).
+	 */
+	leadingAction?: React.ReactNode;
+	/**
+	 * 입력 필드 오른쪽 조작 요소(버튼 등). `aria-hidden` 을 붙이지 않아 보조기기에 그대로 노출된다.
+	 * 아이콘 칸의 위치·크기 CSS 를 재사용하고, 넘긴 요소가 40x40 히트 영역을 채운다(WCAG 2.5.8).
+	 */
+	trailingAction?: React.ReactNode;
+	/**
+	 * 비밀번호 표시/숨기기 토글 버튼을 오른쪽에 내장한다.
+	 * 켜면 `type` 을 토글이 직접 관리한다 - 숨김 상태는 넘긴 `type`(보통 `"password"`), 표시 상태는 `"text"`.
+	 */
+	showPasswordToggle?: boolean;
+	/** 토글 버튼의 `aria-label`. i18n 은 앱이 주입한다 (기본값: 영문). */
+	passwordToggleLabels?: { show: string; hide: string };
 	/** 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 여부 */
 	clearable?: boolean;
 	/** 컨테이너 전체 너비 차지 여부 */
@@ -72,6 +95,8 @@ export interface TextFieldProps
 // X 아이콘 - lucide-react
 const ClearIcon = () => <X size={iconSize.lg} aria-hidden="true" />;
 
+const DEFAULT_PASSWORD_TOGGLE_LABELS = { show: "Show password", hide: "Hide password" } as const;
+
 /**
  * 텍스트 필드를 렌더링한다.
  * Figma DS 기준 outlined 스타일 + floating label을 지원한다.
@@ -88,7 +113,12 @@ export const TextField = ({
 	success,
 	leadingIcon,
 	trailingIcon,
+	leadingAction,
+	trailingAction,
+	showPasswordToggle,
+	passwordToggleLabels,
 	clearable,
+	type,
 	fullWidth,
 	size = "md",
 	variant = "outline",
@@ -110,9 +140,7 @@ export const TextField = ({
 	const applyTransform = (nextValue: string) =>
 		transformValue ? transformValue(nextValue) : nextValue;
 
-	const [innerValue, setInnerValue] = useState(() =>
-		applyTransform(value ?? defaultValue ?? ""),
-	);
+	const [innerValue, setInnerValue] = useState(() => applyTransform(value ?? defaultValue ?? ""));
 
 	const isComposingRef = useRef(false);
 	// 마지막으로 onChangeAction 에 방출한 값 - 중복 호출(특히 IME 종료 직후) 차단용.
@@ -146,6 +174,12 @@ export const TextField = ({
 		emit("");
 	}, [emit]);
 
+	const [passwordRevealed, setPasswordRevealed] = useState(false);
+	const togglePassword = useCallback(() => {
+		setPasswordRevealed((revealed) => !revealed);
+	}, []);
+	const resolvedType = showPasswordToggle && passwordRevealed ? "text" : type;
+
 	// error 가 success 를 이긴다 - 둘 다 켜진 건 대개 검증 상태 전환 중인 순간이고,
 	// 그때 실패를 성공처럼 보여주면 사용자가 잘못된 값을 그대로 제출하게 된다.
 	const isError = !!error;
@@ -163,17 +197,42 @@ export const TextField = ({
 		className,
 	);
 
-	// clearable이 켜져 있고 값이 있으면 X 버튼, 없으면 trailingIcon
-	const resolvedTrailing =
-		clearable && innerValue ? (
-			<button type="button" className="text_field_clear" onClick={handleClear} aria-label="Clear">
-				<ClearIcon />
+	// 오른쪽 칸은 하나뿐이라 우선순위가 필요하다. 토글이 최우선 - 켠 쪽은 값이 있을 때도 계속 보여야 하고,
+	// 비밀번호 칸의 clear 는 잃어도 무해하다. 그 아래는 clear > trailingAction > trailingIcon.
+	const passwordToggleLabel = passwordRevealed
+		? (passwordToggleLabels?.hide ?? DEFAULT_PASSWORD_TOGGLE_LABELS.hide)
+		: (passwordToggleLabels?.show ?? DEFAULT_PASSWORD_TOGGLE_LABELS.show);
+
+	const resolvedTrailing = showPasswordToggle ? (
+		<span className="text_field_icon text_field_action">
+			<button type="button" onClick={togglePassword} aria-label={passwordToggleLabel}>
+				{passwordRevealed ? (
+					<EyeOff size={iconSize.lg} aria-hidden="true" />
+				) : (
+					<Eye size={iconSize.lg} aria-hidden="true" />
+				)}
 			</button>
-		) : trailingIcon ? (
-			<span className="text_field_icon" aria-hidden="true">
-				{trailingIcon}
-			</span>
-		) : null;
+		</span>
+	) : clearable && innerValue ? (
+		<button type="button" className="text_field_clear" onClick={handleClear} aria-label="Clear">
+			<ClearIcon />
+		</button>
+	) : trailingAction ? (
+		<span className="text_field_icon text_field_action">{trailingAction}</span>
+	) : trailingIcon ? (
+		<span className="text_field_icon" aria-hidden="true">
+			{trailingIcon}
+		</span>
+	) : null;
+
+	// 왼쪽 칸도 같은 규칙 - action 이 icon 을 이긴다.
+	const resolvedLeading = leadingAction ? (
+		<span className="text_field_icon text_field_action">{leadingAction}</span>
+	) : leadingIcon ? (
+		<span className="text_field_icon" aria-hidden="true">
+			{leadingIcon}
+		</span>
+	) : null;
 
 	return (
 		<div className={rootClassName}>
@@ -185,11 +244,7 @@ export const TextField = ({
 
 			<div className="text_field_container">
 				<div className="text_field_inner">
-					{leadingIcon && (
-						<span className="text_field_icon" aria-hidden="true">
-							{leadingIcon}
-						</span>
-					)}
+					{resolvedLeading}
 
 					<div
 						className={cn(
@@ -205,6 +260,7 @@ export const TextField = ({
 							aria-describedby={helperId}
 							aria-label={!showLabel ? label : undefined}
 							{...props}
+							type={resolvedType}
 							value={innerValue}
 							onCompositionStart={() => {
 								isComposingRef.current = true;

--- a/src/ui/forms/textfield/style.scss
+++ b/src/ui/forms/textfield/style.scss
@@ -144,9 +144,12 @@
     }
   }
 
-  // ── Clear button ───────────────────────────────────────────────────────
+  // ── Clear button / action slot ──────────────────────────────────────────
 
-  &_clear {
+  // `&_action > *` — 앱이 넘긴 조작 요소가 아이콘 칸(40x40)을 그대로 히트 영역으로 쓰게 한다
+  // (WCAG 2.5.8). 내장 clear 버튼과 hover/focus 처리를 공유해 두 슬롯의 시각이 갈리지 않는다.
+  &_clear,
+  &_action > * {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -298,6 +301,7 @@
   .text_field_label,
   .text_field_container,
   .text_field_clear,
+  .text_field_action > *,
   .text_field_helper {
     transition: none;
   }

--- a/src/ui/forms/textfield/style.scss
+++ b/src/ui/forms/textfield/style.scss
@@ -133,8 +133,9 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 40px;
-    height: 40px;
+    // `&_action > *` 가 이 칸을 그대로 채우므로 두 치수는 같은 토큰이어야 한다 - 갈라지면 자식이 넘친다.
+    width: token.$tap_target_compact;
+    height: token.$tap_target_compact;
     border-radius: token.$radius_full;
     color: token.$color_text_heading;
 
@@ -154,8 +155,8 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 40px;
-    height: 40px;
+    width: token.$tap_target_compact;
+    height: token.$tap_target_compact;
     border: none;
     background: transparent;
     cursor: pointer;

--- a/src/ui/forms/textfield/textfield.stories.tsx
+++ b/src/ui/forms/textfield/textfield.stories.tsx
@@ -170,3 +170,42 @@ export const Clearable: Story = {
 		clearable: true,
 	},
 };
+
+export const PasswordToggle: Story = {
+	args: {
+		label: "비밀번호",
+		type: "password",
+		defaultValue: "hunter2",
+		showPasswordToggle: true,
+		passwordToggleLabels: { show: "비밀번호 보기", hide: "비밀번호 숨기기" },
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"`showPasswordToggle` renders a built-in reveal button. Labels are injected by the app so i18n stays app-side. / `showPasswordToggle` 는 표시/숨기기 버튼을 내장합니다. i18n 은 앱이 담당하므로 문구는 `passwordToggleLabels` 로 주입합니다.",
+			},
+		},
+	},
+};
+
+export const ActionSlot: Story = {
+	args: {
+		label: "Search",
+		placeholder: "Search…",
+		leadingIcon: <SearchIcon />,
+		trailingAction: (
+			<button type="button" aria-label="검색어 지우기">
+				<CloseIcon />
+			</button>
+		),
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"`trailingIcon` / `leadingIcon` stay `aria-hidden` for decoration; put focusable content in `trailingAction` / `leadingAction`, which are exposed to assistive tech. Putting a button in the icon slot breaks WCAG 4.1.2 and Chrome refuses the `aria-hidden`. / `trailingIcon`·`leadingIcon` 은 장식용이라 `aria-hidden` 을 유지합니다. 포커스 가능한 요소는 `trailingAction`·`leadingAction` 에 넣으세요 - 아이콘 슬롯에 버튼을 넣으면 WCAG 4.1.2 위반이고 Chrome 이 `aria-hidden` 적용을 거부합니다.",
+			},
+		},
+	},
+};


### PR DESCRIPTION
## 릴리즈 v3.11.0

`TextField` 의 아이콘 슬롯 접근성 위반 수정 + 조작 슬롯·비밀번호 토글 신설. 새 prop 4개 추가라 **minor**.

## 작업한 내용
- [x] `package.json` `version` 3.10.1 → **3.11.0**
- [x] `CHANGELOG.md` 3.11.0 섹션 추가 (semver 내림차순 유지)
- [x] 포함 PR: [#469](https://github.com/Bigtablet/bigtablet-design-system/pull/469) `fix/text-field-action-slot`

### 주요 변경
- `TextField` 조작 슬롯 `leadingAction` · `trailingAction` 신설 — 아이콘 슬롯은 장식 전용으로 `aria-hidden` 유지, 포커스 가능한 요소는 새 슬롯으로
- 아이콘 슬롯에 버튼을 넣으면 발생하던 WCAG 4.1.2 위반 해소 (`aria-hidden` 조상 아래 포커스 가능 요소)
- `showPasswordToggle` + `passwordToggleLabels` — 비밀번호 표시/숨기기 토글 내장, i18n 은 앱이 주입
- 내장 버튼(토글·지우기)이 `disabled` 를 따르도록 수정 — 비활성 필드에서도 포커스·클릭됐고, 비활성 입력의 비밀번호를 드러낼 수 있었음
- `EmptyState.illustration` · `ErrorState.icon` 장식 슬롯 계약 명시 + 테스트로 고정
- 아이콘·조작 칸 치수를 `$tap_target_compact` 토큰으로 교체 (하드코딩 40px 제거, 값 동일)

## 버전 판단 근거
공개 API 표면(`package.json` `exports`) 기준:

| 표면 | 변경 |
|---|---|
| React (`.`) | prop 4개 **추가** — `leadingAction`, `trailingAction`, `showPasswordToggle`, `passwordToggleLabels`. 제거·이름 변경·시그니처 변경 **없음** |
| Vanilla (`./vanilla`) | 변경 없음 — vanilla 는 애초에 아이콘 슬롯을 `aria-hidden` 으로 감싸지 않아 이 버그가 없음 |
| SCSS 토큰 · CSS 변수 | 변경 없음 — `$tap_target_compact` 는 기존 토큰이고 `40px` 로 컴파일되어 값 동일 |

하위 호환 깨짐 없음 → **minor**.

## 검증
- 866 passed / 9 skipped, `tsc --noEmit` · `lint:css` clean
- `pnpm build` 통과, size-limit 3개 전부 여유:

| 산출물 | 크기 | 한도 |
|---|---|---|
| `dist/index.js` | 50.16 kB | 60 kB |
| `dist/vanilla/bigtablet.min.js` | 5.81 kB | 7 kB |
| `dist/index.css` | 12.44 kB | 130 kB |

- 빌드 산출물 직접 확인: `dist/index.d.ts` 에 새 prop 4개 노출, `dist/index.js` 의 action 슬롯에 `aria-hidden` 없고 장식 슬롯은 유지, `dist/index.css` 의 `.text_field_clear, .text_field_action > *` 규칙과 reduced-motion 목록 반영
- axe 4.13 을 브라우저에 직접 주입해 TextField 13개 · EmptyState 5개 · ErrorState 4개 인스턴스 검사 → 컴포넌트 violation 0

## 전달할 추가 이슈
- **머지 후 태그**: `git tag -a v3.11.0 -m "v3.11.0"` → `git push origin v3.11.0`. `release.yml` 이 `npm publish --provenance` + GitHub Release 를 자동 생성합니다.
- **claude[bot] 리뷰가 #469 에서 안 돌았습니다** — 조직 월간 code review 지출 상한 도달. github-actions 쪽 Claude 리뷰는 첫 커밋(`0ad8ed3`)만 봤고, 뒤 커밋 2개는 CodeRabbit 만 검토했습니다. 상한은 `claude.ai/admin-settings/claude-code` 에서 관리자만 조정 가능합니다.
- **`pnpm test:storybook`(axe) 는 로컬에서 못 돌립니다** — dependabot 이 playwright 를 1.62.1 로 올린 뒤 chromium 바이너리가 없어 `Please run … playwright install` 로 죽습니다. CI 는 설치 스텝이 있어 정상입니다.
- **소비처 반영 필요 (owner 앱 7곳)**: `widgets/signin/index.tsx:88`, `features/signup/ui/password-field/index.tsx:60,84`, `features/signin/ui/forgot-password-modal/views/reset-view.tsx:111,135`, `widgets/profile/modal/ui/views/password-view.tsx:157,191` — 손으로 만든 토글을 `showPasswordToggle` 로 교체하면 됩니다.
- **coupon-web 은 이 수정을 못 받습니다** — `src/widgets/signin/ui/signin-page-client/index.tsx` 도 `trailingIcon` 에 버튼을 넣지만 DS **2.4.2** 에 고정돼 있어 메이저 2개를 올려야 합니다.