### PR TITLE
feat/prose

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -3229,6 +3229,45 @@ const [open, setOpen] = useState<string[]>(initialFromUrl);
 
 ---
 
+### Prose
+
+마크다운 등으로 렌더된 본문에 조판을 입힌다. **파서를 포함하지 않는다** — 앱이 `react-markdown` 같은 렌더러로 만든 결과를 감싸면 자손 셀렉터로 토큰 기반 타이포·간격·색이 적용된다(다크 모드 자동).
+
+```tsx
+import { Prose } from '@bigtablet/design-system';
+import ReactMarkdown from 'react-markdown';
+
+<Prose size="lg">
+  <ReactMarkdown>{policy}</ReactMarkdown>
+</Prose>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `'md' \| 'lg'` | `'md'` | 본문 스케일 |
+| `...rest` | `HTMLAttributes<HTMLDivElement>` | - | 루트 `div` 로 전달 |
+
+#### `size` 선택
+
+| | h1 / h2 / h3 | 제목 위 여백 | 쓰는 곳 |
+|---|---|---|---|
+| `md` (기본) | 24 / 20 / 18 | 20px | 공지 · FAQ · 이메일 프리뷰처럼 좁은 폭 |
+| `lg` | 28 / 24 / 20 | 32px | 약관 · 정책처럼 페이지를 채우는 긴 본문 |
+
+#### 다루는 요소
+
+`h1`~`h6` · `p` · `ul`/`ol`/`li`(중첩 포함) · `a` · `code` · `pre` · `blockquote`(중첩 포함) · `table`/`th`/`td` · `hr` · `img` · `strong` · `em` · `del`.
+
+#### 넓은 표·코드 블록
+
+`table` 과 `pre` 는 페이지를 가로로 밀지 않고 **자기 안에서 스크롤**된다. 스크롤이 실제로 생기는 경우에만 `tabindex="0"` 이 붙어 키보드로도 움직일 수 있다(axe `scrollable-region-focusable`). 폭이 넉넉해져 스크롤이 사라지면 떨어진다 — 불필요한 탭 정지가 남지 않는다.
+
+#### 본문 속 링크는 밑줄이 유지된다
+
+색만으로 구분하면 주변 텍스트와의 대비가 3:1 에 못 미쳐 WCAG 1.4.1(Use of Color) 위반이다. `text-decoration: none` 으로 덮어쓰지 말 것.
+
+---
+
 ### Table
 
 컬럼 정의 기반 데이터 테이블. 로딩 중에는 헤더를 유지한 채 바디만 [Skeleton](#skeleton) 행으로 대체하고, 정렬·행 선택·행 클릭을 지원한다.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -3245,6 +3245,7 @@ import ReactMarkdown from 'react-markdown';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `size` | `'md' \| 'lg'` | `'md'` | 본문 스케일 |
+| `ref` | `Ref<HTMLDivElement>` | - | 루트 `div` ref (React 19 ref-as-prop) |
 | `...rest` | `HTMLAttributes<HTMLDivElement>` | - | 루트 `div` 로 전달 |
 
 #### `size` 선택
@@ -3264,7 +3265,7 @@ import ReactMarkdown from 'react-markdown';
 
 #### 본문 속 링크는 밑줄이 유지된다
 
-색만으로 구분하면 주변 텍스트와의 대비가 3:1 에 못 미쳐 WCAG 1.4.1(Use of Color) 위반이다. `text-decoration: none` 으로 덮어쓰지 말 것.
+WCAG 1.4.1(Use of Color)상 색만으로 구분하는 것도 **링크와 주변 본문의 대비가 3:1 이상이면** 허용되지만, DS 의 accent 색은 그 문턱을 넘지 못해 axe 가 `link-in-text-block` 으로 잡습니다. 밑줄은 색 대비와 무관하게 성립하므로 `text-decoration: none` 으로 덮어쓰지 마세요.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,8 @@ export type {
 	MediaCardShadow,
 } from "./ui/display/media-card";
 export { MediaCard } from "./ui/display/media-card";
+export type { ProseProps, ProseSize } from "./ui/display/prose";
+export { Prose } from "./ui/display/prose";
 export type {
 	TableColumn,
 	TableProps,

--- a/src/ui/display/prose/Prose.test.tsx
+++ b/src/ui/display/prose/Prose.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Prose } from "./index";
 
@@ -35,6 +36,13 @@ describe("Prose", () => {
 		);
 		expect(container.firstChild).toHaveAttribute("data-testid", "p");
 		expect(container.firstChild).toHaveAttribute("aria-label", "정책");
+	});
+
+	// 내부에서 측정용 ref 를 쓰면서도 소비자 ref 가 살아 있어야 한다(React 19 ref-as-prop).
+	it("forwards a consumer ref to the root element", () => {
+		const ref = createRef<HTMLDivElement>();
+		const { container } = render(<Prose ref={ref}>x</Prose>);
+		expect(ref.current).toBe(container.firstChild);
 	});
 
 	// ── 스크롤 컨테이너 키보드 접근 ────────────────────────────────────────
@@ -86,16 +94,21 @@ describe("Prose", () => {
 		const original = globalThis.ResizeObserver;
 		// @ts-expect-error - 미지원 환경 재현
 		globalThis.ResizeObserver = undefined;
-		stubMetrics(500, 200);
-		const { container } = render(
-			<Prose>
-				<pre>
-					<code>long</code>
-				</pre>
-			</Prose>,
-		);
-		expect(container.querySelector("pre")).toHaveAttribute("tabindex", "0");
-		globalThis.ResizeObserver = original;
+		// render 나 단언이 실패해도 전역을 되돌려야 뒤 테스트가 미지원 환경을 물려받지 않는다.
+		// vi.restoreAllMocks 는 직접 대입한 전역은 복원하지 않는다.
+		try {
+			stubMetrics(500, 200);
+			const { container } = render(
+				<Prose>
+					<pre>
+						<code>long</code>
+					</pre>
+				</Prose>,
+			);
+			expect(container.querySelector("pre")).toHaveAttribute("tabindex", "0");
+		} finally {
+			globalThis.ResizeObserver = original;
+		}
 	});
 
 	// 조판만 담당한다 - 파서를 물지 않는다는 계약. children 을 그대로 통과시켜야

--- a/src/ui/display/prose/Prose.test.tsx
+++ b/src/ui/display/prose/Prose.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Prose } from "./index";
+
+describe("Prose", () => {
+	it("renders children", () => {
+		render(
+			<Prose>
+				<p>본문</p>
+			</Prose>,
+		);
+		expect(screen.getByText("본문")).toBeInTheDocument();
+	});
+
+	it("defaults to the md scale", () => {
+		const { container } = render(<Prose>x</Prose>);
+		expect(container.firstChild).toHaveClass("prose", "prose_size_md");
+	});
+
+	it("applies the lg scale", () => {
+		const { container } = render(<Prose size="lg">x</Prose>);
+		expect(container.firstChild).toHaveClass("prose_size_lg");
+	});
+
+	it("merges a consumer className instead of replacing it", () => {
+		const { container } = render(<Prose className="custom">x</Prose>);
+		expect(container.firstChild).toHaveClass("prose", "custom");
+	});
+
+	it("forwards rest props", () => {
+		const { container } = render(
+			<Prose data-testid="p" aria-label="정책">
+				x
+			</Prose>,
+		);
+		expect(container.firstChild).toHaveAttribute("data-testid", "p");
+		expect(container.firstChild).toHaveAttribute("aria-label", "정책");
+	});
+
+	// ── 스크롤 컨테이너 키보드 접근 ────────────────────────────────────────
+	// jsdom 은 레이아웃이 없어 scrollWidth/clientWidth 가 항상 0 이므로 프로토타입에서 대신 잰다.
+	const stubMetrics = (scroll: number, client: number) => {
+		vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(scroll);
+		vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(client);
+	};
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("makes an overflowing pre and table keyboard-reachable", () => {
+		stubMetrics(500, 200);
+		const { container } = render(
+			<Prose>
+				<pre>
+					<code>long</code>
+				</pre>
+				<table>
+					<tbody>
+						<tr>
+							<td>wide</td>
+						</tr>
+					</tbody>
+				</table>
+			</Prose>,
+		);
+		expect(container.querySelector("pre")).toHaveAttribute("tabindex", "0");
+		expect(container.querySelector("table")).toHaveAttribute("tabindex", "0");
+	});
+
+	it("leaves a non-overflowing pre out of the tab order", () => {
+		stubMetrics(200, 200);
+		const { container } = render(
+			<Prose>
+				<pre>
+					<code>short</code>
+				</pre>
+			</Prose>,
+		);
+		expect(container.querySelector("pre")).not.toHaveAttribute("tabindex");
+	});
+
+	// ResizeObserver 가 없는 환경(구형/SSR 후 하이드레이션 전 등)에서도 최초 동기화는 돌아야
+	// 한다 - 건너뛰면 넘치는 코드 블록에 탭 정지가 아예 붙지 않는다.
+	it("still marks overflow when ResizeObserver is unavailable", () => {
+		const original = globalThis.ResizeObserver;
+		// @ts-expect-error - 미지원 환경 재현
+		globalThis.ResizeObserver = undefined;
+		stubMetrics(500, 200);
+		const { container } = render(
+			<Prose>
+				<pre>
+					<code>long</code>
+				</pre>
+			</Prose>,
+		);
+		expect(container.querySelector("pre")).toHaveAttribute("tabindex", "0");
+		globalThis.ResizeObserver = original;
+	});
+
+	// 조판만 담당한다 - 파서를 물지 않는다는 계약. children 을 그대로 통과시켜야
+	// 앱이 어떤 마크다운 렌더러를 쓰든 붙일 수 있다.
+	it("leaves the rendered markup untouched", () => {
+		const { container } = render(
+			<Prose>
+				<h2>제목</h2>
+				<pre>
+					<code>const a = 1;</code>
+				</pre>
+			</Prose>,
+		);
+		expect(container.querySelector(".prose > h2")).toBeInTheDocument();
+		expect(container.querySelector(".prose > pre > code")).toHaveTextContent("const a = 1;");
+	});
+});

--- a/src/ui/display/prose/index.tsx
+++ b/src/ui/display/prose/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "../../../utils";
+import { cn, useSafeLayoutEffect } from "../../../utils";
 import "./style.scss";
 
 export type ProseSize = "md" | "lg";
@@ -13,6 +13,8 @@ export interface ProseProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * - `lg`: 약관·정책처럼 페이지를 채우는 긴 본문 (h1 28 / h2 24 / h3 20, 제목 위 여백도 넓다)
 	 */
 	size?: ProseSize;
+	/** 루트 div 요소 ref (React 19 ref-as-prop) */
+	ref?: React.Ref<HTMLDivElement>;
 }
 
 /**
@@ -28,15 +30,19 @@ export interface ProseProps extends React.HTMLAttributes<HTMLDivElement> {
  * </Prose>
  * ```
  */
-export const Prose = ({ size = "md", className, children, ...props }: ProseProps) => {
+export const Prose = ({ size = "md", className, children, ref, ...props }: ProseProps) => {
+	// 오버플로 측정을 위해 내부 ref 가 필요하므로, 소비자 ref 와 병합해 둘 다 성립하게 한다.
 	const rootRef = React.useRef<HTMLDivElement>(null);
+	React.useImperativeHandle(ref, () => rootRef.current as HTMLDivElement, []);
 
 	// 넓은 표·코드 블록은 자기 안에서 가로 스크롤된다(아래 SCSS). 스크롤 영역은 키보드로도
 	// 움직일 수 있어야 하는데(axe `scrollable-region-focusable`), 그 요소를 만드는 건 소비자다.
 	// 스크롤 컨테이너로 만든 쪽이 DS 이므로 결과도 DS 가 책임진다 - 실제로 넘칠 때만 탭 정지를
 	// 추가하고, 넘치지 않으면 떼어 불필요한 정지가 남지 않게 한다.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: children 은 effect 안에서 쓰지 않지만 내용이 바뀌면 DOM 을 다시 조회해야 하므로 재실행 트리거로 둔다
-	React.useEffect(() => {
+	// 레이아웃 측정이라 paint 전에 끝나야 한다 - useEffect 로 미루면 이미 넘치는 표·코드가
+	// 한 프레임 동안 tabindex 없이 노출된다. tabs · nav-bar · textarea 와 같은 패턴.
+	// children 은 콜백 안에서 쓰지 않지만, 내용이 바뀌면 DOM 을 다시 조회해야 하므로 의존성에 둔다.
+	useSafeLayoutEffect(() => {
 		const root = rootRef.current;
 		if (!root) return;
 

--- a/src/ui/display/prose/index.tsx
+++ b/src/ui/display/prose/index.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "../../../utils";
+import "./style.scss";
+
+export type ProseSize = "md" | "lg";
+
+export interface ProseProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * 본문 스케일 (기본값: "md").
+	 * - `md`: 공지·FAQ·이메일 프리뷰처럼 좁은 폭에 들어가는 본문 (h1 24 / h2 20 / h3 18)
+	 * - `lg`: 약관·정책처럼 페이지를 채우는 긴 본문 (h1 28 / h2 24 / h3 20, 제목 위 여백도 넓다)
+	 */
+	size?: ProseSize;
+}
+
+/**
+ * 마크다운 등으로 렌더된 본문에 조판을 입힌다.
+ *
+ * **파서를 포함하지 않는다.** 앱이 `react-markdown` 등으로 만든 결과를 감싸면
+ * 자손 셀렉터로 토큰 기반 타이포·간격·색이 적용된다(다크 모드 자동).
+ *
+ * @example
+ * ```tsx
+ * <Prose size="lg">
+ *   <ReactMarkdown>{policy}</ReactMarkdown>
+ * </Prose>
+ * ```
+ */
+export const Prose = ({ size = "md", className, children, ...props }: ProseProps) => {
+	const rootRef = React.useRef<HTMLDivElement>(null);
+
+	// 넓은 표·코드 블록은 자기 안에서 가로 스크롤된다(아래 SCSS). 스크롤 영역은 키보드로도
+	// 움직일 수 있어야 하는데(axe `scrollable-region-focusable`), 그 요소를 만드는 건 소비자다.
+	// 스크롤 컨테이너로 만든 쪽이 DS 이므로 결과도 DS 가 책임진다 - 실제로 넘칠 때만 탭 정지를
+	// 추가하고, 넘치지 않으면 떼어 불필요한 정지가 남지 않게 한다.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: children 은 effect 안에서 쓰지 않지만 내용이 바뀌면 DOM 을 다시 조회해야 하므로 재실행 트리거로 둔다
+	React.useEffect(() => {
+		const root = rootRef.current;
+		if (!root) return;
+
+		const targets = Array.from(root.querySelectorAll<HTMLElement>("pre, table"));
+		const sync = () => {
+			for (const el of targets) {
+				if (el.scrollWidth > el.clientWidth) el.setAttribute("tabindex", "0");
+				else el.removeAttribute("tabindex");
+			}
+		};
+
+		// 최초 동기화는 ResizeObserver 유무와 무관하게 한다 - 없다고 건너뛰면 그 환경에서는
+		// 넘치는 표·코드에 탭 정지가 아예 붙지 않는다. 관찰은 폭이 바뀔 때 따라가기 위한 것뿐이다.
+		sync();
+		if (typeof ResizeObserver === "undefined") return;
+
+		const observer = new ResizeObserver(sync);
+		observer.observe(root);
+		for (const el of targets) observer.observe(el);
+		return () => observer.disconnect();
+	}, [children]);
+
+	return (
+		<div ref={rootRef} className={cn("prose", `prose_size_${size}`, className)} {...props}>
+			{children}
+		</div>
+	);
+};
+
+Prose.displayName = "Prose";

--- a/src/ui/display/prose/prose.stories.tsx
+++ b/src/ui/display/prose/prose.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Prose } from ".";
+
+const meta: Meta<typeof Prose> = {
+	title: "Components/Display/Prose",
+	component: Prose,
+	parameters: {
+		layout: "padded",
+		docs: {
+			description: {
+				component: `
+**Prose** - 마크다운 등으로 렌더된 본문에 조판을 입힌다. **파서를 포함하지 않는다** — 앱이 \`react-markdown\` 등으로 만든 결과를 감싸면 자손 셀렉터로 토큰 기반 타이포·간격·색이 적용된다(다크 모드 자동).
+
+\`size\`: \`md\` (기본, 공지·FAQ·이메일 프리뷰처럼 좁은 폭) / \`lg\` (약관·정책처럼 페이지를 채우는 긴 본문).
+
+표와 코드 블록은 자기 안에서 가로 스크롤되어 페이지를 밀지 않는다.
+				`,
+			},
+		},
+	},
+	argTypes: {
+		size: { control: "radio", options: ["md", "lg"], description: "본문 스케일" },
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Prose>;
+
+const Body = () => (
+	<>
+		<h1>이용약관</h1>
+		<p>
+			본 약관은 서비스 이용에 관한 조건을 정합니다. 인라인 <code>code</code> 와{" "}
+			<a href="#anchor">링크</a>, <strong>강조</strong>, <em>기울임</em>, <del>취소선</del> 을
+			포함합니다.
+		</p>
+		<h2>제1조 (목적)</h2>
+		<p>이 절은 목적을 설명합니다.</p>
+		<ul>
+			<li>
+				첫 항목
+				<ul>
+					<li>중첩 항목</li>
+				</ul>
+			</li>
+			<li>둘째 항목</li>
+		</ul>
+		<h3>제1항</h3>
+		<blockquote>
+			<p>인용문입니다.</p>
+			<blockquote>
+				<p>중첩 인용은 테두리를 겹치지 않습니다.</p>
+			</blockquote>
+		</blockquote>
+		<pre>
+			<code>{`const veryLongLine = "코드 블록은 페이지를 밀지 않고 자기 안에서 가로 스크롤됩니다 ----------------";`}</code>
+		</pre>
+		<h4>표</h4>
+		<table>
+			<thead>
+				<tr>
+					<th>항목</th>
+					<th>설명</th>
+					<th>비고가 아주 긴 열 제목입니다</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>A</td>
+					<td>내용</td>
+					<td>넓은 표도 자기 안에서 스크롤됩니다</td>
+				</tr>
+			</tbody>
+		</table>
+		<hr />
+		<p>마지막 문단.</p>
+	</>
+);
+
+export const Medium: Story = {
+	name: "md (공지·FAQ)",
+	args: { size: "md" },
+	render: (args) => (
+		<Prose {...args}>
+			<Body />
+		</Prose>
+	),
+};
+
+export const Large: Story = {
+	name: "lg (약관·정책)",
+	args: { size: "lg" },
+	render: (args) => (
+		<Prose {...args}>
+			<Body />
+		</Prose>
+	),
+};
+
+export const NarrowContainer: Story = {
+	name: "좁은 컨테이너 (오버플로 확인)",
+	parameters: {
+		docs: {
+			description: {
+				story: "320px 폭에서도 표와 코드 블록이 컨테이너를 밀지 않고 각자 가로 스크롤됩니다.",
+			},
+		},
+	},
+	render: () => (
+		<div style={{ width: 320, border: "1px dashed var(--bt-color-border-default)" }}>
+			<Prose>
+				<Body />
+			</Prose>
+		</div>
+	),
+};

--- a/src/ui/display/prose/style.scss
+++ b/src/ui/display/prose/style.scss
@@ -85,6 +85,8 @@
     background: token.$color_bg_solid_dim;
     color: token.$color_text_heading;
     border-radius: token.$radius_xs;
+    // em 단위 유지 - spacing 토큰은 px 라, 부모 글자 크기가 다른 자리(제목 안의 인라인 코드 등)
+    // 에서 여백 비율이 깨진다. 글자 크기에 따라가야 하는 값이다.
     padding: 0.2em 0.45em;
   }
 
@@ -106,8 +108,10 @@
   // ── 인용 ────────────────────────────────────────────────────────────────
 
   blockquote {
+    // border-width 토큰은 0/1/2px 뿐이라 4px 에 대응하는 값이 없다. 인용 표시줄은 1~2px 로는
+    // 눈에 안 띄어 앱 구현들도 4px 을 썼다 - 토큰을 추가할지는 별도 판단이 필요하다.
     border-left: 4px solid token.$color_accent_default;
-    background: color-mix(in srgb, token.$color_accent_default 5%, transparent);
+    background: color-mix(in srgb, token.$color_accent_default #{token.$opacity_5 * 100%}, transparent);
     border-radius: 0 token.$radius_sm token.$radius_sm 0;
     padding: token.$spacing_8 token.$spacing_12;
     color: token.$color_text_body;
@@ -129,8 +133,9 @@
 
   a {
     color: token.$color_accent_default;
-    // 본문 속 링크는 밑줄을 유지한다. 색만으로 구분하면 주변 텍스트와의 대비가 3:1 에 못 미쳐
-    // WCAG 1.4.1(Use of Color) 위반이고 axe 가 `link-in-text-block` 으로 잡는다.
+    // 본문 속 링크는 밑줄을 유지한다. WCAG 1.4.1(Use of Color)상 색만으로 구분하는 것도
+    // 링크와 주변 본문의 대비가 3:1 이상이면 허용되지만, accent 는 그 문턱을 넘지 못해
+    // axe 가 `link-in-text-block` 으로 잡았다. 밑줄은 색 대비와 무관하게 성립하는 수단이다.
     text-decoration: underline;
     text-underline-offset: 0.15em;
 

--- a/src/ui/display/prose/style.scss
+++ b/src/ui/display/prose/style.scss
@@ -1,0 +1,215 @@
+@use "src/styles/token" as token;
+
+.prose {
+  font-family: token.$font_family_primary;
+  color: token.$color_text_heading;
+  @include token.body_medium;
+
+  // 블록 요소는 아래로만 분리한다 - 상단 margin 을 쓰면 형제끼리 상쇄(collapse) 규칙에
+  // 기대게 되어 첫 블록의 여백이 컨테이너 밖으로 새는 등 예측이 어려워진다.
+  p,
+  ul,
+  ol,
+  blockquote,
+  table,
+  pre {
+    margin: 0 0 token.$spacing_16;
+  }
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  // 소비처가 전역 `white-space: pre-line` 을 쓰는 경우, 마크다운 렌더러가 블록 사이에 넣는
+  // 개행 텍스트 노드가 빈 줄로 보인다. 산문 블록은 normal 이 옳은 값이라 여기서 못박는다.
+  // `pre` · `code` 는 개행이 의미를 갖는 자리라 제외한다.
+  &,
+  p,
+  li,
+  blockquote,
+  h1, h2, h3, h4, h5, h6,
+  dl, dd, ul, ol {
+    white-space: normal;
+  }
+
+  // ── 제목 ────────────────────────────────────────────────────────────────
+
+  h1, h2, h3, h4, h5, h6 {
+    color: token.$color_text_heading;
+    margin: token.$spacing_20 0 token.$spacing_8;
+
+    // 첫 요소가 제목이면 위 여백이 컨테이너 상단에 붙어 정렬이 어긋난다.
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  h1 {
+    @include token.heading_medium;
+    padding-bottom: token.$spacing_8;
+    border-bottom: token.$border_width_standard solid token.$color_border_default;
+  }
+
+  h2 { @include token.heading_small; }
+  h3 { @include token.title_large_bold; }
+
+  h4, h5, h6 { @include token.title_medium_bold; }
+
+  // ── 목록 ────────────────────────────────────────────────────────────────
+
+  ul, ol {
+    // 전역 reset(`list-style: none`)을 쓰는 앱에서도 마커가 보이도록 명시한다.
+    padding-left: token.$spacing_24;
+  }
+
+  ul { list-style: disc; }
+  ol { list-style: decimal; }
+
+  li {
+    margin-bottom: token.$spacing_4;
+
+    // 마크다운 렌더러가 loose list 의 li 안에 p 를 넣는다 - 여백이 두 번 붙지 않게 한다.
+    > p {
+      margin-bottom: 0;
+    }
+
+    ul, ol {
+      margin: token.$spacing_4 0 0;
+    }
+  }
+
+  // ── 코드 ────────────────────────────────────────────────────────────────
+
+  code {
+    @include token.code;
+    background: token.$color_bg_solid_dim;
+    color: token.$color_text_heading;
+    border-radius: token.$radius_xs;
+    padding: 0.2em 0.45em;
+  }
+
+  pre {
+    background: token.$color_bg_inverse_surface;
+    border-radius: token.$radius_md;
+    padding: token.$spacing_20;
+    // 긴 코드 줄이 레이아웃을 밀지 않고 자기 안에서 스크롤된다.
+    overflow-x: auto;
+
+    code {
+      background: transparent;
+      color: token.$color_text_inverse;
+      padding: 0;
+      border-radius: 0;
+    }
+  }
+
+  // ── 인용 ────────────────────────────────────────────────────────────────
+
+  blockquote {
+    border-left: 4px solid token.$color_accent_default;
+    background: color-mix(in srgb, token.$color_accent_default 5%, transparent);
+    border-radius: 0 token.$radius_sm token.$radius_sm 0;
+    padding: token.$spacing_8 token.$spacing_12;
+    color: token.$color_text_body;
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+
+    // 중첩 인용까지 테두리·배경을 겹치면 층이 두꺼워져 읽기 어렵다.
+    blockquote {
+      border-left: none;
+      padding-left: 0;
+      background: transparent;
+      margin-bottom: 0;
+    }
+  }
+
+  // ── 인라인 ──────────────────────────────────────────────────────────────
+
+  a {
+    color: token.$color_accent_default;
+    // 본문 속 링크는 밑줄을 유지한다. 색만으로 구분하면 주변 텍스트와의 대비가 3:1 에 못 미쳐
+    // WCAG 1.4.1(Use of Color) 위반이고 axe 가 `link-in-text-block` 으로 잡는다.
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+
+    &:hover { text-decoration-thickness: 2px; }
+
+    &:focus-visible {
+      outline: none;
+      border-radius: token.$radius_xs;
+      box-shadow: token.$focus_ring;
+    }
+  }
+
+  strong { font-weight: token.$font_weight_semi_bold; }
+  em { font-style: italic; }
+
+  del {
+    text-decoration: line-through;
+    color: token.$color_text_caption;
+  }
+
+  hr {
+    border: none;
+    border-top: token.$border_width_thick solid token.$color_border_default;
+    margin: token.$spacing_24 0;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+    border-radius: token.$radius_sm;
+    display: block;
+    margin: token.$spacing_16 auto;
+  }
+
+  // ── 표 ──────────────────────────────────────────────────────────────────
+
+  // display: block 이라야 overflow-x 가 먹는다(table 은 overflow 를 무시한다).
+  // 넓은 표가 페이지를 가로로 밀지 않고 자기 안에서 스크롤된다.
+  table {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    border-collapse: collapse;
+  }
+
+  // 넘칠 때만 tabindex 가 붙는다(index.tsx). 포커스를 받으면 표시가 있어야 한다(WCAG 2.4.7).
+  pre[tabindex],
+  table[tabindex] {
+    &:focus-visible {
+      outline: none;
+      box-shadow: token.$focus_ring;
+    }
+  }
+
+  th, td {
+    padding: token.$spacing_4 token.$spacing_12;
+    border: token.$border_width_standard solid token.$color_border_default;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  th {
+    background: token.$color_bg_solid_dim;
+    font-weight: token.$font_weight_semi_bold;
+  }
+
+  // ── Size: lg (약관·정책 등 긴 본문) ──────────────────────────────────────
+  // 제목을 한 단계 키우고 위 여백을 넓혀, 스크롤이 긴 문서에서 절 경계가 눈에 띄게 한다.
+
+  &_size_lg {
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: token.$spacing_32;
+    }
+
+    h1 { font-size: token.$font_size_28; line-height: token.$line_height_36; }
+    h2 { font-size: token.$font_size_24; line-height: token.$line_height_32; }
+    h3 { font-size: token.$font_size_20; line-height: token.$line_height_28; }
+    h4, h5, h6 { font-size: token.$font_size_16; line-height: token.$line_height_24; }
+
+    li { margin-bottom: token.$spacing_8; }
+  }
+}


### PR DESCRIPTION
## 작업 개요

Closes #478 — 마크다운 본문 조판 컴포넌트 `Prose` 추가.

notiiv 에 같은 문제를 각자 푸는 SCSS 모듈이 셋 있습니다 — admin `markdown-view`(184행), support `markdown-renderer`(212행), support `policy/markdown`(206행). 다루는 셀렉터 집합이 사실상 동일합니다(제목·문단·목록·링크·code·pre·인용·표·hr·img). 그래서 FAQ·공지·정책의 본문 타이포가 서로 다르고 다크 모드도 각자 손질합니다.

스케일은 제가 정하지 않고 **세 파일이 이미 합의한 값**에서 가져왔습니다 — `md`(24/20/18/16)는 admin·FAQ 가 일치, `lg`(28/24/20/16 + 제목 위 여백 32)는 정책 문서. 가장 완성도 높고 토큰화가 된 admin 판을 베이스로 썼습니다.

## 작업한 내용

- [x] `src/ui/display/prose/` — 컴포넌트 + SCSS + 스토리 3개 + 테스트 9건, `src/index.ts` export
- [x] `size` 2단계 (`md` 기본 / `lg`) — 이슈 요구사항
- [x] 파서 비의존 — 앱이 쓰는 렌더러를 그대로 두고 조판만 입힘
- [x] 표·코드 블록 오버플로 — 페이지를 밀지 않고 자기 안에서 가로 스크롤
- [x] `docs/COMPONENTS.md` — prop 표, `size` 선택 기준, 다루는 요소, 오버플로·링크 계약

### 브라우저 검증 중 접근성 결함 2건 발견 (둘 다 앱 CSS 에서 넘어온 결정)

**`scrollable-region-focusable`(serious)** — `table`·`pre` 에 `overflow-x: auto` 를 주면 스크롤 컨테이너가 되는데 키보드로 스크롤할 수 없습니다. 그 요소를 만드는 건 소비자지만 **스크롤 컨테이너로 만든 쪽은 DS** 이므로 DS 가 책임집니다. 실제로 넘칠 때만 `tabindex="0"` 을 붙이고 넘치지 않게 되면 뗍니다(불필요한 탭 정지 방지) + focus ring.

**`link-in-text-block`(serious)** — 앱에서 그대로 가져온 `text-decoration: none` 때문에 링크가 색으로만 구분되어 WCAG 1.4.1 위반이었습니다. 본문 링크는 밑줄을 유지하고 hover 에서 굵어지도록 바꿨습니다.

### 테스트를 쓰다가 세 번째 결함 발견

`ResizeObserver` 가 없는 환경에서 effect 가 조기 return 해 **최초 동기화까지 건너뛰었습니다** — 그 환경에선 넘치는 코드 블록에 탭 정지가 아예 안 붙습니다. 최초 sync 는 무조건 실행하고 관찰만 조건부로 바꿨습니다.

## 검증

- 886 passed, `tsc --noEmit` · `lint:css` · biome clean
- 뮤테이션 — 넘침 판정을 무시하면 1건 실패, `ResizeObserver` 조기 return 을 되돌리면 2건 실패
- 브라우저 320px: 페이지 가로 스크롤 없음, 표·`pre` 각자 스크롤, `tabindex="0"` 부착 확인
- axe 4.13 라이트·다크 **violation 0** (수정 전 2건)
- size-limit 여유 — `index.js` 51.05/60 kB, `index.css` 13.1/130 kB

## 전달할 추가 이슈

- **다크 모드 첫 검사의 `color-contrast` 3건은 하네스 artifact 였습니다.** Storybook 캔버스 배경이 흰색인데 텍스트만 다크 토큰이라 대비가 잘못 계산됐습니다. `.prose` 에 실제 다크 표면을 깔면 사라집니다 — 실제 결함이 아닙니다
- **resize 경로는 브라우저에서 검증하지 못했습니다.** preview 탭이 `visibilityState: hidden` 이라 `ResizeObserver` 콜백이 전달되지 않습니다(스프링 애니메이션이 얼었던 것과 같은 원인 — 대조용 probe observer 도 0회 발화). 해당 경로는 단위 테스트가 담당합니다
- **`email-preview.module.scss` 는 마이그레이션 대상이 아닙니다.** 이슈가 "하드코딩 색상 39건" 으로 지목했지만(실측 12건) HTML 이메일은 CSS 변수를 지원하지 않아 하드코딩이 필수입니다. Prose 로 바꾸면 이메일에서 스타일이 통째로 빠집니다
- 앱 마이그레이션(admin 1곳 + support 2곳)은 DS 배포 후 notiiv 쪽 PR 로 진행하면 됩니다
- 새 export 추가이므로 릴리즈는 **minor** 대상입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마크다운 등으로 렌더링된 본문에 일관된 타이포그래피와 간격을 적용하는 `Prose` 컴포넌트를 추가했습니다.
  * 중간(`md`) 및 큰(`lg`) 본문 크기를 지원합니다.
  * 코드 블록과 넓은 표는 내부 가로 스크롤을 제공하며, 필요할 때 키보드로 접근할 수 있습니다.
  * 제목, 목록, 링크, 인용문, 이미지, 표 등 다양한 본문 요소의 스타일을 지원합니다.

* **문서**
  * `Prose` 사용법, 크기 옵션 및 접근성 동작을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->