### PR TITLE
fix/modal-cluster

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1728,8 +1728,53 @@ const [isOpen, setIsOpen] = useState(false);
 | `open` | `boolean` | required | 열림 상태 |
 | `onClose` | `() => void` | - | 닫기 핸들러 |
 | `title` | `ReactNode` | - | 제목 |
-| `width` | `number \| string` | `520` | 모달 너비 |
+| `onExited` | `() => void` | - | 퇴출 애니메이션이 끝나 패널이 언마운트된 뒤 호출 |
+| `description` | `ReactNode` | - | 제목 아래 설명 |
+| `footer` | `ReactNode` | - | 하단 액션 영역. 미지정 시 영역 자체가 없음 |
+| `footerAlign` | `'end' \| 'between' \| 'start'` | `'end'` | footer 정렬. `between` 은 좌우 분리(destructive 패턴) |
+| `width` | `number \| string` | `480` | 모달 너비 |
 | `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
+| `showCloseIcon` | `boolean` | `true` | 우상단 X 버튼 표시 |
+| `closeLabel` | `string` | `'닫기'` | X 버튼 `aria-label` |
+| `ariaLabel` | `string` | - | `title` 이 없을 때의 접근성 이름 |
+
+#### 접근성 이름은 필수다
+
+`title` 이나 `ariaLabel` 중 **하나는 반드시** 줘야 한다. 폴백이 없으므로 둘 다 비우면 이름 없는 대화상자가 되고, axe 의 `aria-dialog-name`(serious)이 잡는다.
+
+> 이전에는 이름이 없으면 영어 `"Dialog"` 로 조용히 채워졌다. 한국어 제품의 유일한 영어 문자열이었고, 이름을 빼먹은 사실을 감추기만 했다.
+
+#### 스크롤 — 내용이 길 때
+
+패널은 뷰포트 높이(`100dvh` - 여백)를 넘지 않고, **제목·푸터는 고정된 채 `children` 영역만 스크롤**된다. 앱이 따로 `max-height` 를 줄 필요가 없다. 스크롤 영역은 `tabIndex={0}` 을 받아 키보드로도 스크롤된다.
+
+#### 오버레이 클릭 — 폼 모달에서는 끌 것
+
+`closeOnOverlay` 기본값은 `true` 다. 읽기 전용 상세 모달에는 맞지만, **입력 요소를 담은 모달에서는 바깥 클릭 한 번에 작성 중인 내용이 사라진다.** 폼·확인창에는 명시적으로 끈다.
+
+```tsx
+<Modal open={open} onClose={close} closeOnOverlay={false} title="변경사항 저장">
+```
+
+패널 안에서 드래그를 시작해 오버레이에서 놓는 경우(텍스트 선택 등)는 **닫히지 않는다** — 누른 곳과 놓은 곳이 모두 오버레이여야 닫는다.
+
+#### 마운트 수명 — `children` 을 `open` 과 같은 값에 묶지 말 것
+
+패널은 퇴출 스프링이 끝날 때까지 마운트를 유지한다(그래야 페이드아웃이 보인다). 그래서 `children` 을 `open` 과 같은 값으로 감싸면 **본문만 먼저 사라지고 제목만 남은 빈 패널이 페이드아웃**된다 — 두 단계로 닫히는 것이 눈에 보인다.
+
+```tsx
+// ❌ item 이 null 되는 순간 본문만 사라진다
+<Modal open={!!item} onClose={close} title="상세">
+  {item && <Body item={item} />}
+</Modal>
+
+// ✅ onExited 에서 비운다
+<Modal open={open} onClose={() => setOpen(false)} onExited={() => setItem(null)} title="상세">
+  {item && <Body item={item} />}
+</Modal>
+```
+
+`Drawer` 도 같은 수명을 갖는다 (`onExited` 는 현재 `Modal` 만 제공 — Drawer 는 후속).
 
 ---
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Modal } from "./index";
 
@@ -69,7 +69,9 @@ describe("Modal", () => {
 			</Modal>,
 		);
 
-		fireEvent.click(screen.getByRole("dialog"));
+		const overlay = screen.getByRole("dialog");
+		fireEvent.pointerDown(overlay);
+		fireEvent.click(overlay);
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
@@ -81,7 +83,9 @@ describe("Modal", () => {
 			</Modal>,
 		);
 
-		fireEvent.click(screen.getByRole("dialog"));
+		const overlay = screen.getByRole("dialog");
+		fireEvent.pointerDown(overlay);
+		fireEvent.click(overlay);
 		expect(handleClose).not.toHaveBeenCalled();
 	});
 
@@ -105,7 +109,7 @@ describe("Modal", () => {
 			</Modal>,
 		);
 
-		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
+		fireEvent.keyDown(document.querySelector(".modal_panel") as HTMLElement, { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
@@ -211,19 +215,17 @@ describe("Modal", () => {
 				Content
 			</Modal>,
 		);
-		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
+		fireEvent.keyDown(document.querySelector(".modal_panel") as HTMLElement, { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
-	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
-		const consumerClick = vi.fn();
+	it("forwards data props and merges consumer style", () => {
 		render(
 			<Modal
 				open
 				onClose={() => {}}
 				data-testid="panel-x"
 				style={{ backgroundColor: "rgb(255, 0, 0)" }}
-				{...({ role: "menu", onClick: consumerClick } as Record<string, unknown>)}
 			>
 				Content
 			</Modal>,
@@ -231,9 +233,114 @@ describe("Modal", () => {
 		// 포털 렌더라 render container 밖(document.body)에 붙는다
 		const panel = document.querySelector(".modal_panel") as HTMLElement;
 		expect(panel).toHaveAttribute("data-testid", "panel-x");
-		expect(panel).toHaveAttribute("role", "document");
-		fireEvent.click(panel);
-		expect(consumerClick).not.toHaveBeenCalled();
 		expect(panel.style.backgroundColor).toBe("rgb(255, 0, 0)");
+	});
+
+	// ── 오버레이 닫기 판정 ───────────────────────────────────────────────────
+	// 패널에서 누르고 오버레이에서 놓으면 `click` 은 공통 조상인 오버레이에 디스패치된다.
+	// 텍스트 선택 같은 정상 조작이 닫기로 이어져 폼 입력이 사라지던 버그.
+	it("does not close when a drag starts in the panel and ends on the overlay", () => {
+		const handleClose = vi.fn();
+		render(
+			<Modal open onClose={handleClose}>
+				Content
+			</Modal>,
+		);
+		const overlay = screen.getByRole("dialog");
+		const panel = document.querySelector(".modal_panel") as HTMLElement;
+
+		fireEvent.pointerDown(panel);
+		fireEvent.click(overlay);
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	it("does not close when a click lands on the panel", () => {
+		const handleClose = vi.fn();
+		render(
+			<Modal open onClose={handleClose}>
+				Content
+			</Modal>,
+		);
+		const panel = document.querySelector(".modal_panel") as HTMLElement;
+		fireEvent.pointerDown(panel);
+		fireEvent.click(panel);
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	// ── 접근성 이름 ──────────────────────────────────────────────────────────
+	// 폴백("Dialog")을 없앴다 - 이름을 빼먹으면 조용히 영어로 채워지는 대신
+	// 이름 없는 대화상자가 되어 axe `aria-dialog-name` 이 잡는다.
+	it("leaves the dialog unnamed when neither title nor ariaLabel is given", () => {
+		render(
+			<Modal open onClose={() => {}}>
+				Content
+			</Modal>,
+		);
+		const overlay = screen.getByRole("dialog");
+		expect(overlay).not.toHaveAttribute("aria-label");
+		expect(overlay).not.toHaveAttribute("aria-labelledby");
+	});
+
+	it("names the dialog from ariaLabel when there is no title", () => {
+		render(
+			<Modal open onClose={() => {}} ariaLabel="설정">
+				Content
+			</Modal>,
+		);
+		expect(screen.getByRole("dialog", { name: "설정" })).toBeInTheDocument();
+	});
+
+	// role="document" 제거 - ARIA 1.0 시절 워크어라운드였고 현대 스크린리더엔 불필요하다.
+	it("does not nest a document role inside the dialog", () => {
+		render(
+			<Modal open onClose={() => {}} title="제목">
+				Content
+			</Modal>,
+		);
+		expect(document.querySelector(".modal_panel")).not.toHaveAttribute("role");
+	});
+
+	// ── 퇴출 수명 ────────────────────────────────────────────────────────────
+	it("does not fire onExited for a modal that was never opened", () => {
+		const onExited = vi.fn();
+		render(
+			<Modal open={false} onClose={() => {}} onExited={onExited}>
+				Content
+			</Modal>,
+		);
+		expect(onExited).not.toHaveBeenCalled();
+	});
+
+	// reduced-motion 에서 spring 이 immediate 라 퇴출이 한 틱에 끝난다 - 실제 타이밍을 기다리지
+	// 않고 "언마운트된 뒤에 발화한다" 는 계약만 확인한다.
+	it("fires onExited after the panel unmounts", async () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+		const onExited = vi.fn();
+		const { rerender } = render(
+			<Modal open onClose={() => {}} onExited={onExited} title="상세">
+				Content
+			</Modal>,
+		);
+		expect(onExited).not.toHaveBeenCalled();
+
+		rerender(
+			<Modal open={false} onClose={() => {}} onExited={onExited} title="상세">
+				Content
+			</Modal>,
+		);
+		await waitFor(() => expect(onExited).toHaveBeenCalledTimes(1));
+		expect(document.querySelector(".modal_panel")).toBeNull();
+		vi.unstubAllGlobals();
 	});
 });

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -300,6 +300,27 @@ describe("Modal", () => {
 		expect(document.querySelector(".modal_panel")).not.toHaveAttribute("role");
 	});
 
+	// 본문 wrapper 는 스크롤을 위해 tabIndex=0 을 갖지만, 초기 포커스는 그 빈 div 가 아니라
+	// 안쪽의 첫 상호작용 요소로 가야 한다. close 버튼이 없으면 wrapper 가 DOM 상 첫 매치가 된다.
+	it("focuses the first control inside the body, not the scroll wrapper", () => {
+		render(
+			<Modal open onClose={() => {}} showCloseIcon={false} title="폼">
+				<input aria-label="이름" />
+			</Modal>,
+		);
+		expect(document.activeElement).toBe(screen.getByLabelText("이름"));
+	});
+
+	it("still keeps the scroll wrapper in the tab cycle", () => {
+		render(
+			<Modal open onClose={() => {}} showCloseIcon={false} title="폼">
+				<input aria-label="이름" />
+			</Modal>,
+		);
+		const body = document.querySelector(".modal_body") as HTMLElement;
+		expect(body.tabIndex).toBe(0);
+	});
+
 	// ── 퇴출 수명 ────────────────────────────────────────────────────────────
 	it("does not fire onExited for a modal that was never opened", () => {
 		const onExited = vi.fn();

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -203,7 +203,9 @@ export const Modal = ({
 					// `scrollable-region-focusable`). 넘치는지 여부를 측정해 조건부로 주는 방법도 있지만
 					// ResizeObserver 를 들일 만큼의 이득이 없고, 포커스 트랩 안에서 탭 정지 하나가
 					// 늘어나는 정도의 비용이다.
-					<div className="modal_body" tabIndex={0}>
+					// 다만 초기 포커스 대상에서는 제외한다 - 안쪽에 첫 입력이 있는데 빈 wrapper 에
+					// 포커스가 놓이면 열자마자 어디에 있는지 알 수 없다.
+					<div className="modal_body" tabIndex={0} data-focus-trap-skip-autofocus="">
 						{children}
 					</div>
 				)}

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -18,10 +18,13 @@ import "./style.scss";
 
 export type ModalFooterAlign = "end" | "between" | "start";
 
-// onClick/onKeyDown/role 은 오버레이 동작(stopPropagation·Escape·role="document")을 위해
+// onClick/onKeyDown/onPointerDown 은 오버레이 동작(오버레이 닫기 판정·Escape 격리)을 위해
 // 컴포넌트가 전유하므로 타입에서 제외한다. style/className 은 병합되어 소비자 값도 반영된다.
 export interface ModalProps
-	extends Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "onClick" | "onKeyDown" | "role"> {
+	extends Omit<
+		React.HTMLAttributes<HTMLDivElement>,
+		"title" | "onClick" | "onKeyDown" | "onPointerDown"
+	> {
 	/** 모달 열림 여부 */
 	open: boolean;
 	/** 모달 닫기 콜백 */
@@ -42,8 +45,16 @@ export interface ModalProps
 	showCloseIcon?: boolean;
 	/** X 닫기 버튼 접근성 레이블 (기본값: "닫기") */
 	closeLabel?: string;
-	/** 모달 접근성 레이블(기본값: title 또는 "Dialog") */
+	/**
+	 * 모달 접근성 레이블. `title` 이 없으면 이 값이 유일한 접근성 이름이다 - 폴백이 없으므로
+	 * 둘 다 비우면 이름 없는 대화상자가 되고 axe `aria-dialog-name` 이 잡는다.
+	 */
 	ariaLabel?: string;
+	/**
+	 * 퇴출 애니메이션이 끝나 패널이 실제로 언마운트된 뒤 호출된다.
+	 * `open` 을 끈 직후가 아니라 이 시점에 상세 데이터를 비워야 본문만 먼저 사라지지 않는다.
+	 */
+	onExited?: () => void;
 }
 
 /**
@@ -66,9 +77,13 @@ export const Modal = ({
 	children,
 	className,
 	ariaLabel,
+	onExited,
 	...props
 }: ModalProps) => {
 	const panelRef = React.useRef<HTMLDivElement>(null);
+	// 오버레이에서 누르기 시작했는지 - 패널에서 시작한 드래그를 오버레이에서 놓으면 `click` 이
+	// 공통 조상인 오버레이에 디스패치되므로, target 검사만으로는 진짜 오버레이 클릭과 구분되지 않는다.
+	const pressedOverlayRef = React.useRef(false);
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
 	// 클라이언트 마운트 여부 - 서버/하이드레이션 첫 렌더에서는 포털을 만들지 않아 hydration
@@ -98,7 +113,11 @@ export const Modal = ({
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 		onRest: (result) => {
-			if (!open && result.finished) setShouldRender(false);
+			if (open || !result.finished) return;
+			setShouldRender(false);
+			// 열린 적 없는 모달의 스프링은 목표값에 이미 있어 onRest 가 발화하지 않으므로 별도
+			// 가드를 두지 않는다. 그 가정은 "열린 적 없으면 onExited 없음" 테스트가 지킨다.
+			onExited?.();
 		},
 	});
 
@@ -140,31 +159,36 @@ export const Modal = ({
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
-			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
-			onClick={() => closeOnOverlay && onClose?.()}
+			aria-label={ariaLabel}
+			onPointerDown={(e) => {
+				pressedOverlayRef.current = e.target === e.currentTarget;
+			}}
+			onClick={(e) => {
+				// 누른 곳과 놓은 곳이 모두 오버레이여야 닫는다. 패널에서 시작한 드래그(텍스트 선택 등)를
+				// 오버레이에서 놓아도 닫히지 않는다 - 폼 모달에서 입력이 사라지던 원인.
+				if (!closeOnOverlay) return;
+				if (e.target !== e.currentTarget) return;
+				if (!pressedOverlayRef.current) return;
+				onClose?.();
+			}}
 		>
 			<animated.div
 				ref={panelRef}
-				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
-				// 아래 className/style(애니메이션)/role/onClick·onKeyDown 은 컴포넌트가 항상
-				// 이기도록 뒤에 배치한다 (오버레이 동작 보호). Escape 는 공유 스택(useOverlayEscape)이
-				// 처리하고, 여기서는 그 외 키가 모달 밖으로 새어 소비자 단축키를 건드리지 않게 막는다.
+				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id/role 등은 통과시키되,
+				// 아래 className/style(애니메이션)/onKeyDown 은 컴포넌트가 항상 이기도록 뒤에 배치한다.
+				// Escape 는 공유 스택(useOverlayEscape)이 처리하고, 여기서는 그 외 키가 모달 밖으로
+				// 새어 소비자 단축키를 건드리지 않게 막는다.
+				// 패널 클릭을 stopPropagation 하지 않는다 - 오버레이가 target 으로 판정하므로 불필요하고,
+				// 소비자 핸들러가 상위에서 이벤트를 못 받는 부작용만 남는다.
 				{...props}
 				className={cn("modal_panel", className)}
 				style={{ ...props.style, ...panelStyle, width }}
-				role="document"
-				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}
 			>
 				{showCloseIcon && onClose && (
-					<button
-						type="button"
-						className="modal_close"
-						onClick={onClose}
-						aria-label={closeLabel}
-					>
+					<button type="button" className="modal_close" onClick={onClose} aria-label={closeLabel}>
 						<X size={iconSize.md} aria-hidden="true" />
 					</button>
 				)}
@@ -174,7 +198,15 @@ export const Modal = ({
 					</h2>
 				)}
 				{description && <div className="modal_description">{description}</div>}
-				{children && <div className="modal_body">{children}</div>}
+				{children && (
+					// 본문이 스크롤 컨테이너라 키보드로도 스크롤할 수 있어야 한다(axe
+					// `scrollable-region-focusable`). 넘치는지 여부를 측정해 조건부로 주는 방법도 있지만
+					// ResizeObserver 를 들일 만큼의 이득이 없고, 포커스 트랩 안에서 탭 정지 하나가
+					// 늘어나는 정도의 비용이다.
+					<div className="modal_body" tabIndex={0}>
+						{children}
+					</div>
+				)}
 				{footer && (
 					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>{footer}</div>
 				)}

--- a/src/ui/overlay/modal/modal.stories.tsx
+++ b/src/ui/overlay/modal/modal.stories.tsx
@@ -64,7 +64,10 @@ export const CreateToken: Story = {
 					title="Create Token"
 					description={
 						<>
-							<p>Enter a unique name for your token to differentiate it from other tokens and then select the scope.</p>
+							<p>
+								Enter a unique name for your token to differentiate it from other tokens and then
+								select the scope.
+							</p>
 							<p>Some content contained within the modal.</p>
 						</>
 					}
@@ -182,6 +185,41 @@ export const Basic: Story = {
 					이 영역에 설명, 폼, 버튼 등을 자유롭게 배치할 수 있습니다.
 				</Modal>
 			</div>
+		);
+	},
+};
+
+export const LongContent: Story = {
+	name: "긴 내용 (본문 스크롤)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"패널이 뷰포트 높이를 넘지 않고, 제목·푸터는 고정된 채 본문만 스크롤된다. 예전에는 패널이 위아래로 잘리고 body 스크롤도 잠겨 있어 잘린 내용에 닿을 수 없었다.",
+			},
+		},
+	},
+	render: (_args, { viewMode }) => {
+		const [open, setOpen] = useState(viewMode === "story");
+		return (
+			<>
+				<Button onClick={() => setOpen(true)}>긴 모달 열기</Button>
+				<Modal
+					open={open}
+					onClose={() => setOpen(false)}
+					title="이용약관 전문"
+					footer={<Button onClick={() => setOpen(false)}>확인</Button>}
+				>
+					<div>
+						{Array.from({ length: 40 }, (_, i) => (
+							<p key={i}>
+								{i + 1}. 이 문단은 스크롤 동작을 확인하기 위한 더미 본문입니다. 패널은 뷰포트를 넘지
+								않고 이 영역만 스크롤됩니다.
+							</p>
+						))}
+					</div>
+				</Modal>
+			</>
 		);
 	},
 };

--- a/src/ui/overlay/modal/style.scss
+++ b/src/ui/overlay/modal/style.scss
@@ -18,7 +18,14 @@
     border-radius: token.$radius_lg;
     box-shadow: token.$elevation_level3;
     max-width: calc(100% - #{token.$spacing_32 * 2});
+    // 뷰포트보다 긴 내용이 위아래로 잘려 접근 불가가 되던 것을 막는다. body 스크롤이 잠긴 상태라
+    // 페이지 스크롤로도 닿을 수 없었다. 제목·푸터는 고정되고 본문만 스크롤된다(&_body).
+    // dvh 는 모바일 사파리 주소창을 따라가고, 미지원 브라우저는 위의 vh 선언을 쓴다.
+    max-height: calc(100vh - #{token.$spacing_32 * 2});
+    max-height: calc(100dvh - #{token.$spacing_32 * 2});
     padding: token.$spacing_24;
+    // visible 유지 - hidden 으로 바꾸면 우상단 close 버튼의 focus ring(box-shadow)이 잘린다.
+    // 넘치는 내용은 &_body 가 자기 안에서 처리한다.
     overflow: visible;
     will-change: transform, opacity;
 
@@ -63,7 +70,9 @@
     margin: 0;
     padding-right: token.$spacing_32; // 우상단 close 버튼과 겹침 방지
     color: token.$color_text_heading;
-    @include token.heading_large_bold;
+    // 28px 고정이면 360px 화면에서 제목 가용 폭이 280px(패널 패딩 48 + close 자리 32 차감)뿐이라
+    // 열 자 남짓에서 두 줄로 접혔다. compact 에서 24px 로 한 단계 내린다.
+    @include token.heading_large_responsive;
   }
 
   // ── Description (title 아래 paragraph) ─────────────────────────────────
@@ -83,8 +92,19 @@
   // ── Body (자유 children - 폼/리스트 등) ────────────────────────────────
 
   &_body {
+    // 패널 max-height 를 넘는 분량은 여기서만 스크롤한다. min-height: 0 이 없으면 flex item 의
+    // 기본 min-content 때문에 축소되지 않아 스크롤이 생기지 않고 패널이 그대로 넘친다.
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
     color: token.$color_text_body;
     @include token.body_medium;
+
+    // tabIndex=0 으로 포커스를 받으므로 표시가 있어야 한다 (WCAG 2.4.7).
+    &:focus-visible {
+      outline: none;
+      box-shadow: token.$focus_ring;
+    }
   }
 
   // ── Footer (액션 영역) ─────────────────────────────────────────────────

--- a/src/utils/use-focus-trap.ts
+++ b/src/utils/use-focus-trap.ts
@@ -2,6 +2,10 @@
 
 import * as React from "react";
 
+// 초기 포커스에서만 건너뛸 요소 표시. 스크롤 컨테이너처럼 "탭 순환에는 있어야 하지만
+// 열자마자 포커스가 놓일 자리는 아닌" wrapper 를 위한 것 (Modal 의 본문 영역).
+const SKIP_AUTOFOCUS_ATTR = "data-focus-trap-skip-autofocus";
+
 const FOCUSABLE_SELECTORS = [
 	"a[href]",
 	"button:not([disabled])",
@@ -30,10 +34,15 @@ export function useFocusTrap(containerRef: React.RefObject<HTMLElement | null>, 
 
 		let wasTabIndexAdded = false;
 
-		// Focus the first focusable element or the container itself
+		// Focus the first focusable element or the container itself.
+		// 스크롤 wrapper 는 건너뛴다 - 안쪽에 실제 컨트롤이 있는데 빈 div 에 포커스가 놓이면
+		// 사용자는 자기가 어디 있는지 알 수 없다. 건너뛸 대상뿐이면 그냥 그것을 쓴다.
 		const focusableElements = getFocusableElements();
-		if (focusableElements.length > 0) {
-			focusableElements[0].focus();
+		const initialTarget =
+			Array.from(focusableElements).find((el) => !el.hasAttribute(SKIP_AUTOFOCUS_ATTR)) ??
+			focusableElements[0];
+		if (initialTarget) {
+			initialTarget.focus();
 		} else {
 			container.setAttribute("tabindex", "-1");
 			wasTabIndexAdded = true;


### PR DESCRIPTION
## Modal 이슈 6건 + 문서

`Closes #471, #473, #474, #476, #483, #484` — 이슈 6건을 소스에서 전부 재확인한 뒤 고쳤습니다. `#475`·`#482` 는 Modal 해당 부분만 문서로 반영했습니다(전체는 별도 PR).

## 작업한 내용

### #471 — 패널에서 시작한 드래그를 밖에서 놓으면 닫힘
오버레이 `onClick` + 패널 `stopPropagation` 구조라, 패널에서 누르고 오버레이에서 놓으면 `click` 이 **공통 조상인 오버레이**에 디스패치되고 패널의 `stopPropagation` 은 그 경로에 없었습니다. 텍스트 선택이 닫기가 되어 폼 입력이 사라졌습니다.

오버레이가 `pointerdown` 이 자기 위에서 시작했는지 기억하고, **누른 곳과 놓은 곳이 모두 오버레이일 때만** 닫습니다. 그러면 패널의 `stopPropagation` 이 불필요해져 제거했습니다 — 소비자 핸들러가 상위에서 이벤트를 못 받는 부작용만 남는 코드였습니다.

### #483 — 내용이 길면 잘리고 스크롤 수단 없음
패널에 `max-height` 가 없고 본문에 `overflow` 가 없어, 뷰포트보다 긴 내용이 위아래로 잘리고 body 스크롤도 잠겨 접근이 불가능했습니다.

패널을 `100dvh` - 여백으로 제한(구형 브라우저용 `vh` 선언 선행)하고 본문만 스크롤합니다. 제목·푸터는 고정. 패널 `overflow` 는 **의도적으로 `visible` 유지** — `hidden` 으로 바꾸면 close 버튼의 focus ring 이 잘립니다.

> **이 수정이 새 위반을 만들었습니다.** 본문이 스크롤 컨테이너가 되자 axe 가 `scrollable-region-focusable`(serious)을 잡았습니다 — 키보드로 스크롤할 수 없습니다. 본문에 `tabIndex={0}` + focus ring 을 줘서 해소했습니다. 브라우저에서 axe violation 0 확인.

### #484 — 제목 고정 크기
28px 고정이라 360px 화면에서 두 줄로 접혔습니다(패널 패딩 48 + close 자리 32 를 빼면 제목 폭이 280px). **이미 있던** `heading_large_responsive` mixin 으로 교체 — compact 에서 24px.

이슈 TODO 의 "다른 컴포넌트 제목도 점검" 결과: Card 는 20px, Hero·EmptyState 는 이미 반응형입니다. Modal 만 고정이었습니다.

### #474 — 닫힘 애니메이션 동안의 children 수명
`onExited` 추가 — 퇴출 스프링이 끝나 패널이 실제로 언마운트된 뒤 호출됩니다. `open=false` 직후가 아니라 이 시점에 상세 데이터를 비우면 됩니다.

이슈에서 권하지 않은 `keepChildrenWhileClosing`(DS 가 children 캐시) 방식은 채택하지 않았습니다.

### #473 — `aria-label` 영어 폴백
`?? "Dialog"` 를 제거했습니다. 이슈의 권장안(폴백 제거 + 개발 모드 경고) 중 **경고는 넣지 않았습니다** — DS 에 dev 경고 선례가 0이고 `process.env.NODE_ENV` 처리도 없어서, 라이브러리 빌드의 첫 env 의존을 들일 비용이 큽니다. 대신 **axe 가 이미 이 결함을 잡는 것을 확인**했습니다: 이름이 없으면 `aria-dialog-name`(serious), 옛 `"Dialog"` 폴백이 있으면 조용히 통과. 검출 수단이 이미 있으니 새 장치가 필요 없습니다.

### #476 — `role="document"`
제거했습니다. 소비자가 `role` 을 직접 넘기는 길도 열렸습니다(`Omit` 에서 `role` 제외).

### 문서 (#475 · #482 일부)
Modal prop 표가 13개 중 5개만 있었고 `width` 기본값이 **520 으로 잘못 적혀** 있었습니다(코드는 480). 빠진 prop 을 채우고, 소스를 읽어야만 알 수 있던 계약 4개를 절로 추가했습니다 — 접근성 이름 필수 / 본문 스크롤 / `closeOnOverlay` 를 폼에서 끌 것 / children 을 `open` 에 묶지 말 것(`onExited` 사용 예시 포함).

## 검증

873 passed, `tsc --noEmit` · `lint:css` clean.

**뮤테이션** — 각 수정이 테스트로 고정되는지 확인:

| 뮤테이션 | 결과 |
|---|---|
| 드래그 판정 제거(옛 동작) | 1건 실패 |
| `aria-label` 영어 폴백 부활 | 1건 실패 |
| `role="document"` 부활 | 1건 실패 |
| `onExited` 발화 제거 | 1건 실패 |
| `wasOpenRef` 가드 제거 | **생존** |

마지막 것은 제가 처음에 넣은 방어 가드가 **도달 불가한 죽은 코드**였다는 뜻입니다(열린 적 없는 모달의 스프링은 목표값에 이미 있어 `onRest` 가 발화하지 않음). 제거했고, 그 가정은 "열린 적 없으면 `onExited` 없음" 테스트가 지킵니다.

**브라우저 실측** (375×812): 패널 796px 로 뷰포트 안에 들어옴, 본문 스크롤 가능(2415/628), compact 제목 24px 1줄, 패널→오버레이 드래그 시 열린 상태 유지, axe violation 0.

## 전달할 추가 이슈

- **퇴출 애니메이션 자체는 브라우저에서 검증하지 못했습니다.** preview 탭이 `visibilityState: hidden` 이라 `requestAnimationFrame` 이 돌지 않고 react-spring 이 얼어붙습니다(`rafAlive: false` 확인). 그래서 그 환경에서는 X 버튼·ESC·오버레이 클릭 모두 "안 닫히는" 것처럼 보이는데, **develop 원본으로 교체해도 동일**해 제 변경과 무관함을 확인했습니다. 퇴출 경로는 reduced-motion(`immediate`) 스프링을 쓰는 단위 테스트가 담당합니다.
- **`closeOnOverlay` 기본값은 뒤집지 않았습니다** (#475). 이슈에서도 파급이 크니 문서부터가 현실적이라고 했고, 기존 사용처 전수 확인이 선행돼야 합니다. `dismissible` 로 ESC+오버레이를 한 축으로 묶는 API 도 미결로 남깁니다.
- **`Drawer` 에도 같은 것들이 있습니다** — #471 의 오버레이 패턴, #474 의 퇴출 수명. 이 PR 은 Modal 범위로 두고 Drawer 는 따로 보겠습니다.
- 새 prop `onExited` 추가이므로 릴리즈는 **minor** 대상입니다.