### PR TITLE
bug/reduced-motion-flash

### DIFF
--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -227,9 +227,7 @@ describe("Alert", () => {
 
 	it("closeOnOverlay=false ignores overlay clicks", () => {
 		const onCancel = vi.fn();
-		renderWithProvider(
-			<TestComponent options={{ title: "C", onCancel, closeOnOverlay: false }} />,
-		);
+		renderWithProvider(<TestComponent options={{ title: "C", onCancel, closeOnOverlay: false }} />);
 
 		fireEvent.click(screen.getByText("Show Alert"));
 		const overlay = screen.getByRole("alertdialog").parentElement as HTMLElement;

--- a/src/ui/feedback/alert/alert.stories.tsx
+++ b/src/ui/feedback/alert/alert.stories.tsx
@@ -115,12 +115,7 @@ export const Success: Story = {
 
 export const Warning: Story = {
 	render: () => (
-		<AlertDemo
-			variant="warning"
-			title="경고"
-			message="이 작업을 진행하시겠습니까?"
-			showCancel
-		/>
+		<AlertDemo variant="warning" title="경고" message="이 작업을 진행하시겠습니까?" showCancel />
 	),
 };
 

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -9,6 +9,10 @@ import { iconSize } from "../../../styles/icon";
 import {
 	cn,
 	lockBodyScroll,
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
 	unlockBodyScroll,
 	useFocusTrap,
 	useOverlayEscape,
@@ -170,31 +174,26 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	// `from` 을 명시한다. 없으면 첫 렌더의 `to` 가 초기값이 되어, isOpen=true 로 처음
 	// 마운트되면 등장 모션이 없다(Modal 이 그 버그였다). AlertProvider 는 항상 isOpen=false 로
 	// 마운트하므로 지금 동작은 바뀌지 않지만, 그 성질에 기대지 않게 못박는다.
-	//
-	// reduced-motion 에서 `from` 을 빼는 이유는 Modal 과 같다 - 주면 한 프레임 깜빡임이 남는다.
-	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
-	const panelEnterFrom = reduced
-		? {}
-		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+	// reduced-motion 예외는 springEnterFrom 안에 있다.
 
 	const overlayStyle = useSpring({
-		...enterFrom,
+		...springEnterFrom(reduced),
 		to: { opacity: isOpen ? 1 : 0 },
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !isOpen },
+		config: OVERLAY_SPRING_CONFIG,
 		onRest: (result) => {
 			if (!isOpen && result.finished) setShouldRender(false);
 		},
 	});
 
 	const panelStyle = useSpring({
-		...panelEnterFrom,
+		...springEnterFrom(reduced, OVERLAY_PANEL_CLOSED_TRANSFORM),
 		to: {
 			opacity: isOpen ? 1 : 0,
-			transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+			transform: isOpen ? OVERLAY_PANEL_OPEN_TRANSFORM : OVERLAY_PANEL_CLOSED_TRANSFORM,
 		},
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !isOpen },
+		config: OVERLAY_SPRING_CONFIG,
 	});
 
 	// 바디 스크롤 잠금 - Modal/Drawer 와 동일한 data-open-modals 카운터 공유
@@ -220,7 +219,6 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	const modalClassName = cn("alert_modal", `alert_variant_${variant}`);
 
 	return createPortal(
-		// biome-ignore lint/a11y/noStaticElementInteractions: modal overlay pattern
 		<animated.div
 			className="alert_overlay"
 			style={overlayStyle}

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -8,6 +8,10 @@ import { iconSize } from "../../../styles/icon";
 import {
 	cn,
 	lockBodyScroll,
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
 	unlockBodyScroll,
 	useFocusTrap,
 	useIsMounted,
@@ -140,20 +144,15 @@ export const Modal = ({
 	// 전역 모달 스택이나 조건부 렌더(`{isOpen && <Modal open />}`)가 정확히 그 형태다.
 	// `from` 은 첫 렌더에만 쓰이므로 재열림·퇴출 동작은 그대로다.
 	//
-	// 단 reduced-motion 에서는 `from` 을 주지 않는다. 주면 첫 프레임에 from 값이 DOM 에 커밋된
-	// 뒤 immediate 가 목표값으로 점프해, 모션 대신 **한 프레임 깜빡임**이 남는다(실측 확인).
-	// 없으면 첫 렌더의 to 가 초기값이 되어 보간 구간 자체가 생기지 않는다 - 원하는 동작이다.
-	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
-	const panelEnterFrom = reduced
-		? {}
-		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+	// reduced-motion 예외 처리는 springEnterFrom 안에 있다(주면 한 프레임 깜빡임이 남는다).
+	// 오버레이에 transform 을 주지 않는 이유도 그 JSDoc 에 있다.
 
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({
-		...enterFrom,
+		...springEnterFrom(reduced),
 		to: { opacity: open ? 1 : 0 },
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !open },
+		config: OVERLAY_SPRING_CONFIG,
 		onRest: (result) => {
 			if (open || !result.finished) return;
 			setShouldRender(false);
@@ -165,13 +164,13 @@ export const Modal = ({
 
 	// Spring: panel (opacity + scale + translateY) - overlay 와 같은 규칙.
 	const panelStyle = useSpring({
-		...panelEnterFrom,
+		...springEnterFrom(reduced, OVERLAY_PANEL_CLOSED_TRANSFORM),
 		to: {
 			opacity: open ? 1 : 0,
-			transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+			transform: open ? OVERLAY_PANEL_OPEN_TRANSFORM : OVERLAY_PANEL_CLOSED_TRANSFORM,
 		},
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !open },
+		config: OVERLAY_SPRING_CONFIG,
 	});
 
 	// 바디 스크롤 잠금(중첩 모달 지원)
@@ -242,9 +241,7 @@ export const Modal = ({
 						{content.title}
 					</h2>
 				)}
-				{content.description && (
-					<div className="modal_description">{content.description}</div>
-				)}
+				{content.description && <div className="modal_description">{content.description}</div>}
 				{content.children && (
 					// 본문이 스크롤 컨테이너라 키보드로도 스크롤할 수 있어야 한다(axe
 					// `scrollable-region-focusable`). 넘치는지 여부를 측정해 조건부로 주는 방법도 있지만
@@ -252,14 +249,15 @@ export const Modal = ({
 					// 늘어나는 정도의 비용이다.
 					// 다만 초기 포커스 대상에서는 제외한다 - 안쪽에 첫 입력이 있는데 빈 wrapper 에
 					// 포커스가 놓이면 열자마자 어디에 있는지 알 수 없다.
+					// 스크롤 가능한 영역은 키보드로도 스크롤할 수 있어야 한다 (WCAG 2.1.1) - 포커스
+					// 가능해야 화살표 키가 먹는다.
+					// biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable region needs keyboard scroll
 					<div className="modal_body" tabIndex={0} data-focus-trap-skip-autofocus="">
 						{content.children}
 					</div>
 				)}
 				{content.footer && (
-					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>
-						{content.footer}
-					</div>
+					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>{content.footer}</div>
 				)}
 			</animated.div>
 		</animated.div>,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,12 @@ export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export { lockBodyScroll, unlockBodyScroll } from "./scroll-lock";
 export {
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
+} from "./spring-motion";
+export {
 	type AnchoredOptions,
 	type AnchoredResult,
 	type AnchoredSide,

--- a/src/utils/spring-motion.test.ts
+++ b/src/utils/spring-motion.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
+} from "./spring-motion";
+
+describe("springEnterFrom", () => {
+	it("gives an opacity-only from when no transform is passed", () => {
+		// 오버레이에 transform 이 붙으면 position: fixed 자손의 containing block 이 되어버린다.
+		expect(springEnterFrom(false)).toEqual({ from: { opacity: 0 } });
+	});
+
+	it("includes the transform when one is passed", () => {
+		expect(springEnterFrom(false, "scale(0.9)")).toEqual({
+			from: { opacity: 0, transform: "scale(0.9)" },
+		});
+	});
+
+	it("omits from entirely under reduced motion", () => {
+		// `from` 을 주면 첫 프레임에 커밋된 뒤 immediate 가 점프해 한 프레임 깜빡임이 남는다.
+		expect(springEnterFrom(true)).toEqual({});
+		expect(springEnterFrom(true, "scale(0.9)")).toEqual({});
+		expect("from" in springEnterFrom(true)).toBe(false);
+	});
+});
+
+describe("overlay motion constants", () => {
+	it("uses the same transform for the enter start and the exit target", () => {
+		// 진입 시작값과 퇴출 목표값이 갈리면 열고 닫기가 비대칭이 된다.
+		expect(OVERLAY_PANEL_CLOSED_TRANSFORM).toBe("scale(0.96) translateY(-4px)");
+		expect(OVERLAY_PANEL_OPEN_TRANSFORM).toBe("scale(1) translateY(0px)");
+	});
+
+	it("clamps in both directions", () => {
+		expect(OVERLAY_SPRING_CONFIG.clamp).toBe(true);
+	});
+});

--- a/src/utils/spring-motion.ts
+++ b/src/utils/spring-motion.ts
@@ -1,0 +1,46 @@
+/**
+ * 스프링의 진입 시작값(`from`)을 만든다.
+ *
+ * react-spring 은 `from` 이 없으면 **첫 렌더의 `to` 를 초기값으로 잡는다**. 그래서 컴포넌트가
+ * 처음부터 열린 상태로 마운트되면(전역 오버레이 스택, `{isOpen && <Modal open />}` 같은 조건부
+ * 렌더) 보간 구간이 0 이 되어 등장 애니메이션이 사라진다.
+ *
+ * 반대로 reduced-motion 에서는 `from` 을 주면 안 된다. 주면 첫 프레임에 `from` 이 DOM 에 커밋된
+ * 뒤 `immediate` 가 목표값으로 점프해, 모션 대신 **한 프레임 깜빡임**이 남는다(실측 확인).
+ *
+ * 두 조건을 한 곳에서 만족시킨다. 스프레드해서 쓴다:
+ *
+ * ```tsx
+ * useSpring({
+ *   ...springEnterFrom(reduced, "scale(0.96)"),
+ *   to: { opacity: open ? 1 : 0, transform: open ? "scale(1)" : "scale(0.96)" },
+ *   immediate: reduced,
+ * });
+ * ```
+ *
+ * @param reduced `useReducedMotion()` 결과. true 면 빈 객체를 돌려 `from` 자체를 생략한다
+ * @param transform 진입 시작 transform. 생략하면 `opacity` 만 준다(오버레이처럼 transform 이
+ *   붙으면 안 되는 요소 - `position: fixed` 자손의 containing block 이 되어버린다)
+ */
+export function springEnterFrom(
+	reduced: boolean,
+	transform?: string,
+): { from?: { opacity: number; transform?: string } } {
+	if (reduced) return {};
+
+	return { from: transform === undefined ? { opacity: 0 } : { opacity: 0, transform } };
+}
+
+/** 중앙 패널 오버레이(Modal·AlertModal)의 닫힌 상태 transform. 진입 시작값 = 퇴출 목표값. */
+export const OVERLAY_PANEL_CLOSED_TRANSFORM = "scale(0.96) translateY(-4px)";
+
+/** 같은 오버레이의 열린 상태 transform. */
+export const OVERLAY_PANEL_OPEN_TRANSFORM = "scale(1) translateY(0px)";
+
+/**
+ * 오버레이 진입·퇴출 공용 스프링 설정.
+ *
+ * `clamp: true` - 진입에도 오버슈트를 두지 않는다. 감쇠비 0.84 에서 오버슈트는 변화량의
+ * 0.8%(패널 scale 기준 0.03%)라 눈에 보이지 않는 반면, 진입/퇴출이 갈리는 값이 하나 늘어난다.
+ */
+export const OVERLAY_SPRING_CONFIG = { tension: 280, friction: 28, clamp: true } as const;

--- a/src/utils/use-safe-layout-effect.ts
+++ b/src/utils/use-safe-layout-effect.ts
@@ -10,5 +10,4 @@ import { useEffect, useLayoutEffect } from "react";
  * `useLayoutEffect`(paint 전 동기 실행 - 레이아웃 측정/조정용), 서버에선
  * `useEffect` 로 안전하게 대체한다.
  */
-export const useSafeLayoutEffect =
-	typeof window !== "undefined" ? useLayoutEffect : useEffect;
+export const useSafeLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;

--- a/src/utils/use-spring-hover.ts
+++ b/src/utils/use-spring-hover.ts
@@ -26,9 +26,7 @@ export function useSpringHover({
 	const reduced = useReducedMotion();
 
 	const style = useSpring({
-		transform: hovered
-			? `translateY(${lift}px) scale(${scale})`
-			: "translateY(0px) scale(1)",
+		transform: hovered ? `translateY(${lift}px) scale(${scale})` : "translateY(0px) scale(1)",
 		// reduced-motion: lift/scale 모션 제거 (WCAG 2.3.3)
 		immediate: reduced,
 		config: { tension: 320, friction: 22 },

--- a/src/utils/use-spring-presence.test.tsx
+++ b/src/utils/use-spring-presence.test.tsx
@@ -1,0 +1,56 @@
+import { animated, Globals } from "@react-spring/web";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSpringPresence } from "./use-spring-presence";
+
+const Probe = ({ visible }: { visible: boolean }) => {
+	const style = useSpringPresence({ visible, from: "translateX(20px)" });
+	return <animated.div data-testid="probe" style={style} />;
+};
+
+const stubReducedMotion = (matches: boolean) => {
+	vi.stubGlobal(
+		"matchMedia",
+		vi.fn().mockImplementation((query: string) => ({
+			matches: matches && query.includes("prefers-reduced-motion"),
+			media: query,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	);
+};
+
+// src/test/setup.ts 가 스위트 전체에 skipAnimation: true 를 걸어 두므로, 첫 프레임 값을
+// 보려면 이 describe 안에서만 끈다. 켜진 상태에서는 어떤 스프링이든 목표값에서 시작한다.
+describe("useSpringPresence enter frame", () => {
+	beforeEach(() => Globals.assign({ skipAnimation: false }));
+	afterEach(() => {
+		Globals.assign({ skipAnimation: true });
+		vi.unstubAllGlobals();
+	});
+
+	it("starts away from the target when mounted already visible", () => {
+		// Toast 는 useState(true) 로 마운트한다 - `from` 이 없으면 첫 렌더의 to 가 초기값이 되어
+		// 등장 모션이 사라진다.
+		stubReducedMotion(false);
+		render(<Probe visible />);
+
+		const probe = screen.getByTestId("probe");
+		expect(probe.style.opacity).toBe("0");
+		expect(probe.style.transform).toBe("translateX(20px)");
+	});
+
+	it("starts at the target under reduced motion (no one-frame flash)", () => {
+		// 반대로 reduced-motion 에서 `from` 을 주면 그 값이 한 프레임 커밋된 뒤 immediate 가
+		// 점프해 모션 대신 깜빡임이 남는다. from 을 생략해 보간 구간 자체를 없앤다.
+		stubReducedMotion(true);
+		render(<Probe visible />);
+
+		const probe = screen.getByTestId("probe");
+		expect(probe.style.opacity).toBe("1");
+		expect(probe.style.transform).toBe("translateY(0px)");
+	});
+});

--- a/src/utils/use-spring-presence.ts
+++ b/src/utils/use-spring-presence.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSpring } from "@react-spring/web";
+import { springEnterFrom } from "./spring-motion";
 import { useReducedMotion } from "./use-reduced-motion";
 
 /**
@@ -28,7 +29,10 @@ export function useSpringPresence({
 	const reduced = useReducedMotion();
 
 	return useSpring({
-		from: { opacity: 0, transform: from },
+		// reduced-motion 에서는 `from` 을 생략한다 - 주면 첫 프레임에 from 이 DOM 에 커밋된 뒤
+		// immediate 가 목표값으로 점프해 모션 대신 한 프레임 깜빡임이 남는다. Toast 는 항상
+		// visible=true 로 마운트하므로 이 경로를 무조건 탄다. 자세한 근거는 springEnterFrom JSDoc.
+		...springEnterFrom(reduced, from),
 		to: {
 			opacity: visible ? 1 : 0,
 			transform: visible ? "translateY(0px)" : from,


### PR DESCRIPTION
## 작업 개요

Closes #524.

#523 리뷰에서 나온 후속 항목을 한 번에 처리한다. 핵심은 `useSpringPresence` 의 reduced-motion 깜빡임 — #522 에서 Modal·Alert 만 고쳤는데, 같은 메커니즘이 공용 훅에 그대로 남아 있어 `Toast` 는 **모든 토스트에서** 무조건 걸리고 있었다(`useState(true)` 로 마운트).

그 과정에서 Modal·Alert 에 중복돼 있던 `enterFrom` 분기를 공용 헬퍼로 뽑아 훅까지 같이 쓰게 했고, `clamp` 를 진입에도 적용해 진입/퇴출 설정을 하나로 합쳤다.

## 작업한 내용

- [x] `springEnterFrom(reduced, transform?)` 추가 (`src/utils/spring-motion.ts`) — reduced-motion 예외를 한 곳에 둔다. 내부 전용(공개 export 아님)
- [x] `OVERLAY_PANEL_CLOSED_TRANSFORM` / `OVERLAY_PANEL_OPEN_TRANSFORM` / `OVERLAY_SPRING_CONFIG` 공용 상수화 — Modal·Alert 가 손으로 맞춰 온 값
- [x] `useSpringPresence` 가 `reduced` 일 때 `from` 을 생략 (Toast·Drawer·Popover·Tooltip·Menu·Dropdown 6개 소비처)
- [x] `clamp: true` — 진입에도 오버슈트 없음. 감쇠비 0.84 에서 오버슈트는 변화량의 0.8%(패널 scale 기준 0.03%)라 눈에 보이지 않는 반면, 진입/퇴출이 갈리는 값이 하나 줄어든다
- [x] `alert/index.tsx` 의 unused `biome-ignore` 제거 (`role="presentation"` 는 `noStaticElementInteractions` 대상이 아니다)
- [x] `modal_body` 의 의도적인 `tabIndex={0}` 에 근거를 붙인 suppression 추가 (WCAG 2.1.1 — 스크롤 영역은 키보드로도 스크롤돼야 한다)
- [x] 테스트 7건 추가 — `springEnterFrom` 5건, `useSpringPresence` 첫 프레임 2건(일반 / reduced)
- [x] biome 이 어긋나 있던 4개 파일 포맷 정리 (line-width reflow only)

## 검증

- **단위 927 passed** / 9 skipped (60 files, +7)
- **storybook a11y 299 passed** / 68 files
- `tsc --noEmit` 0, `lint:css` 0, `check:prose` / `check:css-vars` 통과, `build` 통과
- `biome check` — `src/utils`, `src/ui/overlay/modal`, `src/ui/feedback/alert` 클린
- **뮤테이션**: `useSpringPresence` 의 `from` 을 무조건 주도록 되돌리면 reduced 테스트가 실패한다(확인)
- **빌드 산출물**: `dist/index.js` 에서 `scale(0.96) translateY(-4px)` 가 4곳 → **1곳**(공용 상수화 확인), `OVERLAY_SPRING_CONFIG` 5회 참조, `springEnterFrom(reduced, from)` 이 훅에 반영

### 확인했지만 테스트로 덮지 못한 것

**Alert 의 마운트-이미-열림 경로는 회귀 테스트를 만들 수 없다.** `AlertModal` 이 export 되지 않고 `AlertProvider` 가 항상 `isOpen=false` 로 마운트하기 때문이다. 프로바이더를 거친 false→true 플립 경로로 테스트를 쓰면 `from` 을 지워도 통과한다(스프링이 이미 `opacity: 0` 에서 초기화되어 있어서) — vacuous 라 쓰지 않았다. 테스트만을 위해 `AlertModal` 을 공개 API 로 노출하는 것보다, 공용 헬퍼를 단위 테스트하고 Alert 가 그 헬퍼를 호출하게 만드는 편이 낫다고 판단했다.

## 전달할 추가 이슈

- `biome check src` 가 repo 전체로는 여전히 실패한다 — `src/stories/**` 포맷·organizeImports 다수, `src/vanilla/examples/index.html` 의 `noLabelWithoutControl` 4건, `page-composition.stories.tsx` 의 `noImgElement` 2건. biome 이 CI 게이트가 아니라 쌓인 부채다. CI 스텝 추가는 조직 규칙상 별도 승인이 필요해 이 PR 에서는 손대지 않았다
