### PR TITLE
docs/storybook-korean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Domain-based structure in `src/styles/` (each folder has `_index.scss` + `index.
 ### Storybook
 - Component stories: `Components/{Category}/{ComponentName}`
 - Foundation stories: `foundation/{token-name}`
-- Include bilingual descriptions (Korean/English)
+- Write descriptions in Korean. 컴포넌트/prop 이름, 코드, `variant` 값 같은 식별자는 원문 그대로 둔다
 
 ### Animation (Required for Interactive Components)
 

--- a/src/stories/foundation/a11y.stories.tsx
+++ b/src/stories/foundation/a11y.stories.tsx
@@ -12,8 +12,6 @@ const meta: Meta = {
 				component: `
 ### 접근성 (Accessibility) 토큰
 
-**Accessibility tokens** - baseline values that help keyboard, low-vision, and touch users perceive every interaction clearly and safely. Covers focus rings, minimum tap targets, and color contrast (WCAG AA).
-
 **키보드 사용자, 저시력 사용자, 터치 사용자**를 고려해
 모든 인터랙션이 명확하고 안전하게 인식되도록 돕는 기준값입니다.
 

--- a/src/stories/foundation/border-width.stories.tsx
+++ b/src/stories/foundation/border-width.stories.tsx
@@ -13,8 +13,6 @@ const meta: Meta = {
 				component: `
 ### Border Width (테두리 두께)
 
-**Border Width** - expresses an element's boundary and emphasis level. \`none\`/\`standard\`/\`thick\`/\`indicator\` map from no border to focus/state indicators.
-
 테두리 두께는 **요소의 경계와 강조 수준**을 표현합니다.
 
 - **none (0px)**: 테두리 없음

--- a/src/stories/foundation/breakpoints.stories.tsx
+++ b/src/stories/foundation/breakpoints.stories.tsx
@@ -11,8 +11,6 @@ const meta: Meta = {
 				component: `
 ### 반응형 기준 (Breakpoints)
 
-**Breakpoints** - threshold values for changing layout and component placement based on screen size. A 4-tier system based on Material Design 3's Window Size Class.
-
 화면 크기에 따라 **레이아웃과 컴포넌트 배치를 변경하기 위한 기준값**입니다.
 
 Material Design 3의 Window Size Class에 기반한 4단계 시스템입니다.

--- a/src/stories/foundation/colors.stories.tsx
+++ b/src/stories/foundation/colors.stories.tsx
@@ -25,8 +25,6 @@ const meta: Meta = {
 				component: `
 ### Colors (색상 시스템)
 
-**Colors** - official color tokens defined in a two-tier Base / Semantic structure. Always use Semantic tokens (brand / text / bg / state / border / status) instead of raw HEX/RGB values.
-
 **Base / Semantic 2계층 구조**로 정의된 공식 색상 토큰입니다.
 
 - **Base**: raw 값 (직접 사용 지양)

--- a/src/stories/foundation/dark-mode.stories.tsx
+++ b/src/stories/foundation/dark-mode.stories.tsx
@@ -15,8 +15,6 @@ const meta: Meta = {
 				component: `
 ### Dark Mode
 
-**Dark Mode** - Bigtablet DS supports dark mode powered by CSS Custom Properties. Set a \`data-theme\` attribute (\`light\`/\`dark\`, or omit it to follow \`prefers-color-scheme\`), or use the \`ThemeProvider\` in React.
-
 Bigtablet DS는 CSS Custom Properties 기반 dark mode를 지원합니다.
 
 #### 작동 방식

--- a/src/stories/foundation/elevation.stories.tsx
+++ b/src/stories/foundation/elevation.stories.tsx
@@ -13,8 +13,6 @@ const meta: Meta = {
 				component: `
 ### Elevation(높이 위계) 기준
 
-**Elevation** - expresses "floating" (layering) and **height hierarchy** via shadows. \`level1\` (cards) through \`level5\` (strongest, top-most layers).
-
 Elevation은 "떠 있음(레이어)"과 **높이 위계** 를 표현합니다.
 
 - **level1**: 아주 가벼운 분리 (카드, 인풋 배경)

--- a/src/stories/foundation/motion.stories.tsx
+++ b/src/stories/foundation/motion.stories.tsx
@@ -14,8 +14,6 @@ const meta: Meta = {
 				component: `
 ### 모션(Motion) 기준
 
-**Motion** - defines **how fast and how smoothly** the UI responds. Shared across all interaction animations (button hover, card emphasis, modal entrance, etc.). Enter/exit pairs use different tokens - exits are shorter than entrances.
-
 UI가 **얼마나 빠르게, 얼마나 부드럽게 반응하는지**를 정의하는 기준입니다.
 
 👉 버튼 hover, 카드 강조, 모달 등장 같은

--- a/src/stories/foundation/opacity.stories.tsx
+++ b/src/stories/foundation/opacity.stories.tsx
@@ -13,8 +13,6 @@ const meta: Meta = {
 				component: `
 ### Opacity (불투명도)
 
-**Opacity** - transparency tokens used for overlays, disabled states, hover effects, etc. (\`0\` fully transparent → \`100\` fully opaque).
-
 투명도 토큰입니다. 오버레이, 비활성 상태, 호버 효과 등에서 사용합니다.
 
 - **0**: 완전 투명 (숨김)

--- a/src/stories/foundation/radius.stories.tsx
+++ b/src/stories/foundation/radius.stories.tsx
@@ -11,8 +11,6 @@ const meta: Meta = {
 				component: `
 ### Radius (모서리 둥글기)
 
-**Radius** - corner rounding expresses a component's **character and approachability**. \`none\`/\`xs\`/\`sm\` for crisp informational UI, \`md\`/\`lg\` for clickable elements, \`xl\` for hero areas, \`full\` for circles.
-
 모서리 둥글기는 컴포넌트의 **성격과 친밀도**를 표현합니다.
 
 - **none**: 모서리 없음 (표, 인라인 UI)

--- a/src/stories/foundation/skeleton.stories.tsx
+++ b/src/stories/foundation/skeleton.stories.tsx
@@ -41,8 +41,6 @@ const meta: Meta = {
 				component: `
 ### 스켈레톤(Skeleton) 토큰
 
-**Skeleton tokens** - used for **placeholder UI** that fills space while content is loading. Includes gradient colors, wave animation, shape radius, height steps, and animation timing.
-
 콘텐츠가 로딩 중일 때 자리를 채우는 **플레이스홀더 UI**에 사용하는 토큰입니다.
 
 - **color**: 스켈레톤 그라디언트를 구성하는 3가지 색상

--- a/src/stories/foundation/spacing.stories.tsx
+++ b/src/stories/foundation/spacing.stories.tsx
@@ -11,8 +11,6 @@ const meta: Meta = {
 				component: `
 ### Spacing (여백)
 
-**Spacing** - the baseline that creates the screen's **breathing room (gaps)**. Use these tokens for all margin / padding / gap "distances".
-
 Spacing은 화면의 **호흡(간격)** 을 만드는 기준입니다.
 margin / padding / gap 같은 "거리"는 가능한 한 **이 토큰만** 사용합니다.
 
@@ -114,7 +112,9 @@ export const LayoutExample: Story = {
 						}}
 					>
 						<span style={{ fontSize: 13, fontWeight: 600 }}>이름</span>
-						<span style={{ fontSize: 11, color: "var(--bt-color-status-error-on-surface)" }}>*</span>
+						<span style={{ fontSize: 11, color: "var(--bt-color-status-error-on-surface)" }}>
+							*
+						</span>
 					</div>
 					<div style={{ position: "relative" }}>
 						<div

--- a/src/stories/foundation/typography.stories.tsx
+++ b/src/stories/foundation/typography.stories.tsx
@@ -14,8 +14,6 @@ const meta: Meta = {
 				component: `
 ### Typography (타이포그래피)
 
-**Typography** - typography tokens defined in a two-tier Base / Semantic structure (5 scales × 3 sizes × 2 weights). Always use Semantic tokens instead of raw px values.
-
 **Base / Semantic 2계층 구조**로 정의된 타이포그래피 토큰입니다.
 
 - **Base**: 원시 값 (fontSize, fontWeight, lineHeight, letterSpacing)

--- a/src/stories/foundation/z-index.stories.tsx
+++ b/src/stories/foundation/z-index.stories.tsx
@@ -13,8 +13,6 @@ const meta: Meta = {
 				component: `
 ### Z-Index (레이어 우선순위)
 
-**Z-Index** - the standard for deciding **which element appears on top** on screen. Higher numbers render above; fix values to the level scale below (\`level0\` base → \`level5\` top-most).
-
 z-index는 **화면에서 어떤 요소가 위에 보일지**를 정하는 기준입니다.
 
 숫자가 클수록 위에 표시되며,

--- a/src/stories/getting-started/installation.stories.tsx
+++ b/src/stories/getting-started/installation.stories.tsx
@@ -9,9 +9,9 @@ const meta: Meta = {
 		docs: {
 			description: {
 				component: `
-### Installation & Setup / 설치 및 설정
+### 설치 및 설정
 
-How to install and use the design system in your project. Supports both React/Next.js and Vanilla (Thymeleaf, JSP, PHP) environments. / 프로젝트에 디자인 시스템을 설치하고 사용하는 방법입니다. React/Next.js와 Vanilla(Thymeleaf, JSP, PHP) 두 환경을 지원합니다.
+프로젝트에 디자인 시스템을 설치하고 사용하는 방법입니다. React/Next.js 와 Vanilla(Thymeleaf, JSP, PHP) 두 환경을 지원합니다.
         `,
 			},
 		},

--- a/src/stories/getting-started/introduction.stories.tsx
+++ b/src/stories/getting-started/introduction.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta = {
 				component: `
 ### Bigtablet Design System
 
-A design system that manages the **UI components and design tokens** used across the service. / 서비스 전반에 사용되는 **UI 컴포넌트와 디자인 토큰**을 관리하는 디자인 시스템입니다.
+서비스 전반에 사용되는 **UI 컴포넌트와 디자인 토큰**을 관리하는 디자인 시스템입니다.
 
 ---
 
@@ -150,7 +150,9 @@ function InfoCard({ label, value }: { label: string; value: string }) {
 				border: "1px solid var(--bt-color-border-default)",
 			}}
 		>
-			<div style={{ fontSize: 11, color: "var(--bt-color-text-caption)", marginBottom: 4 }}>{label}</div>
+			<div style={{ fontSize: 11, color: "var(--bt-color-text-caption)", marginBottom: 4 }}>
+				{label}
+			</div>
 			<div style={{ fontSize: 13, fontWeight: 600 }}>{value}</div>
 		</div>
 	);

--- a/src/ui/display/accordion/accordion.stories.tsx
+++ b/src/ui/display/accordion/accordion.stories.tsx
@@ -18,10 +18,10 @@ const meta: Meta<typeof Accordion> = {
 		docs: {
 			description: {
 				component: `
-**Accordion** - Progressively reveals content via expand/collapse panels. / **Accordion** - 펼침/접힘으로 컨텐츠 점진 노출.
+**Accordion** - 펼침/접힘 패널로 콘텐츠를 점진적으로 노출한다.
 
-\`multiple={false}\` (default): one open at a time / \`multiple={true}\`: independent toggles. - \`multiple={false}\` (기본): 한 번에 하나 / \`multiple={true}\`: 독립 토글.
-WAI-ARIA Disclosure handled automatically (\`aria-expanded\`, \`aria-controls\`, \`role="region"\`). / WAI-ARIA Disclosure 자동.
+\`multiple={false}\` (기본): 한 번에 하나만 열림 / \`multiple={true}\`: 패널마다 독립 토글.
+WAI-ARIA Disclosure 패턴(\`aria-expanded\`, \`aria-controls\`, \`role="region"\`)을 자동 처리한다.
 				`,
 			},
 		},

--- a/src/ui/display/avatar/avatar.stories.tsx
+++ b/src/ui/display/avatar/avatar.stories.tsx
@@ -17,11 +17,11 @@ const meta: Meta<typeof Avatar> = {
 		docs: {
 			description: {
 				component: `
-**Avatar** - User profile display. Image takes priority; falls back to \`name\` initials when missing or on load failure. / **Avatar** - 사용자 프로필. 이미지 우선, 실패/없으면 \`name\` initials fallback.
+**Avatar** - 사용자 프로필 표시. 이미지가 우선이고, 없거나 로드에 실패하면 \`name\` 의 initials 로 대체한다.
 
-Sizes: \`xs\` 24 / \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 64.
-Shapes: \`circle\` (people) / \`square\` (brand). - **Shapes**: \`circle\` (사람) / \`square\` (브랜드).
-Initials rule: 1 word → first letter, 2+ words → first letter of first + last word. / initials 규칙: 1단어 → 첫 글자, 2+단어 → 첫+마지막 단어 첫 글자.
+크기: \`xs\` 24 / \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 64.
+모양: \`circle\` (사람) / \`square\` (브랜드).
+initials 규칙: 1단어면 첫 글자, 2단어 이상이면 첫 단어와 마지막 단어의 첫 글자.
 				`,
 			},
 		},

--- a/src/ui/display/badge/badge.stories.tsx
+++ b/src/ui/display/badge/badge.stories.tsx
@@ -19,12 +19,11 @@ const meta: Meta<typeof Badge> = {
 		docs: {
 			description: {
 				component: `
-**Badge** - Small status/count indicator. Static display only (no click/remove - see Chip).
-작은 상태/카운트 표시. 정적 표시 전용 (클릭/삭제 X - Chip 참고).
+**Badge** - 작은 상태·카운트 표시. 정적 표시 전용이다 (클릭·삭제는 Chip 참고).
 
 - **Shapes** - \`dot\` / \`count\` / \`label\`
 - **Variants** - \`accent\` / \`neutral\` / \`info\` / \`success\` / \`warning\` / \`error\`
-- **Appearance** - \`solid\` (strong fill) / \`soft\` (tint bg + dark text), both WCAG AA. / 강한 fill / tint 배경 + 진한 글자
+- **Appearance** - \`solid\` (강한 fill) / \`soft\` (tint 배경 + 진한 글자). 둘 다 WCAG AA 통과
 - \`count > max\` → \`{max}+\`
 				`,
 			},
@@ -77,7 +76,7 @@ export const SolidVsSoft: Story = {
 		docs: {
 			description: {
 				story:
-					"`appearance=\"solid\"` (default) - strong fill, for notification / status emphasis. `appearance=\"soft\"` - tint bg + dark text, for info labels. Both pass WCAG AA (5~7:1). / 강한 fill (기본) vs tint 배경 + 진한 글자. 둘 다 AA 통과.",
+					"`appearance=\"solid\"` (기본) - 강한 fill. 알림·상태 강조용. `appearance=\"soft\"` - tint 배경 + 진한 글자. 정보 라벨용. 둘 다 WCAG AA (5~7:1) 를 통과한다.",
 			},
 		},
 	},

--- a/src/ui/display/card/card.stories.tsx
+++ b/src/ui/display/card/card.stories.tsx
@@ -30,13 +30,13 @@ const meta: Meta<typeof Card> = {
 		docs: {
 			description: {
 				component: `
-**Card** - Container that groups related content into a single block. / **Card** - 콘텐츠를 한 덩어리로 묶는 컨테이너.
+**Card** - 관련 콘텐츠를 한 덩어리로 묶는 컨테이너.
 
-**Variants**: \`default\` / \`accent\` (inverted bg + white text) / \`glass\` (frosted + backdrop blur, use over colored/image backgrounds) / \`outlined\` (transparent bg + border only). / \`accent\`(반전 bg + 흰 텍스트) · \`glass\`(반투명 blur, 컬러/이미지 배경 위 권장) · \`outlined\`(투명 + 테두리).
+**Variants**: \`default\` / \`accent\` (반전 배경 + 흰 텍스트) / \`glass\` (반투명 + backdrop blur, 컬러·이미지 배경 위 권장) / \`outlined\` (투명 배경 + 테두리만).
 
-**Composition**: \`heading\` (header) + children (body) + \`footer\` (with \`footerAlign\` start/between/end). \`interactive\` adds a hover-lift for clickable cards. / \`heading\`+body+\`footer\` 3단 + \`interactive\` hover-lift.
+**구성**: \`heading\` (헤더) + children (본문) + \`footer\` (\`footerAlign\` start/between/end) 3단. \`interactive\` 를 켜면 클릭 가능한 카드에 hover lift 가 붙는다.
 
-Other props: \`shadow\` (none/sm/md/lg), \`padding\` (none/sm/md/lg), \`bordered\`.
+그 밖의 prop: \`shadow\` (none/sm/md/lg), \`padding\` (none/sm/md/lg), \`bordered\`.
 				`,
 			},
 		},

--- a/src/ui/display/chip/chip.stories.tsx
+++ b/src/ui/display/chip/chip.stories.tsx
@@ -22,10 +22,10 @@ const meta: Meta<typeof Chip> = {
 		docs: {
 			description: {
 				component: `
-**Chip** - Compact element representing an attribute, filter, or input value. / **Chip** - 속성/필터/입력값을 표현하는 컴팩트 요소.
+**Chip** - 속성·필터·입력값을 표현하는 컴팩트 요소.
 
-Types: \`basic\` (tag) / \`input\` (input value, removable) / \`filter\` (dropdown) / \`static\` (label, tone). - **Types**: \`basic\` (태그) / \`input\` (입력값, removable) / \`filter\` (드롭다운) / \`static\` (라벨, tone).
-Key props: \`type\`, \`tone\`, \`size\` (sm 24 / md 28 / default 32), \`selected\`, \`removable\`. / 주요 prop.
+**Types**: \`basic\` (태그) / \`input\` (입력값, removable) / \`filter\` (드롭다운) / \`static\` (라벨, tone).
+주요 prop: \`type\`, \`tone\`, \`size\` (sm 24 / md 28 / 기본 32), \`selected\`, \`removable\`.
 				`,
 			},
 		},

--- a/src/ui/display/divider/divider.stories.tsx
+++ b/src/ui/display/divider/divider.stories.tsx
@@ -20,9 +20,9 @@ const meta: Meta<typeof Divider> = {
 		docs: {
 			description: {
 				component: `
-**Divider** - Horizontal rule separating content areas. / **Divider** - 콘텐츠 영역 수평 구분선.
+**Divider** - 콘텐츠 영역을 나누는 수평 구분선.
 
-\`weight\`: \`standard\` (1px, default) / \`heavy\` (2px, section emphasis). - \`weight\`: \`standard\` (1px, 기본) / \`heavy\` (2px, 섹션 강조).
+\`weight\`: \`standard\` (1px, 기본) / \`heavy\` (2px, 섹션 강조).
         `,
 			},
 		},

--- a/src/ui/display/hero/hero.stories.tsx
+++ b/src/ui/display/hero/hero.stories.tsx
@@ -11,10 +11,10 @@ const meta: Meta<typeof Hero> = {
 		docs: {
 			description: {
 				component: `
-**Hero** - Large banner area at the top of a page. Renders \`<section>\` + \`<h1>\` (one per page). / **Hero** - 페이지 상단 큰 영역. \`<section>\` + \`<h1>\` (페이지당 하나).
+**Hero** - 페이지 상단의 큰 배너 영역. \`<section>\` + \`<h1>\` 로 렌더된다 (페이지당 하나).
 
-Slots: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`. / 슬롯: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`.
-Key props: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`. / 주요 prop: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`.
+슬롯: \`eyebrow\` / \`title\` / \`subtitle\` / \`primaryAction\` / \`secondaryAction\` / \`children\`.
+주요 prop: \`height\` (sm/md/lg/full), \`overlay\` (\`dark\`/\`light\`), \`align\`, \`backgroundImage\`, \`backgroundColor\`.
 				`,
 			},
 		},

--- a/src/ui/display/icon/icon.stories.tsx
+++ b/src/ui/display/icon/icon.stories.tsx
@@ -31,9 +31,9 @@ const meta: Meta<typeof Icon> = {
 		docs: {
 			description: {
 				component: `
-**Icon** - Wrapper around lucide-react icons. Catalog: [lucide.dev/icons](https://lucide.dev/icons/). / lucide-react 아이콘 wrapper.
+**Icon** - lucide-react 아이콘 wrapper. 아이콘 카탈로그: [lucide.dev/icons](https://lucide.dev/icons/).
 
-Key props: \`icon\` (lucide component), \`size\`, \`strokeWidth\`, \`aria-label\` (\`aria-hidden\` applied automatically when omitted). / 주요 prop: \`icon\` (lucide 컴포넌트), \`size\`, \`strokeWidth\`, \`aria-label\` (미지정 시 \`aria-hidden\` 자동).
+주요 prop: \`icon\` (lucide 컴포넌트), \`size\`, \`strokeWidth\`, \`aria-label\` (미지정 시 \`aria-hidden\` 자동 적용).
         `,
 			},
 		},

--- a/src/ui/display/list-item/list-item.stories.tsx
+++ b/src/ui/display/list-item/list-item.stories.tsx
@@ -23,11 +23,11 @@ const meta: Meta<typeof ListItem> = {
 		docs: {
 			description: {
 				component: `
-**ListItem** - A single row in a list. Slot-based (\`leadingElement\` / \`trailingElement\`). / **ListItem** - 목록 한 항목. 슬롯형.
+**ListItem** - 목록의 한 항목. \`leadingElement\` / \`trailingElement\` 슬롯 기반.
 
-Key props: \`label\`, \`overline\` (small text above), \`supportingText\` (secondary text below), \`metadata\` (bottom meta), \`alignment\` (\`top\` multi-line / \`middle\` single line + icon), \`onClick\` (interactive). / 주요 prop: \`label\`, \`overline\` (위 작은 텍스트), \`supportingText\` (아래 보조), \`metadata\` (하단 메타), \`alignment\` (\`top\` 멀티라인 / \`middle\` 한 줄+아이콘), \`onClick\` (인터랙티브).
+주요 prop: \`label\`, \`overline\` (위 작은 텍스트), \`supportingText\` (아래 보조 텍스트), \`metadata\` (하단 메타), \`alignment\` (\`top\` 멀티라인 / \`middle\` 한 줄 + 아이콘), \`onClick\` (인터랙티브).
 
-The four text slots accept **string or ReactNode** — inline \`<strong>\`, \`<a>\`, or a \`Badge\`. / 텍스트 4종 슬롯은 **string·ReactNode 모두 허용** — 인라인 \`<strong>\`, \`<a>\`, \`Badge\` 등.
+텍스트 4종 슬롯은 **string 과 ReactNode 를 모두 허용**한다 — 인라인 \`<strong>\`, \`<a>\`, \`Badge\` 등.
 				`,
 			},
 		},

--- a/src/ui/display/media-card/media-card.stories.tsx
+++ b/src/ui/display/media-card/media-card.stories.tsx
@@ -13,10 +13,10 @@ const meta: Meta<typeof MediaCard> = {
 		docs: {
 			description: {
 				component: `
-**MediaCard** - Image + text content card for blog/product grids and menu displays. / **MediaCard** - 이미지 + 텍스트 콘텐츠 카드. 블로그/제품 그리드/메뉴 진열용.
+**MediaCard** - 이미지 + 텍스트 콘텐츠 카드. 블로그·제품 그리드나 메뉴 진열에 쓴다.
 
-\`imagePosition\`: \`top\` (grid, default 16/9) / \`left\` (list, auto top on mobile) / \`overlay\` (text over image, 4/3). - \`imagePosition\`: \`top\` (그리드, 기본 16/9) / \`left\` (리스트, 모바일 자동 top) / \`overlay\` (이미지 위 텍스트, 4/3).
-Key props: \`image\`, \`heading\`, \`aspectRatio\`, \`shadow\`, \`bordered\`, \`clickable\` (hover lift). / 주요 prop.
+\`imagePosition\`: \`top\` (그리드, 기본 16/9) / \`left\` (리스트, 모바일에서 자동 top) / \`overlay\` (이미지 위 텍스트, 4/3).
+주요 prop: \`image\`, \`heading\`, \`aspectRatio\`, \`shadow\`, \`bordered\`, \`clickable\` (hover lift).
 				`,
 			},
 		},

--- a/src/ui/display/table/table.stories.tsx
+++ b/src/ui/display/table/table.stories.tsx
@@ -56,9 +56,9 @@ const meta: Meta<typeof Table> = {
 		docs: {
 			description: {
 				component: `
-**Table** - Displays structured data in rows/columns with generic row type safety. Supports controlled sort (\`sort\`/\`onSortChange\`) and row selection (\`selectable\`/\`rowKey\`/\`selectedKeys\`/\`onSelectionChange\`) - the DS only renders UI state, the consumer owns sorting the \`data\` array and the selection list. / **Table** - 정형 데이터 행/열 표시. 제네릭 row 타입 안전. 제어형 정렬(\`sort\`/\`onSortChange\`)과 행 선택(\`selectable\`/\`rowKey\`/\`selectedKeys\`/\`onSelectionChange\`)을 지원한다 - DS는 UI 상태만 그리고, 실제 \`data\` 정렬과 선택 목록 관리는 소비자가 담당한다.
+**Table** - 정형 데이터를 행/열로 표시한다. 제네릭 row 타입 안전. 제어형 정렬(\`sort\`/\`onSortChange\`)과 행 선택(\`selectable\`/\`rowKey\`/\`selectedKeys\`/\`onSelectionChange\`)을 지원한다 - DS는 UI 상태만 그리고, 실제 \`data\` 정렬과 선택 목록 관리는 소비자가 담당한다.
 
-Key props: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (auto Skeleton rows), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`. / 주요 prop: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (Skeleton 행 자동), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`.
+주요 prop: \`columns\`, \`rows\`, \`size\` (sm/md/lg), \`isLoading\` (Skeleton 행 자동), \`stickyHeader\`, \`onRowClick\`, \`emptyMessage\`.
         `,
 			},
 		},
@@ -170,7 +170,7 @@ export const Sortable: Story = {
 		docs: {
 			description: {
 				story:
-					"Controlled sort - the DS only renders `aria-sort` + arrow icon on click; the consumer sorts `data` and passes it back. Header click cycles none → asc → desc → none. / 제어형 정렬 - DS는 클릭 시 `aria-sort`와 화살표 아이콘만 그린다. 실제 `data` 정렬은 소비자가 수행해 다시 전달한다. 헤더 클릭 시 none → asc → desc → none 순환.",
+					"제어형 정렬 - DS는 클릭 시 `aria-sort`와 화살표 아이콘만 그린다. 실제 `data` 정렬은 소비자가 수행해 다시 전달한다. 헤더 클릭 시 none → asc → desc → none 순환.",
 			},
 		},
 	},
@@ -209,7 +209,7 @@ export const Selectable: Story = {
 		docs: {
 			description: {
 				story:
-					"Controlled row selection via `selectable` + `rowKey` + `selectedKeys` + `onSelectionChange`. Header checkbox is tri-state (checked/indeterminate/unchecked). Selected rows get `aria-selected` and an accent highlight. / `selectable` + `rowKey` + `selectedKeys` + `onSelectionChange` 로 제어하는 행 선택. 헤더 체크박스는 3-상태(전체선택/일부선택/미선택)이며, 선택된 행은 `aria-selected` 와 accent 강조를 받는다.",
+					"`selectable` + `rowKey` + `selectedKeys` + `onSelectionChange` 로 제어하는 행 선택. 헤더 체크박스는 3-상태(전체선택/일부선택/미선택)이며, 선택된 행은 `aria-selected` 와 accent 강조를 받는다.",
 			},
 		},
 	},
@@ -242,7 +242,7 @@ export const SortableAndSelectable: Story = {
 		docs: {
 			description: {
 				story:
-					"Sort and selection compose independently - both are controlled, and neither DS feature touches `data` directly. / 정렬과 선택은 서로 독립적으로 조합된다 - 둘 다 제어형이며 DS는 `data` 를 직접 건드리지 않는다.",
+					"정렬과 선택은 서로 독립적으로 조합된다 - 둘 다 제어형이며 DS는 `data` 를 직접 건드리지 않는다.",
 			},
 		},
 	},

--- a/src/ui/feedback/alert/alert.stories.tsx
+++ b/src/ui/feedback/alert/alert.stories.tsx
@@ -89,11 +89,11 @@ const meta: Meta<typeof AlertDemo> = {
 		docs: {
 			description: {
 				component: `
-**Alert** - Modal dialog for actions that need immediate confirmation. / **Alert** - 즉각 확인이 필요한 모달 알림.
+**Alert** - 즉각 확인이 필요한 동작을 위한 모달 알림.
 
 Variants: \`info\` / \`success\` / \`warning\` / \`error\`.
-Key props / 주요 prop: \`title\`, \`message\`, \`showCancel\`, \`actionsAlign\`, \`destructive\` (red confirm emphasis / confirm 빨간 강조), \`showIcon\`.
-Usage / 사용: \`useAlert().showAlert({...})\` - inside \`AlertProvider\`. / \`AlertProvider\` 하위에서.
+주요 prop: \`title\`, \`message\`, \`showCancel\`, \`actionsAlign\`, \`destructive\` (confirm 을 빨간색으로 강조), \`showIcon\`.
+사용: \`AlertProvider\` 하위에서 \`useAlert().showAlert({...})\`.
 				`,
 			},
 		},

--- a/src/ui/feedback/empty-state/empty-state.stories.tsx
+++ b/src/ui/feedback/empty-state/empty-state.stories.tsx
@@ -39,9 +39,9 @@ const meta: Meta<typeof EmptyState> = {
 		docs: {
 			description: {
 				component: `
-**EmptyState** - Placeholder for areas with no data. / **EmptyState** - 데이터 없는 영역 placeholder. Slots / 슬롯: \`illustration\` + \`title\` + \`description\` + \`action\`.
+**EmptyState** - 데이터가 없는 영역을 채우는 placeholder. 슬롯: \`illustration\` + \`title\` + \`description\` + \`action\`.
 
-Sizes: \`sm\` (modal/sidebar / 모달·사이드바) / \`md\` (content area, default / 콘텐츠 영역, 기본) / \`lg\` (page main / 페이지 메인).
+크기: \`sm\` (모달·사이드바) / \`md\` (콘텐츠 영역, 기본) / \`lg\` (페이지 메인).
 				`,
 			},
 		},

--- a/src/ui/feedback/error-state/error-state.stories.tsx
+++ b/src/ui/feedback/error-state/error-state.stories.tsx
@@ -17,13 +17,12 @@ const meta: Meta<typeof ErrorState> = {
 		docs: {
 			description: {
 				component: `
-**ErrorState** - Error display for error boundary / data load failure / widget fallback. Sister of \`EmptyState\`.
-에러 표시 (error boundary / 데이터 로드 실패 / 위젯 fallback). \`EmptyState\` 의 형제.
+**ErrorState** - 에러 표시 (error boundary / 데이터 로드 실패 / 위젯 fallback). \`EmptyState\` 의 형제.
 
-- \`variant="page"\` (default) - full-screen fill, large icon + min-height. For error boundary fallback. / 전체 화면 채움.
-- \`variant="widget"\` - inline compact, inside widget/card. / 인라인 컴팩트.
-- Default warning icon + \`status-error\` token. Hide with \`icon={null}\`, replace via \`icon\`. / 기본 경고 아이콘, 숨김/교체 가능.
-- Automatic \`role="alert"\`. / 자동 적용.
+- \`variant="page"\` (기본) - 전체 화면을 채운다. 큰 아이콘 + min-height. error boundary fallback 용.
+- \`variant="widget"\` - 위젯·카드 내부에 넣는 인라인 컴팩트 형태.
+- 기본 경고 아이콘 + \`status-error\` 토큰. \`icon={null}\` 로 숨기고 \`icon\` 으로 교체한다.
+- \`role="alert"\` 자동 적용.
 				`,
 			},
 		},

--- a/src/ui/feedback/linear-progress/linear-progress.stories.tsx
+++ b/src/ui/feedback/linear-progress/linear-progress.stories.tsx
@@ -14,10 +14,10 @@ const meta: Meta<typeof LinearProgress> = {
 		docs: {
 			description: {
 				component: `
-**LinearProgress** - Horizontal step-based progress bar. / **LinearProgress** - 단계 기반 진행률 수평 바. For signup/survey steppers. / 회원가입·설문 Stepper 용.
+**LinearProgress** - 단계 기반 진행률을 보여주는 수평 바. 회원가입·설문 Stepper 용.
 
-Key props / 주요 prop: \`totalSteps\`, \`currentStep\` (0 ~ totalSteps).
-For async loading see \`Spinner\`, for page transitions see \`TopLoading\`. / 비동기 로딩은 \`Spinner\`, 페이지 전환은 \`TopLoading\` 참고.
+주요 prop: \`totalSteps\`, \`currentStep\` (0 ~ totalSteps).
+비동기 로딩은 \`Spinner\`, 페이지 전환은 \`TopLoading\` 을 참고.
 				`,
 			},
 		},

--- a/src/ui/feedback/skeleton/skeleton.stories.tsx
+++ b/src/ui/feedback/skeleton/skeleton.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof Skeleton> = {
 		docs: {
 			description: {
 				component: `
-**Skeleton** - Loading placeholder. / **Skeleton** - 로딩 플레이스홀더. \`aria-hidden\` applied automatically. / \`aria-hidden\` 자동.
+**Skeleton** - 로딩 중 자리를 잡아 두는 플레이스홀더. \`aria-hidden\` 이 자동으로 적용된다.
 
 Variants: \`text\` (12px) / \`title\` (20px) / \`avatar\` (40×40 circle / 원형) / \`rect\` (card/image / 카드·이미지).
 				`,

--- a/src/ui/feedback/spinner/spinner.stories.tsx
+++ b/src/ui/feedback/spinner/spinner.stories.tsx
@@ -18,11 +18,11 @@ const meta: Meta<typeof Spinner> = {
 		docs: {
 			description: {
 				component: `
-**Spinner** - Inline rotating loading indicator. / **Spinner** - 인라인 회전 로딩 표시. For use inside buttons/cards. / 버튼·카드 내부용.
+**Spinner** - 인라인 회전 로딩 표시. 버튼·카드 내부용.
 
-Size / 크기: button 16–24 / 버튼, card 24–32 / 카드, emphasis 40+ / 강조. For page transitions see \`TopLoading\`. / 페이지 전환은 \`TopLoading\` 참고.
+크기: 버튼 16–24, 카드 24–32, 강조 40 이상. 페이지 전환은 \`TopLoading\` 을 참고.
 
-> ⚠️ **Docs view note / Docs 뷰 안내** - The preview on this page is a static capture, so the spinner may appear frozen or show a single frame. / 이 페이지의 미리보기는 정적 캡처라 spinner 가 멈춰 있거나 한 프레임만 보일 수 있다. To see the real rotation, open an individual story (e.g. Basic) from the left sidebar. / 실제 회전은 좌측 사이드바에서 개별 스토리 (Basic 등) 를 열면 확인 가능.
+> ⚠️ **Docs 뷰 안내** - 이 페이지의 미리보기는 정적 캡처라 spinner 가 멈춰 있거나 한 프레임만 보일 수 있다. 실제 회전은 좌측 사이드바에서 개별 스토리(Basic 등)를 열면 확인할 수 있다.
         `,
 			},
 		},

--- a/src/ui/feedback/toast/toast.stories.tsx
+++ b/src/ui/feedback/toast/toast.stories.tsx
@@ -58,10 +58,10 @@ const meta: Meta = {
 		docs: {
 			description: {
 				component: `
-**Toast** - Brief, non-blocking notification that auto-dismisses. / **Toast** - 화면을 막지 않는 짧은 알림. 자동 사라짐.
+**Toast** - 화면을 막지 않는 짧은 알림. 일정 시간 뒤 자동으로 사라진다.
 
-Types: \`message\` (default) / \`success\` / \`warning\` / \`error\` / \`info\`.
-Usage / 사용: wrap with \`<ToastProvider>\` and use the \`useToast()\` hook - \`t.success("저장 완료", 5000)\`. / \`<ToastProvider>\` 감싸고 \`useToast()\` 훅.
+Types: \`message\` (기본) / \`success\` / \`warning\` / \`error\` / \`info\`.
+사용: \`<ToastProvider>\` 로 감싸고 \`useToast()\` 훅을 쓴다 - \`t.success("저장 완료", 5000)\`.
 				`,
 			},
 		},

--- a/src/ui/feedback/top-loading/top-loading.stories.tsx
+++ b/src/ui/feedback/top-loading/top-loading.stories.tsx
@@ -37,10 +37,10 @@ const meta: Meta<typeof TopLoading> = {
 		docs: {
 			description: {
 				component: `
-**TopLoading** - Progress bar pinned to the top of the screen. / **TopLoading** - 화면 상단 고정 프로그레스 바. For page transitions/global loading. / 페이지 전환·전역 로딩용.
+**TopLoading** - 화면 상단에 고정되는 프로그레스 바. 페이지 전환·전역 로딩용.
 
-\`progress\` unset → indeterminate infinite animation / 미지정 → indeterminate 무한 애니메이션; set → determinate percent fill / 지정 → determinate 퍼센트 fill.
-For inline loading see \`Spinner\`. / 인라인 로딩은 \`Spinner\` 참고.
+\`progress\` 미지정 → indeterminate 무한 애니메이션, 지정 → determinate 퍼센트 fill.
+인라인 로딩은 \`Spinner\` 를 참고.
         `,
 			},
 		},

--- a/src/ui/forms/checkbox/checkbox.stories.tsx
+++ b/src/ui/forms/checkbox/checkbox.stories.tsx
@@ -19,12 +19,12 @@ const meta: Meta<typeof Checkbox> = {
 		docs: {
 			description: {
 				component: `
-**Checkbox** - Multi-select control (use Radio for single-select). / **Checkbox** - 다중 선택 (단일 선택은 Radio).
+**Checkbox** - 다중 선택 컨트롤 (단일 선택은 Radio 를 쓴다).
 
-States: \`checked\` / \`indeterminate\` (part of a select-all) / \`disabled\` / \`error\`. / States: \`checked\` / \`indeterminate\` (전체 선택의 일부) / \`disabled\` / \`error\`.
-Native \`<input type="checkbox">\` - Tab/Space handled automatically. / 네이티브 \`<input type="checkbox">\` - Tab/Space 자동.
+States: \`checked\` / \`indeterminate\` (전체 선택의 일부) / \`disabled\` / \`error\`.
+네이티브 \`<input type="checkbox">\` 라 Tab/Space 가 자동으로 동작한다.
 
-> ⚠️ **Docs view note / Docs 뷰 안내** - Hover/focus/active interaction states are not visible in the static preview; open an individual story (e.g. Basic) from the left sidebar and use mouse/keyboard to see real behavior. Checked/Indeterminate box color auto-inverts in dark mode (black↔white). / Hover/focus/active 인터랙션 상태는 정적 미리보기에 안 보인다. 실제 동작은 좌측 사이드바에서 개별 스토리 (Basic 등) 를 열고 마우스/키보드 입력으로 확인. Checked/Indeterminate 박스 색은 다크 모드에서 자동 반전 (검정↔흰).
+> ⚠️ **Docs 뷰 안내** - Hover/focus/active 인터랙션 상태는 정적 미리보기에 보이지 않는다. 실제 동작은 좌측 사이드바에서 개별 스토리(Basic 등)를 열고 마우스·키보드로 확인한다. Checked/Indeterminate 박스 색은 다크 모드에서 자동 반전된다(검정↔흰).
 				`,
 			},
 		},

--- a/src/ui/forms/date-picker/date-picker.stories.tsx
+++ b/src/ui/forms/date-picker/date-picker.stories.tsx
@@ -62,10 +62,10 @@ const meta: Meta<typeof DateFieldDemo> = {
 		docs: {
 			description: {
 				component: `
-**DatePicker** - Year/month/day Dropdown combo. \`onChange\` always returns \`YYYY-MM-DD\`. / **DatePicker** - 연/월/일 Dropdown 조합. \`onChange\` 항상 \`YYYY-MM-DD\` 반환.
+**DatePicker** - 연/월/일 Dropdown 조합. \`onChange\` 는 항상 \`YYYY-MM-DD\` 를 반환한다.
 
-\`mode\`: \`year-month\` (normalized → YYYY-MM-01) / \`year-month-day\`. / \`year-month\` (정규화 → YYYY-MM-01) / \`year-month-day\`.
-Key props: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`. / 주요 prop: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`.
+\`mode\`: \`year-month\` (정규화 → YYYY-MM-01) / \`year-month-day\`.
+주요 prop: \`startYear\`, \`endYear\`, \`selectableRange\` (\`all\` / \`until-today\`), \`disabled\`.
 				`,
 			},
 		},

--- a/src/ui/forms/dropdown/dropdown.stories.tsx
+++ b/src/ui/forms/dropdown/dropdown.stories.tsx
@@ -56,14 +56,14 @@ const meta: Meta<typeof Dropdown> = {
 		docs: {
 			description: {
 				component: `
-**Dropdown** - Single-select dropdown. Floating label (shows when a value is selected/opened). / **Dropdown** - 단일 선택 드롭다운. 플로팅 라벨 (값 선택/열림 시 표시).
+**Dropdown** - 단일 선택 드롭다운. 값이 선택되거나 열릴 때 플로팅 라벨이 표시된다.
 
-Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
-Variants: \`outline\` (default, bordered) / \`filled\` (dim fill, no border — the border appears while open). Same vocabulary as \`TextField\`. / Variants: \`outline\` (기본, 테두리) / \`filled\` (dim 배경 채움, 테두리 없음 — 열려 있는 동안 테두리가 드러남). \`TextField\` 와 같은 어휘입니다.
-\`DropdownOption\` fields: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`. / \`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
-Keyboard: ↑↓/Enter/Esc/Home/End. / 키보드: ↑↓/Enter/Esc/Home/End.
+크기: \`sm\` / \`md\` (기본) / \`lg\`.
+Variants: \`outline\` (기본, 테두리) / \`filled\` (dim 배경 채움, 테두리 없음 — 열려 있는 동안 테두리가 드러남). \`TextField\` 와 같은 어휘를 쓴다.
+\`DropdownOption\` 필드: \`label\`, \`value\`, \`disabled\`, \`supportingText\`, \`leadingIcon\`, \`showDivider\`.
+키보드: ↑↓/Enter/Esc/Home/End.
 
-Opt-in: \`searchable\` adds a label filter (case/whitespace-insensitive, Korean IME safe), \`multiple\` enables multi-select (toggle, list stays open, "N개 선택" summary). / opt-in: \`searchable\` 은 라벨 필터(대소문자·공백 무시, 한글 IME 안전), \`multiple\` 은 다중 선택(토글, 리스트 유지, "N개 선택" 요약)을 켭니다.
+opt-in: \`searchable\` 은 라벨 필터(대소문자·공백 무시, 한글 IME 안전), \`multiple\` 은 다중 선택(토글, 리스트 유지, "N개 선택" 요약)을 켠다.
 				`,
 			},
 		},
@@ -105,7 +105,7 @@ export const Variants: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "Side-by-side comparison of the two variants. / 두 variant 를 나란히 비교합니다.",
+				story: "두 variant 를 나란히 비교한다.",
 			},
 		},
 	},
@@ -172,7 +172,7 @@ export const Searchable: Story = {
 		docs: {
 			description: {
 				story:
-					"Type to filter options by label (case- and whitespace-insensitive). Korean IME composition is committed on composition end so the list does not thrash mid-typing. / 라벨로 옵션을 필터링합니다(대소문자·공백 무시). 한글 IME 는 조합 완료 시점에 반영되어 조합 중 리스트가 흔들리지 않습니다.",
+					"라벨로 옵션을 필터링한다(대소문자·공백 무시). 한글 IME 는 조합 완료 시점에 반영되어 조합 중 리스트가 흔들리지 않는다.",
 			},
 		},
 	},
@@ -217,7 +217,7 @@ export const SearchableMultiple: Story = {
 		docs: {
 			description: {
 				story:
-					"Search and multi-select combine: selecting an option while a filter is active keeps the filter so you can keep picking from the narrowed list. / 검색과 다중 선택 조합: 필터가 걸린 상태에서 항목을 선택해도 필터가 유지되어 좁혀진 목록에서 계속 고를 수 있습니다.",
+					"검색과 다중 선택 조합: 필터가 걸린 상태에서 항목을 선택해도 필터가 유지되어 좁혀진 목록에서 계속 고를 수 있다.",
 			},
 		},
 	},

--- a/src/ui/forms/file/file.stories.tsx
+++ b/src/ui/forms/file/file.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof FileInput> = {
 		},
 		disabled: {
 			control: "boolean",
-			description: "Disabled state. / 비활성화 상태.",
+			description: "비활성화 상태.",
 		},
 		onFiles: { control: false },
 	},

--- a/src/ui/forms/file/file.stories.tsx
+++ b/src/ui/forms/file/file.stories.tsx
@@ -9,20 +9,20 @@ const meta: Meta<typeof FileInput> = {
 	argTypes: {
 		label: {
 			control: "text",
-			description: "Button label / preview empty-state text. / 버튼 라벨 / preview 빈 상태 텍스트.",
+			description: "버튼 라벨 / preview 빈 상태 텍스트.",
 		},
 		variant: {
 			control: "radio",
 			options: ["button", "preview"],
-			description: "Display form. `button` regular button / `preview` image preview inside a large box. / 표시 형태. `button` 일반 버튼 / `preview` 큰 박스 안 이미지 미리보기.",
+			description: "표시 형태. `button` 일반 버튼 / `preview` 큰 박스 안 이미지 미리보기.",
 		},
 		previewSize: {
 			control: { type: "number", min: 80, max: 400, step: 8 },
-			description: "variant=\"preview\" box size (px). / variant=\"preview\" 박스 크기 (px).",
+			description: "variant=\"preview\" 박스 크기 (px).",
 		},
 		multiple: {
 			control: "boolean",
-			description: "Allow selecting multiple files (button variant only). / 여러 파일 선택 허용 여부 (button variant 만).",
+			description: "여러 파일 선택 허용 여부 (button variant 만).",
 		},
 		disabled: {
 			control: "boolean",
@@ -41,12 +41,12 @@ const meta: Meta<typeof FileInput> = {
 		docs: {
 			description: {
 				component: `
-**FileInput** - File selection. Choose the display form with \`variant\`. / **FileInput** - 파일 선택. \`variant\` 로 표시 형태 선택.
+**FileInput** - 파일 선택. \`variant\` 로 표시 형태를 고른다.
 
-- \`variant="button"\` (default): regular file-select button. Show thumbnails below via the \`preview\` option. / (기본): 일반 파일 선택 버튼. \`preview\` 옵션으로 아래 썸네일 표시.
-- \`variant="preview"\`: single image preview inside a large box (avatar / image uploader pattern). Adjust box size with \`previewSize\`. / 큰 박스 안에 단일 이미지 미리보기 (avatar / 이미지 업로더 패턴). \`previewSize\` 로 박스 크기 조정.
+- \`variant="button"\` (기본): 일반 파일 선택 버튼. \`preview\` 옵션으로 아래에 썸네일을 표시한다.
+- \`variant="preview"\`: 큰 박스 안에 단일 이미지 미리보기 (avatar / 이미지 업로더 패턴). \`previewSize\` 로 박스 크기를 조정한다.
 
-Key props: \`accept\`, \`multiple\`, \`onFiles(files)\`. Uploading is a separate API. / 주요 prop: \`accept\`, \`multiple\`, \`onFiles(files)\`. 업로드는 별도 API.
+주요 prop: \`accept\`, \`multiple\`, \`onFiles(files)\`. 업로드는 별도 API 로 처리한다.
         `,
 			},
 		},
@@ -110,7 +110,7 @@ export const Multiple: Story = {
 		docs: {
 			description: {
 				story:
-					"`multiple={true}` + `preview={true}` - when multiple images are selected, 64×64 thumbnails are laid out horizontally below the button. File names show in the text below. / 여러 이미지 선택 시 64×64 썸네일이 버튼 아래 가로로 나열. 파일 이름은 아래 텍스트로 확인.",
+					"`multiple={true}` + `preview={true}` - 여러 이미지를 선택하면 64×64 썸네일이 버튼 아래 가로로 나열된다. 파일 이름은 아래 텍스트에서 확인한다.",
 			},
 		},
 	},
@@ -159,7 +159,7 @@ export const Preview: Story = {
 		docs: {
 			description: {
 				story:
-					"Image preview inside a large box. When empty, shows a dashed border + icon + label. After selection the image fills the box and can be removed via the X in the top-right. / 큰 박스 안에 이미지 미리보기. 비어 있을 때 점선 border + 아이콘 + 라벨. 선택 후 이미지가 박스 채움 + 우상단 X 로 제거 가능.",
+					"큰 박스 안에 이미지 미리보기. 비어 있을 때는 점선 border + 아이콘 + 라벨을 보여준다. 선택하면 이미지가 박스를 채우고 우상단 X 로 제거할 수 있다.",
 			},
 		},
 	},

--- a/src/ui/forms/image-cropper/image-cropper.stories.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.stories.tsx
@@ -49,26 +49,24 @@ const meta = {
 		src: { control: false, description: "크롭할 이미지 (`File`/`Blob`/URL). / Image to crop." },
 		circular: {
 			control: "boolean",
-			description: "원형 가이드(아바타용). / Circular guide for avatars.",
+			description: "원형 가이드(아바타용).",
 		},
 		viewportSize: {
 			control: { type: "number", min: 160, max: 320, step: 8 },
-			description: "뷰포트 한 변(px). / Viewport side length (px).",
+			description: "뷰포트 한 변(px).",
 		},
 		outputSize: {
 			control: { type: "number", min: 128, max: 1024, step: 64 },
-			description: "결과물 한 변(px). / Output side length (px).",
+			description: "결과물 한 변(px).",
 		},
 		outputType: {
 			control: "select",
 			options: ["auto", "image/jpeg", "image/png", "image/webp"],
-			description:
-				"결과 MIME. `auto` 는 PNG 만 유지, 나머지는 JPEG. / Output MIME; `auto` keeps PNG else JPEG.",
+			description: "결과 MIME. `auto` 는 PNG 만 유지, 나머지는 JPEG.",
 		},
 		quality: {
 			control: { type: "number", min: 0.5, max: 1, step: 0.02 },
-			description:
-				"JPEG/WebP 품질 (컨트롤 0.5~1, prop 자체는 0~1 허용). / JPEG/WebP quality (control 0.5–1; the prop accepts 0–1).",
+			description: "JPEG/WebP 품질 (컨트롤 0.5~1, prop 자체는 0~1 허용).",
 		},
 		minZoom: {
 			control: { type: "number", min: 1, max: 3, step: 0.5 },
@@ -80,28 +78,27 @@ const meta = {
 		},
 		label: {
 			control: "text",
-			description: "뷰포트 접근성 레이블. / Viewport accessibility label.",
+			description: "뷰포트 접근성 레이블.",
 		},
 		hint: {
 			control: "text",
-			description: "뷰포트 아래 조작 안내 문구. / Operation hint under the viewport.",
+			description: "뷰포트 아래 조작 안내 문구.",
 		},
 		zoomOutLabel: {
 			control: "text",
-			description: "축소 버튼 레이블. / Zoom-out button label.",
+			description: "축소 버튼 레이블.",
 		},
 		zoomLabel: {
 			control: "text",
-			description: "배율 슬라이더 레이블. / Zoom slider label.",
+			description: "배율 슬라이더 레이블.",
 		},
 		zoomInLabel: {
 			control: "text",
-			description: "확대 버튼 레이블. / Zoom-in button label.",
+			description: "확대 버튼 레이블.",
 		},
 		noPanHint: {
 			control: "text",
-			description:
-				"이동 여유가 없을 때 스크린리더로 알리는 문구. / Announced when the image has no room to pan.",
+			description: "이동 여유가 없을 때 스크린리더로 알리는 문구.",
 		},
 		ref: { table: { disable: true } },
 		onReady: { table: { disable: true } },
@@ -128,8 +125,7 @@ export const LandscapeSource: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story:
-					"cover 배율이라 세로는 꽉 차고 가로만 여유가 생긴다. / With cover scaling, height fills the viewport while only width has room to pan.",
+				story: "cover 배율이라 세로는 꽉 차고 가로만 여유가 생긴다.",
 			},
 		},
 	},
@@ -153,8 +149,7 @@ export const Localized: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story:
-					"기본값은 한국어라, 다국어 앱은 이 prop 들로 갈아 끼운다. / Defaults are Korean, so multilingual apps swap them through these props.",
+				story: "기본값은 한국어라, 다국어 앱은 이 prop 들로 갈아 끼운다.",
 			},
 		},
 	},
@@ -198,8 +193,7 @@ export const WithApply: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story:
-					"소비 앱 패턴: 크로퍼 + 적용 버튼에서 `ref.crop()` → `Blob`. / Real pattern: apply button calls `ref.crop()`.",
+				story: "소비 앱 패턴: 크로퍼 + 적용 버튼에서 `ref.crop()` → `Blob`.",
 			},
 		},
 	},

--- a/src/ui/forms/image-cropper/image-cropper.stories.tsx
+++ b/src/ui/forms/image-cropper/image-cropper.stories.tsx
@@ -46,7 +46,7 @@ const meta = {
 	},
 	tags: ["autodocs"],
 	argTypes: {
-		src: { control: false, description: "크롭할 이미지 (`File`/`Blob`/URL). / Image to crop." },
+		src: { control: false, description: "크롭할 이미지 (`File`/`Blob`/URL)." },
 		circular: {
 			control: "boolean",
 			description: "원형 가이드(아바타용).",
@@ -70,11 +70,11 @@ const meta = {
 		},
 		minZoom: {
 			control: { type: "number", min: 1, max: 3, step: 0.5 },
-			description: "최소 배율. / Min zoom.",
+			description: "최소 배율.",
 		},
 		maxZoom: {
 			control: { type: "number", min: 1, max: 6, step: 0.5 },
-			description: "최대 배율. / Max zoom.",
+			description: "최대 배율.",
 		},
 		label: {
 			control: "text",

--- a/src/ui/forms/otp-input/otp-input.stories.tsx
+++ b/src/ui/forms/otp-input/otp-input.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof OtpInput> = {
 		length: {
 			control: "select",
 			options: [4, 6],
-			description: "Number of OTP digits. / OTP 자릿수입니다.",
+			description: "OTP 자릿수입니다.",
 		},
 		error: {
 			control: "boolean",
@@ -22,7 +22,7 @@ const meta: Meta<typeof OtpInput> = {
 		},
 		supportingText: {
 			control: "text",
-			description: "Helper text shown below. / 하단 도움말 텍스트입니다.",
+			description: "하단 도움말 텍스트입니다.",
 		},
 	},
 	args: {
@@ -34,9 +34,9 @@ const meta: Meta<typeof OtpInput> = {
 		docs: {
 			description: {
 				component: `
-**OtpInput** - OTP/2FA code entry. Auto focus advance, backspace/arrow/paste support. / **OtpInput** - OTP/2FA 코드 입력. 자동 포커스 이동, 백스페이스/화살표/붙여넣기 지원.
+**OtpInput** - OTP/2FA 코드 입력. 자동 포커스 이동, 백스페이스·화살표·붙여넣기를 지원한다.
 
-Key props: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`. / 주요 prop: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`.
+주요 prop: \`length\`, \`value\`, \`onChange\`, \`error\`, \`supportingText\`, \`disabled\`.
         `,
 			},
 		},

--- a/src/ui/forms/otp-input/otp-input.stories.tsx
+++ b/src/ui/forms/otp-input/otp-input.stories.tsx
@@ -14,11 +14,11 @@ const meta: Meta<typeof OtpInput> = {
 		},
 		error: {
 			control: "boolean",
-			description: "Error state. / 에러 상태입니다.",
+			description: "에러 상태입니다.",
 		},
 		disabled: {
 			control: "boolean",
-			description: "Disabled state. / 비활성화 상태입니다.",
+			description: "비활성화 상태입니다.",
 		},
 		supportingText: {
 			control: "text",

--- a/src/ui/forms/radio-group/radio-group.stories.tsx
+++ b/src/ui/forms/radio-group/radio-group.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof RadioGroup> = {
 		orientation: {
 			control: "select",
 			options: ["vertical", "horizontal"],
-			description: "Layout direction. / 배치 방향.",
+			description: "배치 방향.",
 		},
 		error: {
 			control: "boolean",

--- a/src/ui/forms/radio-group/radio-group.stories.tsx
+++ b/src/ui/forms/radio-group/radio-group.stories.tsx
@@ -11,8 +11,7 @@ const meta: Meta<typeof RadioGroup> = {
 		size: {
 			control: "select",
 			options: ["sm", "md", "lg"],
-			description:
-				"Group size, propagated to child Radios. / 그룹 사이즈. 자식 Radio 에 전파됩니다.",
+			description: "그룹 사이즈. 자식 Radio 에 전파됩니다.",
 		},
 		orientation: {
 			control: "select",
@@ -21,11 +20,11 @@ const meta: Meta<typeof RadioGroup> = {
 		},
 		error: {
 			control: "boolean",
-			description: "Error state (label/helper turn red). / 에러 상태 (라벨/보조 텍스트가 빨간색).",
+			description: "에러 상태 (라벨·보조 텍스트가 빨간색으로 바뀐다).",
 		},
 		disabled: {
 			control: "boolean",
-			description: "Disable the whole group. / 그룹 전체 비활성화.",
+			description: "그룹 전체 비활성화.",
 		},
 		label: { control: "text" },
 		supportingText: { control: "text" },
@@ -41,11 +40,11 @@ const meta: Meta<typeof RadioGroup> = {
 		docs: {
 			description: {
 				component: `
-**RadioGroup** - Composite wrapper that groups \`Radio\`s via Context (name/value/size/disabled). / Context 로 \`Radio\` 들을 묶는 합성 래퍼 (name/value/size/disabled 공유).
+**RadioGroup** - Context 로 \`Radio\` 들을 묶는 합성 래퍼 (name/value/size/disabled 공유).
 
-- Controlled (\`value\` + \`onValueChange\`) or uncontrolled (\`defaultValue\`). / 제어형 또는 비제어형.
-- \`role="radiogroup"\` + label/supportingText/error. native radio 라 방향키 이동 기본 지원. / 방향키 이동 기본 지원.
-- Child \`Radio\` needs a \`value\` prop; size/name/disabled are inherited. / 자식 Radio 는 \`value\` 필요, 나머지는 상속.
+- 제어형(\`value\` + \`onValueChange\`) 또는 비제어형(\`defaultValue\`).
+- \`role="radiogroup"\` + label/supportingText/error. 네이티브 radio 라 방향키 이동을 기본 지원한다.
+- 자식 \`Radio\` 는 \`value\` 가 필요하고 size/name/disabled 는 상속받는다.
 				`,
 			},
 		},

--- a/src/ui/forms/radio/radio.stories.tsx
+++ b/src/ui/forms/radio/radio.stories.tsx
@@ -10,11 +10,11 @@ const meta: Meta<typeof Radio> = {
 		size: {
 			control: "select",
 			options: ["sm", "md", "lg"],
-			description: "Radio button size. The text and the selection circle scale together. / 라디오 버튼의 크기입니다. 텍스트와 선택 원(circle)의 크기가 함께 변경됩니다.",
+			description: "라디오 버튼의 크기입니다. 텍스트와 선택 원(circle)의 크기가 함께 변경됩니다.",
 		},
 		disabled: {
 			control: "boolean",
-			description: "Disabled state. Cannot be selected and appears dimmed. / 비활성화 상태입니다. 선택할 수 없으며 흐리게 표시됩니다.",
+			description: "비활성화 상태입니다. 선택할 수 없으며 흐리게 표시됩니다.",
 		},
 	},
 	args: {
@@ -25,9 +25,9 @@ const meta: Meta<typeof Radio> = {
 		docs: {
 			description: {
 				component: `
-**Radio** - Single-select (use Checkbox for multi-select). / **Radio** - 단일 선택 (다중은 Checkbox).
+**Radio** - 단일 선택 (다중 선택은 Checkbox 를 쓴다).
 
-Items in the same group share \`name\` and each has its own \`value\`. Control via \`checked\` / \`onChange\`. / 같은 그룹은 \`name\` 동일 + 각 \`value\`. \`checked\` / \`onChange\` 제어.
+같은 그룹은 \`name\` 을 공유하고 항목마다 \`value\` 를 가진다. \`checked\` / \`onChange\` 로 제어한다.
         `,
 			},
 		},

--- a/src/ui/forms/textarea/textarea.stories.tsx
+++ b/src/ui/forms/textarea/textarea.stories.tsx
@@ -30,13 +30,12 @@ const meta: Meta<typeof Textarea> = {
 		docs: {
 			description: {
 				component: `
-**Textarea** - Multi-line text input, same visuals/tokens as \`TextField\` (border / focus / error / label / helper / disabled).
-멀티라인 텍스트 입력. \`TextField\` 와 동일한 시각/토큰.
+**Textarea** - 멀티라인 텍스트 입력. \`TextField\` 와 동일한 시각·토큰을 쓴다 (border / focus / error / label / helper / disabled).
 
-- **auto-grow** - height grows with content when \`minRows\`/\`maxRows\` set. / \`minRows\`/\`maxRows\` 지정 시 높이 자동 증가
-- **counter** - \`showCounter\` + \`maxLength\` shows character count. / 글자 수 카운터
-- **resize** - none / vertical (default) / both
-- **Korean IME** - \`imeStrategy="immediate"\` for live callback during composition. / 조합 중 실시간 콜백
+- **auto-grow** - \`minRows\`/\`maxRows\` 를 지정하면 내용에 따라 높이가 자동으로 늘어난다
+- **counter** - \`showCounter\` + \`maxLength\` 로 글자 수를 표시한다
+- **resize** - none / vertical (기본) / both
+- **한글 IME** - \`imeStrategy="immediate"\` 로 조합 중에도 실시간 콜백을 받는다
 				`,
 			},
 		},

--- a/src/ui/forms/textfield/textfield.stories.tsx
+++ b/src/ui/forms/textfield/textfield.stories.tsx
@@ -49,12 +49,12 @@ const meta: Meta<typeof TextField> = {
 		docs: {
 			description: {
 				component: `
-**TextField** - Single-line text input. Floating label + leading/trailing icon + supporting text. / **TextField** - 한 줄 텍스트 입력. 플로팅 라벨 + leading/trailing 아이콘 + supporting text.
+**TextField** - 한 줄 텍스트 입력. 플로팅 라벨 + leading/trailing 아이콘 + supporting text.
 
-Sizes: \`sm\` / \`md\` (default) / \`lg\`. / Sizes: \`sm\` / \`md\` (기본) / \`lg\`.
-Variants: \`outline\` (default, bordered) / \`filled\` (dim fill, no border — the border appears on hover or focus). / Variants: \`outline\` (기본, 테두리) / \`filled\` (dim 배경 채움, 테두리 없음 — hover 또는 포커스 시 테두리가 드러남).
-\`error\` sets \`aria-invalid\`; \`aria-describedby\` is wired only when \`supportingText\` is given. / \`error\` 는 \`aria-invalid\` 를 설정하고, \`aria-describedby\` 는 \`supportingText\` 가 있을 때만 연결됩니다.
-\`success\` marks a passing validation and never sets \`aria-invalid\`. When \`error\` and \`success\` are both set, \`error\` wins. / \`success\` 는 검증 통과 표시이며 \`aria-invalid\` 를 켜지 않습니다. \`error\` 와 \`success\` 를 동시에 주면 \`error\` 가 우선합니다.
+크기: \`sm\` / \`md\` (기본) / \`lg\`.
+Variants: \`outline\` (기본, 테두리) / \`filled\` (dim 배경 채움, 테두리 없음 — hover 또는 포커스 시 테두리가 드러남).
+\`error\` 는 \`aria-invalid\` 를 설정하고, \`aria-describedby\` 는 \`supportingText\` 가 있을 때만 연결된다.
+\`success\` 는 검증 통과 표시이며 \`aria-invalid\` 를 켜지 않는다. \`error\` 와 \`success\` 를 동시에 주면 \`error\` 가 우선한다.
 				`,
 			},
 		},
@@ -103,7 +103,7 @@ export const Variants: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "Side-by-side comparison of the two variants. / 두 variant 를 나란히 비교합니다.",
+				story: "두 variant 를 나란히 비교한다.",
 			},
 		},
 	},
@@ -141,7 +141,7 @@ export const ErrorWinsOverSuccess: Story = {
 		docs: {
 			description: {
 				story:
-					"With both `error` and `success` set, `error` wins — a failed validation must never be painted as a pass. / `error` 와 `success` 가 동시에 켜지면 `error` 가 이깁니다 - 검증 실패를 성공처럼 보여주면 안 되기 때문입니다.",
+					"`error` 와 `success` 가 동시에 켜지면 `error` 가 이긴다 - 검증 실패를 성공처럼 보여주면 안 되기 때문이다.",
 			},
 		},
 	},
@@ -183,7 +183,7 @@ export const PasswordToggle: Story = {
 		docs: {
 			description: {
 				story:
-					"`showPasswordToggle` renders a built-in reveal button. Labels are injected by the app so i18n stays app-side. / `showPasswordToggle` 는 표시/숨기기 버튼을 내장합니다. i18n 은 앱이 담당하므로 문구는 `passwordToggleLabels` 로 주입합니다.",
+					"`showPasswordToggle` 는 표시/숨기기 버튼을 내장한다. i18n 은 앱이 담당하므로 문구는 `passwordToggleLabels` 로 주입한다.",
 			},
 		},
 	},
@@ -204,7 +204,7 @@ export const ActionSlot: Story = {
 		docs: {
 			description: {
 				story:
-					"`trailingIcon` / `leadingIcon` stay `aria-hidden` for decoration; put focusable content in `trailingAction` / `leadingAction`, which are exposed to assistive tech. Putting a button in the icon slot breaks WCAG 4.1.2 and Chrome refuses the `aria-hidden`. / `trailingIcon`·`leadingIcon` 은 장식용이라 `aria-hidden` 을 유지합니다. 포커스 가능한 요소는 `trailingAction`·`leadingAction` 에 넣으세요 - 아이콘 슬롯에 버튼을 넣으면 WCAG 4.1.2 위반이고 Chrome 이 `aria-hidden` 적용을 거부합니다.",
+					"`trailingIcon`·`leadingIcon` 은 장식용이라 `aria-hidden` 을 유지한다. 포커스 가능한 요소는 `trailingAction`·`leadingAction` 에 넣을 것 - 아이콘 슬롯에 버튼을 넣으면 WCAG 4.1.2 위반이고 Chrome 이 `aria-hidden` 적용을 거부한다.",
 			},
 		},
 	},

--- a/src/ui/forms/toggle/toggle.stories.tsx
+++ b/src/ui/forms/toggle/toggle.stories.tsx
@@ -10,11 +10,11 @@ const meta: Meta<typeof Toggle> = {
 		size: {
 			control: "select",
 			options: ["sm", "md"],
-			description: "Toggle size. The width/height it occupies on screen scale together. / 토글 크기입니다. 화면에서 토글이 차지하는 크기(가로/세로)가 함께 바뀝니다.",
+			description: "토글 크기입니다. 화면에서 토글이 차지하는 크기(가로/세로)가 함께 바뀝니다.",
 		},
 		disabled: {
 			control: "boolean",
-			description: "Disabled state. Cannot be turned on/off and appears dimmed. / 비활성화 상태입니다. 켜기/끄기 조작이 불가능하며 흐리게 표시됩니다.",
+			description: "비활성화 상태입니다. 켜기/끄기 조작이 불가능하며 흐리게 표시됩니다.",
 		},
 		checked: { control: false },
 		defaultChecked: { control: false },
@@ -29,9 +29,9 @@ const meta: Meta<typeof Toggle> = {
 		docs: {
 			description: {
 				component: `
-**Toggle** - Instant ON/OFF switch. Use Checkbox for multi-select. / **Toggle** - ON/OFF 즉시 전환. 다중 선택은 Checkbox 사용.
+**Toggle** - ON/OFF 를 즉시 전환하는 스위치. 다중 선택은 Checkbox 를 쓴다.
 
-Controlled: \`checked\` + \`onChange\` / Uncontrolled: \`defaultChecked\`.
+제어형: \`checked\` + \`onChange\` / 비제어형: \`defaultChecked\`.
         `,
 			},
 		},

--- a/src/ui/general/button/button.stories.tsx
+++ b/src/ui/general/button/button.stories.tsx
@@ -23,10 +23,10 @@ const meta: Meta<typeof Button> = {
 		docs: {
 			description: {
 				component: `
-**Button** - Triggers a user action. / **Button** - 사용자 액션 트리거.
+**Button** - 사용자 액션을 트리거한다.
 
-Variants: \`filled\` (primary action / 주 액션) / \`tonal\` (soft emphasis / 부드러운 강조) / \`outline\` (secondary / 보조) / \`text\` (inline / 인라인).
-Sizes: \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 56 (auto-bumps one step up on mobile / 모바일 자동 한 단계 ↑).
+Variants: \`filled\` (주 액션) / \`tonal\` (부드러운 강조) / \`outline\` (보조) / \`text\` (인라인).
+크기: \`sm\` 32 / \`md\` 40 / \`lg\` 48 / \`xl\` 56 (모바일에서 한 단계 자동 상승).
 				`,
 			},
 		},
@@ -100,9 +100,6 @@ export const Danger: Story = {
 				story: `
 \`danger\` 는 \`variant\` 와 **직교**하는 modifier 다 — variant 를 대체하지 않고 색만 위험(빨강) 계열로 바꾼다.
 네 variant 어디에나 붙일 수 있고, 생략하면 \`filled\` 위에 적용된다. 삭제·탈퇴처럼 되돌리기 어려운 액션에만 쓴다.
-
-\`danger\` is a modifier **orthogonal** to \`variant\` — it recolors rather than replaces, so it composes with all
-four variants (defaulting to \`filled\`). Reserve it for destructive, hard-to-undo actions such as delete or leave.
 				`,
 			},
 		},
@@ -136,10 +133,6 @@ export const IconSizes: Story = {
 주지 않은 아이콘(뷰박스만 있는 커스텀 svg)은 기본 24px 로 렌더된다.
 
 라벨 옆 아이콘은 라벨 글자 크기에 맞추는 편이 무게가 맞는다 — \`sm\`/\`md\` 버튼이면 14~16 이 보통이다.
-
-The icon decides its own size — the slot only aligns. An icon given \`width\`/\`height\` renders at that size;
-one without (a viewBox-only custom svg) falls back to 24px. Match a leading icon to the label's font size
-(14–16 for \`sm\`/\`md\` buttons) so their visual weight lines up.
 				`,
 			},
 		},

--- a/src/ui/general/icon-button/icon-button.stories.tsx
+++ b/src/ui/general/icon-button/icon-button.stories.tsx
@@ -42,12 +42,12 @@ const meta: Meta<typeof IconButton> = {
 		docs: {
 			description: {
 				component: `
-**IconButton** - A button containing only an icon. \`aria-label\` required. / **IconButton** - 아이콘만 가진 버튼. \`aria-label\` 필수.
+**IconButton** - 아이콘만 가진 버튼. \`aria-label\` 이 필수다.
 
 Variants: \`standard\` / \`filled\` / \`tonal\` / \`outlined\`.
-Sizes: \`sm\` 40 (icon 20 / 아이콘 20) / \`md\` 48 (icon 24 / 아이콘 24).
+크기: \`sm\` 40 (아이콘 20) / \`md\` 48 (아이콘 24).
 
-> ⚠️ **Docs view note / Docs 뷰 안내** - The \`standard\` variant has a transparent background and depends on the parent color. Storybook Docs' story preview panel has a fixed white background, so toggling dark mode may render the icon white-on-white and invisible. To check actual behavior, open an individual story from the left sidebar in Canvas view. / \`standard\` variant 는 배경이 투명이라 부모 색에 의존. Storybook Docs 의 스토리 프리뷰 패널은 흰 배경 고정이라 다크 모드 토글 시 아이콘이 흰 위에 흰으로 안 보일 수 있다. 실제 동작은 좌측 사이드바에서 개별 스토리를 열어 Canvas 뷰에서 확인.
+> ⚠️ **Docs 뷰 안내** - \`standard\` variant 는 배경이 투명이라 부모 색에 의존한다. Storybook Docs 의 스토리 프리뷰 패널은 흰 배경 고정이라, 다크 모드로 토글하면 아이콘이 흰 위에 흰으로 보이지 않을 수 있다. 실제 동작은 좌측 사이드바에서 개별 스토리를 열어 Canvas 뷰에서 확인한다.
 				`,
 			},
 		},

--- a/src/ui/layout/stack/stack.stories.tsx
+++ b/src/ui/layout/stack/stack.stories.tsx
@@ -22,9 +22,9 @@ const meta: Meta<typeof Stack> = {
 		docs: {
 			description: {
 				component: `
-**Stack** - Flex-based 1D layout. For a 2D grid use \`Grid\`. / Flex 기반 1D 레이아웃. 2D 격자는 \`Grid\`.
+**Stack** - flex 기반 1차원 레이아웃. 2차원 격자는 \`Grid\` 를 쓴다.
 
-Key props: \`direction\` (\`vertical\`/\`horizontal\`), \`gap\` (px), \`align\` (cross axis), \`justify\` (main axis), \`wrap\`. / 주요 prop: \`direction\` (\`vertical\`/\`horizontal\`), \`gap\` (px), \`align\` (교차축), \`justify\` (주축), \`wrap\`.
+주요 prop: \`direction\` (\`vertical\`/\`horizontal\`), \`gap\` (px), \`align\` (교차축), \`justify\` (주축), \`wrap\`.
 				`,
 			},
 		},

--- a/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
+++ b/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
@@ -14,11 +14,11 @@ const meta: Meta<typeof BottomNav> = {
 		docs: {
 			description: {
 				component: `
-**BottomNav** - Mobile bottom navigation, composed of 2–5 \`BottomNavItem\`s. / **BottomNav** - 모바일 하단 네비게이션. 2–5개 \`BottomNavItem\` 으로 구성.
+**BottomNav** - 모바일 하단 내비게이션. 2–5개 \`BottomNavItem\` 으로 구성한다.
 
-Pinned to the bottom of the viewport via \`position: fixed; bottom: 0\`. Auto-padding for the iOS home-indicator area (\`env(safe-area-inset-bottom)\`). To keep content from being hidden, add a \`<BottomNavSpacer />\` at the end of the page or use the \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS variables for layout calculation. / \`position: fixed; bottom: 0\` 으로 viewport 하단 고정. iOS 홈 인디케이터 영역 (\`env(safe-area-inset-bottom)\`) 자동 패딩. 본문이 가려지지 않게 페이지 끝에 \`<BottomNavSpacer />\` 깔거나 \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS 변수로 layout 계산.
+\`position: fixed; bottom: 0\` 으로 viewport 하단에 고정된다. iOS 홈 인디케이터 영역(\`env(safe-area-inset-bottom)\`)에 패딩이 자동으로 붙는다. 본문이 가려지지 않게 페이지 끝에 \`<BottomNavSpacer />\` 를 깔거나, \`--bt-bottom-nav-height\` / \`--bt-bottom-nav-total-height\` CSS 변수로 레이아웃을 계산한다.
 
-\`<BottomNavItem icon label active badge as href />\` - \`aria-current="page"\` is set automatically when \`active\`. / \`<BottomNavItem icon label active badge as href />\` - \`active\` 시 \`aria-current="page"\` 자동.
+\`<BottomNavItem icon label active badge as href />\` - \`active\` 면 \`aria-current="page"\` 가 자동으로 붙는다.
 				`,
 			},
 		},
@@ -87,7 +87,7 @@ export const WithBadge: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "Show a notification dot/count at the top-right of the icon via the `badge` prop, using the `<Badge>` component. / 아이콘 우상단에 `badge` prop 으로 알림 dot/카운트 표시. `<Badge>` 컴포넌트 활용.",
+				story: "아이콘 우상단에 `badge` prop 으로 알림 dot 이나 카운트를 표시한다. `<Badge>` 컴포넌트를 쓴다.",
 			},
 		},
 	},
@@ -131,7 +131,7 @@ export const FiveItems: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "Recommended up to 5 items with even distribution. More than that causes label truncation / insufficient tap area. / 5개까지 균등 분할 권장. 그 이상은 라벨 잘림 / 탭 영역 부족.",
+				story: "5개까지 균등 분할을 권장한다. 그 이상은 라벨이 잘리고 탭 영역이 부족해진다.",
 			},
 		},
 	},

--- a/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
+++ b/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
@@ -10,9 +10,9 @@ const meta: Meta<typeof Breadcrumb> = {
 		docs: {
 			description: {
 				component: `
-**Breadcrumb** - Page hierarchy navigation. The last item automatically gets \`aria-current="page"\`. / **Breadcrumb** - 페이지 위계 네비게이션. 마지막 아이템 자동 \`aria-current="page"\`.
+**Breadcrumb** - 페이지 위계 내비게이션. 마지막 항목에 \`aria-current="page"\` 가 자동으로 붙는다.
 
-\`items\` behavior: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / last → \`<span>\`. The \`separator\` prop is customizable. / \`items\` 동작: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / 마지막 → \`<span>\`. \`separator\` prop 커스텀 가능.
+\`items\` 동작: \`href\` → \`<a>\` / \`onClick\` → \`<button>\` / 마지막 → \`<span>\`. \`separator\` prop 으로 구분자를 바꿀 수 있다.
 				`,
 			},
 		},

--- a/src/ui/navigation/menu/menu.stories.tsx
+++ b/src/ui/navigation/menu/menu.stories.tsx
@@ -29,10 +29,10 @@ const meta: Meta<typeof Menu> = {
 		docs: {
 			description: {
 				component: `
-**Menu** - Action menu (context / kebab / per-row). For value selection use \`Dropdown\`. / **Menu** - 액션 메뉴 (컨텍스트/케밥/행 단위). 값 선택은 \`Dropdown\`.
+**Menu** - 액션 메뉴 (컨텍스트 / 케밥 / 행 단위). 값 선택에는 \`Dropdown\` 을 쓴다.
 
-\`align\`: \`start\` (default) / \`end\` (prevents overflow off the right edge). / \`align\`: \`start\` (기본) / \`end\` (우측 화면 밖 방지).
-\`MenuItem\` fields: \`key\`, \`label\`, \`icon\`, \`onSelect\` (auto close), \`destructive\`, \`disabled\`. / \`MenuItem\` 필드: \`key\`, \`label\`, \`icon\`, \`onSelect\` (자동 close), \`destructive\`, \`disabled\`.
+\`align\`: \`start\` (기본) / \`end\` (우측 화면 밖으로 넘치는 것을 방지).
+\`MenuItem\` 필드: \`key\`, \`label\`, \`icon\`, \`onSelect\` (자동 close), \`destructive\`, \`disabled\`.
 				`.trim(),
 			},
 		},

--- a/src/ui/navigation/nav-bar/nav-bar.stories.tsx
+++ b/src/ui/navigation/nav-bar/nav-bar.stories.tsx
@@ -12,10 +12,10 @@ const meta: Meta<typeof NavBar> = {
 		docs: {
 			description: {
 				component: `
-**NavBar** - Top page navigation. Slots: \`brand\` / \`children (NavLink)\` / \`actions\`. / **NavBar** - 페이지 상단 네비게이션. \`brand\` / \`children (NavLink)\` / \`actions\` 슬롯.
+**NavBar** - 페이지 상단 내비게이션. \`brand\` / \`children (NavLink)\` / \`actions\` 슬롯으로 구성한다.
 
-Variants: \`default\` (white bg + border), \`accent\` (dark bg), \`transparent\` (over a hero). / Variants: \`default\` (흰 bg + border), \`accent\` (검정 bg), \`transparent\` (hero 위).
-\`active={true}\` → \`aria-current="page"\` set automatically. / \`active={true}\` → \`aria-current="page"\` 자동.
+Variants: \`default\` (흰 bg + border) / \`accent\` (검정 bg) / \`transparent\` (hero 위).
+\`active={true}\` 면 \`aria-current="page"\` 가 자동으로 붙는다.
 				`,
 			},
 		},
@@ -93,7 +93,7 @@ export const Interactive: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "The active underline slides smoothly on click. / 클릭 시 active underline 부드럽게 이동.",
+				story: "클릭하면 active underline 이 부드럽게 이동한다.",
 			},
 		},
 	},

--- a/src/ui/navigation/pagination/pagenation.stories.tsx
+++ b/src/ui/navigation/pagination/pagenation.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof Pagination> = {
 		docs: {
 			description: {
 				component: `
-**Pagination** - Page navigation. Collapses with \`…\` beyond 7 pages; prev/next are disabled at the first/last page. / **Pagination** - 페이지 이동 네비게이션. 7페이지 초과 시 \`…\` 축약, 첫/마지막에서 prev/next 비활성.
+**Pagination** - 페이지 이동 내비게이션. 7페이지를 넘으면 \`…\` 로 축약하고, 첫/마지막 페이지에서는 prev/next 가 비활성된다.
         `,
 			},
 		},

--- a/src/ui/navigation/sidebar/sidebar.stories.tsx
+++ b/src/ui/navigation/sidebar/sidebar.stories.tsx
@@ -12,11 +12,11 @@ const meta: Meta<typeof Sidebar> = {
 		docs: {
 			description: {
 				component: `
-**Sidebar** - Left navigation for admin/dashboard. Combine \`SidebarItem\` + \`SidebarSection\`. / **Sidebar** - admin/dashboard 좌측 네비게이션. \`SidebarItem\` + \`SidebarSection\` 조합.
+**Sidebar** - admin·dashboard 의 좌측 내비게이션. \`SidebarItem\` + \`SidebarSection\` 을 조합한다.
 
-\`collapsed\` (240→64px) - icons only, with a favicon node via \`headerCollapsed\`. \`collapsible\` (default true) → floating chevron toggle. \`active={true}\` → \`aria-current="page"\` set automatically. / \`collapsed\` (240→64px) - 아이콘만 표시, \`headerCollapsed\` 로 favicon 노드. \`collapsible\` (기본 true) → floating chevron 토글. \`active={true}\` → \`aria-current="page"\` 자동.
+\`collapsed\` (240→64px) - 아이콘만 표시하고 \`headerCollapsed\` 로 favicon 노드를 준다. \`collapsible\` (기본 true) → floating chevron 토글. \`active={true}\` → \`aria-current="page"\` 자동.
 
-**Responsive** - default \`mode="auto"\`: below viewport \`< 600px\` it automatically transforms into a bottom bar (BottomNav style). Header/footer/section labels are hidden and items become a horizontal stack. Use \`mode="static"\` to disable the transform (admin desktop-only cases). / **Responsive** - 기본 \`mode="auto"\`: viewport \`< 600px\` 에서 자동으로 하단 bar (BottomNav 형태) 로 변신. header/footer/섹션 라벨 hide, 아이템은 horizontal stack. \`mode="static"\` 으로 변신 끄기 (admin desktop-only 케이스).
+**반응형** - 기본 \`mode="auto"\`: viewport \`< 600px\` 에서 자동으로 하단 bar (BottomNav 형태) 로 변신한다. header/footer/섹션 라벨은 숨고 아이템은 horizontal stack 이 된다. \`mode="static"\` 으로 변신을 끌 수 있다 (admin desktop 전용 케이스).
 				`,
 			},
 		},

--- a/src/ui/navigation/tabs/tabs.stories.tsx
+++ b/src/ui/navigation/tabs/tabs.stories.tsx
@@ -10,10 +10,10 @@ const meta: Meta<typeof Tabs> = {
 		docs: {
 			description: {
 				component: `
-**Tabs** - Exclusive panel switching. Compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`. / **Tabs** - 배타적 패널 전환. compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`.
+**Tabs** - 배타적 패널 전환. compound API: \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\`.
 
-Variants: \`line\` (default, bottom underline) / \`fills\` (segmented control). / Variants: \`line\` (기본, 하단 underline) / \`fills\` (segmented control).
-WAI-ARIA + roving tabIndex + keyboard (←→/Home/End, skips disabled). / WAI-ARIA + roving tabIndex + 키보드 (←→/Home/End, disabled 스킵).
+Variants: \`line\` (기본, 하단 underline) / \`fills\` (segmented control).
+WAI-ARIA + roving tabIndex + 키보드 (←→/Home/End, disabled 는 건너뜀).
         `,
 			},
 		},

--- a/src/ui/overlay/drawer/drawer.stories.tsx
+++ b/src/ui/overlay/drawer/drawer.stories.tsx
@@ -15,15 +15,15 @@ const meta: Meta<typeof Drawer> = {
 		},
 		size: {
 			control: "text",
-			description: "패널 크기 - left/right 는 너비, bottom 은 높이 / Panel size (width for left/right, height for bottom)",
+			description: "패널 크기 - left/right 는 너비, bottom 은 높이",
 		},
 		closeOnOverlay: {
 			control: "boolean",
-			description: "배경(오버레이)을 클릭했을 때 닫을지 여부 / Close on overlay click",
+			description: "배경(오버레이)을 클릭했을 때 닫을지 여부",
 		},
 		showCloseIcon: {
 			control: "boolean",
-			description: "우상단 X 닫기 아이콘 표시 여부 / Show close icon",
+			description: "우상단 X 닫기 아이콘 표시 여부",
 		},
 	},
 	args: {
@@ -36,9 +36,9 @@ const meta: Meta<typeof Drawer> = {
 		docs: {
 			description: {
 				component: `
-**Drawer** - Panel that slides in from a screen edge. Automatic focus trap + Esc to close + background scroll lock. / 화면 가장자리에서 미끄러져 들어오는 패널. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금 자동.
+**Drawer** - 화면 가장자리에서 미끄러져 들어오는 패널. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금이 자동으로 적용된다.
 
-Key props: \`open\`, \`onClose\`, \`placement\` ("left" | "right" | "bottom"), \`size\`, \`title\`, \`footer\`, \`closeOnOverlay\`. / 주요 prop: \`open\`, \`onClose\`, \`placement\`, \`size\`, \`title\`, \`footer\`, \`closeOnOverlay\`.
+주요 prop: \`open\`, \`onClose\`, \`placement\` ("left" | "right" | "bottom"), \`size\`, \`title\`, \`footer\`, \`closeOnOverlay\`.
         `,
 			},
 		},
@@ -54,7 +54,7 @@ export const Right: Story = {
 		docs: {
 			description: {
 				story:
-					"Default drawer sliding in from the right - the most common side-panel pattern for filters, details, or settings. / 우측에서 들어오는 기본 드로어 - 필터/상세/설정에 가장 흔한 사이드 패널 패턴.",
+					"우측에서 들어오는 기본 드로어 - 필터·상세·설정에 가장 흔한 사이드 패널 패턴.",
 			},
 		},
 	},
@@ -80,7 +80,7 @@ export const Left: Story = {
 		docs: {
 			description: {
 				story:
-					"Left drawer - typical for mobile navigation menus. / 좌측 드로어 - 모바일 내비게이션 메뉴에 자주 쓰입니다.",
+					"좌측 드로어 - 모바일 내비게이션 메뉴에 자주 쓰인다.",
 			},
 		},
 	},
@@ -108,7 +108,7 @@ export const Bottom: Story = {
 		docs: {
 			description: {
 				story:
-					"Bottom sheet - slides up from the bottom, common on touch devices. / 하단 시트 - 아래에서 위로 올라오며 터치 기기에서 흔합니다.",
+					"하단 시트 - 아래에서 위로 올라오며 터치 기기에서 흔하다.",
 			},
 		},
 	},
@@ -133,7 +133,7 @@ export const WithFooter: Story = {
 		docs: {
 			description: {
 				story:
-					"Drawer with a footer action area - confirm/cancel or save patterns. / footer 액션 영역이 있는 드로어 - 확인/취소 또는 저장 패턴.",
+					"footer 액션 영역이 있는 드로어 - 확인·취소 또는 저장 패턴.",
 			},
 		},
 	},

--- a/src/ui/overlay/drawer/drawer.stories.tsx
+++ b/src/ui/overlay/drawer/drawer.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Drawer> = {
 		placement: {
 			control: "radio",
 			options: ["left", "right", "bottom"],
-			description: "슬라이드 방향 / Slide direction",
+			description: "슬라이드 방향",
 		},
 		size: {
 			control: "text",

--- a/src/ui/overlay/modal/modal.stories.tsx
+++ b/src/ui/overlay/modal/modal.stories.tsx
@@ -25,9 +25,9 @@ const meta: Meta<typeof Modal> = {
 		docs: {
 			description: {
 				component: `
-**Modal** - Centered popup layer. Automatic focus trap + Esc to close + background scroll lock. / 화면 중앙 팝업 레이어. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금 자동.
+**Modal** - 화면 중앙 팝업 레이어. 포커스 트랩 + Esc 닫기 + 배경 스크롤 잠금이 자동으로 적용된다.
 
-Key props: \`open\`, \`onClose\`, \`width\`, \`closeOnOverlay\`, \`title\` (auto \`aria-labelledby\`). / 주요 prop: \`open\`, \`onClose\`, \`width\`, \`closeOnOverlay\`, \`title\` (자동 \`aria-labelledby\`).
+주요 prop: \`open\`, \`onClose\`, \`width\`, \`closeOnOverlay\`, \`title\` (\`aria-labelledby\` 자동).
         `,
 			},
 		},
@@ -45,7 +45,7 @@ export const CreateToken: Story = {
 		docs: {
 			description: {
 				story:
-					"New design - large title, paragraph description, right-aligned footer actions. The most common confirm/form modal pattern. / 새 디자인 - 큰 title, paragraph description, 우측 정렬 footer 액션. 가장 일반적인 confirm/form 모달 패턴.",
+					"새 디자인 - 큰 title, paragraph description, 우측 정렬 footer 액션. 가장 일반적인 confirm·form 모달 패턴.",
 			},
 		},
 	},
@@ -88,7 +88,7 @@ export const DestructiveAction: Story = {
 		docs: {
 			description: {
 				story:
-					"`footerAlign=\"between\"` - destructive (Delete) on the left, safe (Cancel) on the right. Visualizes the risk. / `footerAlign=\"between\"` - 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성 시각화.",
+					"`footerAlign=\"between\"` - 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성을 시각화한다.",
 			},
 		},
 	},

--- a/src/ui/overlay/popover/popover.stories.tsx
+++ b/src/ui/overlay/popover/popover.stories.tsx
@@ -13,20 +13,19 @@ const meta: Meta<typeof Popover> = {
 		placement: {
 			control: "select",
 			options: ["top", "bottom", "left", "right"],
-			description:
-				"선호 위치. 뷰포트를 벗어나면 자동 flip/shift, body 로 포탈. / Preferred side — auto flip/shift on viewport overflow, portaled to body.",
+			description: "선호 위치. 뷰포트를 벗어나면 자동 flip/shift, body 로 포탈.",
 		},
 		trigger: {
 			control: false,
-			description: "팝오버를 여는 트리거 ReactElement. / Trigger element that opens the popover.",
+			description: "팝오버를 여는 트리거 ReactElement.",
 		},
 		content: {
 			control: false,
-			description: "임의의 interactive 콘텐츠. / Arbitrary interactive content.",
+			description: "임의의 interactive 콘텐츠.",
 		},
 		open: {
 			control: false,
-			description: "제어 모드 열림 상태. / Controlled open state.",
+			description: "제어 모드 열림 상태.",
 		},
 	},
 	args: {
@@ -36,11 +35,11 @@ const meta: Meta<typeof Popover> = {
 		docs: {
 			description: {
 				component: `
-**Popover** - Click-triggered, non-modal panel for arbitrary interactive content (form / explanation / actions). For an action list use \`Menu\`; for hover info use \`Tooltip\`. / **Popover** - 클릭으로 여는 non-modal 패널. 임의의 interactive 콘텐츠(폼/설명/액션)를 담는다. 액션 리스트는 \`Menu\`, hover 정보는 \`Tooltip\`.
+**Popover** - 클릭으로 여는 non-modal 패널. 임의의 interactive 콘텐츠(폼·설명·액션)를 담는다. 액션 리스트는 \`Menu\`, hover 정보는 \`Tooltip\` 을 쓴다.
 
-Closes on outside click / \`Esc\`. Moves focus into the panel on open; \`Esc\` returns focus to the trigger. / 외부 클릭·\`Esc\`로 닫힘. 열릴 때 패널로 포커스 이동, \`Esc\`로 닫으면 trigger 로 복귀.
+외부 클릭이나 \`Esc\` 로 닫힌다. 열릴 때 패널로 포커스가 이동하고, \`Esc\` 로 닫으면 trigger 로 복귀한다.
 
-\`role="dialog"\` (non-modal) - pass \`aria-label\` or \`aria-labelledby\` for an accessible name. / \`role="dialog"\`(non-modal) - 접근성 이름을 위해 \`aria-label\` 또는 \`aria-labelledby\` 전달.
+\`role="dialog"\` (non-modal) - 접근성 이름을 위해 \`aria-label\` 또는 \`aria-labelledby\` 를 전달한다.
 				`.trim(),
 			},
 		},

--- a/src/ui/overlay/tooltip/tooltip.stories.tsx
+++ b/src/ui/overlay/tooltip/tooltip.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Tooltip> = {
 			control: "select",
 			options: ["top", "bottom", "left", "right"],
 			description:
-				"선호 위치. 뷰포트를 벗어나면 반대편으로 flip + 교차축 shift 되어 실제 위치는 계산 결과를 따른다. / Preferred side. On viewport overflow it flips to the opposite side and shifts on the cross axis, so the final position follows the computed result.",
+				"선호 위치. 뷰포트를 벗어나면 반대편으로 flip + 교차축 shift 되어 실제 위치는 계산 결과를 따른다.",
 		},
 		delay: {
 			control: "number",
@@ -39,10 +39,10 @@ const meta: Meta<typeof Tooltip> = {
 		docs: {
 			description: {
 				component: `
-**Tooltip** - Non-blocking supplementary description on hover/focus. For click interactions use Popover. / hover/focus 시 비차단 보조 설명. 클릭 상호작용은 Popover.
+**Tooltip** - hover·focus 시 화면을 막지 않고 보조 설명을 띄운다. 클릭 상호작용은 Popover 를 쓴다.
 
-Key props: \`content\`, \`placement\` (preferred side — auto flip/shift when it would overflow the viewport; portaled to \`body\`), \`delay\` (default 200ms), \`disabled\`. / 주요 prop: \`content\`, \`placement\` (선호 위치 — 뷰포트를 벗어나면 자동 flip/shift, \`body\` 로 포탈), \`delay\` (기본 200ms), \`disabled\`.
-\`role="tooltip"\` + \`aria-describedby\` set automatically. / \`role="tooltip"\` + \`aria-describedby\` 자동.
+주요 prop: \`content\`, \`placement\` (선호 위치 — 뷰포트를 벗어나면 자동 flip/shift, \`body\` 로 포탈), \`delay\` (기본 200ms), \`disabled\`.
+\`role="tooltip"\` + \`aria-describedby\` 가 자동으로 설정된다.
 				`.trim(),
 			},
 		},


### PR DESCRIPTION
## Storybook 문서를 한글 전용으로 정리

### 먼저 짚을 것 — "다 영어" 는 아니었습니다
68개 스토리 파일 **전부에 한글이 이미 있었습니다.** 실제 문제는 `English 설명 / 한글 설명` 병기에서 **영문이 앞에 와서** 첫눈에 영어 문서로 읽히는 것이었습니다.

```
NavBar - Top page navigation. Slots: brand / children (NavLink) / actions .
  / NavBar - 페이지 상단 내비게이션. brand / children (NavLink) / actions 슬롯.
```

순서만 뒤집는 선택지도 있었지만, 논의 결과 **영문을 삭제**하기로 했습니다. 이 문서의 독자는 사내 팀이고, 두 언어가 서로 어긋나며 낡는 것보다 한 언어를 정확히 유지하는 쪽이 낫다는 판단입니다.

## 작업한 내용
- [x] 컴포넌트 스토리 47개 + foundation·cookbook·getting-started 21개 = **60개 파일**
- [x] `component` / `story` description + argTypes `description` 전부
- [x] `CLAUDE.md` 의 Storybook 규약 갱신 — "Include bilingual descriptions (Korean/English)" → 한글 작성

순증감 **+194 / −234**.

### 기계적 삭제가 아닙니다
한글 쪽이 축약된 곳이 많아서, 그대로 지우면 정보가 날아갔습니다.

```
Key props: `image`, `heading`, `aspectRatio`, `shadow`, `bordered`, `clickable` (hover lift).
  / 주요 prop.        ← 한글 절반이 이것뿐
```

이런 경우는 영문 내용을 한글로 풀어 썼습니다.

foundation 페이지는 형태가 달랐습니다 — 한글 산문 위에 영문 문단이 따로 얹혀 있어서(`**Accessibility tokens** - baseline values that…`) 그 문단만 들어냈습니다.

### 원문 유지한 것
컴포넌트·prop 이름, `variant` 값, 코드 블록, WAI-ARIA 용어, 그리고 **Storybook 사이드바 실제 섹션명**(`Getting Started`, `Cookbook`, `Foundation`, `Components`)입니다. 사이드바 라벨을 번역하면 문서와 실제 UI 가 어긋납니다. 제품명 `Bigtablet Design System` 도 그대로입니다.

## 검증
- 최종 스캔: description 리터럴 중 영문 단독 조각이 남은 것은 제품명·사이드바 라벨, 그리고 `a / b / c` 값 열거(`sm:640 / md:768`, `resize none / vertical / both`, `line / fills`)뿐
- **초기 검증이 부정확했습니다** — 감지기가 조각당 영단어 3개 이상을 요구해서 `Min zoom.` 같은 1~2단어 절이 임계값 아래로 빠졌습니다. 리뷰 지적(image-cropper 3건)을 받아 임계값 1로 재스캔했고, 총 8건을 `8a3396d` 에서 정리했습니다
- 866 passed / 9 skipped, `tsc --noEmit` clean
- **biome 회귀 0** — develop 과 대조했습니다. 기본 `--max-diagnostics` 가 20 이라 처음엔 기존 오류 128건 중 20건만 보여 비교가 틀렸고, 500 으로 올려 다시 대조했습니다. 이 과정에서 제가 유발한 포맷 오류 6건을 잡았고, 덤으로 기존 오류 3건도 해소됐습니다
- Storybook 실제 렌더 확인: NavBar docs·foundation/a11y 모두 한글만 표시

## 전달할 추가 이슈
- **`src/ui/navigation/pagination/pagenation.stories.tsx`** — 파일명이 `pagenation` 으로 오타입니다. 이번 PR 범위가 아니라 두었습니다.
- 이 PR 은 문서 문자열만 건드립니다. 배포 산출물(`dist/`)에 스토리는 포함되지 않으므로 **버전 범프 대상이 아닙니다.**
