### PR TITLE
docs/contracts

### DIFF
--- a/README_KR.md
+++ b/README_KR.md
@@ -139,7 +139,7 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 }
 ```
 
-> React entry 의 `style.css` 가 내보내는 CSS 변수는 `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*` 뿐이다. spacing / radius / typography 는 이 entry 에선 **SCSS 전용**이라 `scss/token` 을 써야 한다 (`--bt-spacing-*` / `--bt-radius-*` 는 [Vanilla 번들](./docs/VANILLA.md) 에만 존재).
+> React entry 의 `style.css` 가 내보내는 CSS 변수는 `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset`, `--bt-scrollbar-width` 뿐이다. spacing / radius / typography 는 이 entry 에선 **SCSS 전용**이라 `scss/token` 을 써야 한다 (`--bt-spacing-*` / `--bt-radius-*` 는 [Vanilla 번들](./docs/VANILLA.md) 에만 존재).
 
 `colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS 전용</sup>
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -56,7 +56,7 @@ Always reference tokens - never inline a hex value.
 
 Two surfaces, and they are **not** interchangeable:
 - **SCSS tokens** (`@use "src/styles/token" as token;` → `token.$spacing_16`) - the full set. Use these in component `style.scss`.
-- **CSS custom properties** (`var(--bt-color-bg-solid)`) - the React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`. Spacing / radius / typography CSS vars exist only in the Vanilla bundle.
+- **CSS custom properties** (`var(--bt-color-bg-solid)`) - the React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset`, `--bt-scrollbar-width`. Spacing / radius / typography CSS vars exist only in the Vanilla bundle. Full contract incl. runtime behaviour: [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수).
 
 ### Color tokens
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1308,7 +1308,7 @@ Admin/dashboard 좌측 메인 네비게이션. **navy 배경 + 흰 텍스트** �
 --bt-sidebar-total-height  /* 합산 */
 ```
 
-> **`compact`(<600px)에서만 정의됩니다.** Sidebar 가 하단 bar 로 변신할 때만 의미가 있기 때문입니다(`mode="auto"` 기본값). 데스크탑 폭에서는 세 변수 모두 존재하지 않으므로 `var(--bt-sidebar-total-height, 0px)` 처럼 폴백을 두세요. 전체 계약은 [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수) 참고.
+> **뷰포트 폭 <600px 에서만 정의됩니다.** `@media (max-width: 599px)` 안의 `:root` 선언이라 **Sidebar 를 렌더하지 않는 페이지나 `mode="static"` Sidebar 에서도 값이 존재**하고, 반대로 데스크탑 폭에서는 Sidebar 가 떠 있어도 정의되지 않습니다. `var(--bt-sidebar-total-height, 0px)` 처럼 폴백을 두세요. 전체 계약은 [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수) 참고.
 
 #### 언제 쓰는가
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1300,6 +1300,16 @@ const [filter, setFilter] = useState("all");
 
 Admin/dashboard 좌측 메인 네비게이션. **navy 배경 + 흰 텍스트** 고정. `SidebarItem` 자식과 함께 사용하며, 선택적으로 `SidebarSection`으로 그룹화. `collapsed` 모드로 아이콘만 표시되는 축소 상태 지원.
 
+#### CSS 변수 (layout 계산용)
+
+```css
+--bt-sidebar-height        /* 56px */
+--bt-sidebar-safe-area     /* env(safe-area-inset-bottom) */
+--bt-sidebar-total-height  /* 합산 */
+```
+
+> **`compact`(<600px)에서만 정의됩니다.** Sidebar 가 하단 bar 로 변신할 때만 의미가 있기 때문입니다(`mode="auto"` 기본값). 데스크탑 폭에서는 세 변수 모두 존재하지 않으므로 `var(--bt-sidebar-total-height, 0px)` 처럼 폴백을 두세요. 전체 계약은 [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수) 참고.
+
 #### 언제 쓰는가
 
 | 상황 | 선택 |

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -13,6 +13,9 @@ Bigtablet Design System의 라이트/다크 테마 시스템 가이드입니다.
   - [React](#react)
   - [SCSS 소비자](#scss-소비자)
   - [CSS 변수 직접 사용](#css-변수-직접-사용)
+  - [레이아웃·런타임 계약 변수](#레이아웃런타임-계약-변수)
+  - [접근성 토큰 — 하드코딩하지 마세요](#접근성-토큰--하드코딩하지-마세요)
+- [컴포넌트 마운트 수명](#컴포넌트-마운트-수명)
 - [오버레이 스크롤 잠금과 `--bt-scrollbar-width`](#오버레이-스크롤-잠금과---bt-scrollbar-width)
 - [자동완성(autofill) 입력칸](#자동완성autofill-입력칸)
 - [Storybook](#storybook)
@@ -199,6 +202,94 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 | `--bt-elevation-level1` ~ `-level5` | elevation shadow |
 
 > 참고: Vanilla JS 패키지(`@bigtablet/design-system/vanilla`)는 `src/vanilla/bigtablet.scss` 에서 동일 토큰을 기반으로 하지만 이름이 다른 자체 `--bt-color-*` 변수 세트를 사용하며(예: `--bt-color-primary`, `--bt-color-background`), 현재 `data-theme`/`prefers-color-scheme` 다크 모드 오버라이드가 없습니다. Vanilla 환경과 React 환경의 CSS 변수는 서로 호환되지 않으니 섞어 쓰지 마세요.
+
+### 레이아웃·런타임 계약 변수
+
+위 표는 **테마 토큰**(색·elevation·focus)입니다. 그 외에 컴포넌트가 **레이아웃 계산용으로 내보내는 변수**가 따로 있습니다. 값이 런타임에 바뀌거나 컴포넌트 존재 여부에 따라 달라지므로, SCSS 토큰이 아니라 CSS 변수로만 제공됩니다.
+
+| 변수 | 정의 주체 | 기본값 | 언제 바뀌나 |
+|------|----------|--------|------------|
+| `--bt-scrollbar-width` | `theme.scss` + 오버레이 잠금 JS | `0px` | Modal·Drawer·Alert 가 열려 body 스크롤이 잠긴 동안 실측 폭. 닫히면 원복 |
+| `--bt-bottom-nav-height` | `BottomNav` 스타일시트 | `56px` | 고정 |
+| `--bt-bottom-nav-safe-area` | 〃 | `env(safe-area-inset-bottom, 0px)` | 기기·방향 |
+| `--bt-bottom-nav-total-height` | 〃 | 위 둘의 합 | 〃 |
+| `--bt-sidebar-height` / `-safe-area` / `-total-height` | `Sidebar` 스타일시트 | `56px` 기준, BottomNav 와 동일 구조 | **`compact`(<600px)에서만 정의됩니다** — Sidebar 가 하단 bar 로 변신할 때만 의미가 있기 때문 |
+
+#### 존재 여부와 값을 혼동하지 마세요
+
+`--bt-bottom-nav-*` 세 변수는 `:root` 에 선언돼 있고 라이브러리 CSS 는 한 파일이므로, **BottomNav 를 렌더하지 않는 화면에서도 항상 정의돼 있습니다.** 하단 고정 요소에서 그대로 더하면 BottomNav 가 없는 페이지에서도 그만큼 밀립니다.
+
+실제로 하단이 가려진 높이는 `--bt-bottom-inset` 입니다 — 기본 `0px` 이고, `BottomNav` 가 DOM 에 있을 때만 값이 생깁니다.
+
+```css
+/* ✅ BottomNav 유무에 따라 알아서 맞는다 */
+.my_floating_bar { bottom: calc(16px + var(--bt-bottom-inset)); }
+
+/* ❌ BottomNav 없는 페이지에서도 56px 밀린다 */
+.my_floating_bar { bottom: calc(16px + var(--bt-bottom-nav-total-height)); }
+```
+
+#### 번들에 따라 변수 집합이 다릅니다
+
+React 진입점의 `style.css` 는 `--bt-color-*` · `--bt-elevation-*` · `--bt-focus-*` · `--bt-scrollbar-width` · `--bt-bottom-nav-*` · `--bt-bottom-inset` · `--bt-sidebar-*` 만 내보냅니다. spacing · radius · typography 계열 CSS 변수는 **Vanilla 번들에만** 있습니다. React 쪽에서는 SCSS 토큰(`token.$spacing_16` 등)을 쓰세요.
+
+#### 문서와 실제가 갈리지 않게 하려면
+
+이 목록은 손으로 관리하면 반드시 낡습니다. 빌드 산출물과 대조하는 절차:
+
+```bash
+pnpm build
+scripts/check-css-vars.sh
+```
+
+문서에 적혔지만 어느 번들에도 없는 변수를 찾아냅니다. 현재는 수동 실행이며 CI 에는 연결돼 있지 않습니다.
+
+### 접근성 토큰 — 하드코딩하지 마세요
+
+포커스 표시와 최소 터치 영역에도 토큰이 있습니다. 존재를 몰라 하드코딩하면 다크 모드에서 포커스 링이 보이지 않는 등의 문제가 실제로 생깁니다.
+
+| 토큰 (SCSS) | CSS 변수 | 값 |
+|---|---|---|
+| `token.$focus_ring` | `--bt-focus-ring` | 포커스 링 box-shadow (light/dark 각각 대비 확보) |
+| `token.$focus_ring_error` / `_success` | `--bt-focus-ring-error` / `-success` | 상태별 포커스 링 |
+| `token.$tap_target_dense` | — | 32px (데스크탑 인라인 폼) |
+| `token.$tap_target_compact` | — | 40px (데스크탑 기본) |
+| `token.$tap_target_comfortable` | — | 48px (모바일/터치 기본) |
+| `token.$tap_target_spacious` | — | 56px (강조 CTA) |
+
+```scss
+// ✅
+&:focus-visible { outline: none; box-shadow: token.$focus_ring; }
+
+// ❌ 다크 테마에서 검정 배경 위 검정 아웃라인 - 보이지 않는다
+&:focus-visible { outline: 2px solid #000; }
+```
+
+Storybook 의 `foundation/a11y` 페이지에서 실제 렌더를 확인할 수 있습니다.
+
+---
+
+## 컴포넌트 마운트 수명
+
+애니메이션이 있는 컴포넌트는 **퇴출 스프링이 끝날 때까지 DOM 에 남습니다.** 그래야 페이드아웃이 보입니다. 이 사실이 앱 코드에 영향을 주는 지점이 있습니다.
+
+해당 컴포넌트: `Modal` · `Drawer` · `Popover` · `Tooltip` · `Alert` · `Toast` · `Menu` · `Dropdown`.
+
+**children 을 열림 상태와 같은 값으로 감싸지 마세요.** 감싸면 본문만 먼저 사라지고 껍데기가 페이드아웃되어, 닫힘이 두 단계로 보입니다.
+
+```tsx
+// ❌ item 이 null 되는 순간 본문만 사라진다
+<Modal open={!!item} onClose={close} title="상세">
+  {item && <Body item={item} />}
+</Modal>
+
+// ✅ 언마운트가 끝난 뒤 비운다
+<Modal open={open} onClose={() => setOpen(false)} onExited={() => setItem(null)} title="상세">
+  {item && <Body item={item} />}
+</Modal>
+```
+
+`onExited` 는 현재 `Modal` 만 제공합니다. 다른 컴포넌트에서는 열림 상태와 데이터를 분리해 두고, 데이터는 다음 열림 때 덮어쓰는 편이 안전합니다.
 
 ---
 

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -213,7 +213,9 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 | `--bt-bottom-nav-height` | `BottomNav` 스타일시트 | `56px` | 고정 |
 | `--bt-bottom-nav-safe-area` | 〃 | `env(safe-area-inset-bottom, 0px)` | 기기·방향 |
 | `--bt-bottom-nav-total-height` | 〃 | 위 둘의 합 | 〃 |
-| `--bt-sidebar-height` / `-safe-area` / `-total-height` | `Sidebar` 스타일시트 | `56px` 기준, BottomNav 와 동일 구조 | **`compact`(<600px)에서만 정의됩니다** — Sidebar 가 하단 bar 로 변신할 때만 의미가 있기 때문 |
+| `--bt-sidebar-height` | `Sidebar` 스타일시트 | `56px` | **뷰포트 폭 <600px 에서만 정의** (아래 주의) |
+| `--bt-sidebar-safe-area` | 〃 | `env(safe-area-inset-bottom, 0px)` | 〃 |
+| `--bt-sidebar-total-height` | 〃 | 위 둘의 합 | 〃 |
 
 #### 존재 여부와 값을 혼동하지 마세요
 
@@ -227,6 +229,16 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 
 /* ❌ BottomNav 없는 페이지에서도 56px 밀린다 */
 .my_floating_bar { bottom: calc(16px + var(--bt-bottom-nav-total-height)); }
+```
+
+#### `--bt-sidebar-*` 는 컴포넌트가 아니라 뷰포트에 달려 있습니다
+
+세 변수는 `@media (max-width: 599px)` 안의 `:root` 에서만 정의됩니다. **Sidebar 를 렌더하지 않는 페이지도, `mode="static"`(하단 bar 로 변신하지 않음) Sidebar 도, 폭이 600px 미만이면 값이 존재합니다.** 반대로 데스크탑 폭에서는 Sidebar 가 떠 있어도 정의되지 않습니다.
+
+`--bt-bottom-inset` 같은 "실제로 가려진 높이" 대응 변수가 Sidebar 쪽에는 없으므로, 데스크탑에서 미정의인 것에 대비해 폴백을 두세요.
+
+```css
+padding-bottom: var(--bt-sidebar-total-height, 0px);
 ```
 
 #### 번들에 따라 변수 집합이 다릅니다
@@ -251,7 +263,8 @@ scripts/check-css-vars.sh
 | 토큰 (SCSS) | CSS 변수 | 값 |
 |---|---|---|
 | `token.$focus_ring` | `--bt-focus-ring` | 포커스 링 box-shadow (light/dark 각각 대비 확보) |
-| `token.$focus_ring_error` / `_success` | `--bt-focus-ring-error` / `-success` | 상태별 포커스 링 |
+| `token.$focus_ring_error` | `--bt-focus-ring-error` | 에러 상태 포커스 링 |
+| `token.$focus_ring_success` | `--bt-focus-ring-success` | 성공 상태 포커스 링 |
 | `token.$tap_target_dense` | — | 32px (데스크탑 인라인 폼) |
 | `token.$tap_target_compact` | — | 40px (데스크탑 기본) |
 | `token.$tap_target_comfortable` | — | 48px (모바일/터치 기본) |

--- a/scripts/check-css-vars.sh
+++ b/scripts/check-css-vars.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# 문서에 적힌 --bt-* CSS 변수가 실제 빌드 산출물에 있는지 대조한다.
+#
+# 배경: 컴포넌트가 내보내는 CSS 변수 목록은 손으로 관리하면 반드시 낡는다.
+# React 번들(dist/index.css)과 Vanilla 번들(dist/vanilla/bigtablet.min.css)이
+# 서로 다른 변수 집합을 갖기 때문에 둘 다 대조해야 한다.
+#
+# 사용: pnpm build && scripts/check-css-vars.sh
+set -eu
+
+REACT_CSS="dist/index.css"
+VANILLA_CSS="dist/vanilla/bigtablet.min.css"
+
+for f in "$REACT_CSS" "$VANILLA_CSS"; do
+	[ -f "$f" ] || { echo "빌드 산출물이 없습니다: $f — 'pnpm build' 를 먼저 실행하세요." >&2; exit 1; }
+done
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# 이름이 잘린 조각(`--bt-`, `--bt-color-` 같은 접두사 표기)은 대조 대상이 아니다.
+grep -rho -- '--bt-[a-z0-9-]*' docs/*.md | grep -v -- '-$' | sort -u > "$tmp/documented"
+cat "$REACT_CSS" "$VANILLA_CSS" | grep -o -- '--bt-[a-z0-9-]*' | sort -u > "$tmp/built"
+
+missing=$(comm -23 "$tmp/documented" "$tmp/built")
+
+if [ -n "$missing" ]; then
+	echo "문서에 있으나 어느 번들에도 없는 CSS 변수:"
+	echo "$missing" | sed 's/^/  /'
+	exit 1
+fi
+
+echo "문서의 CSS 변수 $(wc -l < "$tmp/documented" | tr -d ' ')개 - 모두 빌드 산출물에 존재합니다."

--- a/scripts/check-css-vars.sh
+++ b/scripts/check-css-vars.sh
@@ -18,9 +18,16 @@ done
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
+# 루트 README 도 같은 변수 목록을 싣고 있어 함께 본다 - 한쪽만 갱신하면 문서끼리 갈린다.
+#
 # 이름이 잘린 조각(`--bt-`, `--bt-color-` 같은 접두사 표기)은 대조 대상이 아니다.
-grep -rho -- '--bt-[a-z0-9-]*' docs/*.md | grep -v -- '-$' | sort -u > "$tmp/documented"
-cat "$REACT_CSS" "$VANILLA_CSS" | grep -o -- '--bt-[a-z0-9-]*' | sort -u > "$tmp/built"
+# 반대로 `--bt-focus-ring-error` / `-success` 같은 축약 표기의 뒷부분은 `--bt-` 로 시작하지
+# 않아 여기 걸리지 않는다. 문서에서는 풀네임으로 적어야 검증 대상이 된다.
+#
+# comm 은 두 입력이 같은 바이트 순서라고 가정하므로 로케일을 C 로 고정한다.
+grep -rho -- '--bt-[a-z0-9-]*' docs/*.md README.md README_KR.md \
+	| grep -v -- '-$' | LC_ALL=C sort -u > "$tmp/documented"
+cat "$REACT_CSS" "$VANILLA_CSS" | grep -o -- '--bt-[a-z0-9-]*' | LC_ALL=C sort -u > "$tmp/built"
 
 missing=$(comm -23 "$tmp/documented" "$tmp/built")
 


### PR DESCRIPTION
## 작업한 내용
- [x] `THEMING.md` — 레이아웃·런타임 계약 변수 표 추가 (정의 주체 / 기본값 / 언제 바뀌나)
- [x] `--bt-bottom-nav-*` 는 항상 정의됨 → 그대로 더하면 BottomNav 없는 페이지도 밀림. `--bt-bottom-inset` 을 쓰라는 ✅/❌ 예시
- [x] `--bt-sidebar-*` 3개 신규 문서화 — **`compact`(<600px)에서만 정의**되므로 폴백 필요
- [x] spacing · radius · typography CSS 변수는 Vanilla 번들 전용임을 명시
- [x] `THEMING.md` — 컴포넌트 마운트 수명 절 추가. 퇴출 스프링까지 DOM 에 남는 컴포넌트 8개(`Modal` `Drawer` `Popover` `Tooltip` `Alert` `Toast` `Menu` `Dropdown`) + children 을 열림 상태에 묶는 실수와 `onExited` 해법
- [x] `THEMING.md` — 접근성 토큰 표(`$focus_ring` · `$tap_target_*`) + `outline: 2px solid #000` 안티패턴 명시
- [x] `COMPONENTS.md` — Sidebar 섹션에 CSS 변수 절 추가
- [x] `AGENT_GUIDE.md` — 변수 열거에서 빠져 있던 `--bt-scrollbar-width` · `--bt-bottom-inset` 보강 + THEMING 링크
- [x] `scripts/check-css-vars.sh` — 문서의 `--bt-*` 를 React·Vanilla 두 번들과 대조

## 검증
- 빌드 산출물에서 변수 목록을 추출해 문서와 대조. 현재 **문서의 CSS 변수 77개 전부 존재**
- 스크립트 실효성 확인 — 없는 변수명을 문서에 넣으면 exit 1 로 해당 이름 출력
- `--bt-sidebar-*` 3개는 이슈에 없던 항목으로, 이 추출 과정에서 발견

## 전달할 추가 이슈
- **문서 부패는 없었습니다.** 첫 대조에서 React 번들에 없는 변수가 ~40개 나왔는데 전부 Vanilla 번들의 실제 변수였습니다(`--bt-color-primary`, `--bt-radius-lg` 등). 한쪽 번들만 대조하면 오탐 40건이 납니다 — 스크립트를 두 번들 모두 보도록 짠 이유입니다
- **스크립트는 CI 에 연결하지 않았습니다.** 워크플로 변경은 별도 승인 대상이라 수동 절차로만 뒀습니다. 붙이려면 `ci.yml` test job 에 한 줄(단, `pnpm build` 선행)
- **`--bt-sidebar-*` 가 compact 에서만 정의되는 게 의도된 설계인지 확인 필요.** 코드 주석은 "desktop 에선 fixed bottom 이 아니라 padding 불필요" 라고 하는데, 소비자에겐 "있다가 없어지는 변수" 라 폴백을 강제합니다. `--bt-bottom-inset` 처럼 항상 정의되고 값만 0 이 되는 편이 다루기 쉽습니다
- 이슈 3번 항목(`TextField` 의 `text_field_action` 슬롯)은 v3.11.0 때 `COMPONENTS.md` 에 이미 반영됨
- 문서·스크립트만 바뀌므로 버전 범프 대상 아님

Closes #482
