### PR TITLE
feat/visually-hidden

### DIFF
--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -281,6 +281,27 @@ scripts/check-css-vars.sh
 
 Storybook 의 `foundation/a11y` 페이지에서 실제 렌더를 확인할 수 있습니다.
 
+#### 시각적으로만 숨기기 — `visually_hidden`
+
+라이브 리전, 아이콘 버튼의 텍스트 라벨, 스크린리더 전용 표 헤더처럼 **보이지 않되 보조기기에는 남아야** 하는 내용에 씁니다. `display: none` 과 `visibility: hidden` 은 접근성 트리에서도 빠지므로 쓸 수 없습니다.
+
+```scss
+.live_region { @include token.visually_hidden; }
+.skip_link   { @include token.visually_hidden_focusable; } // 포커스되면 드러남
+```
+
+| 믹스인 | 용도 |
+|---|---|
+| `visually_hidden` | 항상 숨김 |
+| `visually_hidden_focusable` | 평소 숨김, `:focus-visible` 에서 드러남 (스킵 링크) |
+| `visually_hidden_reset` | 조건부로 숨긴 것을 되돌림 (브레이크포인트·상태에 따라 다시 보여야 할 때) |
+
+> **조건부로 숨겼다면 되돌릴 때 `visually_hidden_reset` 을 쓰세요.** 손으로 되돌리면 속성을 빠뜨립니다 — DS 안에서 실제로 `clip-path` 를 되돌리지 않아 라벨이 계속 잘려 있던 자리가 있었습니다(Sidebar 의 모바일 BottomBar 모드). 짝을 믹스인으로 묶어야 한쪽에 속성이 추가될 때 같이 따라옵니다.
+
+`clip: rect()` 는 deprecated 지만 구형 폴백으로 함께 나갑니다 — `clip-path` 단독은 일부 조합에서 요소가 잘리지 않습니다.
+
+Vanilla 번들은 같은 믹스인으로 만든 `.bt-sr-only` · `.bt-sr-only-focusable` 유틸리티 클래스를 제공합니다.
+
 ### 하드코딩 대신 쓸 토큰
 
 소비 앱 SCSS 를 실측한 결과, 토큰이 이미 있는데도 값을 직접 쓴 곳이 많았습니다. 대부분 **토큰의 존재를 몰라서**입니다.

--- a/src/styles/a11y/_index.scss
+++ b/src/styles/a11y/_index.scss
@@ -46,3 +46,48 @@ $tap_target_spacious:    56px;  // 강조 CTA, 풀스크린 액션
     }
   }
 }
+
+// ── Visually hidden ───────────────────────────────────────────────────────
+// 시각적으로 숨기되 보조기기에는 남긴다. 라이브 리전, 아이콘 버튼의 텍스트 라벨,
+// 스크린리더 전용 표 헤더 등. `display: none` · `visibility: hidden` 은 접근성 트리에서도
+// 빠지므로 대신 쓸 수 없다.
+//
+// `clip: rect()` 는 CSS Masking 에서 deprecated 지만 구형 폴백으로 함께 둔다. `clip-path`
+// 단독은 일부 조합에서 요소가 잘리지 않는다.
+@mixin visually_hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+// 조건부로 숨기는 자리(브레이크포인트·상태에 따라 다시 보여야 하는 라벨 등)에서 위를 되돌린다.
+// 짝을 손으로 쓰면 한쪽에 속성을 추가할 때 다른 쪽을 빠뜨린다 - `clip-path` 를 되돌리지 않아
+// 라벨이 계속 잘려 있던 것이 실제로 있었던 실수다.
+@mixin visually_hidden_reset {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  white-space: normal;
+}
+
+// 포커스를 받으면 드러난다. 스킵 링크("본문으로 건너뛰기") 패턴 - 평소엔 안 보이지만
+// 키보드 사용자가 Tab 을 누르면 나타나야 한다.
+@mixin visually_hidden_focusable {
+  @include visually_hidden;
+
+  &:focus-visible {
+    @include visually_hidden_reset;
+  }
+}

--- a/src/ui/display/table/style.scss
+++ b/src/ui/display/table/style.scss
@@ -10,15 +10,7 @@
 
 // 스크린리더 전용(시각적으로 숨김) - clickable 행 동작 힌트를 aria-describedby 로 노출할 때 사용
 .table_sr_only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  @include token.visually_hidden;
 }
 
 .table {

--- a/src/ui/forms/checkbox/style.scss
+++ b/src/ui/forms/checkbox/style.scss
@@ -10,13 +10,7 @@
   // ── Hidden native input ────────────────────────────────────────────────
 
   &_input {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    white-space: nowrap;
+    @include token.visually_hidden;
   }
 
   // ── State layer (circular overlay for hover/focus/pressed) ─────────────

--- a/src/ui/forms/date-picker/style.scss
+++ b/src/ui/forms/date-picker/style.scss
@@ -49,14 +49,6 @@
   }
 
   &_sr_only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
+    @include token.visually_hidden;
   }
 }

--- a/src/ui/forms/image-cropper/style.scss
+++ b/src/ui/forms/image-cropper/style.scss
@@ -140,15 +140,7 @@
 	}
 
 	&_sr_only {
-		position: absolute;
-		width: 1px;
-		height: 1px;
-		padding: 0;
-		margin: -1px;
-		overflow: hidden;
-		clip: rect(0, 0, 0, 0);
-		white-space: nowrap;
-		border: 0;
+		@include token.visually_hidden;
 	}
 }
 

--- a/src/ui/forms/radio/style.scss
+++ b/src/ui/forms/radio/style.scss
@@ -9,13 +9,7 @@
   user-select: none;
 
   &_input {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    white-space: nowrap;
+    @include token.visually_hidden;
   }
 
   // ── State layer (circular overlay for hover/focus/pressed) ─────────────

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -210,15 +210,7 @@
     .sidebar_item_label,
     .sidebar_item_trailing,
     .sidebar_section_label {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
+      @include token.visually_hidden;
     }
 
     .sidebar_section {
@@ -351,14 +343,9 @@
   // collapsed 상태 + mobile + auto → collapsed 무효 (BottomBar 가 우선)
   .sidebar:not(.sidebar_static).sidebar_collapsed {
     .sidebar_item_label {
-      // collapsed 가 적용한 visually-hidden 해제 - BottomBar 에선 label 보여야 함
-      position: static;
-      width: auto;
-      height: auto;
-      padding: 0;
-      margin: 0;
-      overflow: visible;
-      clip: auto;
+      // collapsed 가 적용한 visually-hidden 해제 - BottomBar 에선 label 보여야 함.
+      // 짝 믹스인을 쓴다 - 손으로 쓰면 clip-path 처럼 한쪽에만 있는 속성을 빠뜨린다.
+      @include token.visually_hidden_reset;
     }
   }
 }

--- a/src/vanilla/CLAUDE.md
+++ b/src/vanilla/CLAUDE.md
@@ -64,6 +64,17 @@ jsdom 은 레이아웃을 하지 않으니 스크롤바 폭 같은 값은 직접
 | Pagination | `.bt-pagination` | | |
 | DatePicker | `.bt-date-picker` | `--full-width` | |
 | FileInput | `.bt-file-input` | | `.bt-file-input--disabled` |
+| 유틸리티 | `.bt-hidden`(`display:none`), `.bt-sr-only`(시각적으로만 숨김), `.bt-sr-only-focusable`(포커스 시 드러남 - 스킵 링크) | | |
+
+`.bt-sr-only` 계열은 React 의 `token.visually_hidden` 믹스인과 **같은 소스**에서 생성된다 - 두 번들이 갈라지지 않는다.
+
+```html
+<!-- 라이브 리전: 화면에는 안 보이고 스크린리더만 읽는다 -->
+<span class="bt-sr-only" role="status" aria-live="polite">저장되었습니다</span>
+
+<!-- 스킵 링크: Tab 을 누르면 나타난다 -->
+<a href="#main" class="bt-sr-only-focusable">본문으로 건너뛰기</a>
+```
 
 ### HTML Examples
 

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -463,13 +463,7 @@
   position: relative;
 
   &__input {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    white-space: nowrap;
+    @include token.visually_hidden;
   }
 
   &__box {
@@ -1520,16 +1514,14 @@
    Utility Classes
    ======================================== */
 .bt-hidden { display: none !important; }
+/* React 의 token.visually_hidden 과 같은 믹스인에서 생성 - 두 번들이 갈라지지 않게 */
 .bt-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  @include token.visually_hidden;
+}
+
+/* 포커스되면 드러난다 - 스킵 링크 패턴 */
+.bt-sr-only-focusable {
+  @include token.visually_hidden_focusable;
 }
 
 /* ========================================


### PR DESCRIPTION
## 작업 개요

이슈 #498 - 스크린리더 전용 숨김 레시피가 손으로 **7곳**에 복제돼 있었고, 이미 갈라져 있었다. radio · checkbox · vanilla checkbox input 은 `clip-path: inset(50%)` 를 갖고, image-cropper · date-picker · sidebar · table · 공개 유틸리티 `.bt-sr-only` 는 deprecated `clip: rect()` 만 갖는다. **4곳이 이 PR 로 `clip-path` 를 얻는다 — 정리가 아니라 실질 수정이다.**

`clip-path` 단독은 일부 조합에서 요소가 잘리지 않으므로 두 선언을 함께 둔다.

Closes #498

## 작업한 내용

- [x] `token.visually_hidden` — 표준 레시피(`clip` 구형 폴백 + `clip-path`)
- [x] `token.visually_hidden_reset` — 조건부 숨김을 되돌리는 짝
- [x] `token.visually_hidden_focusable` — 평소 숨김, `:focus-visible` 에서 드러남 (스킵 링크)
- [x] React 6곳 교체 — radio · checkbox · date-picker(`_sr_only`) · image-cropper(`_sr_only`) · sidebar(collapsed 라벨) · table(`.table_sr_only`)
- [x] Vanilla 3곳 — checkbox `&__input`, `.bt-sr-only`(같은 믹스인에서 생성), `.bt-sr-only-focusable` 신설
- [x] **Sidebar 의 해제 규칙을 `visually_hidden_reset` 으로** — 아래 설명
- [x] `docs/THEMING.md` 접근성 절에 믹스인 3개 표 + 짝을 손으로 쓰면 안 되는 이유
- [x] `src/vanilla/CLAUDE.md` 클래스 레퍼런스에 유틸리티 행 + 라이브 리전·스킵 링크 HTML 예시

## Sidebar 해제 규칙 — 이 PR 이 만들 수 있었던 버그

Sidebar 는 collapsed 에서 라벨을 숨기고, 모바일 BottomBar 모드에서 다시 보여준다. 그 **해제가 손으로 작성돼 있었고** `position` · `width` · `height` · `padding` · `margin` · `overflow` · `clip` 은 되돌리지만 `clip-path` 는 되돌리지 않았다.

지금까지는 숨김 쪽에 `clip-path` 가 없었으니 맞았다. **믹스인으로 통일하면서 숨김 쪽에 `clip-path` 가 생기므로, 해제를 그대로 뒀다면 모바일에서 라벨이 영구히 잘린다.** 짝을 믹스인으로 묶어야 한쪽에 속성이 추가될 때 다른 쪽이 따라온다 — 이 이슈가 지적한 드리프트와 정확히 같은 실패 모양이다.

## 검증

- 단위 **896 passed / 9 skipped**, `pnpm lint:css` · `pnpm build` 통과
- `src` 전체에서 손으로 쓴 `clip: rect` **0건** (믹스인 정의 제외)
- 빌드 산출물의 `clip-path: inset(50%)` — `dist/index.css` **6건**, `dist/vanilla/bigtablet.css` **3건**
- 교체된 6곳 전부 빌드 CSS 에서 `clip-path` 를 갖는 것을 개별 확인
- **Chromium 실측** (Storybook `Sidebar/Collapsed`, 375px):
  - 해제가 듣는다 — 라벨 computed `clip-path: none` · `position: static` · `white-space: normal`, 레이아웃 12x16
  - **뮤테이션**: 해제에서 `clip-path` 만 빠진 상태(손으로 쓴 해제의 모양)를 같은 페이지에서 재현하면 `clip-path: inset(50%)` 로 돌아간다 → 짝 믹스인이 실제로 일을 한다
  - 빌드 CSS 파싱으로 특이도·미디어 범위 확인 — 숨김은 `.sidebar_collapsed .sidebar_item_label`(미디어 없음, 0,2,0), 해제는 `@media (max-width:599px)` 안의 `.sidebar:not(.sidebar_static).sidebar_collapsed .sidebar_item_label`(0,4,0). 600px 이상에서는 숨김만 적용된다
- **검증 못 한 것**: collapsed **데스크탑**(≥600px)에서 라벨이 숨는 것을 브라우저로 못 재봤다. 이 환경의 Storybook iframe 이 `innerWidth: 0` 을 보고해 `max-width: 599px` 가 항상 매치된다. 위 CSS 구조 확인으로 대체했고, 실제 폭에서 도는 CI 의 `pnpm test:storybook`(Playwright)에 맡긴다

## 전달할 추가 이슈

- 시각 회귀: `clip-path` 를 새로 얻는 4곳은 렌더 결과가 바뀔 수 있다(숨김이 더 확실해지는 방향). Chromatic 스냅샷 확인 필요
- React 소비자용 공개 클래스(`.bt-sr-only` 대응)를 `style.css` 에도 실을지는 넣지 않았다. 믹스인으로 충분한지 소비처 반응을 보고 판단 — 실을 경우 `docs/THEMING.md` 의 번들별 변수/클래스 차이 표에 반영해야 한다
- notiiv 는 `@bigtablet/styles` 에 자체 믹스인을 두고 4곳 중복을 이미 합쳤다. 이 PR 이 배포되면 그 블록을 지우고 DS 믹스인으로 바꿀 수 있다