### PR TITLE
fix/toast-emptystate

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -2929,7 +2929,7 @@ action={
 </div>
 ```
 
-`flex: 1` 을 쓰므로 **부모가 세로 flex 컨테이너여야** 합니다. 아니라면 부모에 `display: flex; flex-direction: column` 을 주거나 `height: 100%` 로 높이를 확정하세요. 미지정 시 동작은 기존과 동일합니다.
+`flex: 1` 을 쓰므로 **부모가 세로 flex 컨테이너여야** 합니다 — 부모에 `display: flex; flex-direction: column` 과 높이(`min-height` 등)를 주세요. 부모에 높이만 주고 flex 를 안 걸면 `flex: 1` 이 무시되어 아무 변화가 없습니다. 미지정 시 동작은 기존과 동일합니다.
 
 #### DOM 구조 (SCSS override 시 참고)
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -279,7 +279,6 @@ const [fruits, setFruits] = useState<string[]>([]);
 | `label` | `string` | - | 플로팅 라벨 (값 선택 시 또는 열릴 때 표시) |
 | `placeholder` | `string` | `'Select…'` | 플레이스홀더 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
-| `fillHeight` | `boolean` | `false` | 부모 높이를 채우고 세로 중앙 정렬 (`flex: 1` + `justify-content: center`) |
 | `name` | `string` | - | 네이티브 폼 제출용 name. 선택 값이 hidden input 으로 렌더됨 (multiple 은 같은 name 반복) |
 | `id` | `string` | 자동 생성 | 드롭다운 요소 id |
 | `className` | `string` | - | 루트 요소에 추가할 className |
@@ -2908,6 +2907,7 @@ action={
 | `description` | `ReactNode` | - | 보조 설명 (p, max-width 480) |
 | `action` | `ReactNode` | - | 액션 영역 (Button 등) |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
+| `fillHeight` | `boolean` | `false` | 부모 높이를 채우고 세로 중앙 정렬 (`flex: 1` + `justify-content: center`) |
 | `...rest` | `HTMLAttributes<HTMLDivElement>` | - | `role`, `aria-*` 등 |
 
 #### 접근성

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -279,6 +279,7 @@ const [fruits, setFruits] = useState<string[]>([]);
 | `label` | `string` | - | 플로팅 라벨 (값 선택 시 또는 열릴 때 표시) |
 | `placeholder` | `string` | `'Select…'` | 플레이스홀더 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
+| `fillHeight` | `boolean` | `false` | 부모 높이를 채우고 세로 중앙 정렬 (`flex: 1` + `justify-content: center`) |
 | `name` | `string` | - | 네이티브 폼 제출용 name. 선택 값이 hidden input 으로 렌더됨 (multiple 은 같은 name 반복) |
 | `id` | `string` | 자동 생성 | 드롭다운 요소 id |
 | `className` | `string` | - | 루트 요소에 추가할 className |
@@ -1448,7 +1449,16 @@ const [collapsed, setCollapsed] = useState(false);
 --bt-bottom-nav-height        /* 56px */
 --bt-bottom-nav-safe-area     /* env(safe-area-inset-bottom) */
 --bt-bottom-nav-total-height  /* 합산 - BottomNavSpacer 가 자동 사용 */
+--bt-bottom-inset             /* 하단이 실제로 가려진 높이. BottomNav 가 없으면 0px */
 ```
+
+> **하단 고정 요소를 둔다면 `--bt-bottom-inset` 을 쓰세요.** 위의 세 변수는 BottomNav 를 쓰지 않는 화면에서도 항상 정의됩니다(`:root` + 단일 CSS 번들). 그대로 더하면 BottomNav 가 없는 페이지에서도 56px 밀립니다. `--bt-bottom-inset` 만 BottomNav 가 DOM 에 있을 때 값이 생깁니다.
+>
+> ```css
+> .my_floating_bar { bottom: calc(16px + var(--bt-bottom-inset)); }
+> ```
+>
+> `Toast` 는 모바일에서 이 값을 이미 반영합니다 - 앱이 `.toast_container` 를 보정하던 CSS 는 지우면 됩니다.
 
 **Props - BottomNav**
 
@@ -2908,6 +2918,18 @@ action={
 - `illustration`은 `aria-hidden="true"` 자동 적용 - 일러스트가 의미 전달용이면 title/description에 텍스트로 동일 의미 포함시키세요
 - **`illustration` 에 포커스 가능한 요소(버튼/링크 등)를 넣지 마세요.** `aria-hidden` 조상 때문에 포커스는 가는데 보조기기엔 존재하지 않는 요소가 되어 WCAG 4.1.2 (Name/Role/Value) 위반이고, Chrome 은 `Blocked aria-hidden on an element because its descendant retained focus` 를 남기며 `aria-hidden` 적용을 거부합니다. 조작 요소는 `action` 슬롯으로 - 여기엔 `aria-hidden` 이 붙지 않습니다
 - 색상은 caption tone - 너무 흐리지 않도록 description 길이는 1-2줄로 유지
+
+#### 화면 가운데 놓기 — `fillHeight`
+
+기본값은 가로 정렬만 하므로, 높이가 큰 영역에 두면 콘텐츠가 상단에 붙고 아래가 비어 보입니다. 404 · 검색 결과 없음 · 빈 목록처럼 영역 한가운데가 필요하면 `fillHeight` 를 켜세요 — 앱마다 `margin: auto` 래퍼를 만들 필요가 없습니다.
+
+```tsx
+<div style={{ display: "flex", flexDirection: "column", minHeight: "60vh" }}>
+  <EmptyState fillHeight title="검색 결과가 없습니다" />
+</div>
+```
+
+`flex: 1` 을 쓰므로 **부모가 세로 flex 컨테이너여야** 합니다. 아니라면 부모에 `display: flex; flex-direction: column` 을 주거나 `height: 100%` 로 높이를 확정하세요. 미지정 시 동작은 기존과 동일합니다.
 
 #### DOM 구조 (SCSS override 시 참고)
 

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -111,6 +111,13 @@
   --bt-elevation-level3: 0 3px 3px -3px rgba(0, 0, 0, 0.20), 0 9px 9px 0px rgba(0, 0, 0, 0.12);
   --bt-elevation-level4: 0 5px 5px -5px rgba(0, 0, 0, 0.20), 0 15px 15px 0px rgba(0, 0, 0, 0.12);
   --bt-elevation-level5: 0 8px 10px -5px rgba(0, 0, 0, 0.20), 0 20px 20px 0px rgba(0, 0, 0, 0.12);
+
+  // 뷰포트 하단을 DS 고정 요소(현재 BottomNav)가 실제로 차지하는 높이. 기본 0 이고,
+  // BottomNav 가 DOM 에 있으면 그 스타일시트가 body 에서 덮어쓴다. 하단 고정 요소를 두는
+  // 소비처는 `bottom: calc(16px + var(--bt-bottom-inset))` 처럼 더해 겹침을 피한다.
+  // 기본값을 여기 두는 이유: bottom-nav 스타일시트에 두면 그 컴포넌트를 안 쓰는 화면에서
+  // 변수가 아예 없어, 이 값을 참조하는 다른 컴포넌트가 암묵적으로 그 파일에 의존하게 된다.
+  --bt-bottom-inset: 0px;
 }
 
 // ── Dark overrides (mixin - 두 셀렉터에서 공유) ──────────────────────────

--- a/src/ui/feedback/empty-state/EmptyState.test.tsx
+++ b/src/ui/feedback/empty-state/EmptyState.test.tsx
@@ -42,6 +42,17 @@ describe("EmptyState", () => {
 		);
 	});
 
+	// 미지정 시 기존과 동일해야 한다 - 옵션이 기본 동작을 바꾸면 모든 사용처가 회귀한다.
+	it("does not fill height unless asked", () => {
+		const { container } = render(<EmptyState title="t" />);
+		expect(container.firstChild).not.toHaveClass("empty_state_fill_height");
+	});
+
+	it("fills the parent height when fillHeight is set", () => {
+		const { container } = render(<EmptyState title="t" fillHeight />);
+		expect(container.firstChild).toHaveClass("empty_state_fill_height");
+	});
+
 	it("exposes the action slot to the accessibility tree", () => {
 		render(<EmptyState title="t" action={<button type="button">Add</button>} />);
 		expect(screen.getByRole("button", { name: "Add" }).closest("[aria-hidden]")).toBeNull();

--- a/src/ui/feedback/empty-state/index.tsx
+++ b/src/ui/feedback/empty-state/index.tsx
@@ -19,6 +19,13 @@ export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLDivElemen
 	action?: React.ReactNode;
 	/** 크기 (기본 "md") */
 	size?: "sm" | "md" | "lg";
+	/**
+	 * 부모 높이를 채우고 내용을 세로 중앙에 둔다 (`flex: 1` + `justify-content: center`).
+	 * 404 · 검색 결과 없음 · 빈 목록처럼 영역 한가운데 놓여야 하는 경우에 쓴다.
+	 * **부모가 세로 flex 컨테이너여야 `flex: 1` 이 먹는다** - 아닌 경우 `height: 100%` 를 준 부모
+	 * 안에 두거나 부모를 `display: flex; flex-direction: column` 으로 만들 것.
+	 */
+	fillHeight?: boolean;
 }
 
 /**
@@ -40,11 +47,20 @@ export const EmptyState = ({
 	description,
 	action,
 	size = "md",
+	fillHeight,
 	className,
 	...props
 }: EmptyStateProps) => {
 	return (
-		<div className={cn("empty_state", `empty_state_size_${size}`, className)} {...props}>
+		<div
+			className={cn(
+				"empty_state",
+				`empty_state_size_${size}`,
+				fillHeight && "empty_state_fill_height",
+				className,
+			)}
+			{...props}
+		>
 			{illustration && (
 				<div className="empty_state_illustration" aria-hidden="true">
 					{illustration}

--- a/src/ui/feedback/empty-state/style.scss
+++ b/src/ui/feedback/empty-state/style.scss
@@ -8,6 +8,13 @@
   width: 100%;
   gap: token.$spacing_12;
 
+  // 부모 높이를 채우고 세로 중앙 정렬. 없을 때는 콘텐츠가 긴 래퍼 상단에 붙어 아래가 비어 보여
+  // 앱마다 `margin: auto` 래퍼를 따로 만들고 있었다. 미지정 시 위 기본값과 동일하게 동작한다.
+  &_fill_height {
+    flex: 1;
+    justify-content: center;
+  }
+
   &_illustration {
     color: token.$color_text_caption;
     display: inline-flex;

--- a/src/ui/feedback/toast/style.scss
+++ b/src/ui/feedback/toast/style.scss
@@ -34,7 +34,9 @@
 
   @include breakpoint.compact {
     top: auto;
-    bottom: token.$spacing_16;
+    // BottomNav 뒤에 깔려 읽을 수 없던 문제 - 하단을 차지하는 만큼 밀어 올린다.
+    // BottomNav 가 없으면 --bt-bottom-inset 이 0px 이라 여백만 남는다.
+    bottom: calc(#{token.$spacing_16} + var(--bt-bottom-inset, 0px));
     left: token.$spacing_16;
     right: token.$spacing_16;
     width: auto;

--- a/src/ui/navigation/bottom-nav/style.scss
+++ b/src/ui/navigation/bottom-nav/style.scss
@@ -27,6 +27,10 @@ body:has(.bottom_nav) {
   align-items: stretch;
   justify-content: space-around;
 
+  // height 가 safe-area 를 이미 포함하므로 border-box 여야 한다. content-box 면 padding-bottom
+  // 의 safe-area 가 한 번 더 더해지고 border-top 1px 까지 밖으로 나가, 실제 높이가
+  // --bt-bottom-nav-total-height(= --bt-bottom-inset) 보다 커져 하단 고정 요소가 겹친다.
+  box-sizing: border-box;
   height: var(--bt-bottom-nav-total-height);
   padding-bottom: var(--bt-bottom-nav-safe-area); // iOS 홈 인디케이터 영역 회피
   background: token.$color_bg_solid;

--- a/src/ui/navigation/bottom-nav/style.scss
+++ b/src/ui/navigation/bottom-nav/style.scss
@@ -9,6 +9,13 @@
   );
 }
 
+// 위 세 변수는 BottomNav 를 쓰지 않는 페이지에서도 항상 정의된다(:root + 단일 CSS 번들).
+// 그래서 하단 고정 요소가 그대로 더하면 BottomNav 가 없는 화면에서도 56px 밀린다.
+// 실제로 있을 때만 --bt-bottom-inset(기본 0, theme.scss) 에 값을 넣는다.
+body:has(.bottom_nav) {
+  --bt-bottom-inset: var(--bt-bottom-nav-total-height);
+}
+
 .bottom_nav {
   position: fixed;
   left: 0;


### PR DESCRIPTION
## Toast × BottomNav 겹침 + EmptyState 세로 중앙 정렬

`Closes #472, #477`

## #472 — Toast 가 BottomNav 뒤에 깔림

모바일에서 토스트는 `bottom: 16px`, BottomNav 는 `bottom: 0` 이라 토스트가 하단 내비 뒤에 가려졌습니다. notiiv owner · support 두 앱의 `global.css` 에 같은 보정 블록이 복사돼 있었고, 앱이 DS 내부 클래스명(`.toast_container` · `.bottom_nav`)에 의존하는 상태였습니다.

### 이슈가 제안한 방식은 작동하지 않습니다

이슈의 TODO 는 `calc(spacing + var(--bt-bottom-nav-total-height, 0px))` 였는데, **그 변수는 `:root` 에 무조건 정의돼 있습니다.** 라이브러리 CSS 는 한 파일이라 BottomNav 를 안 쓰는 페이지에도 항상 존재하고, 폴백(`, 0px`)은 절대 발동하지 않습니다. 그대로 더하면 **모든 모바일 페이지에서 토스트가 56px 밀립니다.**

달라지는 건 변수의 존재 여부가 아니라 **nav 의 존재 여부**입니다. 그래서 그걸 감지합니다 — 앱이 쓰던 `:has()` 와 같은 메커니즘이고, 이제 DS 가 소유합니다.

```scss
body:has(.bottom_nav) { --bt-bottom-inset: var(--bt-bottom-nav-total-height); }
```

```scss
// Toast (compact)
bottom: calc(#{token.$spacing_16} + var(--bt-bottom-inset, 0px));
```

### 기본값을 `theme.scss` 에 둔 이유

`--bt-bottom-inset: 0px` 기본값을 bottom-nav 스타일시트에 두면, 이 변수를 참조하는 컴포넌트가 **그 파일에 암묵적으로 의존**하게 됩니다. 배포 번들에서는 한 파일이라 드러나지 않지만 Storybook 은 컴포넌트별로 CSS 를 로드합니다 — 실제로 첫 시도가 브라우저에서 이렇게 실패했고(Toast 스토리에 bottom-nav CSS 없음 → 변수 미정의), 그래서 전역으로 옮겼습니다.

### 세 번째 TODO 도 해결됩니다

`--bt-bottom-inset` 은 앱 전용 하단 고정 요소(owner `floating_bar` 의 96px 하드코딩)를 위한 공식 수단이기도 합니다.

```css
.my_floating_bar { bottom: calc(16px + var(--bt-bottom-inset)); }
```

## #477 — EmptyState 세로 중앙 정렬

`fillHeight` prop 추가 (`flex: 1` + `justify-content: center`). 404 · 검색 결과 없음 · 빈 목록이 모두 원하던 형태고, 앱이 `margin: auto` 래퍼를 따로 만들 필요가 없어집니다.

부모가 세로 flex 컨테이너여야 한다는 조건을 prop JSDoc 과 문서 양쪽에 적었습니다. **미지정 시 동작은 기존과 완전히 동일**하며 테스트로 고정했습니다.

## 검증

**브라우저 실측** (375×812, BottomNav 스토리):

| 상태 | `--bt-bottom-inset` | 동일 calc 을 쓴 probe 의 하단 여백 |
|---|---|---|
| nav 있음 | `56px + 0px` | **72px** (= 16 + 56, 57px nav 를 넘김) |
| nav 제거 | `0px` | **16px** |

**배포 번들 확인** — `pnpm build` 후 `dist/index.css` 에 `body:has(.bottom_nav){--bt-bottom-inset:…}`(640행대)과 `bottom: calc(16px + var(--bt-bottom-inset, 0px))`(3505행대)이 모두 들어간 것을 확인했습니다.

868 passed, `tsc --noEmit` · `lint:css` clean.

## 전달할 추가 이슈

- **반영 후 앱 정리 대상**: notiiv owner · support 의 `global.css` 에 있는 `body:has(.bottom_nav) .toast_container { bottom: … }` 블록은 삭제하면 됩니다. owner `floating_bar` 의 96px 하드코딩도 `calc(16px + var(--bt-bottom-inset))` 로 바꿀 수 있습니다.
- **`:has()` 의존**: Baseline 2023 이라 대상 브라우저에선 문제없지만, 미지원 브라우저에서는 토스트가 예전처럼 겹칩니다(기능은 동작). DS 의 브라우저 지원 하한이 문서에 없어서 판단 근거를 못 남겼습니다 — #482 문서 작업에서 같이 다루면 좋겠습니다.
- **Toast + BottomNav 조합 스토리는 넣지 않았습니다.** Toast 스토리는 Provider + 트리거 버튼 구조라 BottomNav 를 얹으면 목적이 흐려집니다. 회귀 감지가 필요하면 별도 cookbook 예제가 나을 것 같습니다.
- 새 prop(`fillHeight`)과 새 CSS 변수(`--bt-bottom-inset`) 추가이므로 릴리즈는 **minor** 대상입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - `EmptyState`가 부모 영역의 남은 높이를 채우고 콘텐츠를 세로 중앙에 배치하도록 설정할 수 있습니다.
  - 하단 내비게이션 높이를 반영하는 `--bt-bottom-inset` CSS 변수를 제공합니다.
- **버그 수정**
  - 하단 내비게이션이 표시되는 환경에서 Toast가 내비게이션 영역과 겹치지 않도록 위치가 자동 조정됩니다.
- **문서**
  - `Dropdown`, `BottomNav`, `EmptyState`의 새 옵션과 레이아웃·여백 설정 방법을 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->