### PR TITLE
config/lint-guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,14 @@ jobs:
         if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.base_ref == 'develop'
         run: pnpm exec commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
-      # SCSS lint — raw hex / named color 금지 (DS 토큰 강제)
+      # SCSS lint — raw hex / named color / raw 값 금지 (DS 토큰 강제)
+      #
+      # 조건을 두지 않는다. 이전 조건(`code || stories`)은 `code` 필터에 src/vanilla/** 가
+      # 없어서 vanilla 만 바뀐 PR 에서 스킵됐고, `deps` 만 바뀐 PR 도 스킵됐다 - 그런데
+      # package.json 이 lint:css 의 글롭 자체를 담고 있다. 조건을 열거하면 이런 구멍이 계속
+      # 생기고, 이 job 이 도는 모든 경우(code/stories/deps/vanilla)에 SCSS 를 봐서 손해가 없다.
+      # Build · size · dist 검사들과 같은 방식이다.
       - name: Lint SCSS (Stylelint)
-        if: needs.changes.outputs.code == 'true' || needs.changes.outputs.stories == 'true'
         run: pnpm lint:css
 
       # 코드 또는 의존성 변경 → unit 테스트 + 커버리지

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,15 @@ jobs:
       - name: Check bundle size
         run: pnpm size
 
+      # 아래 두 검사도 dist 산출물을 읽는다 — 반드시 Build 이후여야 한다.
+      # 단위 테스트로는 잡을 수 없는 종류다: jsdom 은 스타일시트를 계산하지 않고,
+      # 문서와 빌드 산출물의 어긋남은 어떤 테스트도 보지 않는다.
+      - name: Check documented CSS variables
+        run: pnpm check:css-vars
+
+      - name: Check Prose heading weights
+        run: pnpm check:prose
+
       - name: Coverage Report
         uses: davelosert/vitest-coverage-report-action@v2
         if: github.event_name == 'pull_request' && (needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true')

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,30 +1,75 @@
 {
   "customSyntax": "postcss-scss",
   "rules": {
-    "color-no-hex": [true, {
-      "severity": "error",
-      "message": "DS 컴포넌트 SCSS 에 raw hex 금지 — token (var(--bt-color-*) / token.$color_*) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
-    }],
-    "color-named": ["never", {
-      "severity": "error",
-      "message": "named color (white, black, red 등) 금지 — DS 토큰 사용."
-    }],
-    "function-disallowed-list": [["rgb", "rgba", "hsl", "hsla", "hwb", "lab", "lch", "oklab", "oklch", "color"], {
-      "severity": "error",
-      "message": "DS 컴포넌트 SCSS 에 raw 컬러 함수(rgb/rgba/hsl/hsla/hwb/lab/lch/oklab/oklch/color) 금지 — alpha 컬러도 token (token.$color_text_on_dark_* / $color_scrim_* 등) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
-    }]
+    "color-no-hex": [
+      true,
+      {
+        "severity": "error",
+        "message": "DS 컴포넌트 SCSS 에 raw hex 금지 — token (var(--bt-color-*) / token.$color_*) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
+      }
+    ],
+    "color-named": [
+      "never",
+      {
+        "severity": "error",
+        "message": "named color (white, black, red 등) 금지 — DS 토큰 사용."
+      }
+    ],
+    "function-disallowed-list": [
+      [
+        "rgb",
+        "rgba",
+        "hsl",
+        "hsla",
+        "hwb",
+        "lab",
+        "lch",
+        "oklab",
+        "oklch",
+        "color"
+      ],
+      {
+        "severity": "error",
+        "message": "DS 컴포넌트 SCSS 에 raw 컬러 함수(rgb/rgba/hsl/hsla/hwb/lab/lch/oklab/oklch/color) 금지 — alpha 컬러도 token (token.$color_text_on_dark_* / $color_scrim_* 등) 사용. 토큰 정의 자체는 src/styles/** 에 한정."
+      }
+    ],
+    "declaration-property-value-disallowed-list": [
+      {
+        "word-break": [
+          "/break-word/"
+        ],
+        "font-weight": [
+          "/^[0-9]+$/"
+        ],
+        "z-index": [
+          "/^[0-9]{2,}$/"
+        ],
+        "clip": [
+          "/rect/"
+        ]
+      },
+      {
+        "severity": "error",
+        "message": "raw 값 금지 — word-break 는 token.wrap_keep_all, font-weight 는 token.$font_weight_*, z-index(10 이상)는 token.$z_*(역할 이름), clip 은 token.visually_hidden 을 쓰세요. 컴포넌트 내부 겹침용 z-index 0/1/2 는 허용됩니다. 토큰·믹스인 정의 자체는 src/styles/** 에 한정."
+      }
+    ]
   },
   "overrides": [
     {
-      "files": ["src/styles/**/*.scss"],
+      "files": [
+        "src/styles/**/*.scss"
+      ],
       "rules": {
         "color-no-hex": null,
         "color-named": null,
-        "function-disallowed-list": null
+        "function-disallowed-list": null,
+        "declaration-property-value-disallowed-list": null
       }
     },
     {
-      "files": ["src/vanilla/**/*.scss"],
+      "files": [
+        "src/vanilla/**/*.scss"
+      ],
       "rules": {
         "color-no-hex": null,
         "color-named": null,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"test:watch": "vitest --project unit",
 		"test:coverage": "vitest run --project unit --coverage",
 		"test:storybook": "vitest run --project storybook",
-		"lint:css": "stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss'",
+		"lint:css": "stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss' 'src/vanilla/**/*.scss'",
 		"check:css-vars": "scripts/check-css-vars.sh",
 		"check:prose": "scripts/check-prose-headings.sh",
 		"size": "size-limit",

--- a/src/ui/navigation/bottom-nav/style.scss
+++ b/src/ui/navigation/bottom-nav/style.scss
@@ -87,7 +87,7 @@ body:has(.bottom_nav) {
       color: token.$color_accent_default;
 
       .bottom_nav_item_label {
-        font-weight: 600;
+        font-weight: token.$font_weight_semi_bold;
       }
     }
   }

--- a/src/ui/navigation/sidebar/style.scss
+++ b/src/ui/navigation/sidebar/style.scss
@@ -313,7 +313,7 @@
         }
 
         .sidebar_item_label {
-          font-weight: 600;
+          font-weight: token.$font_weight_semi_bold;
         }
       }
     }


### PR DESCRIPTION
## 작업 개요

"DS 에 이런 실수가 많은데 잡는 스크립트를 만들 수 있나" 에 대한 1단계. 이번 달 실제로 배포된 결함만 대상으로 삼았고, **오늘 켜도 정리 부채가 0 인 것만** 넣었다.

제안했던 3층 중 **1층(stylelint) + CI 편입**까지다. 2층(신규 커스텀 스크립트 4개)과 3층(안 되는 것)은 아래 "전달할 추가 이슈" 에 남겼다.

## 작업한 내용

### stylelint 규칙 4개

각 규칙이 스타일 취향이 아니라 **실제로 배포된 결함**에 대응한다.

| 속성 | 금지 | 대응 결함 |
|---|---|---|
| `word-break` | `break-word` | 한글이 어절 중간에서 끊겼다 (Button·Toast, #501) |
| `clip` | `rect(...)` | sr-only 레시피가 7곳에 복제되고 4곳이 `clip-path` 없이 갈렸다 (#498) |
| `z-index` | 두 자리 이상 숫자 | DS 레이어를 손으로 적은 것. 역할 토큰이 있다 (#513) |
| `font-weight` | 숫자 | 스케일 이탈이고, 24px 이상 자간 램프를 함께 잃는다 (#518) |

- [x] `z-index: 0` · `1` · `2` 는 **허용** — 컴포넌트가 자기 하위 트리를 쌓는 것이고 DS 레이어가 아니다
- [x] `src/styles/**` 는 기존 color 규칙과 같은 예외 — 토큰·믹스인 정의 자리다
- [x] 기존 규칙들과 같은 형식으로 **무엇을 대신 쓰라고** 알려주는 message 를 붙였다

### 규칙이 잡아낸 실제 이탈 2건

- `src/ui/navigation/sidebar/style.scss:316` — `font-weight: 600`
- `src/ui/navigation/bottom-nav/style.scss:90` — `font-weight: 600`

`$font_weight_semi_bold: 600` 이 있는데 숫자를 적고 있었다. 토큰으로 교체했고 **산출 CSS 는 동일하다** (`font-weight: 600` 선언 7건 전후 동일).

### CI 편입

- [x] `pnpm check:css-vars` · `pnpm check:prose` 를 `Build` 스텝 뒤에 추가 — 둘 다 `dist` 를 읽는다
- [x] 두 스크립트가 지금까지 **수동 실행 전용**이었다. 이번에 고친 것과 같은 회귀(문서 변수 목록 낡음 · Prose 제목 굵기 변형 되돌림)가 다시 들어와도 CI 는 통과했다

### `lint:css` 가 vanilla 를 안 보고 있었다

`.stylelintrc.json` 에 `src/vanilla/**` override 가 있는데 **glob 에 vanilla 가 없어 도달하지 못하는 설정**이었다. 죽은 설정이 아니라 실제로 일하는 설정이다 — 빼고 돌리면 raw color 4건이 잡힌다. glob 에 추가했고 **위반 0건**이다.

## 검증

- `pnpm lint:css` · `pnpm check:css-vars` · `pnpm check:prose` 전부 `exit=0`
- 단위 **916 passed / 9 skipped**, `pnpm build` 통과
- **규칙 4개 양방향 검증** — 금지 값을 주입하면 4개 다 `exit=2`, 정당한 값 3개(`z-index: 1` · 토큰 `font-weight` · `word-break: keep-all`)는 `exit=0`. 오탐 없음
- 토큰 교체 전후 `dist/index.css` 의 `font-weight: 600` 선언 수 **7 → 7** (`git stash` 로 교체 전 빌드와 대조)
- `ci.yml` 을 파싱해 스텝 순서 확인 — `Build` → `Check bundle size` → `Check documented CSS variables` → `Check Prose heading weights`

## 왜 여기서 멈췄나

제안한 2층 검사 4개는 **현재 트리에서 전부 0건**이라 바로 켤 수 있지만, 이번 세션에서 **제가 만든 검사가 세 번 "통과만 하는" 상태**였다 (sed 가 계열을 합침 · 파일 전체를 스캔 · 단조성만 비교). 검사를 한 번에 4개 늘리는 것보다 하나씩 뮤테이션으로 물리는지 확인하며 가는 게 맞다고 본다.

## 전달할 추가 이슈

**2층 — 기성 도구로 안 되는 교차 파일 계약. 실측으로 현재 전부 0건이라 부채 없이 켤 수 있다.**

- 영문 a11y 문자열 검사 (#497 의 13건을 잡았을 것)
- JSDoc 기본값 vs 실제 기본값 (#518 리뷰에서 나온 낡은 JSDoc 9곳)
- 문서 prop 표 기본값 vs 소스 — 섹션 스코프 + 인용부호 정규화 필요. 거친 파서로는 19건 오탐, 제대로 하면 **27건 판정 중 0건**
- TSX 금지 속성 (`role="document"` 등)

**3층 — 정직하게 안 되는 것.**

- **"기본값과 같은 값을 주입하는 테스트"** — Toast 에서 실제로 잡힌 함정이라 만들어봤지만 **144건 중 실질 신호 1~2건**이다. `type="button"` 같은 네이티브 JSX 속성을 DS prop 으로 오인하고, `variant` 기본값이 Button=`filled`/Dropdown·TextField=`outline` 인데 컴포넌트 구분 없이 풀링해 정당한 `variant="outline"` 을 오탐한다. 컴포넌트별 prop 해석기가 필요하고 그래도 오탐이 남는다 — **권하지 않는다**
- **형제 컴포넌트 계약 불일치** (Modal↔Drawer 5건) — "무엇이 같아야 하는지" 를 사람이 선언해야 하고 그 목록 유지 비용이 검사 가치보다 클 수 있다. PR 템플릿 체크박스가 더 싼 답일 수 있다
- **의도의 문제** — Prose `lg` 가 본문을 안 키운 것(#512), Toast×BottomNav 겹침(#472). 정적으로 잡을 방법이 없고 소비처 피드백 루프가 유일한 답이다

**부수 항목**

- `raw font-size px` 규칙은 넣지 않았다. 12건 중 avatar·badge 의 `10px` 는 타이포 스케일 밖(최소 12px)이라 예외가 필요하고, tooltip 의 `12px` 는 진짜 이탈이다. 스케일 구멍을 먼저 정리해야 규칙이 깔끔해진다
