### PR TITLE
fix/drawer-popover-parity

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1802,7 +1802,21 @@ const [isOpen, setIsOpen] = useState(false);
 </Modal>
 ```
 
-`Drawer` 도 같은 수명을 갖는다 (`onExited` 는 현재 `Modal` 만 제공 — Drawer 는 후속).
+`Drawer` 도 같은 수명을 갖고 `onExited` 를 제공한다.
+
+#### 포털 — `document.body` 로 렌더된다
+
+Modal 은 `createPortal(…, document.body)` 로 렌더한다. **앱이 다시 감쌀 필요가 없다.** 이 DS 는 `transform` 을 광범위하게 쓰는데(`useSpringHover` 등), `transform` 조상 아래에서는 `position: fixed` 의 containing block 이 뷰포트가 아니게 되어 오버레이가 깨진다. 그걸 피하려고 컴포넌트가 스스로 포털한다.
+
+```tsx
+// ❌ 이중 포털 - 사이드바의 스태킹 컨텍스트를 벗어나려고 감쌀 필요가 없다
+createPortal(<Modal open={open}>…</Modal>, document.body)
+
+// ✅ 그대로 쓴다
+<Modal open={open}>…</Modal>
+```
+
+`Drawer` · `Popover` · `Tooltip` · `Alert` · `Toast` 도 같은 계약이다.
 
 ---
 
@@ -1836,13 +1850,38 @@ const [isOpen, setIsOpen] = useState(false);
 | `placement` | `'left' \| 'right' \| 'bottom'` | `'right'` | 슬라이드 방향 |
 | `size` | `number \| string` | `360` | 패널 크기 - left/right 는 너비, bottom 은 높이 (number ⇒ px) |
 | `title` | `ReactNode` | - | 헤더 제목 (있으면 `aria-labelledby` 자동 연결) |
+| `onExited` | `() => void` | - | 퇴출 애니메이션이 끝나 패널이 언마운트된 뒤 호출 |
 | `footer` | `ReactNode` | - | 하단 액션 영역. 미지정 시 footer 영역 미표시 |
 | `closeOnOverlay` | `boolean` | `true` | 오버레이 클릭 시 닫기 |
 | `showCloseIcon` | `boolean` | `true` | 우상단 X 닫기 아이콘 표시 |
 | `closeLabel` | `string` | `'닫기'` | X 닫기 버튼 접근성 레이블 |
-| `ariaLabel` | `string` | `'Dialog'` | `title` 없을 때 dialog 접근성 레이블 |
+| `ariaLabel` | `string` | - | `title` 이 없을 때의 접근성 이름 |
 
 > 방향별 슬라이드 진입/퇴출은 `react-spring` 으로 처리하며 `prefers-reduced-motion: reduce` 시 즉시 표시된다. `placement="top"` 과 배경 상호작용(non-modal) 변형은 현재 범위 밖.
+
+**계약은 Modal 과 같다** — 아래 네 가지는 [Modal](#modal) 절의 설명과 동일하게 적용된다.
+
+#### 접근성 이름은 필수다
+
+`title` 이나 `ariaLabel` 중 **하나는 반드시** 줘야 한다. 폴백이 없으므로 둘 다 비우면 이름 없는 대화상자가 되고, axe 의 `aria-dialog-name`(serious)이 잡는다.
+
+> 이전에는 이름이 없으면 영어 `"Dialog"` 로 조용히 채워졌다. Modal 과 같은 이유로 제거했다.
+
+#### 스크롤 — 내용이 길 때
+
+제목·푸터는 고정된 채 `children` 영역만 스크롤된다. 스크롤 영역은 `tabIndex={0}` 을 받아 키보드로도 스크롤되고, 초기 포커스는 그 wrapper 가 아니라 안쪽 첫 컨트롤로 간다.
+
+#### 오버레이 클릭 — 폼 드로어에서는 끌 것
+
+`closeOnOverlay` 기본값은 `true` 다. **입력 요소를 담은 드로어에서는 바깥 클릭 한 번에 작성 중인 내용이 사라진다** — 폼에는 명시적으로 끈다. 패널 안에서 드래그를 시작해 오버레이에서 놓는 경우(텍스트 선택 등)는 닫히지 않는다.
+
+#### 마운트 수명
+
+패널은 퇴출 스프링이 끝날 때까지 마운트를 유지한다. `children` 을 `open` 과 같은 값에 묶으면 본문만 먼저 사라지므로, 데이터는 `onExited` 에서 비운다.
+
+#### 포털
+
+`document.body` 로 포털된다. 앱이 다시 감쌀 필요가 없다.
 
 ---
 
@@ -2190,7 +2229,7 @@ trigger 클릭으로 펼쳐지는 **범용 non-modal 패널**. **임의의 inter
 - **키보드**: <kbd>Tab</kbd> trigger 포커스 → Enter/Space로 토글 / <kbd>Esc</kbd> 닫음 (+ trigger 복귀)
 - non-modal이므로 Tab을 트랩하지 않음 (Modal과 차이). 페이지 나머지와 상호작용 가능
 
-> 📌 `dialog`는 접근성 이름이 필요하다. content에 제목이 없으면 `aria-label`을, 있으면 그 요소 id로 `aria-labelledby`를 줘라.
+> 📌 `dialog`는 접근성 이름이 필요하다. content에 제목이 없으면 `aria-label`을, 있으면 그 요소 id로 `aria-labelledby`를 줘라. **폴백이 없다** — 둘 다 비우면 이름 없는 대화상자가 되고 axe `aria-dialog-name` 이 잡는다 (Modal · Drawer 와 같은 계약).
 
 #### 애니메이션
 

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Drawer } from "./index";
 
@@ -102,7 +102,9 @@ describe("Drawer", () => {
 				Content
 			</Drawer>,
 		);
-		fireEvent.click(screen.getByRole("dialog"));
+		const overlay = screen.getByRole("dialog");
+		fireEvent.pointerDown(overlay);
+		fireEvent.click(overlay);
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
@@ -113,7 +115,26 @@ describe("Drawer", () => {
 				Content
 			</Drawer>,
 		);
-		fireEvent.click(screen.getByRole("dialog"));
+		const overlay = screen.getByRole("dialog");
+		fireEvent.pointerDown(overlay);
+		fireEvent.click(overlay);
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	// 패널에서 누르고 오버레이에서 놓으면 `click` 은 공통 조상인 오버레이에 디스패치된다.
+	// 텍스트 선택 같은 정상 조작이 닫기로 이어져 폼 입력이 사라지던 버그 (Modal 과 동일 계약).
+	it("does not close when a drag starts in the panel and ends on the overlay", () => {
+		const handleClose = vi.fn();
+		render(
+			<Drawer open onClose={handleClose}>
+				Content
+			</Drawer>,
+		);
+		const overlay = screen.getByRole("dialog");
+		const panel = document.querySelector(".drawer_panel") as HTMLElement;
+
+		fireEvent.pointerDown(panel);
+		fireEvent.click(overlay);
 		expect(handleClose).not.toHaveBeenCalled();
 	});
 
@@ -157,7 +178,7 @@ describe("Drawer", () => {
 				Content
 			</Drawer>,
 		);
-		fireEvent.keyDown(screen.getByRole("document"), { key: "Escape" });
+		fireEvent.keyDown(document.querySelector(".drawer_panel") as HTMLElement, { key: "Escape" });
 		expect(handleClose).toHaveBeenCalledTimes(1);
 	});
 
@@ -183,9 +204,9 @@ describe("Drawer", () => {
 		);
 
 		// 포털 렌더라 DOM 순서가 React 트리 순서와 다를 수 있음 - 내용으로 inner 패널을 찾는다
-		const panels = screen.getAllByRole("document");
+		const panels = document.querySelectorAll(".drawer_panel");
 		expect(panels).toHaveLength(2);
-		const innerPanel = screen.getByText("Inner content").closest('[role="document"]') as HTMLElement;
+		const innerPanel = screen.getByText("Inner content").closest(".drawer_panel") as HTMLElement;
 		fireEvent.keyDown(innerPanel, { key: "Escape" });
 
 		// 최상단(나중에 연 inner)만 닫히고 outer 는 유지된다 (APG)
@@ -244,8 +265,50 @@ describe("Drawer", () => {
 		);
 		const dialog = screen.getByRole("dialog");
 		expect(dialog).toHaveAttribute("aria-modal", "true");
-		// title 이 없으면 aria-label fallback
-		expect(dialog).toHaveAttribute("aria-label", "Dialog");
+	});
+
+	// 폴백("Dialog")을 없앴다 - 이름을 빼먹으면 조용히 영어로 채워지는 대신 이름 없는
+	// 대화상자가 되어 axe `aria-dialog-name` 이 잡는다 (Modal 과 동일 계약).
+	it("leaves the dialog unnamed when neither title nor ariaLabel is given", () => {
+		render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).not.toHaveAttribute("aria-label");
+		expect(dialog).not.toHaveAttribute("aria-labelledby");
+	});
+
+	// role="document" 제거 - ARIA 1.0 시절 워크어라운드였고 현대 스크린리더엔 불필요하다.
+	it("does not nest a document role inside the dialog", () => {
+		render(
+			<Drawer open onClose={() => {}} title="제목">
+				Content
+			</Drawer>,
+		);
+		expect(document.querySelector(".drawer_panel")).not.toHaveAttribute("role");
+	});
+
+	// 본문 wrapper 는 스크롤을 위해 tabIndex=0 을 갖지만, 초기 포커스는 그 빈 div 가 아니라
+	// 안쪽의 첫 상호작용 요소로 가야 한다. close 버튼이 없으면 wrapper 가 DOM 상 첫 매치가 된다.
+	it("focuses the first control inside the body, not the scroll wrapper", () => {
+		render(
+			<Drawer open onClose={() => {}} showCloseIcon={false} title="폼">
+				<input aria-label="이름" />
+			</Drawer>,
+		);
+		expect(document.activeElement).toBe(screen.getByLabelText("이름"));
+	});
+
+	it("still keeps the scroll wrapper in the tab cycle", () => {
+		render(
+			<Drawer open onClose={() => {}} showCloseIcon={false} title="폼">
+				<input aria-label="이름" />
+			</Drawer>,
+		);
+		const body = document.querySelector(".drawer_body") as HTMLElement;
+		expect(body.tabIndex).toBe(0);
 	});
 
 	it("uses ariaLabel for the dialog when provided without a title", () => {
@@ -355,28 +418,62 @@ describe("Drawer", () => {
 		expect(panel).toHaveClass("custom-drawer");
 	});
 
-	it("forwards data props, protects overlay-critical props, and merges consumer style", () => {
-		const consumerClick = vi.fn();
+	it("forwards data props and merges consumer style", () => {
 		render(
 			<Drawer
 				open
 				onClose={() => {}}
 				data-testid="panel-x"
 				style={{ backgroundColor: "rgb(255, 0, 0)" }}
-				{...({ role: "menu", onClick: consumerClick } as Record<string, unknown>)}
 			>
 				Content
 			</Drawer>,
 		);
 		// 포털 렌더라 render container 밖(document.body)에 붙는다
 		const panel = document.querySelector(".drawer_panel") as HTMLElement;
-		// data-* 등은 통과
 		expect(panel).toHaveAttribute("data-testid", "panel-x");
-		// role/onClick 은 컴포넌트가 전유 - 소비자 값 무시(스프레드 순서 회귀 시 깨짐)
-		expect(panel).toHaveAttribute("role", "document");
-		fireEvent.click(panel);
-		expect(consumerClick).not.toHaveBeenCalled();
-		// style 은 병합 - 소비자 값 적용
 		expect(panel.style.backgroundColor).toBe("rgb(255, 0, 0)");
+	});
+
+	// ── 퇴출 수명 ────────────────────────────────────────────────────────────
+	it("does not fire onExited for a drawer that was never opened", () => {
+		const onExited = vi.fn();
+		render(
+			<Drawer open={false} onClose={() => {}} onExited={onExited}>
+				Content
+			</Drawer>,
+		);
+		expect(onExited).not.toHaveBeenCalled();
+	});
+
+	it("fires onExited after the panel unmounts", async () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+		const onExited = vi.fn();
+		const { rerender } = render(
+			<Drawer open onClose={() => {}} onExited={onExited} title="상세">
+				Content
+			</Drawer>,
+		);
+		expect(onExited).not.toHaveBeenCalled();
+
+		rerender(
+			<Drawer open={false} onClose={() => {}} onExited={onExited} title="상세">
+				Content
+			</Drawer>,
+		);
+		await waitFor(() => expect(onExited).toHaveBeenCalledTimes(1));
+		expect(document.querySelector(".drawer_panel")).toBeNull();
+		vi.unstubAllGlobals();
 	});
 });

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -20,10 +20,13 @@ import "./style.scss";
 /** Drawer 가 미끄러져 들어오는 방향 (top 은 범위 외) */
 export type DrawerPlacement = "left" | "right" | "bottom";
 
-// onClick/onKeyDown/role 은 오버레이 동작(stopPropagation·Escape·role="document")을 위해
+// onClick/onKeyDown/onPointerDown 은 오버레이 동작(오버레이 닫기 판정·Escape 격리)을 위해
 // 컴포넌트가 전유하므로 타입에서 제외한다. style/className 은 병합되어 소비자 값도 반영된다.
 export interface DrawerProps
-	extends Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "onClick" | "onKeyDown" | "role"> {
+	extends Omit<
+		React.HTMLAttributes<HTMLDivElement>,
+		"title" | "onClick" | "onKeyDown" | "onPointerDown"
+	> {
 	/** 드로어 열림 여부 */
 	open: boolean;
 	/** 드로어 닫기 콜백 */
@@ -42,8 +45,16 @@ export interface DrawerProps
 	showCloseIcon?: boolean;
 	/** X 닫기 버튼 접근성 레이블 (기본값: "닫기") */
 	closeLabel?: string;
-	/** 드로어 접근성 레이블 (title 없을 때 사용, 기본값: "Dialog") */
+	/**
+	 * 드로어 접근성 레이블. `title` 이 없을 때 이 값이 접근성 이름이 된다.
+	 * 둘 다 비우면 이름 없는 대화상자가 되고 axe `aria-dialog-name` 이 잡는다.
+	 */
 	ariaLabel?: string;
+	/**
+	 * 퇴출 애니메이션이 끝나 패널이 실제로 언마운트된 뒤 호출된다.
+	 * `open` 을 끈 직후가 아니라 이 시점에 상세 데이터를 비워야 본문만 먼저 사라지지 않는다.
+	 */
+	onExited?: () => void;
 }
 
 // placement 별 진입 시작(=퇴출 도착) transform. 방향 축과 단위(%)를 진입/퇴출 양쪽에서
@@ -72,11 +83,14 @@ export const Drawer = ({
 	showCloseIcon = true,
 	closeLabel = "닫기",
 	ariaLabel,
+	onExited,
 	children,
 	className,
 	...props
 }: DrawerProps) => {
 	const panelRef = React.useRef<HTMLDivElement>(null);
+	// 오버레이 닫기 판정용 - pointerdown 이 오버레이에서 시작했는지 기억한다.
+	const pressedOverlayRef = React.useRef(false);
 	const titleId = React.useId();
 	const [shouldRender, setShouldRender] = React.useState(open);
 	const reduced = useReducedMotion();
@@ -103,7 +117,12 @@ export const Drawer = ({
 	const overlayStyle = useSpringPresence({
 		visible: open,
 		from: "translateY(0px)",
-		onExitComplete: () => setShouldRender(false),
+		onExitComplete: () => {
+			setShouldRender(false);
+			// 열린 적 없는 드로어의 스프링은 from 과 to 가 같아 onRest 가 발화하지 않으므로 별도
+			// 가드를 두지 않는다. 그 가정은 "열린 적 없으면 onExited 없음" 테스트가 지킨다.
+			onExited?.();
+		},
 	});
 
 	// 패널 슬라이드 - 진입/퇴출 모두 placement 축을 따라 동일 template 로 보간(정확한 reverse).
@@ -149,20 +168,30 @@ export const Drawer = ({
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby={hasTitle && !ariaLabel ? titleId : undefined}
-			aria-label={!hasTitle ? (ariaLabel ?? "Dialog") : ariaLabel}
-			onClick={() => closeOnOverlay && onClose?.()}
+			aria-label={ariaLabel}
+			onPointerDown={(e) => {
+				pressedOverlayRef.current = e.target === e.currentTarget;
+			}}
+			onClick={(e) => {
+				// 누른 곳과 놓은 곳이 모두 오버레이여야 닫는다. 패널에서 시작한 드래그(텍스트 선택 등)를
+				// 오버레이에서 놓아도 닫히지 않는다 - 폼 드로어에서 입력이 사라지던 원인.
+				if (!closeOnOverlay) return;
+				if (e.target !== e.currentTarget) return;
+				if (!pressedOverlayRef.current) return;
+				onClose?.();
+			}}
 		>
 			<animated.div
 				ref={panelRef}
-				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id 등은 통과시키되,
-				// 아래 className/style(애니메이션)/role/onClick·onKeyDown 은 컴포넌트가 항상
-				// 이기도록 뒤에 배치한다 (오버레이 동작 보호). Escape 는 공유 스택(useOverlayEscape)이
-				// 처리하고, 여기서는 그 외 키가 드로어 밖으로 새어 소비자 단축키를 건드리지 않게 막는다.
+				// {...props} 를 먼저 펼쳐 소비자의 data-*/aria-*/id/role 등은 통과시키되,
+				// 아래 className/style(애니메이션)/onKeyDown 은 컴포넌트가 항상 이기도록 뒤에 배치한다.
+				// Escape 는 공유 스택(useOverlayEscape)이 처리하고, 여기서는 그 외 키가 드로어 밖으로
+				// 새어 소비자 단축키를 건드리지 않게 막는다.
+				// 패널 클릭을 stopPropagation 하지 않는다 - 오버레이가 target 으로 판정하므로 불필요하고,
+				// 소비자 핸들러가 상위에서 이벤트를 못 받는 부작용만 남는다.
 				{...props}
 				className={cn("drawer_panel", className)}
 				style={{ ...props.style, ...panelStyle, ...panelSizeStyle }}
-				role="document"
-				onClick={(e) => e.stopPropagation()}
 				onKeyDown={(e) => {
 					if (e.key !== "Escape") e.stopPropagation();
 				}}
@@ -184,7 +213,14 @@ export const Drawer = ({
 						</h2>
 					</div>
 				)}
-				{children && <div className="drawer_body">{children}</div>}
+				{children && (
+					// 본문이 스크롤 컨테이너라 키보드로도 스크롤할 수 있어야 한다(axe
+					// `scrollable-region-focusable`). 다만 초기 포커스 대상에서는 제외한다 - 안쪽에
+					// 첫 입력이 있는데 빈 wrapper 에 포커스가 놓이면 열자마자 어디에 있는지 알 수 없다.
+					<div className="drawer_body" tabIndex={0} data-focus-trap-skip-autofocus="">
+						{children}
+					</div>
+				)}
 				{footer && <div className="drawer_footer">{footer}</div>}
 			</animated.div>
 		</animated.div>,

--- a/src/ui/overlay/drawer/style.scss
+++ b/src/ui/overlay/drawer/style.scss
@@ -94,6 +94,12 @@
     padding: token.$spacing_24;
     color: token.$color_text_body;
     @include token.body_medium;
+
+    // tabIndex=0 으로 포커스를 받으므로 표시가 있어야 한다 (WCAG 2.4.7).
+    &:focus-visible {
+      outline: none;
+      box-shadow: token.$focus_ring;
+    }
   }
 
   // ── Footer (액션 영역) ─────────────────────────────────────────────────

--- a/src/ui/overlay/popover/Popover.test.tsx
+++ b/src/ui/overlay/popover/Popover.test.tsx
@@ -178,7 +178,9 @@ describe("Popover", () => {
 		expect(screen.getByRole("dialog", { name: "필터 옵션" })).toBeInTheDocument();
 	});
 
-	it('falls back to a "Dialog" accessible name when no label is given', () => {
+	// 폴백("Dialog")을 없앴다 - 이름을 빼먹으면 조용히 영어로 채워지는 대신 이름 없는
+	// 대화상자가 되어 axe `aria-dialog-name` 이 잡는다 (Modal/Drawer 와 동일 계약).
+	it("leaves the dialog unnamed when no label is given", () => {
 		render(
 			<Popover
 				trigger={<button type="button">Open</button>}
@@ -186,10 +188,12 @@ describe("Popover", () => {
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		expect(screen.getByRole("dialog", { name: "Dialog" })).toBeInTheDocument();
+		const dialog = screen.getByRole("dialog");
+		expect(dialog).not.toHaveAttribute("aria-label");
+		expect(dialog).not.toHaveAttribute("aria-labelledby");
 	});
 
-	it("does not add the fallback label when aria-labelledby is provided", () => {
+	it("names the dialog from aria-labelledby when provided", () => {
 		render(
 			<>
 				<h2 id="popover-title">필터</h2>

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -33,7 +33,11 @@ export interface PopoverProps {
 	defaultOpen?: boolean;
 	/** 열림 상태 변경 콜백 */
 	onOpenChange?: (open: boolean) => void;
-	/** 팝오버 접근성 레이블(기본값: "Dialog") - content 에 제목이 없을 때 권장 */
+	/**
+	 * 팝오버 접근성 레이블. `content` 에 제목이 없으면 이 값이 접근성 이름이 된다.
+	 * 폴백이 없으므로 `aria-labelledby` 와 함께 비우면 이름 없는 대화상자가 되고
+	 * axe `aria-dialog-name` 이 잡는다.
+	 */
 	"aria-label"?: string;
 	/** dialog 의 접근성 라벨 요소 id */
 	"aria-labelledby"?: string;

--- a/src/ui/overlay/popover/index.tsx
+++ b/src/ui/overlay/popover/index.tsx
@@ -190,9 +190,9 @@ export const Popover = ({
 							ref={popoverRef}
 							role="dialog"
 							tabIndex={-1}
-							// aria-labelledby 가 없으면 이름 없는 dialog 가 되므로 Modal/Drawer 와 동일하게
-							// "Dialog" 로 폴백한다 (WCAG 2.1 SC 4.1.2).
-							aria-label={ariaLabelledby ? ariaLabel : (ariaLabel ?? "Dialog")}
+							// 이름을 폴백하지 않는다 - Modal/Drawer 와 같은 계약이다. 영문 폴백은 한국어 UI 에서
+							// 그대로 낭독되고, 무엇보다 이름 누락을 가려 axe `aria-dialog-name` 이 거짓 통과한다.
+							aria-label={ariaLabel}
 							aria-labelledby={ariaLabelledby}
 							style={style}
 							className={cn("popover", className)}


### PR DESCRIPTION
## 작업 개요

이슈 #495, #496 - Modal 클러스터(#471 #473 #474 #476 #483)를 고칠 때 같은 오버레이·dialog 코드 형태를 가진 **Drawer 를 보지 않았다.** 결함 5건이 그대로 남아 있었고, `Popover` 는 영문 이름 폴백을 "Modal/Drawer 와 동일하게" 라는 주석으로 정당화하고 있었는데 Modal 이 이미 그 폴백을 버려서 근거가 죽은 상태였다.

Drawer 를 Modal 과 같은 계약으로 맞추고, Popover 의 마지막 폴백을 없앤다. 덤으로 #482 코멘트에서 실재로 판정된 문서 누락(Modal·Drawer 가 `document.body` 로 포털한다는 사실이 문서에 없어 notiiv 앱 2곳이 이중 포털을 만들었다)도 함께 채웠다.

Closes #495
Closes #496

## 작업한 내용

- [x] Drawer: 영문 `"Dialog"` 접근성 이름 폴백 제거 — 이름을 빼먹으면 axe `aria-dialog-name` 이 잡는다
- [x] Drawer: 패널의 `role="document"` 제거 (ARIA 1.0 워크어라운드)
- [x] Drawer: 오버레이 닫힘을 pointerdown 출처로 판정 — 패널에서 시작한 드래그를 오버레이에서 놓아도 닫히지 않는다
- [x] Drawer: 패널의 `onClick` `stopPropagation` 제거 — 오버레이가 `target` 으로 판정하므로 불필요하고 소비자 핸들러만 막았다
- [x] Drawer: `onExited` 추가 (퇴출 스프링 완료 후 발화)
- [x] Drawer: `.drawer_body` 를 `tabIndex={0}` + `data-focus-trap-skip-autofocus` 로 — 키보드 스크롤 가능하되 초기 포커스는 안쪽 첫 컨트롤로
- [x] Drawer: `.drawer_body:focus-visible` 포커스 링 (WCAG 2.4.7)
- [x] Drawer: 타입에서 `onClick`·`role` 전유 해제, `onPointerDown` 을 대신 전유 (Modal 과 동일한 Omit 목록)
- [x] Popover: `?? "Dialog"` 제거 + 죽은 주석 교체
- [x] 테스트: Drawer 회귀 6건 추가(드래그 닫힘, 무명 dialog, `role` 부재, body `tabIndex`, 초기 포커스, `onExited` 2건), `role="document"` 에 의존한 기존 테스트 3곳 교체, Popover 폴백 테스트를 무명 검증으로 전환
- [x] 문서: Modal·Drawer 포털 계약 명시(`document.body`, 앱이 다시 감쌀 필요 없음), Drawer prop 표의 `ariaLabel` 기본값 `'Dialog'` 정정 + `onExited` 추가, Drawer 절에 Modal 과 같은 계약 4개 + 포털 절 추가, Popover 노트에 "폴백 없음" 명시
- [x] `docs/COMPONENTS.md` 의 "`onExited` 는 현재 `Modal` 만 제공 — Drawer 는 후속" 문구 정정

## 검증

- 단위 테스트 **894 passed / 9 skipped** (58 files). 오버레이만 88 passed
- **뮤테이션 7건 전부 사망** — 드래그 가드 제거 / `"Dialog"` 폴백 복원(Drawer) / `role="document"` 복원 / `tabIndex` 제거 / skip-autofocus 속성만 제거 / `onExited?.()` 제거 / `"Dialog"` 폴백 복원(Popover). 각각 정확히 해당 테스트만 실패
- `tsc --noEmit` 통과, `pnpm lint:css`(stylelint) 통과, `pnpm build` 통과
- 빌드 산출물 실측: `dist/index.js` 의 `"Dialog"` **0건**, `dist/index.d.ts` 의 `onExited` 2건(Modal·Drawer), `dist/index.css` 에 `.drawer_body:focus-visible { box-shadow: var(--bt-focus-ring) }` 존재. Vanilla 번들에는 drawer 가 없어 미러링 불필요
- **Chromium 실측** (Storybook `Drawer/Right`, axe-core 4.13.0 주입):
  - 열린 드로어 전체 axe 실행 → **violations 0**
  - `aria-labelledby` 를 벗기면 `aria-dialog-name` **serious 1건** 발생 → 폴백 제거가 의도한 효과를 낸다
  - 패널 `role` = `null`, `.drawer_body` = `tabindex="0"` + skip-autofocus 속성, 초기 포커스 = `.drawer_close`
  - 패널 pointerdown → 오버레이 click: **열린 상태 유지**. 오버레이 pointerdown → 오버레이 click: **닫힘**
  - Popover: 이름 있을 때 violations 0, 이름을 벗기면 `aria-dialog-name` serious 1건
- 검증 못 한 항목: `scrollable-region-focusable` 은 이 환경에서 규칙 자체가 `inapplicable` 로 나온다 — 드로어 밖에 만든 순수 스크롤 대조군 div 에서도 동일해서, 규칙을 실행시킬 수 없는 환경이라고 본다. `.drawer_body` 의 `tabIndex` 근거는 Modal 과의 동일성 + WCAG 2.1.1 키보드 조작성이고, axe 판정은 CI 의 `pnpm test:storybook`(Playwright Chromium)에 맡긴다. 로컬은 Playwright 브라우저 미설치로 실행 불가

## 전달할 추가 이슈

- #499 — `open=false` 시 마지막 `children` 을 붙잡는 freeze. 이 PR 의 `onExited` 는 소비자가 타이밍을 맞출 수 있게 해주지만, shim 자체를 없애는 건 freeze 뿐이다
- #497 — a11y 문자열 영문 기본값 9건 + 교체 수단 없는 하드코딩 4건 (`TextField` clear, `Pagination`·`Breadcrumb` 랜드마크, `Toast` 리전). 이 PR 의 dialog 이름 계약과 같은 계열
- #498 — `visually_hidden` 믹스인. DS 내부 6곳이 복제 중이고 4곳은 `clip-path` 없는 구형 레시피
- `develop` 이 `main` 보다 34 커밋 앞서 있다. `Prose`(#478)·`token.hairline`(#481)이 develop 에만 있어 notiiv 가 소비할 수 없는 상태 — **3.12.0 릴리즈가 다음 순서다**