### PR TITLE
feat/check-prop-defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,16 @@ jobs:
       - name: Lint SCSS (Stylelint)
         run: pnpm lint:css
 
+      # prop 기본값 3축 (노출 문자열 한글 / JSDoc @default / docs 표 Default 열).
+      # 소스와 문서만 읽으므로 Build 앞에 두어 빨리 실패한다. Stylelint 와 같은 이유로 step
+      # 조건은 두지 않는다 - 이 job 이 도는 모든 경우에 검사해서 손해가 없다.
+      #
+      # 다만 워크플로 `paths-ignore` 가 `docs/**` 와 `**.md` 를 빼므로, 문서만 고친 PR 에서는
+      # CI 자체가 돌지 않는다. 즉 3축 중 docs 표 축은 "소스를 바꾸고 문서를 안 고친" 방향만
+      # 잡는다. 반대 방향(문서에 잘못된 기본값을 새로 적는 것)은 리뷰 diff 에서 본다.
+      - name: Check prop defaults
+        run: pnpm check:defaults
+
       # 코드 또는 의존성 변경 → unit 테스트 + 커버리지
       - name: Run tests with coverage
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true'

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"lint:css": "stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss' 'src/vanilla/**/*.scss'",
 		"check:css-vars": "scripts/check-css-vars.sh",
 		"check:prose": "scripts/check-prose-headings.sh",
+		"check:defaults": "python3 scripts/check-prop-defaults.py",
 		"size": "size-limit",
 		"prepare": "husky"
 	},

--- a/scripts/check-prop-defaults.py
+++ b/scripts/check-prop-defaults.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""컴포넌트 prop 기본값을 세 축으로 검사한다.
+
+1. 화면·스크린리더에 노출되는 기본 문자열(`*Label` / `*Text` / `placeholder` 등)은 한글이어야
+   한다. 영문 기본값이 섞여 들어가면 한국어 UI 에서 스크린리더가 영어를 읽는다.
+2. JSDoc `@default` 가 실제 destructuring 기본값과 일치해야 한다. 값을 바꾸고 JSDoc 을 잊으면
+   Storybook autodocs 와 소비자 문서가 조용히 거짓말을 한다.
+3. `docs/COMPONENTS.md` prop 표의 Default 열이 소스 기본값과 일치해야 한다. 소비자가 읽는
+   문서라 어긋나면 그대로 잘못된 코드를 쓴다.
+
+exit 1 이면 위반이 있다.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+UI = Path("src/ui")
+
+# 화면/스크린리더 노출 문자열로 취급하는 prop 이름
+EXPOSED = re.compile(r"^(?:[a-z][A-Za-z]*(?:Label|Text|Format|Message|Title)|placeholder)$")
+HANGUL = re.compile(r"[가-힣]")
+
+# `  someLabel = "값",` 형태의 destructuring 기본값
+DEFAULT_STR = re.compile(r'^\s*([a-z][A-Za-z0-9]*)\s*=\s*"([^"]*)"\s*,?\s*$')
+# 문자열이 아닌 기본값도 포함 (JSDoc 대조용)
+DEFAULT_ANY = re.compile(r'^\s*([a-z][A-Za-z0-9]*)\s*=\s*([^,=][^,]*?)\s*,?\s*$')
+
+JSDOC_DEFAULT = re.compile(r"^\s*\*\s*@default\s+(.+?)\s*$")
+PROP_DECL = re.compile(r"^\s*([a-z][A-Za-z0-9]*)\??\s*:")
+
+
+def normalize(value: str) -> str:
+    value = value.strip().rstrip(";")
+    # 문서 표는 값을 백틱으로 감싼다 - `'filled'` -> 'filled'
+    if len(value) >= 2 and value.startswith("`") and value.endswith("`"):
+        value = value[1:-1].strip()
+    if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+        return value[1:-1]
+    return value
+
+
+def check_file(path: Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    problems: list[str] = []
+
+    # ── 1. 노출 문자열은 한글
+    for i, line in enumerate(lines, start=1):
+        m = DEFAULT_STR.match(line)
+        if not m:
+            continue
+        name, value = m.group(1), m.group(2)
+        if not EXPOSED.match(name) or value == "":
+            continue
+        if not HANGUL.search(value):
+            problems.append(f'{path}:{i}  {name} = "{value}" - 한글이 없다')
+
+    # ── 2. JSDoc @default vs 실제 기본값
+    actual: dict[str, str] = {}
+    for line in lines:
+        m = DEFAULT_ANY.match(line)
+        if m:
+            actual.setdefault(m.group(1), normalize(m.group(2)))
+
+    for i, line in enumerate(lines, start=1):
+        m = JSDOC_DEFAULT.match(line)
+        if not m:
+            continue
+        documented = normalize(m.group(1))
+        # 태그 다음에 오는 첫 prop 선언이 그 태그의 대상이다
+        prop = next(
+            (d.group(1) for d in (PROP_DECL.match(l) for l in lines[i:i + 6]) if d),
+            None,
+        )
+        if prop is None:
+            problems.append(f"{path}:{i}  @default {documented} - 대상 prop 을 찾지 못했다")
+            continue
+        if prop not in actual:
+            # 기본값 없이 문서만 있는 경우 (구조분해에 없음)
+            problems.append(f"{path}:{i}  {prop} - JSDoc 은 @default {documented} 인데 실제 기본값이 없다")
+            continue
+        if actual[prop] != documented:
+            problems.append(
+                f"{path}:{i}  {prop} - JSDoc @default {documented} != 실제 {actual[prop]}"
+            )
+
+    return problems
+
+
+# ── docs/COMPONENTS.md prop 표 대조 ──────────────────────────────────────────
+
+DOC = Path("docs/COMPONENTS.md")
+# 표 셀 구분자. 타입 열의 `\|`(escape 된 union 파이프)는 구분자가 아니다.
+CELL_SPLIT = re.compile(r"(?<!\\)\|")
+DEFAULT_HEADER = re.compile(r"^(?:Default|기본값)$", re.IGNORECASE)
+# destructuring 기본값 한 줄. `({` 시그니처와 `const { ... } = props` 두 형태를 모두 잡으려고
+# 블록 경계를 찾지 않고 "탭 들여쓰기 + 이름 = 값 + 쉼표"인 줄만 받는다. JSX 속성은 `=` 양쪽에
+# 공백이 없고, 객체 리터럴은 `:` 를 쓰고, 일반 대입은 `const` 로 시작하므로 섞이지 않는다.
+DESTRUCTURED = re.compile(r"^\t+([a-z][A-Za-z0-9]*)\s+=\s+(.+),$")
+
+
+def destructured_defaults(path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = DESTRUCTURED.match(line)
+        if m:
+            out.setdefault(m.group(1), normalize(m.group(2)))
+    return out
+
+
+def cells_of(line: str) -> list[str]:
+    parts = CELL_SPLIT.split(line.strip())
+    if parts and parts[0] == "":
+        parts = parts[1:]
+    if parts and parts[-1] == "":
+        parts = parts[:-1]
+    return [c.strip() for c in parts]
+
+
+def check_docs(files: list[Path]) -> tuple[list[str], int]:
+    by_name = {f.parent.name.replace("-", "").lower(): f for f in files}
+    problems: list[str] = []
+    compared = 0
+    component: Path | None = None
+    default_col: int | None = None
+
+    for i, line in enumerate(DOC.read_text(encoding="utf-8").splitlines(), start=1):
+        if line.startswith("#"):
+            key = re.sub(r"[^A-Za-z0-9]", "", line.lstrip("# ")).lower()
+            component, default_col = by_name.get(key), None
+            continue
+        if not line.startswith("|"):
+            default_col = None
+            continue
+
+        cells = cells_of(line)
+        header = next((n for n, c in enumerate(cells) if DEFAULT_HEADER.match(c)), None)
+        if header is not None:
+            default_col = header
+            continue
+        if default_col is None or component is None or len(cells) <= default_col:
+            continue
+        if set(line.replace("|", "").strip()) <= set("-: "):
+            continue
+
+        prop = normalize(cells[0])
+        if not re.fullmatch(r"[a-z][A-Za-z0-9]*", prop):
+            continue
+        documented = normalize(cells[default_col])
+        # 값이 없거나 산문(`자동 생성`)이거나 함수인 경우는 문자 비교가 의미 없다.
+        if documented in ("", "-", "—", "자동 생성") or "=>" in documented:
+            continue
+
+        actual = destructured_defaults(component)
+        if prop not in actual or "=>" in actual[prop]:
+            continue
+
+        compared += 1
+        if actual[prop] != documented:
+            problems.append(
+                f"{DOC}:{i}  {component.parent.name}.{prop} - 문서 {documented!r}"
+                f" != 소스 {actual[prop]!r}"
+            )
+
+    return problems, compared
+
+
+def main() -> int:
+    files = sorted(UI.rglob("index.tsx"))
+    if not files:
+        print("검사할 컴포넌트를 찾지 못했다 - 실행 위치가 repo 루트인지 확인하라", file=sys.stderr)
+        return 1
+
+    problems = [p for f in files for p in check_file(f)]
+    doc_problems, doc_compared = check_docs(files)
+    problems += doc_problems
+
+    exposed = sum(
+        1
+        for f in files
+        for line in f.read_text(encoding="utf-8").splitlines()
+        if (m := DEFAULT_STR.match(line)) and EXPOSED.match(m.group(1)) and m.group(2)
+    )
+    documented = sum(
+        1
+        for f in files
+        for line in f.read_text(encoding="utf-8").splitlines()
+        if JSDOC_DEFAULT.match(line)
+    )
+
+    if exposed == 0 or documented == 0 or doc_compared == 0:
+        print(
+            f"검사 대상이 사라졌다 (노출 문자열 {exposed}, @default {documented},"
+            f" 문서 표 {doc_compared})"
+            " - 정규식이나 파일 구조가 바뀌었는지 확인하라",
+            file=sys.stderr,
+        )
+        return 1
+
+    if problems:
+        print("prop 기본값 검사 실패:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        return 1
+
+    print(f"노출 기본 문자열 {exposed}개 - 전부 한글입니다.")
+    print(f"JSDoc @default {documented}개 - 전부 실제 기본값과 일치합니다.")
+    print(f"docs/COMPONENTS.md prop 표 기본값 {doc_compared}개 - 전부 소스와 일치합니다.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 작업 개요

Closes #526.

3.14.1 에서 넣은 `check:css-vars` / `check:prose` / stylelint 규칙에 이어, "위반이 지금 0건이라 처음부터 게이트로 쓸 수 있는" 검사 세 축을 추가한다. 세 축 모두 이 repo 에서 실제로 나온 결함 유형이다 — 영문 a11y 기본값, 어긋난 JSDoc `@default` 9곳, 문서 표와 소스의 기본값 불일치.

측정해서 **부채가 있는 항목은 넣지 않았다**(아래 `## 전달할 추가 이슈`).

## 작업한 내용

- [x] `pnpm check:defaults` (`scripts/check-prop-defaults.py`) 추가
- [x] 1축 — 노출 기본 문자열 27개가 전부 한글인지 (`*Label` / `*Text` / `*Format` / `*Message` / `*Title` / `placeholder`)
- [x] 2축 — JSDoc `@default` 9개가 실제 destructuring 기본값과 일치하는지
- [x] 3축 — `docs/COMPONENTS.md` prop 표 Default 열 69개가 소스와 일치하는지
- [x] canary — 검사 대상 수가 0 으로 떨어지면 실패 (정규식·구조가 바뀌어 "조용히 통과"하는 것을 막는다)
- [x] CI 게이트 연결 (승인받음) — `Lint SCSS` 다음, `Build` 앞. step 조건 없음

## 검증

**뮤테이션 4/4 사망** — 검사가 실제로 위반을 잡는지 축마다 확인했다.

| 심은 위반 | 결과 |
|---|---|
| `prevLabel` 을 `"Previous page"` 로 | killed |
| `@default 3` → `@default 4` | killed |
| 문서의 `button.size` 기본값을 `'lg'` 로 | killed (`docs/COMPONENTS.md:193` 지목) |
| 스캔 경로를 좁혀 대상 소실 | killed (canary) |

작성 중 **자기 검사에서 두 번 걸렸다**. 둘 다 뮤테이션이 잡았다.

- 문서 셀의 백틱을 벗기지 않아 prop 이름 매칭이 전부 실패했다 → 3축이 0건 비교로 통과. canary 가 먼저 잡았다
- 그걸 고친 뒤에도 `Button` 이 빠져 있었다. `destructured_defaults` 가 `({` 시그니처 형태만 읽어서, `const { ... } = props` 형태(Button·Chip 등)를 통째로 놓쳤다. 문서 기본값을 바꿔도 통과했다 → 블록 경계 탐색을 버리고 "탭 들여쓰기 + `이름 = 값,`" 한 줄 패턴으로 바꿨다. 비교 대상 58 → **69**

그 밖에: `pnpm test` 927 passed, `tsc --noEmit` 0. 스크립트만 추가하므로 런타임 산출물 변화 없다.

## 전달할 추가 이슈

측정해보니 부채가 있어 이번에 넣지 않은 것들이다.

- **인라인 `style={{` 금지** — `src/ui/**/index.tsx` 에 19곳 존재. 스타일은 `style.scss` 로 간다는 규약과 어긋나지만 게이트로 넣으면 즉시 실패한다
- **`biome check src`** — repo 전체로는 실패한다. `src/stories/**` 포맷·organizeImports 다수, `src/vanilla/examples/index.html` 의 `noLabelWithoutControl` 4건, `page-composition.stories.tsx` 의 `noImgElement` 2건
- **raw `font-size: px` stylelint 규칙** — avatar·badge 의 `10px` 이 타이포 스케일(최소 12px) 밖이라 여전히 보류
- **docs 표 축은 한쪽 방향만 잡는다** — 워크플로 `paths-ignore` 가 `docs/**` · `**.md` 를 빼므로 문서만 고친 PR 에서는 CI 자체가 돌지 않는다. 즉 "소스를 바꾸고 문서를 안 고친" 방향은 잡지만, "문서에 잘못된 기본값을 새로 적는" 방향은 리뷰 diff 에 의존한다. 트리거 정책을 바꾸면(md PR 도 CI 실행) 닫히는데, 이번 승인 범위(스텝 추가) 밖이라 손대지 않았다
