### PR TITLE
feat/a11y-labels

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -277,7 +277,7 @@ const [fruits, setFruits] = useState<string[]>([]);
 | `emptyText` | `string` | `'결과 없음'` | 필터 결과가 0개일 때 표시할 텍스트 |
 | `selectedSummary` | `(count: number) => string` | ``(count) => `${count}개 선택` `` | 다중 선택 요약 텍스트 |
 | `label` | `string` | - | 플로팅 라벨 (값 선택 시 또는 열릴 때 표시) |
-| `placeholder` | `string` | `'Select…'` | 플레이스홀더 |
+| `placeholder` | `string` | `'선택…'` | 플레이스홀더 |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | 크기 |
 | `name` | `string` | - | 네이티브 폼 제출용 name. 선택 값이 hidden input 으로 렌더됨 (multiple 은 같은 name 반복) |
 | `id` | `string` | 자동 생성 | 드롭다운 요소 id |
@@ -443,7 +443,7 @@ import { Search, X } from 'lucide-react';
 | `leadingAction` | `ReactNode` | - | 왼쪽 조작 요소 (v3.11, `aria-hidden` 없음) |
 | `trailingAction` | `ReactNode` | - | 오른쪽 조작 요소 (v3.11, `aria-hidden` 없음) |
 | `showPasswordToggle` | `boolean` | `false` | 비밀번호 표시/숨기기 토글 내장 (v3.11) |
-| `passwordToggleLabels` | `{ show: string; hide: string }` | 영문 | 토글 버튼 `aria-label` |
+| `passwordToggleLabels` | `{ show: string; hide: string }` | `{ show: '비밀번호 표시', hide: '비밀번호 숨기기' }` | 토글 버튼 `aria-label` |
 | `clearable` | `boolean` | `false` | 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 |
 | `clearLabel` | `string` | `'지우기'` | 지우기 버튼 `aria-label` |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -445,6 +445,7 @@ import { Search, X } from 'lucide-react';
 | `showPasswordToggle` | `boolean` | `false` | 비밀번호 표시/숨기기 토글 내장 (v3.11) |
 | `passwordToggleLabels` | `{ show: string; hide: string }` | 영문 | 토글 버튼 `aria-label` |
 | `clearable` | `boolean` | `false` | 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 |
+| `clearLabel` | `string` | `'지우기'` | 지우기 버튼 `aria-label` |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
 | `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 (호출 시점은 `imeStrategy` 에 따름) |
 | ~~`onChangeAction`~~ | `(value: string) => void` | - | **deprecated** (v3.3.0, `onValueChange` alias). Next 서버 액션 전달용 `Action` 접미사가 필요하면 계속 사용 가능 |
@@ -822,7 +823,7 @@ import { FileInput } from '@bigtablet/design-system';
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `label` | `string` | `'Choose file'` | 파일 선택 버튼 라벨 / `variant="preview"` 의 빈 상태 텍스트 |
+| `label` | `string` | `'파일 선택'` | 파일 선택 버튼 라벨 / `variant="preview"` 의 빈 상태 텍스트 |
 | `variant` | `'button' \| 'preview'` | `'button'` | 표시 형태. `preview` 는 큰 박스에 이미지를 채우는 단일 이미지 업로더 |
 | `previewSize` | `number` | `160` | `variant="preview"` 박스 한 변 크기 (px) |
 | `preview` | `boolean` | `false` | 이미지 선택 시 64×64 썸네일을 버튼 아래 나열 (`variant="button"` 전용) |
@@ -1057,6 +1058,15 @@ function YourComponent() {
 }
 ```
 
+#### `ToastProvider` props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `closeAriaLabel` | `string` | `'닫기'` | 각 토스트의 X 버튼 `aria-label` |
+| `regionLabel` | `string` | `'알림'` | 토스트 리전(`role="region"`)의 접근성 이름. 스크린리더 리전 목록에 뜬다 |
+
+> **다국어(ko/en) 앱은 두 값을 주입하세요.** DS 기본값은 한글입니다 — [MIGRATION.md](./MIGRATION.md#v3130-a11y-문자열-기본값-한글화) 참고.
+
 ---
 
 ### Spinner
@@ -1072,6 +1082,7 @@ import { Spinner } from '@bigtablet/design-system';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `size` | `number` | `24` | 스피너 크기 (px) |
+| `ariaLabel` | `string` | `'로딩 중'` | `role="status"` 의 접근성 이름 |
 
 > ℹ️ React 는 12개 bar 가 순차 페이드하는 iOS 스타일이고, `prefers-reduced-motion: reduce` 에서는 애니메이션을 완전히 정지시킨다(멈춰 있어도 12개 spoke 형태가 로딩 위젯으로 읽히기 때문). Vanilla `.bt-spinner` 는 서버 템플릿의 마크업 단순성(빈 요소 하나)을 위해 단일 border ring 이고, 정지 대신 회전을 늦춘다(0.8s → 2.4s). **의도된 차이이며 통일 계획은 없다** - 자세한 근거는 [VANILLA.md#spinner](./VANILLA.md#spinner).
 
@@ -1101,7 +1112,7 @@ import { TopLoading } from '@bigtablet/design-system';
 | `progress` | `number` | - | 진행률 (0-100), 없으면 indeterminate |
 | `color` | `string` | primary | 로딩바 색상 |
 | `height` | `number` | `3` | 로딩바 높이 (px) |
-| `ariaLabel` | `string` | `'Page loading'` | 접근성 라벨 |
+| `ariaLabel` | `string` | `'페이지 로딩 중'` | 접근성 라벨 |
 
 ---
 
@@ -1186,6 +1197,9 @@ const [page, setPage] = useState(1);
 | `page` | `number` | required | 현재 페이지 |
 | `totalPages` | `number` | required | 전체 페이지 수 |
 | `onPageChange` | `(page: number) => void` | required | 페이지 변경 핸들러 |
+| `prevLabel` | `string` | `'이전 페이지'` | 이전 버튼 `aria-label` |
+| `nextLabel` | `string` | `'다음 페이지'` | 다음 버튼 `aria-label` |
+| `navLabel` | `string` | `'페이지 이동'` | `<nav>` 랜드마크 이름. 스크린리더 리전 목록에 뜬다 |
 
 ---
 
@@ -1676,6 +1690,7 @@ import { NavBar, NavLink, Button } from "@bigtablet/design-system";
 |------|------|---------|-------------|
 | `items` | `BreadcrumbItem[]` | required | 경로 아이템 배열. 마지막은 현재 페이지로 자동 처리 |
 | `separator` | `ReactNode` | `<ChevronRight size={14} />` | 아이템 사이 구분자. `/`, `>`, 커스텀 아이콘 등 가능 |
+| `navLabel` | `string` | `'현재 위치'` | `<nav>` 랜드마크 이름. 스크린리더 리전 목록에 뜬다 |
 
 **BreadcrumbItem**
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,7 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 ## 목차
 
 - [개요](#개요)
+- [v3.13.0 (a11y 문자열 기본값 한글화)](#v3130-a11y-문자열-기본값-한글화)
 - [v3.9.0 (React variant/success)](#v390-react-variantsuccess)
 - [v3.8.0 (Vanilla 패키지 정리)](#v380-vanilla-패키지-정리)
 - [v3.5.0](#v350)
@@ -26,6 +27,62 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 - React 컴포넌트 섹션은 `grep -rn "@deprecated" src/ui --include=index.tsx` 로 코드에 실제 존재하는 deprecated prop 전체를 기준으로 작성했습니다.
 - **Vanilla JS 패키지(`/vanilla`)는 deprecated 유예 없이 한 번에 정리**했습니다. 클래스 이름은 컴파일러가 잡아주지 않으므로 [v3.8.0 섹션](#v380-vanilla-패키지-정리)의 old → new 표와 치환 스크립트를 그대로 사용하세요.
 - 버전은 semver 내림차순으로 정렬되어 있습니다.
+
+---
+
+## v3.13.0 (a11y 문자열 기본값 한글화)
+
+> **다국어(ko/en) 앱은 업그레이드 전에 라벨을 주입하세요.** 지금까지 영문 기본값이 영어 UI 에서는 **우연히 맞는 동작**이었습니다. 이번 변경으로 라벨을 주입하지 않은 자리에 한글이 낭독됩니다. deprecated 가 아니라 **기본값 변경**이므로 컴파일러가 잡아주지 않습니다.
+
+### 기본값이 바뀐 prop
+
+| 컴포넌트 | prop | 이전 | 이후 |
+|---|---|---|---|
+| `FileInput` | `label` | `"Choose file"` | `"파일 선택"` |
+| `DatePicker` | `yearLabel` / `monthLabel` / `dayLabel` | `"Year"` / `"Month"` / `"Day"` | `"년"` / `"월"` / `"일"` |
+| `Pagination` | `prevLabel` / `nextLabel` | `"Previous page"` / `"Next page"` | `"이전 페이지"` / `"다음 페이지"` |
+| `TopLoading` | `ariaLabel` | `"Page loading"` | `"페이지 로딩 중"` |
+| `ToastProvider` | `closeAriaLabel` | `"Close"` | `"닫기"` |
+| `Spinner` | `ariaLabel` | `"Loading"` | `"로딩 중"` |
+| `TextField` | `passwordToggleLabels` | `"Show password"` / `"Hide password"` | `"비밀번호 표시"` / `"비밀번호 숨기기"` |
+
+`FileInput` 의 `label` 은 `aria-label` 이 아니라 **화면에 보이는 버튼 텍스트**입니다 - 영어 화면에서 가장 눈에 띕니다.
+
+### 신설된 prop — 이전엔 교체 수단이 아예 없었습니다
+
+아래 4곳은 문자열이 하드코딩돼 있어 앱이 고칠 방법이 없었습니다. 랜드마크·리전 이름은 스크린리더의 리전 목록에 그대로 뜹니다.
+
+| 컴포넌트 | 신규 prop | 기본값 | 이전 |
+|---|---|---|---|
+| `TextField` | `clearLabel` | `"지우기"` | `aria-label="Clear"` 하드코딩 |
+| `Pagination` | `navLabel` | `"페이지 이동"` | `aria-label="Pagination"` 하드코딩 |
+| `Breadcrumb` | `navLabel` | `"현재 위치"` | `aria-label="Breadcrumb"` 하드코딩 |
+| `ToastProvider` | `regionLabel` | `"알림"` | `aria-label="Notifications"` 하드코딩 |
+
+### 다국어 앱의 업그레이드 절차
+
+1. 위 두 표의 prop 을 **전부** 자기 i18n 사전에서 주입하도록 바꿉니다 (기본값에 의존하지 않게)
+2. 그 다음 버전을 올립니다
+
+```tsx
+// ✅ 언어에 관계없이 앱이 결정한다
+<Pagination
+  page={page}
+  totalPages={total}
+  onPageChange={setPage}
+  navLabel={t("pagination.nav")}
+  prevLabel={t("pagination.prev")}
+  nextLabel={t("pagination.next")}
+/>
+<Spinner ariaLabel={t("common.loading")} />
+<ToastProvider closeAriaLabel={t("common.close")} regionLabel={t("common.notifications")}>
+```
+
+### 왜 기본값을 영어로 두지 않았나
+
+랜드마크·리전 이름은 반드시 어떤 문자열이어야 하고 언어 중립인 값이 없습니다. DS 는 이미 절반이 한글 기본값이었습니다(`closeLabel "닫기"`, `BottomNav "주요 메뉴"`, `Table "전체 선택"`, `Sidebar "사이드바 토글"`, `OtpInput "OTP 입력"`, `ImageCropper`, `FileInput` 의 이미지 제거). 한쪽으로 통일하는 것이 신규 컴포넌트가 같은 실수를 반복하지 않는 유일한 방법입니다.
+
+**다국어 앱에서는 DS 기본값이 항상 틀린 값**이라는 것을 계약으로 인정하고, 대신 모든 문자열에 주입 수단을 보장합니다 - 위 신설 prop 4개가 그 마지막 구멍을 막습니다.
 
 ---
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -36,6 +36,8 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 
 ### 기본값이 바뀐 prop
 
+`Dropdown` 은 형제 prop 이 이미 한글이었습니다 (`searchPlaceholder = "검색…"`, `emptyText = "결과 없음"`) — `placeholder` 만 영문이라 한 컴포넌트 안에서 갈려 있었습니다.
+
 | 컴포넌트 | prop | 이전 | 이후 |
 |---|---|---|---|
 | `FileInput` | `label` | `"Choose file"` | `"파일 선택"` |
@@ -45,6 +47,9 @@ Bigtablet Design System의 deprecated prop 마이그레이션 가이드입니다
 | `ToastProvider` | `closeAriaLabel` | `"Close"` | `"닫기"` |
 | `Spinner` | `ariaLabel` | `"Loading"` | `"로딩 중"` |
 | `TextField` | `passwordToggleLabels` | `"Show password"` / `"Hide password"` | `"비밀번호 표시"` / `"비밀번호 숨기기"` |
+| `Dropdown` | `placeholder` | `"Select…"` | `"선택…"` |
+| `DatePicker` | `minDateSrFormat` | `"Minimum date: {date}"` | `"최소 날짜: {date}"` |
+| `DatePicker` | `selectableRangeUntilTodaySrText` | `"Selectable up to today"` | `"오늘까지 선택 가능"` |
 
 `FileInput` 의 `label` 은 `aria-label` 이 아니라 **화면에 보이는 버튼 텍스트**입니다 - 영어 화면에서 가장 눈에 띕니다.
 

--- a/docs/VANILLA-PROMPT.md
+++ b/docs/VANILLA-PROMPT.md
@@ -232,8 +232,8 @@ Bigtablet Design System + Thymeleaf로 카테고리 Select HTML 만들어줘.
 
 ### Spinner
 ```html
-<span class="bt-spinner" role="status" aria-label="Loading"></span>
-<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" role="status" aria-label="로딩 중"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="로딩 중"></span>
 ```
 
 ### Pagination

--- a/docs/VANILLA.md
+++ b/docs/VANILLA.md
@@ -726,12 +726,12 @@ React `<Spinner size>` 가 px 숫자를 그대로 받는 것과 맞춰, 크기�
 
 ```html
 <!-- 기본 24px -->
-<span class="bt-spinner" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" role="status" aria-label="로딩 중"></span>
 
 <!-- 임의 크기 -->
-<span class="bt-spinner" style="--bt-spinner-size: 16px" role="status" aria-label="Loading"></span>
-<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
-<span class="bt-spinner" style="--bt-spinner-size: 48px" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 16px" role="status" aria-label="로딩 중"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="로딩 중"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 48px" role="status" aria-label="로딩 중"></span>
 ```
 
 > `role="status"` + `aria-label` 을 직접 붙이세요 - React `<Spinner>` 는 이 둘을 자동으로

--- a/src/ui/feedback/spinner/Spinner.test.tsx
+++ b/src/ui/feedback/spinner/Spinner.test.tsx
@@ -19,7 +19,7 @@ describe("Spinner", () => {
 	it("has correct accessibility attributes", () => {
 		render(<Spinner />);
 		const spinner = screen.getByRole("status");
-		expect(spinner).toHaveAttribute("aria-label", "Loading");
+		expect(spinner).toHaveAttribute("aria-label", "로딩 중");
 	});
 
 	it("has spinner class", () => {

--- a/src/ui/feedback/spinner/index.tsx
+++ b/src/ui/feedback/spinner/index.tsx
@@ -5,7 +5,7 @@ import "./style.scss";
 export interface SpinnerProps {
 	/** 스피너 크기(px) (기본값: 24) */
 	size?: number;
-	/** 스피너 접근성 레이블 (기본값: "Loading") */
+	/** 스피너 접근성 레이블 (기본값: "로딩 중") */
 	ariaLabel?: string;
 }
 

--- a/src/ui/feedback/spinner/index.tsx
+++ b/src/ui/feedback/spinner/index.tsx
@@ -15,7 +15,7 @@ export interface SpinnerProps {
  * @param props 스피너 속성
  * @returns 렌더링된 스피너 요소
  */
-export const Spinner = ({ size = 24, ariaLabel = "Loading" }: SpinnerProps) => {
+export const Spinner = ({ size = 24, ariaLabel = "로딩 중" }: SpinnerProps) => {
 	return (
 		<span
 			className="spinner"

--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -213,7 +213,7 @@ describe("Toast close", () => {
 		fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 		expect(screen.getByText("닫기 테스트")).toBeInTheDocument();
 
-		fireEvent.click(screen.getByRole("button", { name: "Close" }));
+		fireEvent.click(screen.getByRole("button", { name: "닫기" }));
 
 		// spring exit 완료 후 unmount (실제 RAF 진행 대기)
 		await waitFor(
@@ -233,7 +233,7 @@ describe("Toast close", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-		const closeBtn = screen.getByRole("button", { name: "Close" });
+		const closeBtn = screen.getByRole("button", { name: "닫기" });
 		// 빠르게 두 번 클릭 - closingRef 가 두 번째 호출 무시
 		fireEvent.click(closeBtn);
 		fireEvent.click(closeBtn);
@@ -316,7 +316,7 @@ describe("Toast portal & a11y", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-		const region = screen.getByRole("region", { name: "Notifications" });
+		const region = screen.getByRole("region", { name: "알림" });
 		expect(region).toHaveAttribute("aria-live", "polite");
 		expect(region).toHaveAttribute("aria-atomic", "false");
 	});
@@ -365,15 +365,34 @@ describe("Toast portal & a11y", () => {
 
 	it("respects custom closeAriaLabel prop", () => {
 		render(
-			<ToastProvider closeAriaLabel="닫기">
+			// 기본값이 "닫기" 이므로 커스텀 값은 그와 달라야 주입이 실제로 먹었는지 알 수 있다
+			<ToastProvider closeAriaLabel="Dismiss">
 				<ToastTrigger fn={(t) => t.success("커스텀 라벨")} />
 			</ToastProvider>,
 		);
 
 		fireEvent.click(screen.getByRole("button", { name: "trigger" }));
 
-		expect(screen.getByRole("button", { name: "닫기" })).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "닫기" })).not.toBeInTheDocument();
+	});
+
+	it("names the toast region in Korean by default and lets the app override it", () => {
+		const { unmount } = render(
+			<ToastProvider>
+				<ToastTrigger fn={(t) => t.success("기본 리전 이름")} />
+			</ToastProvider>,
+		);
+		expect(screen.getByRole("region", { name: "알림" })).toBeInTheDocument();
+		unmount();
+
+		render(
+			<ToastProvider regionLabel="Notifications">
+				<ToastTrigger fn={(t) => t.success("커스텀 리전 이름")} />
+			</ToastProvider>,
+		);
+		expect(screen.getByRole("region", { name: "Notifications" })).toBeInTheDocument();
+		expect(screen.queryByRole("region", { name: "알림" })).not.toBeInTheDocument();
 	});
 });
 
@@ -480,7 +499,7 @@ describe("Toast auto-dismiss", () => {
 		const item = document.querySelector(".toast_item");
 		expect(item).not.toBeNull();
 
-		fireEvent.click(screen.getByRole("button", { name: "Close" }));
+		fireEvent.click(screen.getByRole("button", { name: "닫기" }));
 
 		// spring exit 진행 중 - 잠시 DOM 유지
 		expect(document.querySelector(".toast_item")).not.toBeNull();
@@ -621,7 +640,7 @@ describe("Toast stack & ids", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: "two" }));
 
-		const closeButtons = screen.getAllByRole("button", { name: "Close" });
+		const closeButtons = screen.getAllByRole("button", { name: "닫기" });
 		expect(closeButtons).toHaveLength(2);
 
 		// 첫 번째(맨 위) 토스트의 닫기 버튼에 포커스를 두고 닫으면,

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -28,7 +28,7 @@ export interface ToastProviderProps {
 	children: React.ReactNode;
 	/** 최대 동시 표시 토스트 수 (기본값: 5) */
 	maxCount?: number;
-	/** 토스트 닫기 버튼의 aria-label (기본값: "Close") */
+	/** 토스트 닫기 버튼의 aria-label (기본값: "닫기") */
 	closeAriaLabel?: string;
 	/** 토스트 리전(`role="region"`)의 접근성 이름 (기본값: "알림"). 스크린리더의 리전 목록에 뜬다 */
 	regionLabel?: string;

--- a/src/ui/feedback/toast/index.tsx
+++ b/src/ui/feedback/toast/index.tsx
@@ -30,6 +30,8 @@ export interface ToastProviderProps {
 	maxCount?: number;
 	/** 토스트 닫기 버튼의 aria-label (기본값: "Close") */
 	closeAriaLabel?: string;
+	/** 토스트 리전(`role="region"`)의 접근성 이름 (기본값: "알림"). 스크린리더의 리전 목록에 뜬다 */
+	regionLabel?: string;
 }
 
 const VARIANT_ICONS: Record<ToastVariant, React.ReactElement> = {
@@ -130,7 +132,8 @@ const ToastItemComponent = ({ item, onRemove, closeAriaLabel }: ToastItemCompone
 export const ToastProvider = ({
 	children,
 	maxCount = 5,
-	closeAriaLabel = "Close",
+	closeAriaLabel = "닫기",
+	regionLabel = "알림",
 }: ToastProviderProps) => {
 	const [toasts, setToasts] = React.useState<ToastItem[]>([]);
 	// 포털은 클라이언트 마운트 후에만 렌더 (SSR/hydration 안전) - 공유 훅
@@ -174,7 +177,7 @@ export const ToastProvider = ({
 						role="region"
 						aria-live="polite"
 						aria-atomic="false"
-						aria-label="Notifications"
+						aria-label={regionLabel}
 					>
 						{toasts.map((item) => (
 							<ToastItemComponent

--- a/src/ui/feedback/top-loading/TopLoading.test.tsx
+++ b/src/ui/feedback/top-loading/TopLoading.test.tsx
@@ -24,7 +24,7 @@ describe("TopLoading", () => {
 
 		expect(progressbar).toHaveAttribute("aria-valuemin", "0");
 		expect(progressbar).toHaveAttribute("aria-valuemax", "100");
-		expect(progressbar).toHaveAttribute("aria-label", "Page loading");
+		expect(progressbar).toHaveAttribute("aria-label", "페이지 로딩 중");
 	});
 
 	it("uses custom aria-label", () => {

--- a/src/ui/feedback/top-loading/index.tsx
+++ b/src/ui/feedback/top-loading/index.tsx
@@ -12,7 +12,7 @@ export interface TopLoadingProps {
 	height?: number;
 	/** 표시 여부 */
 	isLoading?: boolean;
-	/** 프로그레스 바의 접근성 레이블 (기본값: "Page loading") */
+	/** 프로그레스 바의 접근성 레이블 (기본값: "페이지 로딩 중") */
 	ariaLabel?: string;
 }
 

--- a/src/ui/feedback/top-loading/index.tsx
+++ b/src/ui/feedback/top-loading/index.tsx
@@ -27,7 +27,7 @@ export const TopLoading = ({
 	color,
 	height = 3,
 	isLoading = true,
-	ariaLabel = "Page loading",
+	ariaLabel = "페이지 로딩 중",
 }: TopLoadingProps) => {
 	if (!isLoading) return null;
 

--- a/src/ui/forms/date-picker/DatePicker.test.tsx
+++ b/src/ui/forms/date-picker/DatePicker.test.tsx
@@ -130,12 +130,12 @@ describe("DatePicker", () => {
 
 	it("renders sr-only constraint description when minDate is set", () => {
 		render(<DatePicker minDate="2020-01-01" onChange={() => {}} />);
-		expect(screen.getByText(/Minimum date: 2020-01-01/)).toBeInTheDocument();
+		expect(screen.getByText(/최소 날짜: 2020-01-01/)).toBeInTheDocument();
 	});
 
 	it("renders sr-only constraint description when selectableRange is until-today", () => {
 		render(<DatePicker selectableRange="until-today" onChange={() => {}} />);
-		expect(screen.getByText(/Selectable up to today/)).toBeInTheDocument();
+		expect(screen.getByText(/오늘까지 선택 가능/)).toBeInTheDocument();
 	});
 
 	it("links group to constraint description via aria-describedby", () => {

--- a/src/ui/forms/date-picker/DatePicker.test.tsx
+++ b/src/ui/forms/date-picker/DatePicker.test.tsx
@@ -10,19 +10,19 @@ describe("DatePicker", () => {
 
 	it("renders year/month selects by default", () => {
 		render(<DatePicker onChange={() => {}} />);
-		// label + placeholder 로 각 Dropdown 에 두 번씩 "Year"/"Month" 나타남
-		expect(screen.getAllByText("Year").length).toBeGreaterThan(0);
-		expect(screen.getAllByText("Month").length).toBeGreaterThan(0);
+		// label + placeholder 로 각 Dropdown 에 두 번씩 "년"/"월" 나타남
+		expect(screen.getAllByText("년").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("월").length).toBeGreaterThan(0);
 	});
 
 	it("renders day select in year-month-day mode", () => {
 		render(<DatePicker mode="year-month-day" onChange={() => {}} />);
-		expect(screen.getAllByText("Day").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("일").length).toBeGreaterThan(0);
 	});
 
 	it("does not render day select in year-month mode", () => {
 		render(<DatePicker mode="year-month" onChange={() => {}} />);
-		expect(screen.queryByText("Day")).not.toBeInTheDocument();
+		expect(screen.queryByText("일")).not.toBeInTheDocument();
 	});
 
 	it("renders 3 select buttons in year-month-day mode", () => {

--- a/src/ui/forms/date-picker/index.tsx
+++ b/src/ui/forms/date-picker/index.tsx
@@ -88,9 +88,9 @@ export const DatePicker = ({
 	disabled,
 	fullWidth = true,
 	width,
-	yearLabel = "Year",
-	monthLabel = "Month",
-	dayLabel = "Day",
+	yearLabel = "년",
+	monthLabel = "월",
+	dayLabel = "일",
 	minDateSrFormat = "Minimum date: {date}",
 	selectableRangeUntilTodaySrText = "Selectable up to today",
 }: DatePickerProps) => {

--- a/src/ui/forms/date-picker/index.tsx
+++ b/src/ui/forms/date-picker/index.tsx
@@ -32,20 +32,20 @@ interface DatePickerBaseProps {
 	 * @deprecated `fullWidth` 사용 또는 CSS로 처리
 	 */
 	width?: number | string;
-	/** 연도 select의 라벨/플레이스홀더 (기본값: "Year") */
+	/** 연도 select의 라벨/플레이스홀더 (기본값: "년") */
 	yearLabel?: string;
-	/** 월 select의 라벨/플레이스홀더 (기본값: "Month") */
+	/** 월 select의 라벨/플레이스홀더 (기본값: "월") */
 	monthLabel?: string;
-	/** 일 select의 라벨/플레이스홀더 (기본값: "Day") */
+	/** 일 select의 라벨/플레이스홀더 (기본값: "일") */
 	dayLabel?: string;
 	/**
 	 * minDate 설정 시 스크린리더에 전달할 안내 문구 포맷.
-	 * `{date}` 자리에 minDate 값이 치환됩니다. (기본값: "Minimum date: {date}")
+	 * `{date}` 자리에 minDate 값이 치환됩니다. (기본값: "최소 날짜: {date}")
 	 */
 	minDateSrFormat?: string;
 	/**
 	 * selectableRange="until-today" 설정 시 스크린리더에 전달할 안내 문구.
-	 * (기본값: "Selectable up to today")
+	 * (기본값: "오늘까지 선택 가능")
 	 */
 	selectableRangeUntilTodaySrText?: string;
 }
@@ -91,8 +91,8 @@ export const DatePicker = ({
 	yearLabel = "년",
 	monthLabel = "월",
 	dayLabel = "일",
-	minDateSrFormat = "Minimum date: {date}",
-	selectableRangeUntilTodaySrText = "Selectable up to today",
+	minDateSrFormat = "최소 날짜: {date}",
+	selectableRangeUntilTodaySrText = "오늘까지 선택 가능",
 }: DatePickerProps) => {
 	const groupId = React.useId();
 	const constraintId = React.useId();

--- a/src/ui/forms/dropdown/Dropdown.test.tsx
+++ b/src/ui/forms/dropdown/Dropdown.test.tsx
@@ -235,7 +235,7 @@ describe("Dropdown", () => {
 
 	it("uses default placeholder when none is provided", () => {
 		render(<Dropdown options={options} />);
-		expect(screen.getByText("Select…")).toBeInTheDocument();
+		expect(screen.getByText("선택…")).toBeInTheDocument();
 	});
 
 	it("renders defaultValue in uncontrolled mode", () => {
@@ -348,7 +348,7 @@ describe("Dropdown", () => {
 				</button>
 			</div>,
 		);
-		fireEvent.click(screen.getByRole("button", { name: /Select/ }));
+		fireEvent.click(screen.getByRole("button", { name: /선택/ }));
 		expect(screen.getByRole("listbox")).toBeInTheDocument();
 
 		fireEvent.mouseDown(screen.getByTestId("outside"));
@@ -496,7 +496,7 @@ describe("Dropdown", () => {
 		const onChange = vi.fn();
 		render(<Dropdown options={options} onChange={onChange} value="999" />);
 		// value="999" 는 옵션에 없음 - placeholder가 보여야 함
-		expect(screen.getByText("Select…")).toBeInTheDocument();
+		expect(screen.getByText("선택…")).toBeInTheDocument();
 	});
 
 	it("calls onValueChange (canonical) on select", () => {

--- a/src/ui/forms/dropdown/index.tsx
+++ b/src/ui/forms/dropdown/index.tsx
@@ -37,7 +37,7 @@ interface DropdownCommonProps {
 	id?: string;
 	/** 드롭다운 위에 표시할 플로팅 라벨 텍스트 */
 	label?: string;
-	/** 선택 전 표시할 플레이스홀더 (기본값: "Select…") */
+	/** 선택 전 표시할 플레이스홀더 (기본값: "선택…") */
 	placeholder?: string;
 	/** 표시할 옵션 목록 */
 	options: DropdownOption[];
@@ -119,7 +119,7 @@ export const Dropdown = (props: DropdownProps) => {
 	const {
 		id,
 		label,
-		placeholder = "Select…",
+		placeholder = "선택…",
 		options,
 		disabled,
 		size = "md",

--- a/src/ui/forms/file/FileInput.test.tsx
+++ b/src/ui/forms/file/FileInput.test.tsx
@@ -5,7 +5,7 @@ import { FileInput } from "./index";
 describe("FileInput", () => {
 	it("renders with default label", () => {
 		render(<FileInput />);
-		expect(screen.getByText("Choose file")).toBeInTheDocument();
+		expect(screen.getByText("파일 선택")).toBeInTheDocument();
 	});
 
 	it("renders with custom label", () => {
@@ -22,7 +22,7 @@ describe("FileInput", () => {
 	it("associates label with input", () => {
 		render(<FileInput />);
 		const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-		const label = screen.getByText("Choose file");
+		const label = screen.getByText("파일 선택");
 
 		expect(label).toHaveAttribute("for", input.id);
 	});
@@ -79,7 +79,7 @@ describe("FileInput", () => {
 
 	it("has file_input_label class on label", () => {
 		render(<FileInput />);
-		const label = screen.getByText("Choose file");
+		const label = screen.getByText("파일 선택");
 		expect(label).toHaveClass("file_input_label");
 	});
 

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -9,7 +9,7 @@ import "./style.scss";
 export type FileInputVariant = "button" | "preview";
 
 export interface FileInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-	/** 파일 선택 버튼 라벨 / preview variant 빈 상태 텍스트 (기본값: "Choose file") */
+	/** 파일 선택 버튼 라벨 / preview variant 빈 상태 텍스트 (기본값: "파일 선택") */
 	label?: string;
 	/** 파일 선택 시 호출되는 콜백 */
 	onFiles?: (files: FileList | null) => void;

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -34,7 +34,7 @@ export interface FileInputProps extends React.InputHTMLAttributes<HTMLInputEleme
  * @returns 렌더링된 파일 입력 UI
  */
 export const FileInput = ({
-	label = "Choose file",
+	label = "파일 선택",
 	onFiles,
 	supportingText,
 	preview = false,

--- a/src/ui/forms/textfield/TextField.test.tsx
+++ b/src/ui/forms/textfield/TextField.test.tsx
@@ -296,14 +296,14 @@ describe("TextField", () => {
 		const input = screen.getByLabelText("Password");
 		expect(input).toHaveAttribute("type", "password");
 
-		const toggle = screen.getByRole("button", { name: "Show password" });
+		const toggle = screen.getByRole("button", { name: "비밀번호 표시" });
 		expect(toggle.closest("[aria-hidden]")).toBeNull();
 
 		fireEvent.click(toggle);
 		expect(input).toHaveAttribute("type", "text");
-		expect(screen.getByRole("button", { name: "Hide password" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "비밀번호 숨기기" })).toBeInTheDocument();
 
-		fireEvent.click(screen.getByRole("button", { name: "Hide password" }));
+		fireEvent.click(screen.getByRole("button", { name: "비밀번호 숨기기" }));
 		expect(input).toHaveAttribute("type", "password");
 	});
 
@@ -322,8 +322,8 @@ describe("TextField", () => {
 	// 토글은 clear 를 이긴다 - 값이 찬 비밀번호 칸에서 토글이 사라지면 쓸 수 없다.
 	it("keeps the password toggle visible when clearable also has a value", () => {
 		render(<TextField type="password" showPasswordToggle clearable defaultValue="secret" />);
-		expect(screen.getByRole("button", { name: "Show password" })).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "비밀번호 표시" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "지우기" })).not.toBeInTheDocument();
 	});
 
 	it("leaves the input type untouched when the toggle is off", () => {
@@ -336,7 +336,7 @@ describe("TextField", () => {
 	// 내장 버튼은 disabled 속성을 직접 받아야 한다. 없으면 비활성 필드의 비밀번호가 드러난다.
 	it("disables the built-in password toggle with the field", () => {
 		render(<TextField label="Password" type="password" showPasswordToggle disabled />);
-		const toggle = screen.getByRole("button", { name: "Show password" });
+		const toggle = screen.getByRole("button", { name: "비밀번호 표시" });
 		expect(toggle).toBeDisabled();
 
 		fireEvent.click(toggle);
@@ -346,7 +346,7 @@ describe("TextField", () => {
 	it("disables the built-in clear button with the field", () => {
 		const handleChange = vi.fn();
 		render(<TextField clearable defaultValue="text" disabled onValueChange={handleChange} />);
-		const clear = screen.getByRole("button", { name: "Clear" });
+		const clear = screen.getByRole("button", { name: "지우기" });
 		expect(clear).toBeDisabled();
 
 		fireEvent.click(clear);
@@ -361,7 +361,7 @@ describe("TextField", () => {
 		const input = screen.getByLabelText("Password");
 		expect(input).toHaveAttribute("type", "password");
 
-		fireEvent.click(screen.getByRole("button", { name: "Show password" }));
+		fireEvent.click(screen.getByRole("button", { name: "비밀번호 표시" }));
 		expect(input).toHaveAttribute("type", "text");
 	});
 
@@ -380,5 +380,17 @@ describe("TextField", () => {
 	it("leaves the input unmarked when identifier is off", () => {
 		render(<TextField label="이름" />);
 		expect(screen.getByLabelText("이름")).not.toHaveClass("text_field_input_identifier");
+	});
+
+	// 지우기 버튼의 라벨은 이전엔 영문 "Clear" 하드코딩이라 앱이 고칠 수단이 없었다.
+	it("names the clear button in Korean by default", () => {
+		render(<TextField label="이름" clearable defaultValue="값" />);
+		expect(screen.getByRole("button", { name: "지우기" })).toBeInTheDocument();
+	});
+
+	it("lets the app override the clear button label", () => {
+		render(<TextField label="이름" clearable defaultValue="값" clearLabel="Clear" />);
+		expect(screen.getByRole("button", { name: "Clear" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "지우기" })).not.toBeInTheDocument();
 	});
 });

--- a/src/ui/forms/textfield/index.tsx
+++ b/src/ui/forms/textfield/index.tsx
@@ -72,10 +72,12 @@ export interface TextFieldProps
 	 * 켜면 `type` 을 토글이 직접 관리한다 - 숨김 상태는 넘긴 `type`(보통 `"password"`), 표시 상태는 `"text"`.
 	 */
 	showPasswordToggle?: boolean;
-	/** 토글 버튼의 `aria-label`. i18n 은 앱이 주입한다 (기본값: 영문). */
+	/** 토글 버튼의 `aria-label` (기본값: "비밀번호 표시" / "비밀번호 숨기기"). 다국어 앱은 주입할 것 */
 	passwordToggleLabels?: { show: string; hide: string };
 	/** 값이 있을 때 오른쪽에 지우기(X) 버튼 표시 여부 */
 	clearable?: boolean;
+	/** 지우기(X) 버튼의 `aria-label` (기본값: "지우기") */
+	clearLabel?: string;
 	/** 컨테이너 전체 너비 차지 여부 */
 	fullWidth?: boolean;
 	/** 값 변경 콜백 (canonical). 호출 시점은 `imeStrategy` 에 따름 (기본: 조합 완료 후) */
@@ -100,7 +102,7 @@ export interface TextFieldProps
 // X 아이콘 - lucide-react
 const ClearIcon = () => <X size={iconSize.lg} aria-hidden="true" />;
 
-const DEFAULT_PASSWORD_TOGGLE_LABELS = { show: "Show password", hide: "Hide password" } as const;
+const DEFAULT_PASSWORD_TOGGLE_LABELS = { show: "비밀번호 표시", hide: "비밀번호 숨기기" } as const;
 
 /**
  * 텍스트 필드를 렌더링한다.
@@ -124,6 +126,7 @@ export const TextField = ({
 	showPasswordToggle,
 	passwordToggleLabels,
 	clearable,
+	clearLabel = "지우기",
 	type,
 	fullWidth,
 	size = "md",
@@ -237,7 +240,7 @@ export const TextField = ({
 			type="button"
 			className="text_field_clear"
 			onClick={handleClear}
-			aria-label="Clear"
+			aria-label={clearLabel}
 			disabled={props.disabled}
 		>
 			<ClearIcon />

--- a/src/ui/navigation/breadcrumb/Breadcrumb.test.tsx
+++ b/src/ui/navigation/breadcrumb/Breadcrumb.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Breadcrumb } from "./index";
 
-describe("Breadcrumb", () => {
+describe("현재 위치", () => {
 	it("renders all items", () => {
 		render(
 			<Breadcrumb
@@ -59,6 +59,12 @@ describe("Breadcrumb", () => {
 
 	it("uses nav with aria-label", () => {
 		render(<Breadcrumb items={[{ label: "Home" }]} />);
+		expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "현재 위치");
+	});
+
+	// <nav> 랜드마크 이름은 스크린리더의 리전 목록에 그대로 뜬다. 이전엔 영문 하드코딩이었다.
+	it("lets the app override the nav landmark name", () => {
+		render(<Breadcrumb items={[{ label: "홈", href: "/" }, { label: "상세" }]} navLabel="Breadcrumb" />);
 		expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "Breadcrumb");
 	});
 });

--- a/src/ui/navigation/breadcrumb/Breadcrumb.test.tsx
+++ b/src/ui/navigation/breadcrumb/Breadcrumb.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Breadcrumb } from "./index";
 
-describe("현재 위치", () => {
+describe("Breadcrumb", () => {
 	it("renders all items", () => {
 		render(
 			<Breadcrumb

--- a/src/ui/navigation/breadcrumb/index.tsx
+++ b/src/ui/navigation/breadcrumb/index.tsx
@@ -20,6 +20,8 @@ export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
 	items: BreadcrumbItem[];
 	/** 구분자 (기본값: ChevronRight 아이콘) */
 	separator?: React.ReactNode;
+	/** `<nav>` 랜드마크 이름 (기본값: "현재 위치"). 스크린리더의 리전 목록에 그대로 뜬다 */
+	navLabel?: string;
 }
 
 /**
@@ -37,13 +39,14 @@ export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
 export const Breadcrumb = ({
 	items,
 	separator,
+	navLabel = "현재 위치",
 	className,
 	...props
 }: BreadcrumbProps) => {
 	const sep = separator ?? <ChevronRight size={iconSize.xs} aria-hidden="true" />;
 
 	return (
-		<nav aria-label="Breadcrumb" className={cn("breadcrumb", className)} {...props}>
+		<nav aria-label={navLabel} className={cn("breadcrumb", className)} {...props}>
 			<ol className="breadcrumb_list">
 				{items.map((item, idx) => {
 					const isLast = idx === items.length - 1;

--- a/src/ui/navigation/pagination/Pagination.test.tsx
+++ b/src/ui/navigation/pagination/Pagination.test.tsx
@@ -2,39 +2,39 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Pagination } from "./index";
 
-describe("Pagination", () => {
+describe("페이지 이동", () => {
 	it("renders pagination navigation", () => {
 		render(<Pagination page={1} totalPages={10} onChange={() => {}} />);
-		expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "Pagination");
+		expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "페이지 이동");
 	});
 
 	it("renders previous and next buttons", () => {
 		render(<Pagination page={5} totalPages={10} onChange={() => {}} />);
-		expect(screen.getByLabelText("Previous page")).toBeInTheDocument();
-		expect(screen.getByLabelText("Next page")).toBeInTheDocument();
+		expect(screen.getByLabelText("이전 페이지")).toBeInTheDocument();
+		expect(screen.getByLabelText("다음 페이지")).toBeInTheDocument();
 	});
 
 	it("disables previous button on first page", () => {
 		render(<Pagination page={1} totalPages={10} onChange={() => {}} />);
-		expect(screen.getByLabelText("Previous page")).toBeDisabled();
+		expect(screen.getByLabelText("이전 페이지")).toBeDisabled();
 	});
 
 	it("disables next button on last page", () => {
 		render(<Pagination page={10} totalPages={10} onChange={() => {}} />);
-		expect(screen.getByLabelText("Next page")).toBeDisabled();
+		expect(screen.getByLabelText("다음 페이지")).toBeDisabled();
 	});
 
 	it("enables both buttons on middle page", () => {
 		render(<Pagination page={5} totalPages={10} onChange={() => {}} />);
-		expect(screen.getByLabelText("Previous page")).not.toBeDisabled();
-		expect(screen.getByLabelText("Next page")).not.toBeDisabled();
+		expect(screen.getByLabelText("이전 페이지")).not.toBeDisabled();
+		expect(screen.getByLabelText("다음 페이지")).not.toBeDisabled();
 	});
 
 	it("calls onChange with previous page when clicking previous", () => {
 		const onChange = vi.fn();
 		render(<Pagination page={5} totalPages={10} onChange={onChange} />);
 
-		fireEvent.click(screen.getByLabelText("Previous page"));
+		fireEvent.click(screen.getByLabelText("이전 페이지"));
 		expect(onChange).toHaveBeenCalledWith(4);
 	});
 
@@ -42,7 +42,7 @@ describe("Pagination", () => {
 		const onChange = vi.fn();
 		render(<Pagination page={5} totalPages={10} onChange={onChange} />);
 
-		fireEvent.click(screen.getByLabelText("Next page"));
+		fireEvent.click(screen.getByLabelText("다음 페이지"));
 		expect(onChange).toHaveBeenCalledWith(6);
 	});
 
@@ -81,7 +81,7 @@ describe("Pagination", () => {
 	it("calls onPageChange (canonical) when clicking previous", () => {
 		const onPageChange = vi.fn();
 		render(<Pagination page={5} totalPages={10} onPageChange={onPageChange} />);
-		fireEvent.click(screen.getByLabelText("Previous page"));
+		fireEvent.click(screen.getByLabelText("이전 페이지"));
 		expect(onPageChange).toHaveBeenCalledWith(4);
 	});
 
@@ -92,11 +92,17 @@ describe("Pagination", () => {
 			<Pagination page={5} totalPages={10} onPageChange={onPageChange} onChange={onChange} />,
 		);
 
-		fireEvent.click(screen.getByLabelText("Previous page"));
+		fireEvent.click(screen.getByLabelText("이전 페이지"));
 
 		expect(onPageChange).toHaveBeenCalledTimes(1);
 		expect(onPageChange).toHaveBeenCalledWith(4);
 		expect(onChange).not.toHaveBeenCalled();
 	});
 
+
+	// <nav> 랜드마크 이름은 스크린리더의 리전 목록에 그대로 뜬다. 이전엔 영문 하드코딩이었다.
+	it("lets the app override the nav landmark name", () => {
+		render(<Pagination page={2} totalPages={5} onPageChange={() => {}} navLabel="Pagination" />);
+		expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "Pagination");
+	});
 });

--- a/src/ui/navigation/pagination/Pagination.test.tsx
+++ b/src/ui/navigation/pagination/Pagination.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Pagination } from "./index";
 
-describe("페이지 이동", () => {
+describe("Pagination", () => {
 	it("renders pagination navigation", () => {
 		render(<Pagination page={1} totalPages={10} onChange={() => {}} />);
 		expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "페이지 이동");

--- a/src/ui/navigation/pagination/index.tsx
+++ b/src/ui/navigation/pagination/index.tsx
@@ -9,10 +9,12 @@ interface PaginationBaseProps {
 	page: number;
 	/** 전체 페이지 수 */
 	totalPages: number;
-	/** 이전 페이지 버튼 aria-label (기본값: "Previous page") */
+	/** 이전 페이지 버튼 aria-label (기본값: "이전 페이지") */
 	prevLabel?: string;
-	/** 다음 페이지 버튼 aria-label (기본값: "Next page") */
+	/** 다음 페이지 버튼 aria-label (기본값: "다음 페이지") */
 	nextLabel?: string;
+	/** `<nav>` 랜드마크 이름 (기본값: "페이지 이동"). 스크린리더의 리전 목록에 그대로 뜬다 */
+	navLabel?: string;
 }
 
 // Pagination 은 controlled 전용 → 콜백 최소 하나 필수. canonical `onPageChange` 권장, 구 `onChange` 허용(@deprecated).
@@ -84,8 +86,9 @@ export const Pagination = ({
 	totalPages,
 	onPageChange,
 	onChange,
-	prevLabel = "Previous page",
-	nextLabel = "Next page",
+	prevLabel = "이전 페이지",
+	nextLabel = "다음 페이지",
+	navLabel = "페이지 이동",
 }: PaginationProps) => {
 	const emit = onPageChange ?? onChange;
 	const prevDisabled = page <= 1;
@@ -94,7 +97,7 @@ export const Pagination = ({
 	const items = React.useMemo(() => getPaginationItems(page, totalPages), [page, totalPages]);
 
 	return (
-		<nav className="pagination" aria-label="Pagination">
+		<nav className="pagination" aria-label={navLabel}>
 			<button
 				type="button"
 				className="pagination_item"

--- a/src/vanilla/CLAUDE.md
+++ b/src/vanilla/CLAUDE.md
@@ -170,7 +170,7 @@ React 와 동일하게 `multiple` / `searchable` 을 지원한다. 마크업은 
 
 <div id="my-modal" class="bt-modal" data-bt-modal>
   <div class="bt-modal__panel" style="width: 480px;">
-    <button class="bt-modal__close" data-modal-close aria-label="Close">
+    <button class="bt-modal__close" data-modal-close aria-label="닫기">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
     </button>
     <div class="bt-modal__header">Title</div>
@@ -210,9 +210,9 @@ React 와 동일하게 `multiple` / `searchable` 을 지원한다. 마크업은 
 #### Spinner
 ```html
 <!-- 기본 24px (React <Spinner /> 기본값) -->
-<span class="bt-spinner" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" role="status" aria-label="로딩 중"></span>
 <!-- 임의 크기 -->
-<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="Loading"></span>
+<span class="bt-spinner" style="--bt-spinner-size: 32px" role="status" aria-label="로딩 중"></span>
 ```
 
 #### Pagination


### PR DESCRIPTION
## 작업 개요

이슈 #497 - DS 의 a11y 문자열이 절반은 한글 기본값, 절반은 영문이었고 그중 4건은 **앱이 고칠 수단조차 없었다.** 컴포넌트마다 어떤 언어를 말하는지가 그 컴포넌트가 뭐냐에 달려 있는 상태였다.

랜드마크·리전 이름(`Pagination`·`Breadcrumb`의 `<nav>`, `Toast` 의 `role="region"`)은 스크린리더의 리전 목록에 그대로 뜬다 — 한국어 페이지에 "Pagination"·"Breadcrumb"·"Notifications" 가 섞여 나왔다.

정책을 한쪽으로 통일한다: **기본값은 한글, 모든 a11y 문자열은 prop 으로 교체 가능.** 다국어 앱에서는 DS 기본값이 항상 틀린 값이라는 것을 계약으로 인정하고, 대신 주입 수단을 100% 보장한다.

Closes #497

## 작업한 내용

### A. 교체 수단이 없던 4건 — 신규 prop

- [x] `TextField` `clearLabel` (기본값 `"지우기"`) — 이전엔 `aria-label="Clear"` 하드코딩
- [x] `Pagination` `navLabel` (기본값 `"페이지 이동"`) — 이전엔 `aria-label="Pagination"` 하드코딩
- [x] `Breadcrumb` `navLabel` (기본값 `"현재 위치"`) — 이전엔 `aria-label="Breadcrumb"` 하드코딩
- [x] `ToastProvider` `regionLabel` (기본값 `"알림"`) — 이전엔 `aria-label="Notifications"` 하드코딩

### B. 영문 기본값 7건 → 한글 (동작 변경)

- [x] `FileInput` `label` `"Choose file"` → `"파일 선택"` — 이건 `aria-label` 이 아니라 **화면에 보이는 버튼 텍스트**다
- [x] `DatePicker` `yearLabel`·`monthLabel`·`dayLabel` → `"년"`·`"월"`·`"일"`
- [x] `Pagination` `prevLabel`·`nextLabel` → `"이전 페이지"`·`"다음 페이지"`
- [x] `TopLoading` `ariaLabel` → `"페이지 로딩 중"`
- [x] `ToastProvider` `closeAriaLabel` → `"닫기"`
- [x] `Spinner` `ariaLabel` → `"로딩 중"`
- [x] `TextField` `passwordToggleLabels` → `"비밀번호 표시"`·`"비밀번호 숨기기"` (v3.11 에서 "기본값 영문" 으로 문서화했던 것을 정책에 맞춰 정정)

### 문서

- [x] `docs/MIGRATION.md` v3.13.0 절 — 두 표 + **다국어(ko/en) 앱 업그레이드 절차** + 왜 영문 기본값을 둘 수 없었나
- [x] `docs/COMPONENTS.md` — 신규 prop 행 4개, `FileInput`·`TopLoading` 의 낡은 기본값 정정, `Spinner` `ariaLabel` 행, **없던 `ToastProvider` props 표** 신설
- [x] `docs/VANILLA.md` · `docs/VANILLA-PROMPT.md` · `src/vanilla/CLAUDE.md` 의 HTML 예시에 있던 영문 `aria-label` 도 한글로

## 검증

- 단위 **901 passed / 9 skipped** (기존 901 → 910 총량, 신규 5건)
- `tsc --noEmit` · `pnpm lint:css` · `pnpm build` 통과
- **`src/ui` 에 남은 영문 `aria-label` 리터럴과 영문 `*Label` 기본값 0건** (전수 grep)
- 빌드 산출물(`dist/index.js`) 실측 — 번들이 non-ASCII 를 `\uXXXX` 로 이스케이프하므로 같은 형태로 인코딩해 검색:

| 문자열 | 건수 | | 문자열 | 건수 |
|---|---|---|---|---|
| 지우기 | 1 | | 로딩 중 | 2 |
| 페이지 이동 | 1 | | 페이지 로딩 중 | 1 |
| 현재 위치 | 1 | | 비밀번호 표시 / 숨기기 | 1 / 1 |
| 알림 | 1 | | 닫기 | 3 |
| 파일 선택 | 1 | | 년 / 월 / 일 | 1 / 1 / 2 |
| 이전 / 다음 페이지 | 1 / 1 | | | |

  영문 잔존 — `"Clear"` · `"Pagination"` · `"Breadcrumb"` · `"Notifications"` · `"Choose file"` · `"Previous page"` · `"Show password"` 모두 **0건**

- **뮤테이션 4건 전부 사망** — 신규 prop 을 무시하고 하드코딩 영문으로 되돌리면 각각 해당 테스트만 실패 (`clearLabel` 2건, `navLabel`×2 각 1건, `regionLabel` 2건)
- **기존 테스트에서 발견한 함정 하나**: `closeAriaLabel` 주입을 검증하는 Toast 테스트가 커스텀 값으로 `"닫기"` 를 넘기고 있었다. 그게 새 기본값이라 **prop 을 무시해도 통과하는 테스트**가 된다. 다른 값으로 바꿨다

## 전달할 추가 이슈

- **B 는 동작 변경이고 컴파일러가 잡아주지 않는다.** 다국어 앱은 업그레이드 전에 라벨을 주입해야 한다 — 지금까지 영문 기본값이 영어 UI 에서 우연히 맞았을 뿐이다. `docs/MIGRATION.md` 에 절차를 적었고, 릴리즈 노트에도 눈에 띄게 넣어야 한다
- notiiv 는 `Pagination`(7곳) · `Breadcrumb`(3곳) · `Spinner`/`TopLoading` 에 라벨을 안 넘기는 자리가 있다고 확인됐다. **이 PR 이 배포되기 전에** 그쪽 주입이 먼저 나가야 영어 화면에 한글이 뜨지 않는다
- 회귀 방지 스크립트(`src/ui` 의 `aria-label` 리터럴·`*Label` 기본값 언어 검사)는 넣지 않았다. `scripts/check-css-vars.sh` 와 같은 자리가 맞지만 CI 편입은 별도 승인이 필요하다
- 정책 자체를 `CLAUDE.md` 나 `docs/CONTRIBUTING.md` 규약에 박아야 신규 컴포넌트가 같은 실수를 반복하지 않는다 — 이 PR 은 문서(MIGRATION·COMPONENTS)까지만 했다