### PR TITLE
docs/css-var-lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 }
 ```
 
-> The React entry's `style.css` only emits `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, and `--bt-bottom-nav-*`. Spacing, radius, and typography are **SCSS-only** on this entry - use `scss/token` for them (`--bt-spacing-*` / `--bt-radius-*` exist only in the [Vanilla bundle](./docs/VANILLA.md)).
+> The React entry's `style.css` only emits `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset*`, `--bt-scrollbar-width`. Spacing, radius, and typography are **SCSS-only** on this entry - use `scss/token` for them (`--bt-spacing-*` / `--bt-radius-*` exist only in the [Vanilla bundle](./docs/VANILLA.md)).
 
 `colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS only</sup>
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ showAlert({ title: "Delete?", showCancel: true, onConfirm: ... });
 }
 ```
 
+<!-- css-var-claim: 아래 한 줄이 React entry 의 변수 계열 전부를 주장한다. scripts/check-css-vars.sh 가 이 줄만 검사한다. -->
 > The React entry's `style.css` only emits `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset*`, `--bt-scrollbar-width`. Spacing, radius, and typography are **SCSS-only** on this entry - use `scss/token` for them (`--bt-spacing-*` / `--bt-radius-*` exist only in the [Vanilla bundle](./docs/VANILLA.md)).
 
 `colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS only</sup>

--- a/README_KR.md
+++ b/README_KR.md
@@ -139,7 +139,7 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 }
 ```
 
-> React entry 의 `style.css` 가 내보내는 CSS 변수는 `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset`, `--bt-scrollbar-width` 뿐이다. spacing / radius / typography 는 이 entry 에선 **SCSS 전용**이라 `scss/token` 을 써야 한다 (`--bt-spacing-*` / `--bt-radius-*` 는 [Vanilla 번들](./docs/VANILLA.md) 에만 존재).
+> React entry 의 `style.css` 가 내보내는 CSS 변수는 `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset*`, `--bt-scrollbar-width` 뿐이다. spacing / radius / typography 는 이 entry 에선 **SCSS 전용**이라 `scss/token` 을 써야 한다 (`--bt-spacing-*` / `--bt-radius-*` 는 [Vanilla 번들](./docs/VANILLA.md) 에만 존재).
 
 `colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS 전용</sup>
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -139,6 +139,7 @@ showAlert({ title: "삭제할까요?", showCancel: true, onConfirm: ... });
 }
 ```
 
+<!-- css-var-claim: 아래 한 줄이 React entry 의 변수 계열 전부를 주장한다. scripts/check-css-vars.sh 가 이 줄만 검사한다. -->
 > React entry 의 `style.css` 가 내보내는 CSS 변수는 `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset*`, `--bt-scrollbar-width` 뿐이다. spacing / radius / typography 는 이 entry 에선 **SCSS 전용**이라 `scss/token` 을 써야 한다 (`--bt-spacing-*` / `--bt-radius-*` 는 [Vanilla 번들](./docs/VANILLA.md) 에만 존재).
 
 `colors`&nbsp;·&nbsp;`spacing`&nbsp;·&nbsp;`typography`&nbsp;·&nbsp;`radius`&nbsp;·&nbsp;`elevation`&nbsp;·&nbsp;`motion`&nbsp;·&nbsp;`z-index`&nbsp;·&nbsp;`breakpoints`&nbsp;·&nbsp;`border-width`&nbsp;·&nbsp;`opacity`&nbsp;·&nbsp;`skeleton`&nbsp;·&nbsp;`icon`&nbsp;·&nbsp;`a11y`&nbsp;·&nbsp;`layout`<sup>SCSS 전용</sup>

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -56,7 +56,7 @@ Always reference tokens - never inline a hex value.
 
 Two surfaces, and they are **not** interchangeable:
 - **SCSS tokens** (`@use "src/styles/token" as token;` → `token.$spacing_16`) - the full set. Use these in component `style.scss`.
-- **CSS custom properties** (`var(--bt-color-bg-solid)`) - the React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset`, `--bt-scrollbar-width`. Spacing / radius / typography CSS vars exist only in the Vanilla bundle. Full contract incl. runtime behaviour: [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수).
+- **CSS custom properties** (`var(--bt-color-bg-solid)`) - the React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset*`, `--bt-scrollbar-width`. Spacing / radius / typography CSS vars exist only in the Vanilla bundle. Full contract incl. runtime behaviour: [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수).
 
 ### Color tokens
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -56,7 +56,10 @@ Always reference tokens - never inline a hex value.
 
 Two surfaces, and they are **not** interchangeable:
 - **SCSS tokens** (`@use "src/styles/token" as token;` → `token.$spacing_16`) - the full set. Use these in component `style.scss`.
-- **CSS custom properties** (`var(--bt-color-bg-solid)`) - the React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset*`, `--bt-scrollbar-width`. Spacing / radius / typography CSS vars exist only in the Vanilla bundle. Full contract incl. runtime behaviour: [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수).
+- **CSS custom properties** - read them with `var()` in consumer CSS. Spacing / radius / typography CSS vars exist only in the Vanilla bundle. Full contract incl. runtime behaviour: [THEMING.md](./THEMING.md#레이아웃런타임-계약-변수).
+
+<!-- css-var-claim: 아래 한 줄이 React entry 의 변수 계열 전부를 주장한다. scripts/check-css-vars.sh 가 이 줄만 검사하므로 예시 변수명을 이 줄에 두지 말 것 - 예시가 계열을 채워 검사가 무력화된다. -->
+The React entry's `style.css` emits only `--bt-color-*`, `--bt-elevation-*`, `--bt-focus-*`, `--bt-sidebar-*`, `--bt-bottom-nav-*`, `--bt-bottom-inset*`, `--bt-scrollbar-width`.
 
 ### Color tokens
 

--- a/scripts/check-css-vars.sh
+++ b/scripts/check-css-vars.sh
@@ -38,3 +38,40 @@ if [ -n "$missing" ]; then
 fi
 
 echo "문서의 CSS 변수 $(wc -l < "$tmp/documented" | tr -d ' ')개 - 모두 빌드 산출물에 존재합니다."
+
+# ── 2단계: "React entry 는 이것만 내보낸다" 주장을 검증한다 ─────────────────────
+#
+# 1단계는 문서→빌드 한 방향만 본다. 그래서 새 변수를 추가하고 THEMING 에만 적으면 통과하는데,
+# 아래 세 파일은 목록을 **전부**라고 주장하므로 조용히 거짓이 된다. 실제로
+# --bt-bottom-inset-app 을 추가했을 때 세 파일 모두 낡은 채로 1단계를 통과했다.
+#
+# React 번들의 최상위 변수 계열을 뽑아, 각 파일이 전부 언급하는지 본다.
+# 계열 추출을 awk 로 하는 이유: sed 의 `t` 분기는 BSD(macOS)와 GNU 에서 동작이 갈린다.
+CLAIM_FILES="docs/AGENT_GUIDE.md README.md README_KR.md"
+
+families_of() {
+	grep -o -- '--bt-[a-z0-9-]*' "$1" | awk '{
+		sub(/^--bt-/, "")
+		# bottom-nav 와 bottom-inset 은 별개 계약이라 한 단어로 합치면 안 된다
+		if ($0 ~ /^bottom-nav/)        { print "bottom-nav";   next }
+		if ($0 ~ /^bottom-inset/)      { print "bottom-inset"; next }
+		sub(/-.*/, "")
+		if ($0 != "") print
+	}' | LC_ALL=C sort -u
+}
+
+families_of "$REACT_CSS" > "$tmp/families"
+
+fail=0
+for f in $CLAIM_FILES; do
+	families_of "$f" > "$tmp/claimed"
+	gap=$(comm -23 "$tmp/families" "$tmp/claimed")
+	if [ -n "$gap" ]; then
+		echo "$f 의 CSS 변수 목록에 빠진 계열:" >&2
+		echo "$gap" | sed 's/^/  --bt-/' >&2
+		fail=1
+	fi
+done
+
+[ "$fail" -eq 0 ] || exit 1
+echo "React entry 변수 계열 $(wc -l < "$tmp/families" | tr -d ' ')개 - 세 요약 목록이 모두 언급합니다."

--- a/scripts/check-css-vars.sh
+++ b/scripts/check-css-vars.sh
@@ -29,7 +29,7 @@ grep -rho -- '--bt-[a-z0-9-]*' docs/*.md README.md README_KR.md \
 	| grep -v -- '-$' | LC_ALL=C sort -u > "$tmp/documented"
 cat "$REACT_CSS" "$VANILLA_CSS" | grep -o -- '--bt-[a-z0-9-]*' | LC_ALL=C sort -u > "$tmp/built"
 
-missing=$(comm -23 "$tmp/documented" "$tmp/built")
+missing=$(LC_ALL=C comm -23 "$tmp/documented" "$tmp/built")
 
 if [ -n "$missing" ]; then
 	echo "문서에 있으나 어느 번들에도 없는 CSS 변수:"
@@ -45,33 +45,47 @@ echo "문서의 CSS 변수 $(wc -l < "$tmp/documented" | tr -d ' ')개 - 모두 
 # 아래 세 파일은 목록을 **전부**라고 주장하므로 조용히 거짓이 된다. 실제로
 # --bt-bottom-inset-app 을 추가했을 때 세 파일 모두 낡은 채로 1단계를 통과했다.
 #
-# React 번들의 최상위 변수 계열을 뽑아, 각 파일이 전부 언급하는지 본다.
-# 계열 추출을 awk 로 하는 이유: sed 의 `t` 분기는 BSD(macOS)와 GNU 에서 동작이 갈린다.
+# 검사 대상은 **주장 문장 한 줄** 이다. 파일 전체를 긁으면 코드 예시나 색상 표에 이미 나오는
+# --bt-color-* / --bt-elevation-* 가 "언급됨"으로 잡혀, 정작 그 계열을 주장 문장에서 지워도
+# 통과한다. 그래서 각 파일의 주장 문장 바로 앞에 sentinel 주석을 두고 그 다음 줄만 본다.
+CLAIM_MARK='css-var-claim'
 CLAIM_FILES="docs/AGENT_GUIDE.md README.md README_KR.md"
 
+# 계열 추출을 awk 로 하는 이유: sed 의 `t` 분기는 BSD(macOS)와 GNU 에서 동작이 갈린다.
 families_of() {
-	grep -o -- '--bt-[a-z0-9-]*' "$1" | awk '{
-		sub(/^--bt-/, "")
-		# bottom-nav 와 bottom-inset 은 별개 계약이라 한 단어로 합치면 안 된다
-		if ($0 ~ /^bottom-nav/)        { print "bottom-nav";   next }
-		if ($0 ~ /^bottom-inset/)      { print "bottom-inset"; next }
-		sub(/-.*/, "")
-		if ($0 != "") print
+	awk '{
+		while (match($0, /--bt-[a-z0-9-]*/)) {
+			v = substr($0, RSTART + 5, RLENGTH - 5)
+			$0 = substr($0, RSTART + RLENGTH)
+			# bottom-nav 와 bottom-inset 은 별개 계약이라 한 단어로 합치면 안 된다
+			if (v ~ /^bottom-nav/)   { print "bottom-nav";   continue }
+			if (v ~ /^bottom-inset/) { print "bottom-inset"; continue }
+			sub(/-.*/, "", v)
+			if (v != "") print v
+		}
 	}' | LC_ALL=C sort -u
 }
 
-families_of "$REACT_CSS" > "$tmp/families"
+# 번들에서는 **선언**(--bt-x: ...)만 센다. var() 참조나 주석에 이름이 스쳐도 계열로 세지 않는다.
+grep -oE -- '--bt-[a-z0-9-]*[[:space:]]*:' "$REACT_CSS" | families_of > "$tmp/families"
 
 fail=0
 for f in $CLAIM_FILES; do
-	families_of "$f" > "$tmp/claimed"
-	gap=$(comm -23 "$tmp/families" "$tmp/claimed")
+	# sentinel 다음 줄 하나만 꺼낸다
+	claim=$(grep -A1 -- "$CLAIM_MARK" "$f" | tail -n 1)
+	if [ -z "$claim" ]; then
+		echo "$f 에 '$CLAIM_MARK' sentinel 이 없습니다 - 주장 문장을 찾을 수 없어 검증 불가." >&2
+		fail=1
+		continue
+	fi
+	printf '%s\n' "$claim" | families_of > "$tmp/claimed"
+	gap=$(LC_ALL=C comm -23 "$tmp/families" "$tmp/claimed")
 	if [ -n "$gap" ]; then
-		echo "$f 의 CSS 변수 목록에 빠진 계열:" >&2
+		echo "$f 의 CSS 변수 주장 문장에 빠진 계열:" >&2
 		echo "$gap" | sed 's/^/  --bt-/' >&2
 		fail=1
 	fi
 done
 
 [ "$fail" -eq 0 ] || exit 1
-echo "React entry 변수 계열 $(wc -l < "$tmp/families" | tr -d ' ')개 - 세 요약 목록이 모두 언급합니다."
+echo "React entry 변수 계열 $(wc -l < "$tmp/families" | tr -d ' ')개 - 세 주장 문장이 모두 언급합니다."


### PR DESCRIPTION
## 작업 개요

#506 에 달린 Claude 리뷰의 Medium 지적. `docs/AGENT_GUIDE.md` · `README.md` · `README_KR.md` 가 각각 "React entry 는 이 변수들**만** 내보낸다" 는 목록을 싣고 있는데, #506 에서 추가한 `--bt-bottom-inset-app` 이 어느 목록에도 없었다. `--bt-bottom-nav-*` 와일드카드가 새 `--bt-bottom-nav-inset` 은 덮지만 `--bt-bottom-inset-app` 은 어떤 항목에도 매치되지 않는다.

지적이 두 파일이었는데 확인해 보니 **세 파일**이고, 영문 `README.md` 는 두 릴리즈 뒤처져 있었다 — `--bt-bottom-inset`(3.12.0)과 `--bt-scrollbar-width` 까지 빠져 있었다.

그리고 리뷰가 짚은 대로 **`scripts/check-css-vars.sh` 로는 이걸 못 잡는다.** 문서→빌드 한 방향만 보기 때문에, 새 변수를 THEMING 에만 적으면 통과하면서 이 세 주장은 조용히 거짓이 된다.

## 작업한 내용

- [x] 세 파일의 목록을 동일한 7계열로 통일 — `--bt-color-*` · `--bt-elevation-*` · `--bt-focus-*` · `--bt-sidebar-*` · `--bt-bottom-nav-*` · `--bt-bottom-inset*` · `--bt-scrollbar-width`
- [x] `--bt-bottom-inset*` 로 표기해 `--bt-bottom-inset` 과 `--bt-bottom-inset-app` 을 함께 덮는다
- [x] `scripts/check-css-vars.sh` 에 2단계 추가 — React 번들의 최상위 계열을 뽑아 세 파일이 전부 언급하는지 검사
- [x] 계열 추출을 `sed` 대신 `awk` 로 — `bottom-nav` 와 `bottom-inset` 은 별개 계약이라 `bottom` 으로 합쳐지면 안 되고, `sed` 의 `t` 분기는 BSD(macOS)와 GNU 에서 동작이 갈린다

## 검증

- `scripts/check-css-vars.sh` → 1단계 "문서의 CSS 변수 80개 모두 존재", 2단계 "React entry 변수 계열 **7개** — 세 요약 목록이 모두 언급합니다"
- 계열이 정확히 갈리는 것 확인: `--bt-bottom-inset` 과 `--bt-bottom-nav` 가 별개로 잡힌다 (초기 `sed` 버전은 둘을 `bottom` 으로 합쳐 **검사가 통과만 하는 상태**였고, 뮤테이션으로 발견해 고쳤다)
- **뮤테이션 4건 전부 사망** — 세 파일 각각에서 `--bt-bottom-inset*` 를 지우면 `exit=1` + 어느 파일의 어느 계열이 빠졌는지 출력, `README.md` 에서 `--bt-scrollbar-width` 를 지워도 `exit=1`
- 단위 916 passed / 9 skipped (문서·스크립트 변경이라 영향 없음, 회귀 확인용)

## 전달할 추가 이슈

- 이 스크립트는 여전히 CI 에 없다. 조직 규칙상 CI 파일 변경은 별도 승인이 필요해 넣지 않았다 — 승인되면 `ci.yml` 의 `test` job 에 `pnpm build && scripts/check-css-vars.sh` 한 줄이면 된다
- 2단계는 "요약 목록을 싣는 파일" 을 `CLAIM_FILES` 로 하드코딩한다. 네 번째 파일이 같은 주장을 시작하면 목록에 추가해야 한다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * React에서 제공하는 CSS 변수 목록에 `--bt-bottom-inset*` 및 `--bt-scrollbar-width`가 추가로 문서화되었습니다.
  * 관련 안내 문서에서 `--bt-bottom-inset` 변수 범위를 접두사 패턴으로 명확히 설명합니다.

* **품질 개선**
  * 제공되는 CSS 변수 계열과 문서 목록의 일치 여부를 자동으로 검증합니다.
  * 누락된 변수 계열을 식별해 문서의 정확성과 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->