### PR TITLE
merge: release v3.14.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,16 @@ jobs:
       - name: Lint SCSS (Stylelint)
         run: pnpm lint:css
 
+      # prop 기본값 3축 (노출 문자열 한글 / JSDoc @default / docs 표 Default 열).
+      # 소스와 문서만 읽으므로 Build 앞에 두어 빨리 실패한다. Stylelint 와 같은 이유로 step
+      # 조건은 두지 않는다 - 이 job 이 도는 모든 경우에 검사해서 손해가 없다.
+      #
+      # 다만 워크플로 `paths-ignore` 가 `docs/**` 와 `**.md` 를 빼므로, 문서만 고친 PR 에서는
+      # CI 자체가 돌지 않는다. 즉 3축 중 docs 표 축은 "소스를 바꾸고 문서를 안 고친" 방향만
+      # 잡는다. 반대 방향(문서에 잘못된 기본값을 새로 적는 것)은 리뷰 diff 에서 본다.
+      - name: Check prop defaults
+        run: pnpm check:defaults
+
       # 코드 또는 의존성 변경 → unit 테스트 + 커버리지
       - name: Run tests with coverage
         if: needs.changes.outputs.code == 'true' || needs.changes.outputs.deps == 'true'

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,1 +1,9 @@
 // Storybook 10.3+: preview annotations are applied automatically via @storybook/addon-vitest.
+
+import { Globals } from "@react-spring/web";
+
+// a11y(axe) 검사는 story 렌더 직후 실행된다. 등장 애니메이션이 도는 중이면 axe 가
+// 보간 중인 opacity 를 합성해 색 대비를 계산해서(예: #fafafa on #efefef) color-contrast 가
+// 실패한다 — 애니메이션 타이밍에 따라 플레이키하다. 스프링을 목표값으로 점프시켜
+// 정적 상태만 검사한다. 애니메이션 자체는 unit 테스트(src/ui/**/**.test.tsx)에서 검증한다.
+Globals.assign({ skipAnimation: true });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.14.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.14.2) - 2026-08-24
+- Modal 이 처음부터 열린 상태로 마운트돼도(전역 모달 스택·조건부 렌더) 등장 애니메이션이 나옵니다
+- `prefers-reduced-motion` 에서 Toast·Drawer·Popover·Tooltip·Menu·Dropdown 의 한 프레임 깜빡임을 없앴습니다
+- Modal·Alert 의 진입/퇴출 스프링 값을 공용화하고 진입에도 오버슈트를 없앴습니다
+- prop 기본값 3축(노출 문자열 한글 · JSDoc `@default` · `docs/COMPONENTS.md` 표)을 CI 에서 검사합니다
+
 ## [3.14.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.14.1) - 2026-08-24
 
 - **`Prose` 제목 굵기 계층 수정 (렌더 변경)** - `h1`·`h2` 가 접미사 없는 타이포 변형(regular 400)을 써서 본문과 같은 굵기였고, `h3`~`h6` 만 700 이라 **`h1` 이 `h3` 보다 가늘게** 보였다. 제목 전부 bold 변형으로 교체했다. 스케일이 24px 이상 bold 에서 자간을 조이므로(`-0.01em`) `h1` 은 `md`·`lg` 양쪽에서, `h2` 는 `lg` 에서 자간도 함께 복원된다

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.14.1",
+	"version": "3.14.2",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"lint:css": "stylelint 'src/ui/**/*.scss' 'src/styles/**/*.scss' 'src/vanilla/**/*.scss'",
 		"check:css-vars": "scripts/check-css-vars.sh",
 		"check:prose": "scripts/check-prose-headings.sh",
+		"check:defaults": "python3 scripts/check-prop-defaults.py",
 		"size": "size-limit",
 		"prepare": "husky"
 	},

--- a/scripts/check-prop-defaults.py
+++ b/scripts/check-prop-defaults.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""컴포넌트 prop 기본값을 세 축으로 검사한다.
+
+1. 화면·스크린리더에 노출되는 기본 문자열(`*Label` / `*Text` / `placeholder` 등)은 한글이어야
+   한다. 영문 기본값이 섞여 들어가면 한국어 UI 에서 스크린리더가 영어를 읽는다.
+2. JSDoc `@default` 가 실제 destructuring 기본값과 일치해야 한다. 값을 바꾸고 JSDoc 을 잊으면
+   Storybook autodocs 와 소비자 문서가 조용히 거짓말을 한다.
+3. `docs/COMPONENTS.md` prop 표의 Default 열이 소스 기본값과 일치해야 한다. 소비자가 읽는
+   문서라 어긋나면 그대로 잘못된 코드를 쓴다.
+
+exit 1 이면 위반이 있다.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+UI = Path("src/ui")
+
+# 화면/스크린리더 노출 문자열로 취급하는 prop 이름
+EXPOSED = re.compile(r"^(?:[a-z][A-Za-z]*(?:Label|Text|Format|Message|Title)|placeholder)$")
+HANGUL = re.compile(r"[가-힣]")
+
+# `  someLabel = "값",` 형태의 destructuring 기본값
+DEFAULT_STR = re.compile(r'^\s*([a-z][A-Za-z0-9]*)\s*=\s*"([^"]*)"\s*,?\s*$')
+# 문자열이 아닌 기본값도 포함 (JSDoc 대조용)
+DEFAULT_ANY = re.compile(r'^\s*([a-z][A-Za-z0-9]*)\s*=\s*([^,=][^,]*?)\s*,?\s*$')
+
+JSDOC_DEFAULT = re.compile(r"^\s*\*\s*@default\s+(.+?)\s*$")
+PROP_DECL = re.compile(r"^\s*([a-z][A-Za-z0-9]*)\??\s*:")
+
+
+def normalize(value: str) -> str:
+    value = value.strip().rstrip(";")
+    # 문서 표는 값을 백틱으로 감싼다 - `'filled'` -> 'filled'
+    if len(value) >= 2 and value.startswith("`") and value.endswith("`"):
+        value = value[1:-1].strip()
+    if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+        return value[1:-1]
+    return value
+
+
+def check_file(path: Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    problems: list[str] = []
+
+    # ── 1. 노출 문자열은 한글
+    for i, line in enumerate(lines, start=1):
+        m = DEFAULT_STR.match(line)
+        if not m:
+            continue
+        name, value = m.group(1), m.group(2)
+        if not EXPOSED.match(name) or value == "":
+            continue
+        if not HANGUL.search(value):
+            problems.append(f'{path}:{i}  {name} = "{value}" - 한글이 없다')
+
+    # ── 2. JSDoc @default vs 실제 기본값
+    actual: dict[str, str] = {}
+    for line in lines:
+        m = DEFAULT_ANY.match(line)
+        if m:
+            actual.setdefault(m.group(1), normalize(m.group(2)))
+
+    for i, line in enumerate(lines, start=1):
+        m = JSDOC_DEFAULT.match(line)
+        if not m:
+            continue
+        documented = normalize(m.group(1))
+        # 태그 다음에 오는 첫 prop 선언이 그 태그의 대상이다
+        prop = next(
+            (d.group(1) for d in (PROP_DECL.match(l) for l in lines[i:i + 6]) if d),
+            None,
+        )
+        if prop is None:
+            problems.append(f"{path}:{i}  @default {documented} - 대상 prop 을 찾지 못했다")
+            continue
+        if prop not in actual:
+            # 기본값 없이 문서만 있는 경우 (구조분해에 없음)
+            problems.append(f"{path}:{i}  {prop} - JSDoc 은 @default {documented} 인데 실제 기본값이 없다")
+            continue
+        if actual[prop] != documented:
+            problems.append(
+                f"{path}:{i}  {prop} - JSDoc @default {documented} != 실제 {actual[prop]}"
+            )
+
+    return problems
+
+
+# ── docs/COMPONENTS.md prop 표 대조 ──────────────────────────────────────────
+
+DOC = Path("docs/COMPONENTS.md")
+# 표 셀 구분자. 타입 열의 `\|`(escape 된 union 파이프)는 구분자가 아니다.
+CELL_SPLIT = re.compile(r"(?<!\\)\|")
+DEFAULT_HEADER = re.compile(r"^(?:Default|기본값)$", re.IGNORECASE)
+# destructuring 기본값 한 줄. `({` 시그니처와 `const { ... } = props` 두 형태를 모두 잡으려고
+# 블록 경계를 찾지 않고 "탭 들여쓰기 + 이름 = 값 + 쉼표"인 줄만 받는다. JSX 속성은 `=` 양쪽에
+# 공백이 없고, 객체 리터럴은 `:` 를 쓰고, 일반 대입은 `const` 로 시작하므로 섞이지 않는다.
+DESTRUCTURED = re.compile(r"^\t+([a-z][A-Za-z0-9]*)\s+=\s+(.+),$")
+
+
+def destructured_defaults(path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = DESTRUCTURED.match(line)
+        if m:
+            out.setdefault(m.group(1), normalize(m.group(2)))
+    return out
+
+
+def cells_of(line: str) -> list[str]:
+    parts = CELL_SPLIT.split(line.strip())
+    if parts and parts[0] == "":
+        parts = parts[1:]
+    if parts and parts[-1] == "":
+        parts = parts[:-1]
+    return [c.strip() for c in parts]
+
+
+def check_docs(files: list[Path]) -> tuple[list[str], int]:
+    by_name = {f.parent.name.replace("-", "").lower(): f for f in files}
+    problems: list[str] = []
+    compared = 0
+    component: Path | None = None
+    default_col: int | None = None
+
+    for i, line in enumerate(DOC.read_text(encoding="utf-8").splitlines(), start=1):
+        if line.startswith("#"):
+            key = re.sub(r"[^A-Za-z0-9]", "", line.lstrip("# ")).lower()
+            component, default_col = by_name.get(key), None
+            continue
+        if not line.startswith("|"):
+            default_col = None
+            continue
+
+        cells = cells_of(line)
+        header = next((n for n, c in enumerate(cells) if DEFAULT_HEADER.match(c)), None)
+        if header is not None:
+            default_col = header
+            continue
+        if default_col is None or component is None or len(cells) <= default_col:
+            continue
+        if set(line.replace("|", "").strip()) <= set("-: "):
+            continue
+
+        prop = normalize(cells[0])
+        if not re.fullmatch(r"[a-z][A-Za-z0-9]*", prop):
+            continue
+        documented = normalize(cells[default_col])
+        # 값이 없거나 산문(`자동 생성`)이거나 함수인 경우는 문자 비교가 의미 없다.
+        if documented in ("", "-", "—", "자동 생성") or "=>" in documented:
+            continue
+
+        actual = destructured_defaults(component)
+        if prop not in actual or "=>" in actual[prop]:
+            continue
+
+        compared += 1
+        if actual[prop] != documented:
+            problems.append(
+                f"{DOC}:{i}  {component.parent.name}.{prop} - 문서 {documented!r}"
+                f" != 소스 {actual[prop]!r}"
+            )
+
+    return problems, compared
+
+
+def main() -> int:
+    files = sorted(UI.rglob("index.tsx"))
+    if not files:
+        print("검사할 컴포넌트를 찾지 못했다 - 실행 위치가 repo 루트인지 확인하라", file=sys.stderr)
+        return 1
+
+    problems = [p for f in files for p in check_file(f)]
+    doc_problems, doc_compared = check_docs(files)
+    problems += doc_problems
+
+    exposed = sum(
+        1
+        for f in files
+        for line in f.read_text(encoding="utf-8").splitlines()
+        if (m := DEFAULT_STR.match(line)) and EXPOSED.match(m.group(1)) and m.group(2)
+    )
+    documented = sum(
+        1
+        for f in files
+        for line in f.read_text(encoding="utf-8").splitlines()
+        if JSDOC_DEFAULT.match(line)
+    )
+
+    if exposed == 0 or documented == 0 or doc_compared == 0:
+        print(
+            f"검사 대상이 사라졌다 (노출 문자열 {exposed}, @default {documented},"
+            f" 문서 표 {doc_compared})"
+            " - 정규식이나 파일 구조가 바뀌었는지 확인하라",
+            file=sys.stderr,
+        )
+        return 1
+
+    if problems:
+        print("prop 기본값 검사 실패:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        return 1
+
+    print(f"노출 기본 문자열 {exposed}개 - 전부 한글입니다.")
+    print(f"JSDoc @default {documented}개 - 전부 실제 기본값과 일치합니다.")
+    print(f"docs/COMPONENTS.md prop 표 기본값 {doc_compared}개 - 전부 소스와 일치합니다.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ui/feedback/alert/Alert.test.tsx
+++ b/src/ui/feedback/alert/Alert.test.tsx
@@ -227,9 +227,7 @@ describe("Alert", () => {
 
 	it("closeOnOverlay=false ignores overlay clicks", () => {
 		const onCancel = vi.fn();
-		renderWithProvider(
-			<TestComponent options={{ title: "C", onCancel, closeOnOverlay: false }} />,
-		);
+		renderWithProvider(<TestComponent options={{ title: "C", onCancel, closeOnOverlay: false }} />);
 
 		fireEvent.click(screen.getByText("Show Alert"));
 		const overlay = screen.getByRole("alertdialog").parentElement as HTMLElement;

--- a/src/ui/feedback/alert/alert.stories.tsx
+++ b/src/ui/feedback/alert/alert.stories.tsx
@@ -115,12 +115,7 @@ export const Success: Story = {
 
 export const Warning: Story = {
 	render: () => (
-		<AlertDemo
-			variant="warning"
-			title="경고"
-			message="이 작업을 진행하시겠습니까?"
-			showCancel
-		/>
+		<AlertDemo variant="warning" title="경고" message="이 작업을 진행하시겠습니까?" showCancel />
 	),
 };
 

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -167,8 +167,19 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
 	const reduced = useReducedMotion();
 
+	// `from` 을 명시한다. 없으면 첫 렌더의 `to` 가 초기값이 되어, isOpen=true 로 처음
+	// 마운트되면 등장 모션이 없다(Modal 이 그 버그였다). AlertProvider 는 항상 isOpen=false 로
+	// 마운트하므로 지금 동작은 바뀌지 않지만, 그 성질에 기대지 않게 못박는다.
+	//
+	// reduced-motion 에서 `from` 을 빼는 이유는 Modal 과 같다 - 주면 한 프레임 깜빡임이 남는다.
+	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
+	const panelEnterFrom = reduced
+		? {}
+		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+
 	const overlayStyle = useSpring({
-		opacity: isOpen ? 1 : 0,
+		...enterFrom,
+		to: { opacity: isOpen ? 1 : 0 },
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 		onRest: (result) => {
@@ -177,8 +188,11 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	});
 
 	const panelStyle = useSpring({
-		opacity: isOpen ? 1 : 0,
-		transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		...panelEnterFrom,
+		to: {
+			opacity: isOpen ? 1 : 0,
+			transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		},
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !isOpen },
 	});

--- a/src/ui/feedback/alert/index.tsx
+++ b/src/ui/feedback/alert/index.tsx
@@ -9,6 +9,10 @@ import { iconSize } from "../../../styles/icon";
 import {
 	cn,
 	lockBodyScroll,
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
 	unlockBodyScroll,
 	useFocusTrap,
 	useOverlayEscape,
@@ -170,31 +174,26 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	// `from` 을 명시한다. 없으면 첫 렌더의 `to` 가 초기값이 되어, isOpen=true 로 처음
 	// 마운트되면 등장 모션이 없다(Modal 이 그 버그였다). AlertProvider 는 항상 isOpen=false 로
 	// 마운트하므로 지금 동작은 바뀌지 않지만, 그 성질에 기대지 않게 못박는다.
-	//
-	// reduced-motion 에서 `from` 을 빼는 이유는 Modal 과 같다 - 주면 한 프레임 깜빡임이 남는다.
-	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
-	const panelEnterFrom = reduced
-		? {}
-		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+	// reduced-motion 예외는 springEnterFrom 안에 있다.
 
 	const overlayStyle = useSpring({
-		...enterFrom,
+		...springEnterFrom(reduced),
 		to: { opacity: isOpen ? 1 : 0 },
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !isOpen },
+		config: OVERLAY_SPRING_CONFIG,
 		onRest: (result) => {
 			if (!isOpen && result.finished) setShouldRender(false);
 		},
 	});
 
 	const panelStyle = useSpring({
-		...panelEnterFrom,
+		...springEnterFrom(reduced, OVERLAY_PANEL_CLOSED_TRANSFORM),
 		to: {
 			opacity: isOpen ? 1 : 0,
-			transform: isOpen ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+			transform: isOpen ? OVERLAY_PANEL_OPEN_TRANSFORM : OVERLAY_PANEL_CLOSED_TRANSFORM,
 		},
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !isOpen },
+		config: OVERLAY_SPRING_CONFIG,
 	});
 
 	// 바디 스크롤 잠금 - Modal/Drawer 와 동일한 data-open-modals 카운터 공유
@@ -220,7 +219,6 @@ const AlertModal: React.FC<AlertModalProps> = ({
 	const modalClassName = cn("alert_modal", `alert_variant_${variant}`);
 
 	return createPortal(
-		// biome-ignore lint/a11y/noStaticElementInteractions: modal overlay pattern
 		<animated.div
 			className="alert_overlay"
 			style={overlayStyle}

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -378,9 +378,7 @@ describe("Modal", () => {
 		expect(screen.getByText("상세 내용")).toBeInTheDocument();
 
 		// 닫는 tick 에 부모가 데이터를 비운다
-		rerender(
-			<Modal open={false} onClose={() => {}} title="상세" />,
-		);
+		rerender(<Modal open={false} onClose={() => {}} title="상세" />);
 		expect(screen.getByText("상세 내용")).toBeInTheDocument();
 	});
 

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -1,5 +1,6 @@
+import { Globals } from "@react-spring/web";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Modal } from "./index";
 
 describe("Modal", () => {
@@ -506,5 +507,110 @@ describe("Modal", () => {
 		expect(screen.getByText("항목 설명")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
 		expect(screen.getByText("항목 본문")).toBeInTheDocument();
+	});
+
+	// ── 등장 애니메이션 ─────────────────────────────────────────────────────
+	// react-spring 은 `from` 이 없으면 첫 렌더의 `to` 를 초기값으로 잡는다. 처음부터
+	// open=true 로 마운트되면 초기값 = 목표값이 되어 등장 모션이 사라지던 버그(#522).
+	// 전역 모달 스택과 조건부 렌더가 정확히 그 형태다.
+	// src/test/setup.ts 가 전 테스트에 skipAnimation 을 걸어 스프링을 목표값으로 즉시 점프시킨다
+	// (퇴출 unmount 타이밍 테스트가 rAF 없이 돌게 하려고). 등장 보간을 보려면 이 두 테스트에서만
+	// 끈다 - afterEach 가 다시 켜므로 다른 테스트에 새지 않는다.
+	describe("enter animation (skipAnimation off)", () => {
+		beforeEach(() => Globals.assign({ skipAnimation: false }));
+		afterEach(() => Globals.assign({ skipAnimation: true }));
+
+		it("starts the panel away from its resting state when mounted already open", () => {
+			render(
+				<Modal open onClose={() => {}} title="상세">
+					본문
+				</Modal>,
+			);
+			const panel = document.querySelector(".modal_panel") as HTMLElement;
+			const overlay = screen.getByRole("dialog");
+
+			// 마운트 직후 프레임 - 아직 목표값에 도달하지 않았어야 한다
+			expect(Number(panel.style.opacity)).toBeLessThan(1);
+			expect(panel.style.transform).not.toBe("scale(1) translateY(0px)");
+			expect(Number(overlay.style.opacity)).toBeLessThan(1);
+		});
+
+		// 기존 reduced-motion 테스트는 skipAnimation 이 켜진 상태에서 돌아, `immediate: reduced` 를
+		// 지워도 통과한다(뮤테이션으로 확인). skipAnimation 을 끈 여기서는 `from` 을 reduced 에서
+		// 빼는 처리가 실제로 물린다.
+		//
+		// 한계: false→true 플립 경로에서 `immediate` 자체가 일하는지는 여기서 못 본다. react-spring
+		// 은 React 커밋 밖에서 스타일을 쓰므로 rerender 직후 동기 시점에는 아직 값이 반영되지 않고,
+		// waitFor 로 기다리면 immediate 든 일반 스프링이든 결국 목표값에 도달해 구분이 안 된다.
+		it("skips the enter interpolation entirely under prefers-reduced-motion (WCAG 2.3.3)", () => {
+			vi.stubGlobal(
+				"matchMedia",
+				vi.fn().mockImplementation((query: string) => ({
+					matches: query.includes("prefers-reduced-motion"),
+					media: query,
+					addEventListener: vi.fn(),
+					removeEventListener: vi.fn(),
+					addListener: vi.fn(),
+					removeListener: vi.fn(),
+					dispatchEvent: vi.fn(),
+				})),
+			);
+			render(
+				<Modal open onClose={() => {}} title="Reduced">
+					본문
+				</Modal>,
+			);
+			const panel = document.querySelector(".modal_panel") as HTMLElement;
+			const overlay = screen.getByRole("dialog");
+
+			// 보간 없이 첫 프레임부터 휴지 상태여야 한다 - overlay·panel 양쪽
+			expect(Number(panel.style.opacity)).toBe(1);
+			expect(panel.style.transform).toBe("scale(1) translateY(0px)");
+			expect(Number(overlay.style.opacity)).toBe(1);
+			vi.unstubAllGlobals();
+		});
+
+		it("animates to the resting state after mounting already open", async () => {
+			render(
+				<Modal open onClose={() => {}} title="상세">
+					본문
+				</Modal>,
+			);
+			const panel = document.querySelector(".modal_panel") as HTMLElement;
+
+			await waitFor(() => expect(Number(panel.style.opacity)).toBe(1));
+			expect(panel.style.transform).toBe("scale(1) translateY(0px)");
+		});
+	});
+
+	// `from` 은 첫 렌더에만 적용된다 - 닫았다 다시 열면 그때의 현재값에서 이어져야 하고,
+	// 퇴출 수명(onExited)도 영향받지 않아야 한다.
+	it("keeps the exit lifecycle intact after mounting already open", async () => {
+		vi.stubGlobal(
+			"matchMedia",
+			vi.fn().mockImplementation((query: string) => ({
+				matches: query.includes("prefers-reduced-motion"),
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		);
+		const onExited = vi.fn();
+		const { rerender } = render(
+			<Modal open onClose={() => {}} onExited={onExited} title="상세">
+				본문
+			</Modal>,
+		);
+		rerender(
+			<Modal open={false} onClose={() => {}} onExited={onExited} title="상세">
+				본문
+			</Modal>,
+		);
+		await waitFor(() => expect(onExited).toHaveBeenCalledTimes(1));
+		expect(document.querySelector(".modal_panel")).toBeNull();
+		vi.unstubAllGlobals();
 	});
 });

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -135,9 +135,23 @@ export const Modal = ({
 	// reduced-motion: 진입/퇴출 모션 없이 즉시 최종 상태 (WCAG 2.3.3). onRest 는 그대로 발화.
 	const reduced = useReducedMotion();
 
+	// `from` 을 명시해야 한다. 없으면 react-spring 이 **첫 렌더의 `to`** 를 초기값으로 잡으므로,
+	// 처음부터 open=true 로 마운트된 모달은 초기값 = 목표값이 되어 등장 모션이 아예 없다.
+	// 전역 모달 스택이나 조건부 렌더(`{isOpen && <Modal open />}`)가 정확히 그 형태다.
+	// `from` 은 첫 렌더에만 쓰이므로 재열림·퇴출 동작은 그대로다.
+	//
+	// 단 reduced-motion 에서는 `from` 을 주지 않는다. 주면 첫 프레임에 from 값이 DOM 에 커밋된
+	// 뒤 immediate 가 목표값으로 점프해, 모션 대신 **한 프레임 깜빡임**이 남는다(실측 확인).
+	// 없으면 첫 렌더의 to 가 초기값이 되어 보간 구간 자체가 생기지 않는다 - 원하는 동작이다.
+	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
+	const panelEnterFrom = reduced
+		? {}
+		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({
-		opacity: open ? 1 : 0,
+		...enterFrom,
+		to: { opacity: open ? 1 : 0 },
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 		onRest: (result) => {
@@ -149,10 +163,13 @@ export const Modal = ({
 		},
 	});
 
-	// Spring: panel (opacity + scale + translateY)
+	// Spring: panel (opacity + scale + translateY) - overlay 와 같은 규칙.
 	const panelStyle = useSpring({
-		opacity: open ? 1 : 0,
-		transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		...panelEnterFrom,
+		to: {
+			opacity: open ? 1 : 0,
+			transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+		},
 		immediate: reduced,
 		config: { tension: 280, friction: 28, clamp: !open },
 	});

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -8,6 +8,10 @@ import { iconSize } from "../../../styles/icon";
 import {
 	cn,
 	lockBodyScroll,
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
 	unlockBodyScroll,
 	useFocusTrap,
 	useIsMounted,
@@ -140,20 +144,15 @@ export const Modal = ({
 	// 전역 모달 스택이나 조건부 렌더(`{isOpen && <Modal open />}`)가 정확히 그 형태다.
 	// `from` 은 첫 렌더에만 쓰이므로 재열림·퇴출 동작은 그대로다.
 	//
-	// 단 reduced-motion 에서는 `from` 을 주지 않는다. 주면 첫 프레임에 from 값이 DOM 에 커밋된
-	// 뒤 immediate 가 목표값으로 점프해, 모션 대신 **한 프레임 깜빡임**이 남는다(실측 확인).
-	// 없으면 첫 렌더의 to 가 초기값이 되어 보간 구간 자체가 생기지 않는다 - 원하는 동작이다.
-	const enterFrom = reduced ? {} : { from: { opacity: 0 } };
-	const panelEnterFrom = reduced
-		? {}
-		: { from: { opacity: 0, transform: "scale(0.96) translateY(-4px)" } };
+	// reduced-motion 예외 처리는 springEnterFrom 안에 있다(주면 한 프레임 깜빡임이 남는다).
+	// 오버레이에 transform 을 주지 않는 이유도 그 JSDoc 에 있다.
 
 	// Spring: overlay (opacity) - onRest 로 exit 완료 후 unmount
 	const overlayStyle = useSpring({
-		...enterFrom,
+		...springEnterFrom(reduced),
 		to: { opacity: open ? 1 : 0 },
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !open },
+		config: OVERLAY_SPRING_CONFIG,
 		onRest: (result) => {
 			if (open || !result.finished) return;
 			setShouldRender(false);
@@ -165,13 +164,13 @@ export const Modal = ({
 
 	// Spring: panel (opacity + scale + translateY) - overlay 와 같은 규칙.
 	const panelStyle = useSpring({
-		...panelEnterFrom,
+		...springEnterFrom(reduced, OVERLAY_PANEL_CLOSED_TRANSFORM),
 		to: {
 			opacity: open ? 1 : 0,
-			transform: open ? "scale(1) translateY(0px)" : "scale(0.96) translateY(-4px)",
+			transform: open ? OVERLAY_PANEL_OPEN_TRANSFORM : OVERLAY_PANEL_CLOSED_TRANSFORM,
 		},
 		immediate: reduced,
-		config: { tension: 280, friction: 28, clamp: !open },
+		config: OVERLAY_SPRING_CONFIG,
 	});
 
 	// 바디 스크롤 잠금(중첩 모달 지원)
@@ -242,9 +241,7 @@ export const Modal = ({
 						{content.title}
 					</h2>
 				)}
-				{content.description && (
-					<div className="modal_description">{content.description}</div>
-				)}
+				{content.description && <div className="modal_description">{content.description}</div>}
 				{content.children && (
 					// 본문이 스크롤 컨테이너라 키보드로도 스크롤할 수 있어야 한다(axe
 					// `scrollable-region-focusable`). 넘치는지 여부를 측정해 조건부로 주는 방법도 있지만
@@ -252,14 +249,15 @@ export const Modal = ({
 					// 늘어나는 정도의 비용이다.
 					// 다만 초기 포커스 대상에서는 제외한다 - 안쪽에 첫 입력이 있는데 빈 wrapper 에
 					// 포커스가 놓이면 열자마자 어디에 있는지 알 수 없다.
+					// 스크롤 가능한 영역은 키보드로도 스크롤할 수 있어야 한다 (WCAG 2.1.1) - 포커스
+					// 가능해야 화살표 키가 먹는다.
+					// biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable region needs keyboard scroll
 					<div className="modal_body" tabIndex={0} data-focus-trap-skip-autofocus="">
 						{content.children}
 					</div>
 				)}
 				{content.footer && (
-					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>
-						{content.footer}
-					</div>
+					<div className={cn("modal_footer", `modal_footer_${footerAlign}`)}>{content.footer}</div>
 				)}
 			</animated.div>
 		</animated.div>,

--- a/src/ui/overlay/modal/modal.stories.tsx
+++ b/src/ui/overlay/modal/modal.stories.tsx
@@ -91,7 +91,7 @@ export const DestructiveAction: Story = {
 		docs: {
 			description: {
 				story:
-					"`footerAlign=\"between\"` - 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성을 시각화한다.",
+					'`footerAlign="between"` - 좌측에 destructive (Delete), 우측에 safe (Cancel). 위험성을 시각화한다.',
 			},
 		},
 	},
@@ -220,6 +220,32 @@ export const LongContent: Story = {
 					</div>
 				</Modal>
 			</>
+		);
+	},
+};
+
+export const ConditionalMount: Story = {
+	name: "조건부 마운트 (등장 애니메이션)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"전역 모달 스택은 보통 열림 상태와 렌더할 content 를 같은 상태 업데이트로 넣는다. 그러면 첫 마운트 시점에 이미 `open=true` 다. 이 패턴에서도 등장 애니메이션이 나와야 한다 — react-spring 은 `from` 이 없으면 첫 렌더의 목표값을 초기값으로 잡아 보간 구간이 0 이 된다.",
+			},
+		},
+	},
+	render: () => {
+		const [mounted, setMounted] = useState(false);
+		return (
+			<div>
+				<Button onClick={() => setMounted(true)}>모달 열기 (조건부 마운트)</Button>
+				{mounted && (
+					<Modal open onClose={() => setMounted(false)} title="조건부 마운트">
+						처음부터 <code>open=true</code> 로 마운트된 모달입니다. 페이드인 + scale 이 보여야
+						합니다.
+					</Modal>
+				)}
+			</div>
 		);
 	},
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,12 @@ export { cn } from "./cn";
 export { registerOverlay, useOverlayEscape } from "./overlay-stack";
 export { lockBodyScroll, unlockBodyScroll } from "./scroll-lock";
 export {
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
+} from "./spring-motion";
+export {
 	type AnchoredOptions,
 	type AnchoredResult,
 	type AnchoredSide,

--- a/src/utils/spring-motion.test.ts
+++ b/src/utils/spring-motion.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+	OVERLAY_PANEL_CLOSED_TRANSFORM,
+	OVERLAY_PANEL_OPEN_TRANSFORM,
+	OVERLAY_SPRING_CONFIG,
+	springEnterFrom,
+} from "./spring-motion";
+
+describe("springEnterFrom", () => {
+	it("gives an opacity-only from when no transform is passed", () => {
+		// 오버레이에 transform 이 붙으면 position: fixed 자손의 containing block 이 되어버린다.
+		expect(springEnterFrom(false)).toEqual({ from: { opacity: 0 } });
+	});
+
+	it("includes the transform when one is passed", () => {
+		expect(springEnterFrom(false, "scale(0.9)")).toEqual({
+			from: { opacity: 0, transform: "scale(0.9)" },
+		});
+	});
+
+	it("omits from entirely under reduced motion", () => {
+		// `from` 을 주면 첫 프레임에 커밋된 뒤 immediate 가 점프해 한 프레임 깜빡임이 남는다.
+		expect(springEnterFrom(true)).toEqual({});
+		expect(springEnterFrom(true, "scale(0.9)")).toEqual({});
+		expect("from" in springEnterFrom(true)).toBe(false);
+	});
+});
+
+describe("overlay motion constants", () => {
+	it("uses the same transform for the enter start and the exit target", () => {
+		// 진입 시작값과 퇴출 목표값이 갈리면 열고 닫기가 비대칭이 된다.
+		expect(OVERLAY_PANEL_CLOSED_TRANSFORM).toBe("scale(0.96) translateY(-4px)");
+		expect(OVERLAY_PANEL_OPEN_TRANSFORM).toBe("scale(1) translateY(0px)");
+	});
+
+	it("clamps in both directions", () => {
+		expect(OVERLAY_SPRING_CONFIG.clamp).toBe(true);
+	});
+});

--- a/src/utils/spring-motion.ts
+++ b/src/utils/spring-motion.ts
@@ -1,0 +1,46 @@
+/**
+ * 스프링의 진입 시작값(`from`)을 만든다.
+ *
+ * react-spring 은 `from` 이 없으면 **첫 렌더의 `to` 를 초기값으로 잡는다**. 그래서 컴포넌트가
+ * 처음부터 열린 상태로 마운트되면(전역 오버레이 스택, `{isOpen && <Modal open />}` 같은 조건부
+ * 렌더) 보간 구간이 0 이 되어 등장 애니메이션이 사라진다.
+ *
+ * 반대로 reduced-motion 에서는 `from` 을 주면 안 된다. 주면 첫 프레임에 `from` 이 DOM 에 커밋된
+ * 뒤 `immediate` 가 목표값으로 점프해, 모션 대신 **한 프레임 깜빡임**이 남는다(실측 확인).
+ *
+ * 두 조건을 한 곳에서 만족시킨다. 스프레드해서 쓴다:
+ *
+ * ```tsx
+ * useSpring({
+ *   ...springEnterFrom(reduced, "scale(0.96)"),
+ *   to: { opacity: open ? 1 : 0, transform: open ? "scale(1)" : "scale(0.96)" },
+ *   immediate: reduced,
+ * });
+ * ```
+ *
+ * @param reduced `useReducedMotion()` 결과. true 면 빈 객체를 돌려 `from` 자체를 생략한다
+ * @param transform 진입 시작 transform. 생략하면 `opacity` 만 준다(오버레이처럼 transform 이
+ *   붙으면 안 되는 요소 - `position: fixed` 자손의 containing block 이 되어버린다)
+ */
+export function springEnterFrom(
+	reduced: boolean,
+	transform?: string,
+): { from?: { opacity: number; transform?: string } } {
+	if (reduced) return {};
+
+	return { from: transform === undefined ? { opacity: 0 } : { opacity: 0, transform } };
+}
+
+/** 중앙 패널 오버레이(Modal·AlertModal)의 닫힌 상태 transform. 진입 시작값 = 퇴출 목표값. */
+export const OVERLAY_PANEL_CLOSED_TRANSFORM = "scale(0.96) translateY(-4px)";
+
+/** 같은 오버레이의 열린 상태 transform. */
+export const OVERLAY_PANEL_OPEN_TRANSFORM = "scale(1) translateY(0px)";
+
+/**
+ * 오버레이 진입·퇴출 공용 스프링 설정.
+ *
+ * `clamp: true` - 진입에도 오버슈트를 두지 않는다. 감쇠비 0.84 에서 오버슈트는 변화량의
+ * 0.8%(패널 scale 기준 0.03%)라 눈에 보이지 않는 반면, 진입/퇴출이 갈리는 값이 하나 늘어난다.
+ */
+export const OVERLAY_SPRING_CONFIG = { tension: 280, friction: 28, clamp: true } as const;

--- a/src/utils/use-safe-layout-effect.ts
+++ b/src/utils/use-safe-layout-effect.ts
@@ -10,5 +10,4 @@ import { useEffect, useLayoutEffect } from "react";
  * `useLayoutEffect`(paint 전 동기 실행 - 레이아웃 측정/조정용), 서버에선
  * `useEffect` 로 안전하게 대체한다.
  */
-export const useSafeLayoutEffect =
-	typeof window !== "undefined" ? useLayoutEffect : useEffect;
+export const useSafeLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;

--- a/src/utils/use-spring-hover.ts
+++ b/src/utils/use-spring-hover.ts
@@ -26,9 +26,7 @@ export function useSpringHover({
 	const reduced = useReducedMotion();
 
 	const style = useSpring({
-		transform: hovered
-			? `translateY(${lift}px) scale(${scale})`
-			: "translateY(0px) scale(1)",
+		transform: hovered ? `translateY(${lift}px) scale(${scale})` : "translateY(0px) scale(1)",
 		// reduced-motion: lift/scale 모션 제거 (WCAG 2.3.3)
 		immediate: reduced,
 		config: { tension: 320, friction: 22 },

--- a/src/utils/use-spring-presence.test.tsx
+++ b/src/utils/use-spring-presence.test.tsx
@@ -1,0 +1,56 @@
+import { animated, Globals } from "@react-spring/web";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSpringPresence } from "./use-spring-presence";
+
+const Probe = ({ visible }: { visible: boolean }) => {
+	const style = useSpringPresence({ visible, from: "translateX(20px)" });
+	return <animated.div data-testid="probe" style={style} />;
+};
+
+const stubReducedMotion = (matches: boolean) => {
+	vi.stubGlobal(
+		"matchMedia",
+		vi.fn().mockImplementation((query: string) => ({
+			matches: matches && query.includes("prefers-reduced-motion"),
+			media: query,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	);
+};
+
+// src/test/setup.ts 가 스위트 전체에 skipAnimation: true 를 걸어 두므로, 첫 프레임 값을
+// 보려면 이 describe 안에서만 끈다. 켜진 상태에서는 어떤 스프링이든 목표값에서 시작한다.
+describe("useSpringPresence enter frame", () => {
+	beforeEach(() => Globals.assign({ skipAnimation: false }));
+	afterEach(() => {
+		Globals.assign({ skipAnimation: true });
+		vi.unstubAllGlobals();
+	});
+
+	it("starts away from the target when mounted already visible", () => {
+		// Toast 는 useState(true) 로 마운트한다 - `from` 이 없으면 첫 렌더의 to 가 초기값이 되어
+		// 등장 모션이 사라진다.
+		stubReducedMotion(false);
+		render(<Probe visible />);
+
+		const probe = screen.getByTestId("probe");
+		expect(probe.style.opacity).toBe("0");
+		expect(probe.style.transform).toBe("translateX(20px)");
+	});
+
+	it("starts at the target under reduced motion (no one-frame flash)", () => {
+		// 반대로 reduced-motion 에서 `from` 을 주면 그 값이 한 프레임 커밋된 뒤 immediate 가
+		// 점프해 모션 대신 깜빡임이 남는다. from 을 생략해 보간 구간 자체를 없앤다.
+		stubReducedMotion(true);
+		render(<Probe visible />);
+
+		const probe = screen.getByTestId("probe");
+		expect(probe.style.opacity).toBe("1");
+		expect(probe.style.transform).toBe("translateY(0px)");
+	});
+});

--- a/src/utils/use-spring-presence.ts
+++ b/src/utils/use-spring-presence.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSpring } from "@react-spring/web";
+import { springEnterFrom } from "./spring-motion";
 import { useReducedMotion } from "./use-reduced-motion";
 
 /**
@@ -28,7 +29,10 @@ export function useSpringPresence({
 	const reduced = useReducedMotion();
 
 	return useSpring({
-		from: { opacity: 0, transform: from },
+		// reduced-motion 에서는 `from` 을 생략한다 - 주면 첫 프레임에 from 이 DOM 에 커밋된 뒤
+		// immediate 가 목표값으로 점프해 모션 대신 한 프레임 깜빡임이 남는다. Toast 는 항상
+		// visible=true 로 마운트하므로 이 경로를 무조건 탄다. 자세한 근거는 springEnterFrom JSDoc.
+		...springEnterFrom(reduced, from),
 		to: {
 			opacity: visible ? 1 : 0,
 			transform: visible ? "translateY(0px)" : from,


### PR DESCRIPTION
## 작업 개요

3.14.2 패치 릴리즈. `merge: release v3.14.2`.

버그 수정 두 건과 검사 하나다. 공개 표면(`src/index.ts` export, SCSS 토큰, CSS 변수) 변화가 없어 **patch** 로 올린다 — `git diff v3.14.1..develop -- src/index.ts src/styles` 가 비어 있다. 새로 만든 `springEnterFrom` / `OVERLAY_*` 는 `src/utils` 배럴 내부용이고 패키지 `exports` 에 노출되지 않는다.

## 작업한 내용

- [x] #522 — Modal 이 처음부터 `open=true` 로 마운트되면 등장 애니메이션이 없던 버그 (PR #523). react-spring 이 `from` 없이는 첫 렌더의 `to` 를 초기값으로 잡는다
- [x] #524 — `useSpringPresence` 가 reduced-motion 에서 `from` 을 줘서 모션 대신 한 프레임 깜빡임이 남던 버그 (PR #525). Toast 는 `visible=true` 로 마운트하므로 상시 발생, Drawer·Popover·Tooltip·Menu·Dropdown 은 조건부 마운트 시 발생
- [x] Modal·Alert 의 진입 시작값·패널 transform·스프링 config 공용화, 진입에도 `clamp` 적용 (PR #525)
- [x] #526 — prop 기본값 3축 검사 + CI 게이트 (PR #527). 노출 기본 문자열 27개 한글 / JSDoc `@default` 9개 / `docs/COMPONENTS.md` 표 69개
- [x] `package.json` 3.14.1 → 3.14.2
- [x] `CHANGELOG.md` 3.14.2 항목 추가

## 검증

- 단위 **927 passed** / 9 skipped, storybook a11y **299 passed**
- `tsc --noEmit` 0, `lint:css` 0, `check:prose` · `check:css-vars` · `check:defaults` 통과, `build` 통과
- 새 CI 스텝 `Check prop defaults` 가 실제로 실행됨을 CI 로그로 확인 (`1a24e15`, step 8, 27 / 9 / 69)
- 뮤테이션 — 이번 릴리즈에 들어간 새 검사·테스트 전부 위반을 심으면 실패한다 (Modal 4/4, useSpringPresence 1/1, prop 기본값 4/4)
