### PR TITLE
fix/modal-enter-animation

### DIFF
--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,1 +1,9 @@
 // Storybook 10.3+: preview annotations are applied automatically via @storybook/addon-vitest.
+
+import { Globals } from "@react-spring/web";
+
+// a11y(axe) 검사는 story 렌더 직후 실행된다. 등장 애니메이션이 도는 중이면 axe 가
+// 보간 중인 opacity 를 합성해 색 대비를 계산해서(예: #fafafa on #efefef) color-contrast 가
+// 실패한다 — 애니메이션 타이밍에 따라 플레이키하다. 스프링을 목표값으로 점프시켜
+// 정적 상태만 검사한다. 애니메이션 자체는 unit 테스트(src/ui/**/**.test.tsx)에서 검증한다.
+Globals.assign({ skipAnimation: true });

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -167,8 +167,19 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
 	const reduced = useReducedMotion();
 
+	// `from` 을 명시한다. 없으면 첫 렌더의 `to` 가 초기값이 되어, isOpen=true 로 처음
+	// 마운트되면 등장 모션이 없다(Modal 이 그 버그였다). AlertProvider 는 항상 isOpen=false 로
+	// 마운트하므로 지금 동작은 바뀌지 않지만, 그 성질에 기대지 않게 못박는다.
+	//
+	// reduced-motion 에서 `from` 을 빼는 이유는 Modal 과 같다 - 주면 한 프레임 깜빡임이 남는다.
+	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
+	const panelEnterFrom = reduced
+		? {}
+		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+
 	const overlayStyle = useSpring({
-		opacity: isOpen ? 1 : 0,
+		...enterFrom,
+		to: { opacity: isOpen ? 1 : 0 },
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 		onRest: (result) => {
@@ -177,8 +188,11 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	});
 
 	const panelStyle = useSpring({
-		opacity: isOpen ? 1 : 0,
-		transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		...panelEnterFrom,
+		to: {
+			opacity: isOpen ? 1 : 0,
+			transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		},
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 	});

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -378,9 +378,7 @@ describe("Modal", () => {
 		expect(screen.getByText("상세 내용")).toBeInTheDocument();
 
 		// 닫는 tick 에 부모가 데이터를 비운다
-		rerender(
-			<Modal open={false} onClose={() => {}} title="상세" />,
-		);
+		rerender(<Modal open={false} onClose={() => {}} title="상세" />);
 		expect(screen.getByText("상세 내용")).toBeInTheDocument();
 	});
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -1,5 +1,6 @@
+import { Globals } from "@react-spring/web";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Modal } from "./index";
 
 describe("Modal", () => {
@@ -506,5 +507,110 @@ describe("Modal", () => {
 		expect(screen.getByText("항목 설명")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
 		expect(screen.getByText("항목 본문")).toBeInTheDocument();
+	});
+
+	// ── 등장 애니메이션 ─────────────────────────────────────────────────────
+	// react-spring 은 `from` 이 없으면 첫 렌더의 `to` 를 초기값으로 잡는다. 처음부터
+	// open=true 로 마운트되면 초기값 = 목표값이 되어 등장 모션이 사라지던 버그(#522).
+	// 전역 모달 스택과 조건부 렌더가 정확히 그 형태다.
+	// src/test/setup.ts 가 전 테스트에 skipAnimation 을 걸어 스프링을 목표값으로 즉시 점프시킨다
+	// (퇴출 unmount 타이밍 테스트가 rAF 없이 돌게 하려고). 등장 보간을 보려면 이 두 테스트에서만
+	// 끈다 - afterEach 가 다시 켜므로 다른 테스트에 새지 않는다.
+	describe("enter animation (skipAnimation off)", () => {
+		beforeEach(() => Globals.assign({ skipAnimation: false }));
+		afterEach(() => Globals.assign({ skipAnimation: true }));
+
+		it("starts the panel away from its resting state when mounted already open", () => {
+			render(
+				<Modal open onClose={() => {}} title="상세">
+					본문
+				</Modal>,
+			);
+			const panel = document.querySelector(".modal_panel") as HTMLElement;
+			const overlay = screen.getByRole("dialog");
+
+			// 마운트 직후 프레임 - 아직 목표값에 도달하지 않았어야 한다
+			expect(Number(panel.style.opacity)).toBeLessThan(1);
+			expect(panel.style.transform).not.toBe("scale(1) translateY(0px)");
+			expect(Number(overlay.style.opacity)).toBeLessThan(1);
+		});
+
+		// 기존 reduced-motion 테스트는 skipAnimation 이 켜진 상태에서 돌아, `immediate: reduced` 를
+		// 지워도 통과한다(뮤테이션으로 확인). skipAnimation 을 끈 여기서는 `from` 을 reduced 에서
+		// 빼는 처리가 실제로 물린다.
+		//
+		// 한계: false→true 플립 경로에서 `immediate` 자체가 일하는지는 여기서 못 본다. react-spring
+		// 은 React 커밋 밖에서 스타일을 쓰므로 rerender 직후 동기 시점에는 아직 값이 반영되지 않고,
+		// waitFor 로 기다리면 immediate 든 일반 스프링이든 결국 목표값에 도달해 구분이 안 된다.
+		it("skips the enter interpolation entirely under prefers-reduced-motion (WCAG 2.3.3)", () => {
+			vi.stubGlobal(
+				"matchMedia",
+				vi.fn().mockImplementation((query: string) => ({
+					matches: query.includes("prefers-reduced-motion"),
+					media: query,
+					addEventListener: vi.fn(),
+					removeEventListener: vi.fn(),
+					addListener: vi.fn(),
+					removeListener: vi.fn(),
+					dispatchEvent: vi.fn(),
+				})),
+			);
+			render(
+				<Modal open onClose={() => {}} title="Reduced">
+					본문
+				</Modal>,
+			);
+			const panel = document.querySelector(".modal_panel") as HTMLElement;
+			const overlay = screen.getByRole("dialog");
+
+			// 보간 없이 첫 프레임부터 휴지 상태여야 한다 - overlay·panel 양쪽
+			expect(Number(panel.style.opacity)).toBe(1);
+			expect(panel.style.transform).toBe("scale(1) translateY(0px)");
+			expect(Number(overlay.style.opacity)).toBe(1);
+			vi.unstubAllGlobals();
+		});
+
+		it("animates to the resting state after mounting already open", async () => {
+			render(
+				<Modal open onClose={() => {}} title="상세">
+					본문
+				</Modal>,
+			);
+			const panel = document.querySelector(".modal_panel") as HTMLElement;
+
+			await waitFor(() => expect(Number(panel.style.opacity)).toBe(1));
+			expect(panel.style.transform).toBe("scale(1) translateY(0px)");
+		});
+	});
+
+	// `from` 은 첫 렌더에만 적용된다 - 닫았다 다시 열면 그때의 현재값에서 이어져야 하고,
+	// 퇴출 수명(onExited)도 영향받지 않아야 한다.
+	it("keeps the exit lifecycle intact after mounting already open", async () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+		const onExited = vi.fn();
+		const { rerender } = render(
+			<Modal open onClose={() => {}} onExited={onExited} title="상세">
+				본문
+			</Modal>,
+		);
+		rerender(
+			<Modal open={false} onClose={() => {}} onExited={onExited} title="상세">
+				본문
+			</Modal>,
+		);
+		await waitFor(() => expect(onExited).toHaveBeenCalledTimes(1));
+		expect(document.querySelector(".modal_panel")).toBeNull();
+		vi.unstubAllGlobals();
 	});
 });

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -135,9 +135,23 @@ export const Modal = ({
 	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
 	const reduced = useReducedMotion();
 
+	// `from` 을 명시해야 한다. 없으면 react-spring 이 **첫 렌더의 `to`** 를 초기값으로 잡으므로,
+	// 처음부터 open=true 로 마운트된 모달은 초기값 = 목표값이 되어 등장 모션이 아예 없다.
+	// 전역 모달 스택이나 조건부 렌더(`{isOpen && <Modal open />}`)가 정확히 그 형태다.
+	// `from` 은 첫 렌더에만 쓰이므로 재열림·퇴출 동작은 그대로다.
+	//
+	// 단 reduced-motion 에서는 `from` 을 주지 않는다. 주면 첫 프레임에 from 값이 DOM 에 커밋된
+	// 뒤 immediate 가 목표값으로 점프해, 모션 대신 **한 프레임 깜빡임**이 남는다(실측 확인).
+	// 없으면 첫 렌더의 to 가 초기값이 되어 보간 구간 자체가 생기지 않는다 - 원하는 동작이다.
+	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
+	const panelEnterFrom = reduced
+		? {}
+		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({
-		opacity: open ? 1 : 0,
+		...enterFrom,
+		to: { opacity: open ? 1 : 0 },
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 		onRest: (result) => {
@@ -149,10 +163,13 @@ export const Modal = ({
 		},
 	});
 
-	// Spring: panel (opacity + scale + translateY)
+	// Spring: panel (opacity + scale + translateY) - overlay 와 같은 규칙.
 	const panelStyle = useSpring({
-		opacity: open ? 1 : 0,
-		transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		...panelEnterFrom,
+		to: {
+			opacity: open ? 1 : 0,
+			transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		},
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 	});

--- a/src/ui/overlay/modal/modal.stories.tsx
+++ b/src/ui/overlay/modal/modal.stories.tsx
@@ -91,7 +91,7 @@ export const DestructiveAction: Story = {
 		docs: {
 			description: {
 				story:
-					"`footerAlign=\"between\"` - 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성을 시각화한다.",
+					'`footerAlign="between"` - 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성을 시각화한다.',
 			},
 		},
 	},
@@ -220,6 +220,32 @@ export const LongContent: Story = {
 					</div>
 				</Modal>
 			</>
+		);
+	},
+};
+
+export const ConditionalMount: Story = {
+	name: "조건부 마운트 (등장 애니메이션)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"전역 모달 스택은 보통 열림 상태와 렌더할 content 를 같은 상태 업데이트로 넣는다. 그러면 첫 마운트 시점에 이미 `open=true` 다. 이 패턴에서도 등장 애니메이션이 나와야 한다 — react-spring 은 `from` 이 없으면 첫 렌더의 목표값을 초기값으로 잡아 보간 구간이 0 이 된다.",
+			},
+		},
+	},
+	render: () => {
+		const [mounted, setMounted] = useState(false);
+		return (
+			<div>
+				<Button onClick={() => setMounted(true)}>모달 열기 (조건부 마운트)</Button>
+				{mounted && (
+					<Modal open onClose={() => setMounted(false)} title="조건부 마운트">
+						처음부터 <code>open=true</code> 로 마운트된 모달입니다. 페이드인 + scale 이 보여야
+						합니다.
+					</Modal>
+				)}
+			</div>
 		);
 	},
 };


### PR DESCRIPTION
## 작업 개요

이슈 #522 - 처음부터 `open=true` 로 마운트된 `Modal` 은 등장 애니메이션이 없다. react-spring 은 `from` 이 없으면 **첫 렌더의 `to` 를 초기값으로** 잡으므로 초기값 = 목표값이 되어 보간 구간이 0 이다. 퇴장은 정상이라 화면별 불일치처럼 보였다.

전역 모달 스택은 "열림 상태" 와 "렌더할 content" 를 같은 상태 업데이트로 넣으니 첫 마운트가 이미 열린 상태다. 조건부 렌더도 같다. 소비처 owner 앱에서 이 경로를 타는 모달 5개 전부 등장 모션이 없었고, 유일하게 나오던 화면만 항상 마운트 패턴이었다.

Closes #522

## 작업한 내용

- [x] `Modal` 의 overlay·panel 두 스프링에 `from` 명시
- [x] **`Alert` 도 같은 형태라 함께 수정** — 지금 깨져 있지는 않다(`AlertProvider` 가 `isOpen: false` 로 항상 렌더하고 플립한다). 다만 그건 애니메이션이 컴포넌트가 아니라 **provider 의 마운트 방식에 의존**한다는 뜻이라 못박았다. 관측 가능한 변화는 없다
- [x] `Popover` · `Tooltip` 확인 — `useSpringPresence` 를 쓰고 그 훅에 `from` 이 있어 문제 없다. #495(Drawer 누락)의 반복을 피하려고 네 형제를 전부 봤다
- [x] 테스트 3건 + 조건부 마운트 스토리

### `useSpringPresence` 로 통일하지 않은 이유

그 훅은 **항상 `transform` 을 설정한다** — Drawer overlay 가 `from: "translateY(0px)"` 로 no-op transform 을 넣는 이유다. `transform` 이 붙은 요소는 `position: fixed` 자손의 **containing block** 이 되고, Modal 의 `children` 은 소비자 컨텐츠다. Drawer 는 이미 그 위험을 안고 있지만 Modal 에 새로 들일 이유가 없어 명시적 `from` 을 택했다.

### reduced-motion — 순진한 수정이 회귀를 만들었다

`from` 을 무조건 주면 **reduced-motion 에서 모션 대신 한 프레임 깜빡임**이 남는다. `from` 값이 DOM 에 커밋된 뒤 `immediate` 가 목표값으로 점프하기 때문이다. 실측으로 확인했다 — 첫 프레임 panel `opacity: 0`.

리포트의 회귀 조건 3번("reduced-motion 에서 여전히 즉시 최종 상태")이 그대로 깨지는 지점이었다. `reduced` 일 때는 `from` 을 주지 않는다 — 그러면 첫 렌더의 `to` 가 초기값이 되어 보간 구간 자체가 생기지 않는다.

```tsx
const enterFrom = reduced ? {} : { from: { opacity: 0 } };
```

## 검증

- 단위 **920 passed / 9 skipped**, `tsc --noEmit` · `pnpm lint:css` · `pnpm build` 통과
- **뮤테이션 4/4 사망** — overlay `from` 제거 · panel `from` 제거 · overlay `reduced` 무시 · panel `reduced` 무시. 각각 해당 테스트만 실패
- **Chromium 실측** (Storybook, 새 `ConditionalMount` 스토리) — 조건부 마운트 직후 첫 프레임: panel `opacity: 0`, `transform: scale(0.96) translateY(-4px)`, overlay `opacity: 0`. **수락 기준 충족**
- 회귀 — "열린 적 없으면 `onExited` 없음" 테스트 통과. Drawer 가 같은 구조로 그 가정을 이미 문서화하고 있다(`drawer/index.tsx:150-151`: "`from` 과 `to` 가 같아 `onRest` 가 발화하지 않는다")
- 회귀 — 마운트 후 퇴출 수명 테스트 추가, `onExited` 1회 발화 + 패널 unmount 확인
- 빌드 산출물에 `scale(0.96) translateY(-4px)` 4건 (Modal·Alert 의 `from`+`to`)

### 검증 과정에서 기존 테스트의 문제를 하나 찾았다

기존 `renders without motion when prefers-reduced-motion is set` 는 **`immediate: reduced` 를 두 스프링에서 지워도 통과한다.** `src/test/setup.ts` 가 스위트 전체에 `skipAnimation: true` 를 걸어 어떤 스프링이든 목표값으로 점프하기 때문이다. 그 상태로는 등장 보간을 관측할 수 없어서, 새 테스트들은 `skipAnimation` 을 끈 `describe` 안에 두고 `afterEach` 로 되돌린다.

## 검증하지 못한 것

**`immediate: reduced` 가 false→true 플립 경로에서 일하는지는 단위 테스트로 확인할 수 없다.** react-spring 은 React 커밋 밖에서 스타일을 쓰므로 `rerender` 직후 동기 시점에는 값이 아직 반영되지 않고, `waitFor` 로 기다리면 `immediate` 든 일반 스프링이든 결국 목표값에 도달해 구분이 안 된다. 그 시도를 했다가 잘못된 가정임을 확인하고 테스트를 뺐고, 한계를 테스트 파일 주석에 남겼다.

마운트 경로의 reduced-motion 은 위 뮤테이션 2건으로 덮인다.

## 전달할 추가 이슈

- `clamp: !open` 은 유지했다. enter 구간에 clamp 가 없어 scale 이 1 을 살짝 넘길 수 있는데, tension 280 / friction 28 이면 감쇠비 약 0.84 로 오버슈트가 4% 변화량의 소수점 수준이다. Drawer 도 동일 config 다. 다르게 판단하면 알려달라 — **이슈로 만들까요?**
- `Alert` 에는 등장 애니메이션 회귀 테스트를 넣지 않았다. provider 를 거쳐야 열리는 구조라 `skipAnimation` 을 끈 상태에서 마운트-이미-열림 상황을 만들기 어렵다. Modal 과 같은 코드 형태를 공유하는 것으로 갈음했다 — **별건으로 만들까요?**
- `src/ui/feedback/alert/index.tsx:223` 의 `biome-ignore` 가 unused 로 잡힌다(이 PR 전부터 그렇다, `git stash` 로 확인). biome 은 CI 게이트가 아니라 이 PR 에서 건드리지 않았다 — **이슈로 만들까요?**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 모달과 알림창이 처음 표시될 때 자연스러운 페이드 및 확대 등장 애니메이션을 제공합니다.
  * 모션 줄이기 설정을 사용하는 경우 불필요한 깜빡임 없이 즉시 표시됩니다.
  * 모달을 조건부로 처음 열 때도 등장 애니메이션이 정상적으로 적용됩니다.

* **테스트**
  * 모달의 등장·퇴장 애니메이션과 접근성 설정에 따른 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->