### PR TITLE
fix/bottom-inset-composition

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1481,13 +1481,21 @@ const [collapsed, setCollapsed] = useState(false);
 --bt-bottom-nav-height        /* 56px */
 --bt-bottom-nav-safe-area     /* env(safe-area-inset-bottom) */
 --bt-bottom-nav-total-height  /* 합산 - BottomNavSpacer 가 자동 사용 */
---bt-bottom-inset             /* 하단이 실제로 가려진 높이. BottomNav 가 없으면 0px */
+--bt-bottom-nav-inset         /* DS 몫 - BottomNav 가 DOM 에 있을 때만 total-height */
+--bt-bottom-inset-app         /* 앱 몫 - 앱이 소유한 하단 크롬 높이 (앱이 쓴다) */
+--bt-bottom-inset             /* 위 두 몫의 합. 읽기 전용으로 쓴다 */
 ```
 
 > **하단 고정 요소를 둔다면 `--bt-bottom-inset` 을 쓰세요.** 위의 세 변수는 BottomNav 를 쓰지 않는 화면에서도 항상 정의됩니다(`:root` + 단일 CSS 번들). 그대로 더하면 BottomNav 가 없는 페이지에서도 56px 밀립니다. `--bt-bottom-inset` 만 BottomNav 가 DOM 에 있을 때 값이 생깁니다.
 >
 > ```css
 > .my_floating_bar { bottom: calc(16px + var(--bt-bottom-inset)); }
+> ```
+>
+> **앱이 소유한 하단 크롬(플로팅 바 등)은 `--bt-bottom-inset-app` 에 쓰세요.** `--bt-bottom-inset` 을 직접 쓰면 DS 규칙과 특이도가 같아 로드 순서 싸움이 되고, 둘이 동시에 있을 때 합성되지 않습니다. 자세한 내용은 [THEMING.md](../docs/THEMING.md#앱이-소유한-하단-크롬은---bt-bottom-inset-app-에-씁니다).
+>
+> ```scss
+> body:has(.floating_bar) { --bt-bottom-inset-app: 96px; }
 > ```
 >
 > `Toast` 는 모바일에서 이 값을 이미 반영합니다 - 앱이 `.toast_container` 를 보정하던 CSS 는 지우면 됩니다.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1486,13 +1486,13 @@ const [collapsed, setCollapsed] = useState(false);
 --bt-bottom-inset             /* 위 두 몫의 합. 읽기 전용으로 쓴다 */
 ```
 
-> **하단 고정 요소를 둔다면 `--bt-bottom-inset` 을 쓰세요.** 위의 세 변수는 BottomNav 를 쓰지 않는 화면에서도 항상 정의됩니다(`:root` + 단일 CSS 번들). 그대로 더하면 BottomNav 가 없는 페이지에서도 56px 밀립니다. `--bt-bottom-inset` 만 BottomNav 가 DOM 에 있을 때 값이 생깁니다.
+> **하단 고정 요소를 둔다면 `--bt-bottom-inset` 을 쓰세요.** `--bt-bottom-nav-height` · `-safe-area` · `-total-height` 세 변수는 BottomNav 를 쓰지 않는 화면에서도 항상 정의됩니다(`:root` + 단일 CSS 번들). 그대로 더하면 BottomNav 가 없는 페이지에서도 56px 밀립니다. `--bt-bottom-inset` 은 **실제로 가려진 만큼만** 값을 갖습니다 — BottomNav 가 DOM 에 있거나, 앱이 `--bt-bottom-inset-app` 을 설정했거나, 둘 다일 때입니다.
 >
 > ```css
 > .my_floating_bar { bottom: calc(16px + var(--bt-bottom-inset)); }
 > ```
 >
-> **앱이 소유한 하단 크롬(플로팅 바 등)은 `--bt-bottom-inset-app` 에 쓰세요.** `--bt-bottom-inset` 을 직접 쓰면 DS 규칙과 특이도가 같아 로드 순서 싸움이 되고, 둘이 동시에 있을 때 합성되지 않습니다. 자세한 내용은 [THEMING.md](../docs/THEMING.md#앱이-소유한-하단-크롬은---bt-bottom-inset-app-에-씁니다).
+> **앱이 소유한 하단 크롬(플로팅 바 등)은 `--bt-bottom-inset-app` 에 쓰세요.** `--bt-bottom-inset` 을 직접 쓰면 DS 규칙과 특이도가 같아 로드 순서 싸움이 되고, 둘이 동시에 있을 때 합성되지 않습니다. 자세한 내용은 [THEMING.md](./THEMING.md#앱이-소유한-하단-크롬은---bt-bottom-inset-app-에-씁니다).
 >
 > ```scss
 > body:has(.floating_bar) { --bt-bottom-inset-app: 96px; }

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -225,7 +225,7 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 
 `--bt-bottom-nav-*` 세 변수는 `:root` 에 선언돼 있고 라이브러리 CSS 는 한 파일이므로, **BottomNav 를 렌더하지 않는 화면에서도 항상 정의돼 있습니다.** 하단 고정 요소에서 그대로 더하면 BottomNav 가 없는 페이지에서도 그만큼 밀립니다.
 
-실제로 하단이 가려진 높이는 `--bt-bottom-inset` 입니다 — 기본 `0px` 이고, `BottomNav` 가 DOM 에 있을 때만 값이 생깁니다.
+실제로 하단이 가려진 높이는 `--bt-bottom-inset` 입니다 — 기본 `0px` 이고, **BottomNav 가 DOM 에 있거나 앱이 `--bt-bottom-inset-app` 을 설정했을 때** 값이 생깁니다 (둘 다면 합).
 
 ```css
 /* ✅ BottomNav 유무에 따라 알아서 맞는다 */
@@ -252,13 +252,9 @@ body:has(.floating_bar) { --bt-bottom-inset: 96px; }
 1. **특이도가 같습니다.** `:has()` 의 특이도는 인자를 따르므로 DS 의 `body:has(.bottom_nav)` 와 앱의 `body:has(.floating_bar)` 가 둘 다 `(0,1,1)` 입니다. 그러면 CSS **로드 순서**가 승자를 정합니다
 2. **합성이 안 됩니다.** 둘이 동시에 떠 있으면 필요한 값은 둘 중 하나가 아니라 합인데, 한쪽이 다른 쪽을 덮습니다
 
-`--bt-bottom-inset` 은 두 몫의 **합**입니다. 앱 하단 바가 BottomNav 위에 쌓이는 배치를 기본으로 봤습니다. 겹치는 배치라면 앱 몫에 `max()` 를 직접 쓰세요.
+`--bt-bottom-inset` 은 두 몫의 **합**입니다. 앱 하단 바가 BottomNav 위에 쌓이는 배치를 기본으로 봤습니다.
 
-```scss
-body:has(.floating_bar) {
-  --bt-bottom-inset-app: max(0px, 96px - var(--bt-bottom-nav-inset, 0px));
-}
-```
+**기본(합) 동작 기준 결과** — 앱 하단 바가 96px 일 때:
 
 | BottomNav | 앱 하단 바 96px | `--bt-bottom-inset` |
 |---|---|---|
@@ -266,6 +262,16 @@ body:has(.floating_bar) {
 | 있음 | 있음 | `152px` |
 | 없음 | 있음 | `96px` |
 | 없음 | 없음 | `0px` |
+
+**겹치는 배치**라면 — 앱 하단 바가 BottomNav 위에 쌓이지 않고 그 자리를 덮는다면 — 앱 몫에 `max()` 를 직접 쓰세요.
+
+```scss
+body:has(.floating_bar) {
+  --bt-bottom-inset-app: max(0px, 96px - var(--bt-bottom-nav-inset, 0px));
+}
+```
+
+이때 `있음 / 있음` 행은 `152px` 대신 `96px` 가 됩니다 (`56px + max(0, 96 - 56) = 56 + 40`). 나머지 행은 위 표와 같습니다.
 
 > z-index 는 이 계약과 별개입니다. DS 내부 순서는 `.modal`(100) < `.toast_container`(200) 로 맞아 있지만, 앱 레이어가 자기 스케일에서 더 높은 값을 쓰면 DS 요소를 덮습니다. 그 경우는 앱이 z-index 를 직접 조정해야 합니다.
 

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -214,6 +214,9 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 | `--bt-bottom-nav-height` | `BottomNav` 스타일시트 | `56px` | 고정 |
 | `--bt-bottom-nav-safe-area` | 〃 | `env(safe-area-inset-bottom, 0px)` | 기기·방향 |
 | `--bt-bottom-nav-total-height` | 〃 | 위 둘의 합 | 〃 |
+| `--bt-bottom-nav-inset` | 〃 | `0px` | **DS 몫** — BottomNav 가 DOM 에 있을 때만 total-height. 앱은 쓰지 않습니다 |
+| `--bt-bottom-inset-app` | **앱** | `0px` | **앱 몫** — 앱이 소유한 하단 크롬(플로팅 바·고정 액션 바) 높이 |
+| `--bt-bottom-inset` | `theme.scss` (`body`) | 위 두 몫의 합 | 읽기 전용으로 쓰세요 — 쓰는 변수는 위 두 개입니다 |
 | `--bt-sidebar-height` | `Sidebar` 스타일시트 | `56px` | **뷰포트 폭 <600px 에서만 정의** (아래 주의) |
 | `--bt-sidebar-safe-area` | 〃 | `env(safe-area-inset-bottom, 0px)` | 〃 |
 | `--bt-sidebar-total-height` | 〃 | 위 둘의 합 | 〃 |
@@ -231,6 +234,40 @@ React/SCSS 빌드 파이프라인 없이 `--bt-color-*` CSS 변수만 직접 참
 /* ❌ BottomNav 없는 페이지에서도 56px 밀린다 */
 .my_floating_bar { bottom: calc(16px + var(--bt-bottom-nav-total-height)); }
 ```
+
+#### 앱이 소유한 하단 크롬은 `--bt-bottom-inset-app` 에 씁니다
+
+플로팅 액션 바, 고정 하단 CTA 처럼 **앱이 소유한** 하단 크롬도 하단을 가립니다. 그 높이는 `--bt-bottom-inset-app` 에 쓰세요.
+
+```scss
+// ✅ 앱 몫에 쓴다 - DS 몫과 합쳐져 --bt-bottom-inset 이 된다
+body:has(.floating_bar) { --bt-bottom-inset-app: 96px; }
+
+// ❌ --bt-bottom-inset 을 직접 쓰지 마세요
+body:has(.floating_bar) { --bt-bottom-inset: 96px; }
+```
+
+직접 쓰면 안 되는 이유가 두 개입니다.
+
+1. **특이도가 같습니다.** `:has()` 의 특이도는 인자를 따르므로 DS 의 `body:has(.bottom_nav)` 와 앱의 `body:has(.floating_bar)` 가 둘 다 `(0,1,1)` 입니다. 그러면 CSS **로드 순서**가 승자를 정합니다
+2. **합성이 안 됩니다.** 둘이 동시에 떠 있으면 필요한 값은 둘 중 하나가 아니라 합인데, 한쪽이 다른 쪽을 덮습니다
+
+`--bt-bottom-inset` 은 두 몫의 **합**입니다. 앱 하단 바가 BottomNav 위에 쌓이는 배치를 기본으로 봤습니다. 겹치는 배치라면 앱 몫에 `max()` 를 직접 쓰세요.
+
+```scss
+body:has(.floating_bar) {
+  --bt-bottom-inset-app: max(0px, 96px - var(--bt-bottom-nav-inset, 0px));
+}
+```
+
+| BottomNav | 앱 하단 바 96px | `--bt-bottom-inset` |
+|---|---|---|
+| 있음 | 없음 | `56px` |
+| 있음 | 있음 | `152px` |
+| 없음 | 있음 | `96px` |
+| 없음 | 없음 | `0px` |
+
+> z-index 는 이 계약과 별개입니다. DS 내부 순서는 `.modal`(100) < `.toast_container`(200) 로 맞아 있지만, 앱 레이어가 자기 스케일에서 더 높은 값을 쓰면 DS 요소를 덮습니다. 그 경우는 앱이 z-index 를 직접 조정해야 합니다.
 
 #### `--bt-sidebar-*` 는 컴포넌트가 아니라 뷰포트에 달려 있습니다
 

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -112,12 +112,24 @@
   --bt-elevation-level4: 0 5px 5px -5px rgba(0, 0, 0, 0.20), 0 15px 15px 0px rgba(0, 0, 0, 0.12);
   --bt-elevation-level5: 0 8px 10px -5px rgba(0, 0, 0, 0.20), 0 20px 20px 0px rgba(0, 0, 0, 0.12);
 
-  // 뷰포트 하단을 DS 고정 요소(현재 BottomNav)가 실제로 차지하는 높이. 기본 0 이고,
-  // BottomNav 가 DOM 에 있으면 그 스타일시트가 body 에서 덮어쓴다. 하단 고정 요소를 두는
-  // 소비처는 `bottom: calc(16px + var(--bt-bottom-inset))` 처럼 더해 겹침을 피한다.
-  // 기본값을 여기 두는 이유: bottom-nav 스타일시트에 두면 그 컴포넌트를 안 쓰는 화면에서
-  // 변수가 아예 없어, 이 값을 참조하는 다른 컴포넌트가 암묵적으로 그 파일에 의존하게 된다.
-  --bt-bottom-inset: 0px;
+  // 뷰포트 하단이 고정 크롬에 가려진 높이. 소비처는 `bottom: calc(16px + var(--bt-bottom-inset))`
+  // 처럼 더해 겹침을 피한다. 읽는 쪽은 이 변수 하나만 보면 된다.
+  //
+  // 값은 두 몫의 합이다. DS 몫은 DS 가 쓰고 앱은 건드리지 않으며, 앱 몫은 앱이 쓰고 DS 가
+  // 건드리지 않는다. 같은 변수를 양쪽이 쓰면 `body:has(.bottom_nav)` 와 앱의
+  // `body:has(.floating_bar)` 가 특이도 (0,1,1) 로 동일해져 CSS 로드 순서가 승자를 정하고,
+  // 둘이 동시에 있을 때 한쪽이 다른 쪽을 덮는다. 그래서 분리한다.
+  --bt-bottom-nav-inset: 0px; // DS 몫 - BottomNav 가 있으면 그 스타일시트가 채운다
+  --bt-bottom-inset-app: 0px; // 앱 몫 - 플로팅 바·고정 액션 바 등 앱이 소유한 하단 크롬
+}
+
+// 합성은 body 에서 한다. DS 몫을 `body:has(.bottom_nav)` 가 채우므로 :root 에서 계산하면
+// 자손 스코프의 값을 읽지 못한다. 기본은 합 - 앱 하단 바가 BottomNav 위에 쌓이는 배치가
+// 일반적이다. 겹치는 배치라면 앱이 자기 몫에 `max()` 를 직접 쓰면 된다.
+body {
+  --bt-bottom-inset: calc(
+    var(--bt-bottom-nav-inset, 0px) + var(--bt-bottom-inset-app, 0px)
+  );
 }
 
 // ── Dark overrides (mixin - 두 셀렉터에서 공유) ──────────────────────────

--- a/src/ui/navigation/bottom-nav/style.scss
+++ b/src/ui/navigation/bottom-nav/style.scss
@@ -11,9 +11,11 @@
 
 // 위 세 변수는 BottomNav 를 쓰지 않는 페이지에서도 항상 정의된다(:root + 단일 CSS 번들).
 // 그래서 하단 고정 요소가 그대로 더하면 BottomNav 가 없는 화면에서도 56px 밀린다.
-// 실제로 있을 때만 --bt-bottom-inset(기본 0, theme.scss) 에 값을 넣는다.
+// 실제로 있을 때만 DS 몫(--bt-bottom-nav-inset, 기본 0, theme.scss)에 값을 넣는다.
+// 소비처가 읽는 --bt-bottom-inset 은 theme.scss 가 이 값과 앱 몫을 합쳐 만든다 -
+// 여기서 직접 쓰면 앱이 같은 변수를 쓸 때 로드 순서 싸움이 된다.
 body:has(.bottom_nav) {
-  --bt-bottom-inset: var(--bt-bottom-nav-total-height);
+  --bt-bottom-nav-inset: var(--bt-bottom-nav-total-height);
 }
 
 .bottom_nav {


### PR DESCRIPTION
## 작업 개요

이슈 #505 - 앱이 소유한 하단 크롬(플로팅 액션 바·고정 하단 CTA)의 높이를 넣을 자리가 없었다. `--bt-bottom-inset` 을 앱이 직접 쓰면 DS 규칙과 충돌한다.

`:has()` 의 특이도는 인자를 따르므로 DS 의 `body:has(.bottom_nav)` 와 앱의 `body:has(.floating_bar)` 가 둘 다 `(0,1,1)` 로 같다. 그러면 CSS **로드 순서**가 승자를 정하고, 둘이 동시에 떠 있을 때는 합이 필요한데 한쪽이 다른 쪽을 조용히 덮는다.

DS 몫과 앱 몫을 분리해서 `theme.scss` 가 합친다. 소비처가 읽는 `--bt-bottom-inset` 의 이름·의미는 그대로라 기존 사용처는 안 깨진다.

Closes #505

## 작업한 내용

- [x] `--bt-bottom-nav-inset` 신설 (DS 몫) — `BottomNav` 스타일시트가 이것만 쓴다. 이전엔 `--bt-bottom-inset` 을 직접 썼다
- [x] `--bt-bottom-inset-app` 신설 (앱 몫) — 기본 `0px`, 앱이 쓴다
- [x] `theme.scss` 의 `body` 에서 두 몫을 합쳐 `--bt-bottom-inset` 을 만든다. 합성을 `body` 에 두는 이유는 DS 몫이 `body:has(.bottom_nav)` 로 설정되기 때문 — `:root` 에서 계산하면 자손 스코프 값을 못 읽는다
- [x] 합(`+`)을 기본으로. 앱 하단 바가 BottomNav 위에 쌓이는 배치가 일반적이다. 겹치는 배치는 앱 몫에 `max()` 를 쓰는 방법을 문서에 예시
- [x] `docs/THEMING.md` — 계약 변수 표에 새 변수 2개 추가, "앱이 소유한 하단 크롬은 `--bt-bottom-inset-app` 에 씁니다" 절 신설(직접 쓰면 안 되는 이유 2개 + 조합별 결과 표 + z-index 는 별개라는 주의)
- [x] `docs/COMPONENTS.md` BottomNav 절의 CSS 변수 블록과 주의 문구 갱신

## 검증

- 단위 **896 passed / 9 skipped**, `pnpm lint:css` · `pnpm build` 통과
- `scripts/check-css-vars.sh` — 문서의 CSS 변수 **80개**(78 → 80) 전부 빌드 산출물에 존재
- **Chromium 실측** (Storybook `BottomNav/Default`, `position: fixed` 프로브를 `bottom: calc(16px + var(--bt-bottom-inset))` 로 두고 실제 픽셀 측정, 앱 몫 96px):

| BottomNav | 앱 몫 | 기대 | 실측 |
|---|---|---|---|
| 있음 | 없음 | 16+56 = 72 | **72** |
| 있음 | 96px | 16+56+96 = 168 | **168** |
| 없음 | 96px | 16+96 = 112 | **112** |
| 없음 | 없음 | 16 | **16** |

- **이전 구조가 실패하는 것도 같은 페이지에서 재현**했다. `body:has(.bottom_nav)` 와 `body:has(.floating_bar)` 가 같은 변수를 쓰게 두고 `<style>` 삽입 순서만 바꾸면 결과가 **112 ↔ 72** 로 뒤집힌다. 기대값 168 은 **어느 순서에서도 나오지 않는다** — 로드 순서가 승자를 정하고 합성이 안 된다는 것이 실측으로 확인된다
- `--bt-bottom-nav-inset: 0px` · `--bt-bottom-inset-app: 0px` 가 `dist/index.css` 의 `:root` 에, 합성 규칙이 `body` 에 존재

## 전달할 추가 이슈

- **z-index 는 이 계약과 별개다.** DS 내부 순서는 맞다(`.modal` 100 < `.toast_container` 200). 문제는 앱 레이어가 자기 스케일에서 더 높은 값을 쓰면 DS 요소를 덮는 것이고(notiiv 플로팅 바 900 vs 토스트 200), 그래서 소비처가 `body .toast_container { z-index: 10001 }` 을 유지해야 한다. 앱 레이어와 DS 레이어를 한 축에서 비교할 수단이 없다는 게 본질이라 별도 이슈가 필요하다
- notiiv: 이 PR 이 배포되면 owner `global.css` 의 플로팅 바 토스트 보정 블록(`min-width:600px`, `bottom: 96px`)을 `body:has([class*="floating_bar"]) { --bt-bottom-inset-app: 96px; }` 로 이관할 수 있다. z-index 블록은 위 이슈까지 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 하단 고정 영역의 여백 계산을 디자인 시스템 영역과 앱 영역으로 분리했습니다.
  * BottomNav와 앱 하단 바가 함께 표시되거나 겹치는 경우에도 실제 가림 영역이 정확히 반영됩니다.
  * 관련 테마 설정과 조합별 동작 규칙을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->