### PR TITLE
fix/storybook-asset-paths

### DIFF
--- a/src/stories/cookbook/layout.stories.tsx
+++ b/src/stories/cookbook/layout.stories.tsx
@@ -173,7 +173,7 @@ export const SidebarLayout: Story = {
 			<Sidebar
 				header={
 					<img
-						src="/images/logo/bigtablet.png"
+						src="images/logo/bigtablet.png"
 						alt="Bigtablet"
 						height={28}
 						style={{ display: "block" }}
@@ -181,7 +181,7 @@ export const SidebarLayout: Story = {
 				}
 				headerCollapsed={
 					<img
-						src="/images/logo/favicon.png"
+						src="images/logo/favicon.png"
 						alt="Bigtablet"
 						width={28}
 						height={28}

--- a/src/stories/cookbook/layout.stories.tsx
+++ b/src/stories/cookbook/layout.stories.tsx
@@ -172,6 +172,8 @@ export const SidebarLayout: Story = {
 		<div style={{ display: "flex", minHeight: "100vh", background: "var(--bt-color-bg-solid-dim)" }}>
 			<Sidebar
 				header={
+					// 로고 경로는 iframe 기준 상대경로다 — 절대경로(`/images/…`)로 되돌리면 GH Pages
+					// 하위 경로(`/bigtablet-design-system/`)를 건너뛰어 404 가 난다. 로컬은 루트 서빙이라 안 드러난다.
 					<img
 						src="images/logo/bigtablet.png"
 						alt="Bigtablet"

--- a/src/stories/examples/page-composition.stories.tsx
+++ b/src/stories/examples/page-composition.stories.tsx
@@ -332,6 +332,8 @@ export const AdminDashboard: Story = {
 			{/* Sidebar */}
 			<Sidebar
 				header={
+					// 로고 경로는 iframe 기준 상대경로다 — 절대경로(`/images/…`)로 되돌리면 GH Pages
+					// 하위 경로(`/bigtablet-design-system/`)를 건너뛰어 404 가 난다. 로컬은 루트 서빙이라 안 드러난다.
 					<img src="images/logo/bigtablet.png" alt="Bigtablet" height={28} style={{ display: "block" }} />
 				}
 				headerCollapsed={

--- a/src/stories/examples/page-composition.stories.tsx
+++ b/src/stories/examples/page-composition.stories.tsx
@@ -332,10 +332,10 @@ export const AdminDashboard: Story = {
 			{/* Sidebar */}
 			<Sidebar
 				header={
-					<img src="/images/logo/bigtablet.png" alt="Bigtablet" height={28} style={{ display: "block" }} />
+					<img src="images/logo/bigtablet.png" alt="Bigtablet" height={28} style={{ display: "block" }} />
 				}
 				headerCollapsed={
-					<img src="/images/logo/favicon.png" alt="Bigtablet" width={28} height={28} style={{ display: "block", borderRadius: 6 }} />
+					<img src="images/logo/favicon.png" alt="Bigtablet" width={28} height={28} style={{ display: "block", borderRadius: 6 }} />
 				}
 				footer={
 					<div

--- a/src/ui/navigation/nav-bar/nav-bar.stories.tsx
+++ b/src/ui/navigation/nav-bar/nav-bar.stories.tsx
@@ -27,8 +27,10 @@ type Story = StoryObj<typeof NavBar>;
 
 function Brand({ invert = false }: { invert?: boolean }) {
 	return (
+		// GH Pages 는 `/bigtablet-design-system/` 하위에 배포되므로 절대경로(`/images/…`)는
+		// 그 접두사를 건너뛰어 404 가 난다. iframe 기준 상대경로여야 로컬·배포 양쪽에서 맞는다.
 		<img
-			src="/images/logo/bigtablet.png"
+			src="images/logo/bigtablet.png"
 			alt="Bigtablet"
 			height={28}
 			style={{ display: "block", filter: invert ? "brightness(0) invert(1)" : undefined }}

--- a/src/ui/navigation/sidebar/sidebar.stories.tsx
+++ b/src/ui/navigation/sidebar/sidebar.stories.tsx
@@ -35,8 +35,10 @@ const SAMPLE_ITEMS = [
 
 function BrandHeader() {
 	return (
+		// GH Pages 는 `/bigtablet-design-system/` 하위에 배포되므로 절대경로(`/images/…`)는
+		// 그 접두사를 건너뛰어 404 가 난다. iframe 기준 상대경로여야 로컬·배포 양쪽에서 맞는다.
 		<img
-			src="/images/logo/bigtablet.png"
+			src="images/logo/bigtablet.png"
 			alt="Bigtablet"
 			height={28}
 			style={{ display: "block" }}
@@ -48,7 +50,7 @@ function FaviconHeader() {
 	// collapsed 시 표시되는 favicon (작은 정사각형 마크)
 	return (
 		<img
-			src="/images/logo/favicon.png"
+			src="images/logo/favicon.png"
 			alt="Bigtablet"
 			width={28}
 			height={28}


### PR DESCRIPTION
## Storybook 로고 이미지가 배포본에서 깨지던 문제

Sidebar · NavBar · layout 쿡북 · page-composition 스토리가 로고를 `/images/logo/…` 절대경로로 불러왔습니다. GitHub Pages 는 사이트를 `/bigtablet-design-system/` 하위에 서빙하므로 루트 절대경로는 그 접두사를 건너뛰어 404 가 납니다.

**로컬에서는 안 보이던 버그입니다** — Storybook dev 서버는 루트(`localhost:6006/`)에 서빙되니 절대경로가 그대로 맞았습니다. 배포본에서만 깨졌습니다.

## 작업한 내용
- [x] 7곳의 `src="/images/logo/…"` → `src="images/logo/…"` (앞 슬래시 제거)
- [x] Sidebar · NavBar 스토리에 이유 주석 (절대경로로 되돌리는 회귀 방지)

`iframe.html` 기준 상대경로가 되어 로컬·배포 양쪽에서 맞습니다.

### Vite `base` 를 안 쓴 이유
`base` 를 설정하면 로컬과 Pages 에서 값이 달라야 하고, Storybook 자체 청크는 이미 상대경로로 빌드되어 base 를 필요로 하지 않았습니다. 앞 슬래시 하나만 빼면 되는 문제에 빌드 설정 분기를 들일 이유가 없습니다.

## 검증

**로컬 (회귀 없음)** — Sidebar · NavBar docs 페이지에서 로고 6개 전부 `naturalWidth > 0` 으로 로드, 깨진 이미지 0.

**배포 경로 (수정 증명)** — `https://bigtablet.github.io/bigtablet-design-system/iframe.html` 기준 URL 해석:

| 형태 | 해석 결과 | 실제 응답 |
|---|---|---|
| `/images/logo/bigtablet.png` (기존) | `https://bigtablet.github.io/images/…` | **404** |
| `images/logo/bigtablet.png` (수정) | `https://bigtablet.github.io/bigtablet-design-system/images/…` | **200** |

`tsc --noEmit` clean.

## 전달할 추가 이슈
- **죽은 에셋 2개**: `public/images/sidebar/arrow-close.svg` · `menu.svg` 는 코드에서 참조하는 곳이 전혀 없습니다. 커밋돼 있고 `staticDirs` 로 배포까지 되고 있는데 쓰이지 않습니다 — 지울지 알려주시면 별도로 처리하겠습니다. 이번 PR 범위(경로 수정)와 무관해 손대지 않았습니다.
- **`public/images/logo/.DS_Store`** 가 디스크에 있습니다. `.gitignore` 에 걸려 커밋은 안 됐지만 로컬 정리하시면 좋겠습니다.
- `layout.stories.tsx` 의 biome `noImgElement` 경고 2건은 이 PR 이전부터 있던 것이고 CI 는 biome 를 돌리지 않습니다 — 손대지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - iframe 및 GitHub Pages 배포 환경에서 로고와 헤더 이미지가 정상적으로 표시되도록 이미지 경로를 개선했습니다.
  - 사이드바 확장·축소 상태와 내비게이션 컴포넌트의 브랜드 이미지 로딩 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->