### PR TITLE
feat/token-discoverability

### DIFF
--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -15,6 +15,7 @@ Bigtablet Design System의 라이트/다크 테마 시스템 가이드입니다.
   - [CSS 변수 직접 사용](#css-변수-직접-사용)
   - [레이아웃·런타임 계약 변수](#레이아웃런타임-계약-변수)
   - [접근성 토큰 — 하드코딩하지 마세요](#접근성-토큰--하드코딩하지-마세요)
+  - [하드코딩 대신 쓸 토큰](#하드코딩-대신-쓸-토큰)
 - [컴포넌트 마운트 수명](#컴포넌트-마운트-수명)
 - [오버레이 스크롤 잠금과 `--bt-scrollbar-width`](#오버레이-스크롤-잠금과---bt-scrollbar-width)
 - [자동완성(autofill) 입력칸](#자동완성autofill-입력칸)
@@ -279,6 +280,53 @@ scripts/check-css-vars.sh
 ```
 
 Storybook 의 `foundation/a11y` 페이지에서 실제 렌더를 확인할 수 있습니다.
+
+### 하드코딩 대신 쓸 토큰
+
+소비 앱 SCSS 를 실측한 결과, 토큰이 이미 있는데도 값을 직접 쓴 곳이 많았습니다. 대부분 **토큰의 존재를 몰라서**입니다.
+
+| 하드코딩 | 실측 건수 | 대신 쓸 것 |
+|---|---|---|
+| `1px` 경계선 | 232 | `@include token.hairline;` (아래) |
+| `font-size: 13px` | 29 | `@include token.label_medium;` (또는 `_medium` / `_bold` 변형) |
+| hex 색상 | 55 | `token.$color_*` — 목업 일러스트를 제외하면 대부분 위반 |
+| `2px` / `6px` 간격 | 61 / 28 | `token.$spacing_2` / `token.$spacing_6` |
+
+#### `hairline` — 1px 경계선
+
+`border: token.$border_width_standard solid token.$color_border_default` 는 `border: 1px solid #E5E5E5` 보다 길어서 실제로 쓰이지 않았습니다. 짧게 쓸 수 있어야 토큰이 채택됩니다.
+
+```scss
+.card   { @include token.hairline; }                            // 사방
+.header { @include token.hairline(bottom); }                    // 한 면
+.active { @include token.hairline(left, token.$color_border_hover); }
+```
+
+두 번째 인자로 색을 바꿀 수 있고, 기본값은 `$color_border_default` 입니다. 두께가 2px 이어야 하는 자리(포커스·선택 인디케이터)는 `token.$border_width_indicator` 를 직접 쓰세요.
+
+#### 타이포는 크기가 아니라 역할로
+
+`font-size` 를 직접 쓰지 말고 semantic mixin 을 쓰면 굵기·행간·자간이 함께 따라옵니다.
+
+| 크기 | mixin |
+|---|---|
+| 28px | `heading_large` · `heading_large_bold` |
+| 24px | `heading_medium` · `heading_medium_bold` |
+| 20px | `heading_small` · `heading_small_bold` |
+| 18px | `title_large` · `title_large_bold` |
+| 16px | `body_large` · `title_medium_bold` |
+| 15px | `body_medium` |
+| 14px | `body_small` · `label_large` |
+| **13px** | **`label_medium`** · `label_medium_medium` · `label_medium_bold` |
+| 12px | `label_small` |
+
+`@include token.code` 는 13px 고정폭 조합입니다.
+
+#### 스켈레톤
+
+`Skeleton` 의 높이도 토큰입니다 — `token.$skeleton_height_xs`(4px) · `_sm`(8) · `_md`(12) · `_lg`(16) · `_xl`(20). 반경은 `$skeleton_radius_sm/md/lg`.
+
+> 스케일이 20px 에서 끝나므로 그보다 큰 블록(카드·썸네일 자리)은 스켈레톤 높이 토큰이 아니라 해당 요소의 실제 크기를 쓰세요.
 
 ---
 

--- a/src/styles/border-width/_index.scss
+++ b/src/styles/border-width/_index.scss
@@ -10,3 +10,26 @@ $border_width_none:      $border_width_0;
 $border_width_standard:  $border_width_1;
 $border_width_thick:     $border_width_2;
 $border_width_indicator: $border_width_2;
+
+// ── Hairline mixin ───────────────────────────────────────────────────────────
+//
+// 1px 경계선용 단축. `border: $border_width_standard solid $color_border_default` 는
+// `border: 1px solid #E5E5E5` 보다 길어서, 실측상 소비 앱 SCSS 에 `1px` 하드코딩이
+// 232 건 남아 있었다. 짧게 쓸 수 있어야 실제로 토큰을 쓴다.
+//
+// @example
+// ```scss
+// .card   { @include token.hairline; }              // 사방
+// .header { @include token.hairline(bottom); }      // 한 면
+// .active { @include token.hairline(left, token.$color_border_hover); }
+// ```
+
+@use "../colors" as colors;
+
+@mixin hairline($side: all, $color: colors.$color_border_default) {
+  @if $side == all {
+    border: $border_width_standard solid $color;
+  } @else {
+    border-#{$side}: $border_width_standard solid $color;
+  }
+}

--- a/src/styles/border-width/_index.scss
+++ b/src/styles/border-width/_index.scss
@@ -1,3 +1,6 @@
+@use "sass:list";
+@use "../colors" as colors;
+
 // ── Base border-width ────────────────────────────────────────────────────────
 
 $border_width_0: 0px;
@@ -24,12 +27,15 @@ $border_width_indicator: $border_width_2;
 // .active { @include token.hairline(left, token.$color_border_hover); }
 // ```
 
-@use "../colors" as colors;
 
 @mixin hairline($side: all, $color: colors.$color_border_default) {
   @if $side == all {
     border: $border_width_standard solid $color;
-  } @else {
+  } @else if list.index(top right bottom left, $side) {
     border-#{$side}: $border_width_standard solid $color;
+  } @else {
+    // 검증이 없으면 `hairline(letf)` 같은 오타가 컴파일을 통과해 `border-letf` 라는
+    // 무효 속성을 조용히 만든다. 소비 앱에 권장하는 공개 API 라 여기서 끊는다.
+    @error "token.hairline: $side 는 all · top · right · bottom · left 중 하나여야 합니다 (받은 값: #{$side})";
   }
 }

--- a/src/ui/display/card/style.scss
+++ b/src/ui/display/card/style.scss
@@ -15,7 +15,7 @@
   }
 
   &_bordered {
-    border: 1px solid token.$color_border_default;
+    @include token.hairline;
   }
 
   &_shadow_none {

--- a/src/ui/general/button/style.scss
+++ b/src/ui/general/button/style.scss
@@ -125,7 +125,7 @@
 
   &_variant_outline {
     background: transparent;
-    border: 1px solid token.$color_border_default;
+    @include token.hairline;
     color: token.$color_text_heading;
 
     &:hover:not(:disabled)::before {

--- a/src/ui/general/icon-button/style.scss
+++ b/src/ui/general/icon-button/style.scss
@@ -119,7 +119,7 @@
 
   &_variant_outlined {
     background: transparent;
-    border: 1px solid token.$color_border_default;
+    @include token.hairline;
     color: token.$color_text_heading;
 
     &:hover:not(:disabled)::before {


### PR DESCRIPTION
## 작업 개요

이슈 #481 의 TODO 4개 중 3개 반영 — `hairline` mixin, 스켈레톤 토큰 문서화, 13px 타이포 매핑. 스페이싱 스케일에 28·36 추가 여부는 제품 결정이라 별도로 정리해 올립니다.

이슈 수치를 그대로 쓰지 않고 소비 앱 SCSS 133개를 다시 실측했고, 그 결과 두 항목의 진단이 바뀌었습니다.

## 작업한 내용

- [x] `token.hairline($side, $color)` mixin 추가 — 1px 경계선 단축
- [x] DS 자체의 하드코딩 `border: 1px solid` 3곳 교체 (Button outline · IconButton outlined · Card bordered)
- [x] `THEMING.md` — "하드코딩 대신 쓸 토큰" 절: 실측 건수 + 대체 토큰 표
- [x] 타이포 크기 → semantic mixin 매핑표 (28px ~ 12px 전 구간)
- [x] 스켈레톤 토큰(`$skeleton_height_*` · `$skeleton_radius_*`) 문서화 + 20px 상한 명시

### 실측으로 바뀐 진단 2건

**`13px` 29건은 전부 `font-size`** 이고, DS 에 **`label_medium` 이 이미 있습니다.** 스케일 구멍이 아니라 발견성 문제였습니다 — `label_medium` · `skeleton_height_*` · `border_width_*` 가 `docs/` 에 **한 번도 안 나옵니다**(Storybook 에만 존재).

**`28px` 은 스켈레톤 높이가 아닙니다.** 이슈는 "대부분 스켈레톤 높이인데 `skeleton_height_*` 를 안 쓴다" 로 봤지만, 그 스케일은 20px(xl)에서 끝나고 28px 이 붙은 곳은 `.tab` · `.back_button` · `.stepper_button` · `.pagination_btn` — **컨트롤 높이**입니다. 36px 도 `.action_button` 입니다. spacing 문제가 아니라서 이번 변경에서 제외했습니다.

### `hairline` 을 만든 이유

이슈의 관찰이 정확했습니다 — 이름 길이가 채택률을 정합니다.

```scss
border: token.$border_width_standard solid token.$color_border_default;  // 기존
@include token.hairline;                                                 // 신규
```

DS 자체 하드코딩 3곳을 같이 고쳤습니다. 내부에서 안 쓰는 토큰을 밖에 권할 수는 없습니다.

## 검증

- 실측(SCSS 133개): `1px` 232 / `2px` 61 / `6px` 28 / `13px` 29 / hex 55 — hex 55 는 이슈 수치와 정확히 일치, 나머지는 근사
- `hairline` 3형태 컴파일 확인 — `border: 1px solid var(--bt-color-border-default)`, `border-bottom: …`, `border-left: … var(--bt-color-border-hover)`
- DS 교체 3곳의 빌드 산출물 **값 동일** (`dist/index.css` 에서 `.card_bordered` · `.button_variant_outline` 확인). `src/ui` 잔여 하드코딩 border 0
- 타이포 매핑표 17행을 소스와 프로그램으로 대조 — 불일치 0
- 877 passed, `tsc --noEmit` · `lint:css` clean

## 전달할 추가 이슈

- **28·36px 은 별도 판단이 필요합니다.** 컨트롤 높이인데 DS 의 tap-target 스케일은 `dense` 32px 에서 시작합니다. 즉 앱이 DS 최소 터치 영역보다 **작은** 컨트롤을 만들고 있다는 뜻이라, 스페이싱 스케일에 28 을 추가하면 그 상태를 정당화하게 됩니다. 실제 질문은 (a) tap-target 스케일에 28/36 단계를 둘 것인가 (b) 해당 컨트롤들이 WCAG 2.5.8 을 위반하는가 입니다. 근거를 정리해 따로 올리겠습니다
- 앱 SCSS 정리(1px 232건 등)는 위 결정이 난 뒤 한 번에 하는 편이 낫습니다 — 이슈 본문의 판단과 같습니다
- 새 mixin 추가이므로 릴리즈는 **minor** 대상입니다