### PR TITLE
revert/biome-format

### DIFF
--- a/src/stories/cookbook/data.stories.tsx
+++ b/src/stories/cookbook/data.stories.tsx
@@ -14,10 +14,10 @@ import { Badge } from "../../ui/display/badge";
 import { Card } from "../../ui/display/card";
 import { Chip } from "../../ui/display/chip";
 import { Divider } from "../../ui/display/divider";
-import { IconButton } from "../../ui/general/icon-button";
 import { Grid } from "../../ui/layout/grid";
-import { Stack } from "../../ui/layout/stack";
+import { IconButton } from "../../ui/general/icon-button";
 import { Menu } from "../../ui/navigation/menu";
+import { Stack } from "../../ui/layout/stack";
 
 const meta: Meta = {
 	title: "Cookbook/Data Display",
@@ -136,13 +136,7 @@ export const UserList: Story = {
 									</span>
 									<Stack gap={2}>
 										<Stack direction="horizontal" gap={8} align="center">
-											<span
-												style={{
-													fontSize: 14,
-													fontWeight: 600,
-													color: "var(--bt-color-text-heading)",
-												}}
-											>
+											<span style={{ fontSize: 14, fontWeight: 600, color: "var(--bt-color-text-heading)" }}>
 												{user.name}
 											</span>
 											<Badge variant={STATUS_VARIANT[user.status]} shape="label">
@@ -303,9 +297,7 @@ export const StatCards: Story = {
 				<Card key={stat.label} bordered padding="lg" shadow="sm">
 					<Stack gap={12}>
 						<Stack direction="horizontal" justify="between" align="center">
-							<span
-								style={{ fontSize: 13, color: "var(--bt-color-text-caption)", fontWeight: 500 }}
-							>
+							<span style={{ fontSize: 13, color: "var(--bt-color-text-caption)", fontWeight: 500 }}>
 								{stat.label}
 							</span>
 							<span
@@ -354,9 +346,7 @@ export const StatCards: Story = {
 								{stat.positive ? <TrendingUp size={12} /> : <TrendingDown size={12} />}
 								{stat.delta}
 							</span>
-							<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
-								{stat.caption}
-							</span>
+							<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>{stat.caption}</span>
 						</Stack>
 					</Stack>
 				</Card>
@@ -499,9 +489,7 @@ export const OrderTimeline: Story = {
 										</span>
 										<Chip type="static" size="sm" tone={item.statusTone} label={item.statusLabel} />
 									</Stack>
-									<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
-										{item.time}
-									</span>
+									<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>{item.time}</span>
 									<p
 										style={{
 											margin: 0,

--- a/src/stories/cookbook/feedback.stories.tsx
+++ b/src/stories/cookbook/feedback.stories.tsx
@@ -1,15 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Search, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { Button } from "../../ui/general/button";
 import { Card } from "../../ui/display/card";
 import { EmptyState } from "../../ui/feedback/empty-state";
+import { Grid } from "../../ui/layout/grid";
+import { Modal } from "../../ui/overlay/modal";
 import { Skeleton } from "../../ui/feedback/skeleton";
+import { Stack } from "../../ui/layout/stack";
 import { ToastProvider } from "../../ui/feedback/toast";
 import { useToast } from "../../ui/feedback/toast/use-toast";
-import { Button } from "../../ui/general/button";
-import { Grid } from "../../ui/layout/grid";
-import { Stack } from "../../ui/layout/stack";
-import { Modal } from "../../ui/overlay/modal";
 
 const meta: Meta = {
 	title: "Cookbook/Feedback Patterns",
@@ -102,22 +102,10 @@ export const LoadingSkeleton: Story = {
 											{post.name.charAt(0)}
 										</div>
 										<Stack gap={4} style={{ flex: 1 }}>
-											<span
-												style={{
-													fontSize: 13,
-													color: "var(--bt-color-text-caption)",
-													fontWeight: 500,
-												}}
-											>
+											<span style={{ fontSize: 13, color: "var(--bt-color-text-caption)", fontWeight: 500 }}>
 												{post.name}
 											</span>
-											<span
-												style={{
-													fontSize: 15,
-													fontWeight: 700,
-													color: "var(--bt-color-text-heading)",
-												}}
-											>
+											<span style={{ fontSize: 15, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 												{post.title}
 											</span>
 											<p
@@ -211,24 +199,16 @@ export const ConfirmationModal: Story = {
 					width={440}
 				>
 					<Stack gap={20}>
-						<p
-							style={{
-								margin: 0,
-								fontSize: 14,
-								color: "var(--bt-color-text-body)",
-								lineHeight: 1.6,
-							}}
-						>
-							계정을 삭제하면 모든 매장 데이터·정산 기록·연동 정보가 영구적으로 제거되며, 이 작업은
-							되돌릴 수 없습니다.
+						<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)", lineHeight: 1.6 }}>
+							계정을 삭제하면 모든 매장 데이터·정산 기록·연동 정보가 영구적으로
+							제거되며, 이 작업은 되돌릴 수 없습니다.
 						</p>
 						<div
 							style={{
 								padding: 12,
 								borderRadius: 8,
 								background: "color-mix(in srgb, var(--bt-color-status-error) 12%, transparent)",
-								border:
-									"1px solid color-mix(in srgb, var(--bt-color-status-error) 35%, transparent)",
+								border: "1px solid color-mix(in srgb, var(--bt-color-status-error) 35%, transparent)",
 								fontSize: 13,
 								color: "var(--bt-color-status-error)",
 							}}
@@ -266,14 +246,7 @@ const ToastDemo = () => {
 		<Card bordered padding="lg" shadow="sm">
 			<Stack gap={16} style={{ width: 360 }}>
 				<Stack gap={4}>
-					<h3
-						style={{
-							margin: 0,
-							fontSize: 16,
-							fontWeight: 700,
-							color: "var(--bt-color-text-heading)",
-						}}
-					>
+					<h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 						토스트 메시지
 					</h3>
 					<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>

--- a/src/stories/cookbook/form.stories.tsx
+++ b/src/stories/cookbook/form.stories.tsx
@@ -1,15 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Filter, Lock, Mail, Search, User } from "lucide-react";
 import { useState } from "react";
+import { Button } from "../../ui/general/button";
+import { Checkbox } from "../../ui/forms/checkbox";
 import { Chip } from "../../ui/display/chip";
 import { Divider } from "../../ui/display/divider";
-import { Checkbox } from "../../ui/forms/checkbox";
 import { Dropdown } from "../../ui/forms/dropdown";
 import { Radio } from "../../ui/forms/radio";
+import { Stack } from "../../ui/layout/stack";
 import { TextField } from "../../ui/forms/textfield";
 import { Toggle } from "../../ui/forms/toggle";
-import { Button } from "../../ui/general/button";
-import { Stack } from "../../ui/layout/stack";
 
 const meta: Meta = {
 	title: "Cookbook/Form Patterns",
@@ -123,9 +123,7 @@ export const LoginForm: Story = {
 					<Divider />
 
 					<Stack direction="horizontal" justify="center" gap={4} align="center">
-						<span style={{ fontSize: 13, color: "var(--bt-color-text-body)" }}>
-							아직 계정이 없으신가요?
-						</span>
+						<span style={{ fontSize: 13, color: "var(--bt-color-text-body)" }}>아직 계정이 없으신가요?</span>
 						<button
 							type="button"
 							style={{
@@ -232,7 +230,12 @@ export const SignUpForm: Story = {
 						onChange={(e) => setAgreed(e.target.checked)}
 					/>
 
-					<Button variant="filled" size="lg" fullWidth disabled={!agreed || passwordMismatch}>
+					<Button
+						variant="filled"
+						size="lg"
+						fullWidth
+						disabled={!agreed || passwordMismatch}
+					>
 						가입 완료
 					</Button>
 				</Stack>
@@ -248,7 +251,10 @@ export const SearchWithFilter: Story = {
 	render: () => {
 		const [keyword, setKeyword] = useState("");
 		const [sort, setSort] = useState<string | null>("newest");
-		const [activeFilters, setActiveFilters] = useState<string[]>(["카페", "서울"]);
+		const [activeFilters, setActiveFilters] = useState<string[]>([
+			"카페",
+			"서울",
+		]);
 
 		const removeFilter = (label: string) =>
 			setActiveFilters((prev) => prev.filter((item) => item !== label));
@@ -261,7 +267,8 @@ export const SearchWithFilter: Story = {
 					borderRadius: 16,
 					border: "1px solid var(--bt-color-border-default)",
 					padding: "24px",
-					boxShadow: "0 1px 3px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.04)",
+					boxShadow:
+						"0 1px 3px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.04)",
 				}}
 			>
 				<Stack gap={16}>
@@ -399,9 +406,7 @@ export const SettingsSection: Story = {
 						</p>
 						<Stack direction="horizontal" justify="between" align="center">
 							<Stack gap={2}>
-								<span
-									style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}
-								>
+								<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 									이메일 알림
 								</span>
 								<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
@@ -417,9 +422,7 @@ export const SettingsSection: Story = {
 						</Stack>
 						<Stack direction="horizontal" justify="between" align="center">
 							<Stack gap={2}>
-								<span
-									style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}
-								>
+								<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 									푸시 알림
 								</span>
 								<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
@@ -435,16 +438,19 @@ export const SettingsSection: Story = {
 						</Stack>
 						<Stack direction="horizontal" justify="between" align="center">
 							<Stack gap={2}>
-								<span
-									style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}
-								>
+								<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 									SMS 알림
 								</span>
 								<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
 									긴급 알림만 SMS로 발송
 								</span>
 							</Stack>
-							<Toggle ariaLabel="SMS 알림" checked={notifySms} onChange={setNotifySms} size="md" />
+							<Toggle
+								ariaLabel="SMS 알림"
+								checked={notifySms}
+								onChange={setNotifySms}
+								size="md"
+							/>
 						</Stack>
 					</Stack>
 

--- a/src/stories/cookbook/layout.stories.tsx
+++ b/src/stories/cookbook/layout.stories.tsx
@@ -14,18 +14,18 @@ import {
 } from "lucide-react";
 import { Avatar } from "../../ui/display/avatar";
 import { Badge } from "../../ui/display/badge";
+import { Breadcrumb } from "../../ui/navigation/breadcrumb";
+import { Button } from "../../ui/general/button";
 import { Card } from "../../ui/display/card";
 import { Chip } from "../../ui/display/chip";
-import { Hero } from "../../ui/display/hero";
-import { Table } from "../../ui/display/table";
-import { Button } from "../../ui/general/button";
 import { Container } from "../../ui/layout/container";
 import { Grid } from "../../ui/layout/grid";
+import { Hero } from "../../ui/display/hero";
 import { Section } from "../../ui/layout/section";
-import { Stack } from "../../ui/layout/stack";
-import { Breadcrumb } from "../../ui/navigation/breadcrumb";
 import { Sidebar, SidebarItem, SidebarSection } from "../../ui/navigation/sidebar";
+import { Stack } from "../../ui/layout/stack";
 import { Tab, TabList, TabPanel, Tabs } from "../../ui/navigation/tabs";
+import { Table } from "../../ui/display/table";
 
 const meta: Meta = {
 	title: "Cookbook/Layout Patterns",
@@ -133,7 +133,8 @@ export const MarketingHeroFeatureGrid: Story = {
 												width: 44,
 												height: 44,
 												borderRadius: 12,
-												background: "linear-gradient(135deg, #47555E 0%, #303841 100%)",
+												background:
+													"linear-gradient(135deg, #47555E 0%, #303841 100%)",
 												color: "#fff",
 											}}
 										>
@@ -149,14 +150,7 @@ export const MarketingHeroFeatureGrid: Story = {
 										>
 											{feature.title}
 										</h3>
-										<p
-											style={{
-												margin: 0,
-												fontSize: 14,
-												color: "var(--bt-color-text-body)",
-												lineHeight: 1.55,
-											}}
-										>
+										<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)", lineHeight: 1.55 }}>
 											{feature.desc}
 										</p>
 									</Stack>
@@ -175,9 +169,7 @@ export const MarketingHeroFeatureGrid: Story = {
 export const SidebarLayout: Story = {
 	name: "사이드바 레이아웃",
 	render: () => (
-		<div
-			style={{ display: "flex", minHeight: "100vh", background: "var(--bt-color-bg-solid-dim)" }}
-		>
+		<div style={{ display: "flex", minHeight: "100vh", background: "var(--bt-color-bg-solid-dim)" }}>
 			<Sidebar
 				header={
 					// 로고 경로는 iframe 기준 상대경로다 — 절대경로(`/images/…`)로 되돌리면 GH Pages
@@ -272,30 +264,16 @@ export const SidebarLayout: Story = {
 					<Card bordered padding="lg" shadow="sm">
 						<Stack gap={12}>
 							<Stack direction="horizontal" justify="between" align="center">
-								<h2
-									style={{
-										margin: 0,
-										fontSize: 16,
-										fontWeight: 700,
-										color: "var(--bt-color-text-heading)",
-									}}
-								>
+								<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 									최근 활동
 								</h2>
 								<Button variant="text" size="sm">
 									모두 보기
 								</Button>
 							</Stack>
-							<p
-								style={{
-									margin: 0,
-									fontSize: 14,
-									color: "var(--bt-color-text-body)",
-									lineHeight: 1.6,
-								}}
-							>
-								사이드바 + main content 영역의 기본 골격입니다. Sidebar 컴포넌트와 우측 Stack 기반
-								레이아웃을 조합해 어드민·관리자 페이지를 빠르게 시작할 수 있습니다.
+							<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)", lineHeight: 1.6 }}>
+								사이드바 + main content 영역의 기본 골격입니다. Sidebar 컴포넌트와 우측 Stack
+								기반 레이아웃을 조합해 어드민·관리자 페이지를 빠르게 시작할 수 있습니다.
 							</p>
 						</Stack>
 					</Card>
@@ -377,14 +355,10 @@ export const TwoColumnDashboard: Story = {
 							<Card key={stat.label} bordered padding="md" shadow="sm">
 								<Stack gap={12}>
 									<Stack direction="horizontal" justify="between" align="center">
-										<span style={{ fontSize: 13, color: "var(--bt-color-text-caption)" }}>
-											{stat.label}
-										</span>
+										<span style={{ fontSize: 13, color: "var(--bt-color-text-caption)" }}>{stat.label}</span>
 										<span style={{ color: "var(--bt-color-text-body)" }}>{stat.icon}</span>
 									</Stack>
-									<span
-										style={{ fontSize: 24, fontWeight: 700, color: "var(--bt-color-text-heading)" }}
-									>
+									<span style={{ fontSize: 24, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 										{stat.value}
 									</span>
 									<span
@@ -407,14 +381,7 @@ export const TwoColumnDashboard: Story = {
 							<Card bordered padding="lg" shadow="sm">
 								<Stack gap={16}>
 									<Stack direction="horizontal" justify="between" align="center">
-										<h2
-											style={{
-												margin: 0,
-												fontSize: 16,
-												fontWeight: 700,
-												color: "var(--bt-color-text-heading)",
-											}}
-										>
+										<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 											시간대별 매출
 										</h2>
 										<Chip type="static" size="sm" tone="success" label="실시간" />
@@ -441,14 +408,7 @@ export const TwoColumnDashboard: Story = {
 						</div>
 						<Card bordered padding="lg" shadow="sm">
 							<Stack gap={16}>
-								<h2
-									style={{
-										margin: 0,
-										fontSize: 16,
-										fontWeight: 700,
-										color: "var(--bt-color-text-heading)",
-									}}
-								>
+								<h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 									Best 메뉴
 								</h2>
 								<Stack gap={12}>
@@ -458,7 +418,12 @@ export const TwoColumnDashboard: Story = {
 										{ name: "샌드위치", count: 15 },
 										{ name: "쿠키", count: 12 },
 									].map((item, idx) => (
-										<Stack key={item.name} direction="horizontal" justify="between" align="center">
+										<Stack
+											key={item.name}
+											direction="horizontal"
+											justify="between"
+											align="center"
+										>
 											<Stack direction="horizontal" gap={12} align="center">
 												<span
 													style={{
@@ -476,23 +441,11 @@ export const TwoColumnDashboard: Story = {
 												>
 													{idx + 1}
 												</span>
-												<span
-													style={{
-														fontSize: 14,
-														fontWeight: 500,
-														color: "var(--bt-color-text-heading)",
-													}}
-												>
+												<span style={{ fontSize: 14, fontWeight: 500, color: "var(--bt-color-text-heading)" }}>
 													{item.name}
 												</span>
 											</Stack>
-											<span
-												style={{
-													fontSize: 13,
-													color: "var(--bt-color-text-body)",
-													fontWeight: 600,
-												}}
-											>
+											<span style={{ fontSize: 13, color: "var(--bt-color-text-body)", fontWeight: 600 }}>
 												{item.count}건
 											</span>
 										</Stack>
@@ -547,10 +500,7 @@ const ORDERS = [
 	},
 ];
 
-const STATUS_LABELS: Record<
-	string,
-	{ label: string; tone: "success" | "accent" | "warning" | "error" }
-> = {
+const STATUS_LABELS: Record<string, { label: string; tone: "success" | "accent" | "warning" | "error" }> = {
 	completed: { label: "완료", tone: "success" },
 	processing: { label: "처리중", tone: "accent" },
 	pending: { label: "대기", tone: "warning" },
@@ -612,7 +562,9 @@ export const ListPage: Story = {
 												render: (row) => (
 													<Stack direction="horizontal" gap={8} align="center">
 														<Avatar name={row.customer} size="sm" />
-														<span style={{ fontSize: 14, fontWeight: 500 }}>{row.customer}</span>
+														<span style={{ fontSize: 14, fontWeight: 500 }}>
+															{row.customer}
+														</span>
 													</Stack>
 												),
 											},

--- a/src/stories/examples/page-composition.stories.tsx
+++ b/src/stories/examples/page-composition.stories.tsx
@@ -1,17 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Award, BarChart3, Building2, CalendarClock, Package, Receipt } from "lucide-react";
+import {
+	Award,
+	BarChart3,
+	Building2,
+	CalendarClock,
+	Package,
+	Receipt,
+} from "lucide-react";
 import { Avatar } from "../../ui/display/avatar";
 import { Badge } from "../../ui/display/badge";
+import { Button } from "../../ui/general/button";
 import { Chip } from "../../ui/display/chip";
+import { Container } from "../../ui/layout/container";
+import { EmptyState } from "../../ui/feedback/empty-state";
+import { Grid } from "../../ui/layout/grid";
 import { Hero } from "../../ui/display/hero";
 import { MediaCard } from "../../ui/display/media-card";
-import { EmptyState } from "../../ui/feedback/empty-state";
-import { Button } from "../../ui/general/button";
-import { Container } from "../../ui/layout/container";
-import { Grid } from "../../ui/layout/grid";
 import { Section } from "../../ui/layout/section";
-import { Stack } from "../../ui/layout/stack";
 import { Sidebar, SidebarItem, SidebarSection } from "../../ui/navigation/sidebar";
+import { Stack } from "../../ui/layout/stack";
 import { Tab, TabList, TabPanel, Tabs } from "../../ui/navigation/tabs";
 
 const meta: Meta = {
@@ -65,14 +72,7 @@ export const MarketingPage: Story = {
 							>
 								왜 Bigtablet인가요?
 							</h2>
-							<p
-								style={{
-									margin: 0,
-									color: "var(--bt-color-text-body)",
-									textAlign: "center",
-									maxWidth: 480,
-								}}
-							>
+							<p style={{ margin: 0, color: "var(--bt-color-text-body)", textAlign: "center", maxWidth: 480 }}>
 								수천 개의 매장이 신뢰하는 올인원 솔루션
 							</p>
 						</Stack>
@@ -146,7 +146,8 @@ export const MarketingPage: Story = {
 											width: 44,
 											height: 44,
 											borderRadius: 12,
-											background: "linear-gradient(135deg, #47555E 0%, #303841 100%)",
+											background:
+												"linear-gradient(135deg, #47555E 0%, #303841 100%)",
 											color: "#fff",
 											marginBottom: 14,
 											boxShadow:
@@ -166,14 +167,7 @@ export const MarketingPage: Story = {
 									>
 										{f.title}
 									</h3>
-									<p
-										style={{
-											margin: 0,
-											fontSize: 14,
-											color: "var(--bt-color-text-body)",
-											lineHeight: 1.55,
-										}}
-									>
+									<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-body)", lineHeight: 1.55 }}>
 										{f.desc}
 									</p>
 								</div>
@@ -250,9 +244,11 @@ export const MarketingPage: Story = {
 					style={{
 						position: "absolute",
 						inset: 0,
-						backgroundImage: "radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px)",
+						backgroundImage:
+							"radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px)",
 						backgroundSize: "24px 24px",
-						maskImage: "radial-gradient(ellipse at center, black 0%, transparent 70%)",
+						maskImage:
+							"radial-gradient(ellipse at center, black 0%, transparent 70%)",
 						pointerEvents: "none",
 					}}
 				/>
@@ -266,7 +262,8 @@ export const MarketingPage: Story = {
 						width: 600,
 						height: 1,
 						transform: "translateX(-50%)",
-						background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.4), transparent)",
+						background:
+							"linear-gradient(90deg, transparent, rgba(255,255,255,0.4), transparent)",
 						pointerEvents: "none",
 					}}
 				/>
@@ -331,29 +328,16 @@ export const MarketingPage: Story = {
 export const AdminDashboard: Story = {
 	name: "어드민 대시보드",
 	render: () => (
-		<div
-			style={{ display: "flex", minHeight: "100vh", background: "var(--bt-color-bg-solid-dim)" }}
-		>
+		<div style={{ display: "flex", minHeight: "100vh", background: "var(--bt-color-bg-solid-dim)" }}>
 			{/* Sidebar */}
 			<Sidebar
 				header={
 					// 로고 경로는 iframe 기준 상대경로다 — 절대경로(`/images/…`)로 되돌리면 GH Pages
 					// 하위 경로(`/bigtablet-design-system/`)를 건너뛰어 404 가 난다. 로컬은 루트 서빙이라 안 드러난다.
-					<img
-						src="images/logo/bigtablet.png"
-						alt="Bigtablet"
-						height={28}
-						style={{ display: "block" }}
-					/>
+					<img src="images/logo/bigtablet.png" alt="Bigtablet" height={28} style={{ display: "block" }} />
 				}
 				headerCollapsed={
-					<img
-						src="images/logo/favicon.png"
-						alt="Bigtablet"
-						width={28}
-						height={28}
-						style={{ display: "block", borderRadius: 6 }}
-					/>
+					<img src="images/logo/favicon.png" alt="Bigtablet" width={28} height={28} style={{ display: "block", borderRadius: 6 }} />
 				}
 				footer={
 					<div
@@ -392,14 +376,7 @@ export const AdminDashboard: Story = {
 				<SidebarSection label="메인">
 					<SidebarItem
 						icon={
-							<svg
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-							>
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
 								<rect x="3" y="3" width="7" height="7" />
 								<rect x="14" y="3" width="7" height="7" />
 								<rect x="14" y="14" width="7" height="7" />
@@ -412,37 +389,19 @@ export const AdminDashboard: Story = {
 					</SidebarItem>
 					<SidebarItem
 						icon={
-							<svg
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-							>
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
 								<path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
 								<line x1="3" y1="6" x2="21" y2="6" />
 								<path d="M16 10a4 4 0 0 1-8 0" />
 							</svg>
 						}
-						trailing={
-							<Badge shape="count" variant="error">
-								5
-							</Badge>
-						}
+						trailing={<Badge shape="count" variant="error">5</Badge>}
 					>
 						주문
 					</SidebarItem>
 					<SidebarItem
 						icon={
-							<svg
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-							>
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
 								<line x1="12" y1="1" x2="12" y2="23" />
 								<path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
 							</svg>
@@ -454,14 +413,7 @@ export const AdminDashboard: Story = {
 				<SidebarSection label="관리">
 					<SidebarItem
 						icon={
-							<svg
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-							>
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
 								<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
 								<circle cx="9" cy="7" r="4" />
 								<path d="M23 21v-2a4 4 0 0 0-3-3.87" />
@@ -473,14 +425,7 @@ export const AdminDashboard: Story = {
 					</SidebarItem>
 					<SidebarItem
 						icon={
-							<svg
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-							>
+							<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
 								<circle cx="12" cy="12" r="3" />
 								<path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14" />
 							</svg>
@@ -494,27 +439,10 @@ export const AdminDashboard: Story = {
 			{/* Main content */}
 			<div style={{ flex: 1, padding: "32px", overflowY: "auto" }}>
 				{/* Header */}
-				<Stack
-					direction="horizontal"
-					justify="between"
-					align="center"
-					gap={0}
-					style={{ marginBottom: 24 }}
-				>
+				<Stack direction="horizontal" justify="between" align="center" gap={0} style={{ marginBottom: 24 }}>
 					<Stack gap={4}>
-						<h1
-							style={{
-								margin: 0,
-								fontSize: 24,
-								fontWeight: 700,
-								color: "var(--bt-color-text-heading)",
-							}}
-						>
-							대시보드
-						</h1>
-						<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-caption)" }}>
-							2026년 5월 20일 화요일
-						</p>
+						<h1 style={{ margin: 0, fontSize: 24, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>대시보드</h1>
+						<p style={{ margin: 0, fontSize: 14, color: "var(--bt-color-text-caption)" }}>2026년 5월 20일 화요일</p>
 					</Stack>
 					<Stack direction="horizontal" gap={12} align="center">
 						<Badge shape="dot" variant="success" />
@@ -539,27 +467,11 @@ export const AdminDashboard: Story = {
 								border: "1px solid var(--bt-color-border-default)",
 							}}
 						>
-							<p style={{ margin: "0 0 4px", fontSize: 13, color: "var(--bt-color-text-caption)" }}>
-								{stat.label}
-							</p>
-							<p
-								style={{
-									margin: "0 0 4px",
-									fontSize: 24,
-									fontWeight: 700,
-									color: "var(--bt-color-text-heading)",
-								}}
-							>
+							<p style={{ margin: "0 0 4px", fontSize: 13, color: "var(--bt-color-text-caption)" }}>{stat.label}</p>
+							<p style={{ margin: "0 0 4px", fontSize: 24, fontWeight: 700, color: "var(--bt-color-text-heading)" }}>
 								{stat.value}
 							</p>
-							<p
-								style={{
-									margin: 0,
-									fontSize: 12,
-									color: "var(--bt-color-accent-default)",
-									fontWeight: 600,
-								}}
-							>
+							<p style={{ margin: 0, fontSize: 12, color: "var(--bt-color-accent-default)", fontWeight: 600 }}>
 								{stat.delta}
 							</p>
 						</div>
@@ -604,9 +516,7 @@ export const AdminDashboard: Story = {
 											<Avatar name={order.customer} size="sm" />
 											<Stack gap={2}>
 												<span style={{ fontSize: 14, fontWeight: 600 }}>{order.customer}</span>
-												<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>
-													{order.id}
-												</span>
+												<span style={{ fontSize: 12, color: "var(--bt-color-text-caption)" }}>{order.id}</span>
 											</Stack>
 										</Stack>
 										<Stack direction="horizontal" gap={12} align="center">

--- a/src/stories/foundation/a11y.stories.tsx
+++ b/src/stories/foundation/a11y.stories.tsx
@@ -327,10 +327,10 @@ export const Density: Story = {
 			<section>
 				<h3 style={{ marginBottom: 4 }}>왜 반응형 밀도인가요?</h3>
 				<p style={{ color: "#555", fontSize: 13, marginTop: 0 }}>
-					웹과 앱은 입력 방식이 다릅니다. 데스크탑은 마우스라 작은 컨트롤도 정확히 누르지만,
-					모바일은 손가락이라 더 큰 영역이 필요합니다. Bigtablet DS는 동일한 사이즈 prop이
-					viewport에 따라 자동으로 한 단계 키워지도록 설계됩니다 - 데스크탑 <code>compact(40)</code>{" "}
-					→ 모바일 <code>comfortable(48)</code>.
+					웹과 앱은 입력 방식이 다릅니다. 데스크탑은 마우스라 작은 컨트롤도 정확히 누르지만, 모바일은
+					손가락이라 더 큰 영역이 필요합니다. Bigtablet DS는 동일한 사이즈 prop이 viewport에 따라
+					자동으로 한 단계 키워지도록 설계됩니다 - 데스크탑 <code>compact(40)</code> → 모바일{" "}
+					<code>comfortable(48)</code>.
 				</p>
 			</section>
 
@@ -416,8 +416,8 @@ export const Density: Story = {
 			<section>
 				<h3 style={{ marginBottom: 4 }}>실사용 예시</h3>
 				<p style={{ color: "#555", fontSize: 13, marginTop: 0 }}>
-					Storybook 뷰포트 툴(▼)에서 모바일로 전환하면 같은 <code>size="md"</code> Button이 자동으로
-					키워지는 걸 확인할 수 있습니다.
+					Storybook 뷰포트 툴(▼)에서 모바일로 전환하면 같은 <code>size="md"</code> Button이
+					자동으로 키워지는 걸 확인할 수 있습니다.
 				</p>
 				<p style={{ color: "#555", fontSize: 12, marginTop: 4 }}>
 					적용: Button, TextField, Dropdown. Chip은 인라인 컴포넌트라 제외.

--- a/src/stories/foundation/breakpoints.stories.tsx
+++ b/src/stories/foundation/breakpoints.stories.tsx
@@ -91,9 +91,7 @@ export const LayoutTransition: Story = {
 			>
 				<div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
 					<strong style={{ fontSize: 13 }}>compact</strong>
-					<span style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>
-						~ 599px (모바일)
-					</span>
+					<span style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>~ 599px (모바일)</span>
 				</div>
 				<div style={{ display: "grid", gap: 8, maxWidth: 200 }}>
 					<div style={{ height: 24, background: "#e5e5e5", borderRadius: 6 }} />
@@ -109,9 +107,7 @@ export const LayoutTransition: Story = {
 			>
 				<div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
 					<strong style={{ fontSize: 13 }}>medium</strong>
-					<span style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>
-						600px ~ 839px (태블릿)
-					</span>
+					<span style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>600px ~ 839px (태블릿)</span>
 				</div>
 				<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, maxWidth: 320 }}>
 					<div style={{ height: 24, background: "#e5e5e5", borderRadius: 6 }} />
@@ -128,9 +124,7 @@ export const LayoutTransition: Story = {
 			>
 				<div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
 					<strong style={{ fontSize: 13 }}>expanded</strong>
-					<span style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>
-						840px+ (데스크탑)
-					</span>
+					<span style={{ fontSize: 11, color: "var(--bt-color-text-caption)" }}>840px+ (데스크탑)</span>
 				</div>
 				<div style={{ display: "grid", gridTemplateColumns: "80px 1fr", gap: 8, maxWidth: 400 }}>
 					<div style={{ height: 80, background: "#d4d4d4", borderRadius: 6 }} />

--- a/src/stories/foundation/colors.stories.tsx
+++ b/src/stories/foundation/colors.stories.tsx
@@ -340,8 +340,7 @@ export const NeutralDarkPalette: Story = {
 	render: () => (
 		<div style={{ display: "grid", gap: 12, maxWidth: 720 }}>
 			<p style={{ margin: 0, fontSize: 13, color: "#666" }}>
-				<strong>Dark mode 표면 컬러</strong> - Vercel-style 순수 중성 그레이. 925/950은 dark mode
-				전용 추가 단계.
+				<strong>Dark mode 표면 컬러</strong> - Vercel-style 순수 중성 그레이. 925/950은 dark mode 전용 추가 단계.
 			</p>
 			{NEUTRAL_DARK_SCALE.map(({ key, value }) => (
 				<div

--- a/src/stories/foundation/dark-mode.stories.tsx
+++ b/src/stories/foundation/dark-mode.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../../ui/general/button";
 import { Card } from "../../ui/display/card";
 import { TextField } from "../../ui/forms/textfield";
-import { Button } from "../../ui/general/button";
 import { ThemeProvider, useTheme } from "../../ui/system/theme-provider";
 
 const meta: Meta = {

--- a/src/stories/foundation/form-comparison.stories.tsx
+++ b/src/stories/foundation/form-comparison.stories.tsx
@@ -24,15 +24,7 @@ const sampleOptions = [
 export const SideBySide: Story = {
 	name: "나란히 비교",
 	render: () => (
-		<div
-			style={{
-				display: "grid",
-				gridTemplateColumns: "1fr 1fr",
-				gap: 32,
-				padding: 24,
-				maxWidth: 800,
-			}}
-		>
+		<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 32, padding: 24, maxWidth: 800 }}>
 			<div>
 				<h3 style={{ marginBottom: 16 }}>TextField</h3>
 				<div style={{ display: "flex", flexDirection: "column", gap: 16 }}>

--- a/src/stories/foundation/typography.stories.tsx
+++ b/src/stories/foundation/typography.stories.tsx
@@ -610,12 +610,7 @@ export const BoldVariants: Story = {
 	name: "Extras - Bold weights (강조용)",
 	render: () => (
 		<div
-			style={{
-				display: "flex",
-				flexDirection: "column",
-				gap: 12,
-				color: "var(--bt-color-text-heading)",
-			}}
+			style={{ display: "flex", flexDirection: "column", gap: 12, color: "var(--bt-color-text-heading)" }}
 		>
 			<ExtrasRow label="@include display_large_bold" desc="48px / 700 / -0.02em letter-spacing">
 				<div style={inlineDisplayLargeBold}>매장 운영을 더 스마트하게</div>
@@ -637,18 +632,15 @@ export const SemanticAliases: Story = {
 	name: "Extras - 의미적 alias",
 	render: () => (
 		<div
-			style={{
-				display: "flex",
-				flexDirection: "column",
-				gap: 12,
-				color: "var(--bt-color-text-heading)",
-			}}
+			style={{ display: "flex", flexDirection: "column", gap: 12, color: "var(--bt-color-text-heading)" }}
 		>
 			<ExtrasRow label="@include subtitle" desc="제목 아래 보조 설명 - 15/500/22.5">
 				<div style={inlineSubtitle}>14일 무료 체험 · 신용카드 불필요</div>
 			</ExtrasRow>
 			<ExtrasRow label="@include overline" desc="섹션 위 작은 라벨 - 12/600/uppercase">
-				<div style={{ ...inlineOverline, color: "var(--bt-color-accent-default)" }}>핵심 기능</div>
+				<div style={{ ...inlineOverline, color: "var(--bt-color-accent-default)" }}>
+					핵심 기능
+				</div>
 			</ExtrasRow>
 			<ExtrasRow label="@include caption" desc="이미지/카드 캡션 - 12/400/tight">
 				<div style={{ ...inlineCaption, color: "var(--bt-color-text-caption)" }}>
@@ -666,16 +658,13 @@ export const TextWrapHelpers: Story = {
 	name: "Extras - Text wrap helpers",
 	render: () => (
 		<div
-			style={{
-				display: "flex",
-				flexDirection: "column",
-				gap: 16,
-				color: "var(--bt-color-text-heading)",
-			}}
+			style={{ display: "flex", flexDirection: "column", gap: 16, color: "var(--bt-color-text-heading)" }}
 		>
 			<div>
 				<code style={{ fontSize: 12 }}>@include text_balance</code>
-				<p style={{ fontSize: 11, color: "var(--bt-color-text-caption)", margin: "2px 0 8px" }}>
+				<p
+					style={{ fontSize: 11, color: "var(--bt-color-text-caption)", margin: "2px 0 8px" }}
+				>
 					줄바꿈 자연스럽게 - 마지막 줄 한두 단어 외톨이 방지. 헤딩에 유용.
 				</p>
 				<h2
@@ -691,7 +680,9 @@ export const TextWrapHelpers: Story = {
 			</div>
 			<div>
 				<code style={{ fontSize: 12 }}>@include text_truncate</code>
-				<p style={{ fontSize: 11, color: "var(--bt-color-text-caption)", margin: "2px 0 8px" }}>
+				<p
+					style={{ fontSize: 11, color: "var(--bt-color-text-caption)", margin: "2px 0 8px" }}
+				>
 					한 줄 ellipsis (...).
 				</p>
 				<div
@@ -718,7 +709,9 @@ export const NumericFeatures: Story = {
 			</p>
 			<div style={{ display: "flex", gap: 32 }}>
 				<div>
-					<div style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 6 }}>
+					<div
+						style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 6 }}
+					>
 						기본 (proportional)
 					</div>
 					<div style={{ ...inlineHeadingLargeBold, fontVariantNumeric: "normal" }}>
@@ -730,7 +723,9 @@ export const NumericFeatures: Story = {
 					</div>
 				</div>
 				<div>
-					<div style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 6 }}>
+					<div
+						style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 6 }}
+					>
 						tabular-nums (정렬)
 					</div>
 					<div

--- a/src/stories/getting-started/installation.stories.tsx
+++ b/src/stories/getting-started/installation.stories.tsx
@@ -31,12 +31,7 @@ export const React: Story = {
 					subtitle="React 19, Next.js App Router 호환. pnpm/npm/yarn 모두 가능."
 				/>
 				<div style={{ display: "grid", gap: 20 }}>
-					<Step
-						number={1}
-						title="패키지 설치"
-						lang="bash"
-						code="pnpm add @bigtablet/design-system"
-					/>
+					<Step number={1} title="패키지 설치" lang="bash" code="pnpm add @bigtablet/design-system" />
 					<Step
 						number={2}
 						title="스타일 import"
@@ -152,9 +147,7 @@ function Card({
 	variant?: "default" | "subtle";
 }) {
 	const bg =
-		variant === "subtle"
-			? "var(--bt-color-bg-solid-dim, #F4F4F4)"
-			: "var(--bt-color-bg-solid, #fff)";
+		variant === "subtle" ? "var(--bt-color-bg-solid-dim, #F4F4F4)" : "var(--bt-color-bg-solid, #fff)";
 	return (
 		<section
 			style={{

--- a/src/ui/display/accordion/accordion.stories.tsx
+++ b/src/ui/display/accordion/accordion.stories.tsx
@@ -32,16 +32,8 @@ export default meta;
 type Story = StoryObj<typeof Accordion>;
 
 const FAQ = [
-	{
-		key: "1",
-		title: "Bigtablet은 무엇인가요?",
-		content: "B2B 매장 운영을 위한 통합 관리 솔루션입니다.",
-	},
-	{
-		key: "2",
-		title: "어떻게 시작하나요?",
-		content: "무료 체험을 신청하시면 영업팀이 연락드립니다.",
-	},
+	{ key: "1", title: "Bigtablet은 무엇인가요?", content: "B2B 매장 운영을 위한 통합 관리 솔루션입니다." },
+	{ key: "2", title: "어떻게 시작하나요?", content: "무료 체험을 신청하시면 영업팀이 연락드립니다." },
 	{ key: "3", title: "결제 방식은요?", content: "월간 / 연간 구독 방식입니다." },
 ];
 

--- a/src/ui/display/accordion/index.tsx
+++ b/src/ui/display/accordion/index.tsx
@@ -55,7 +55,11 @@ export const Accordion = ({
 
 	const toggle = (key: string) => {
 		const isOpen = open.includes(key);
-		const next = isOpen ? open.filter((k) => k !== key) : multiple ? [...open, key] : [key];
+		const next = isOpen
+			? open.filter((k) => k !== key)
+			: multiple
+				? [...open, key]
+				: [key];
 		if (!isControlled) setInternalKeys(next);
 		(onValueChange ?? onChange)?.(next);
 	};

--- a/src/ui/display/avatar/index.tsx
+++ b/src/ui/display/avatar/index.tsx
@@ -65,7 +65,12 @@ export const Avatar = ({
 		>
 			{showImage ? (
 				// biome-ignore lint/performance/noImgElement: DS is framework-agnostic - consumers wrap with next/image
-				<img src={src} alt={name} onError={() => setImgFailed(true)} className="avatar_image" />
+				<img
+					src={src}
+					alt={name}
+					onError={() => setImgFailed(true)}
+					className="avatar_image"
+				/>
 			) : (
 				<span className="avatar_initials" aria-hidden="true">
 					{initials}

--- a/src/ui/display/badge/Badge.test.tsx
+++ b/src/ui/display/badge/Badge.test.tsx
@@ -38,20 +38,14 @@ describe("Badge", () => {
 
 	it("applies appearance=soft class when specified", () => {
 		const { container } = render(
-			<Badge variant="success" appearance="soft">
-				+5%
-			</Badge>,
+			<Badge variant="success" appearance="soft">+5%</Badge>,
 		);
 		expect(container.firstChild).toHaveClass("badge_appearance_soft");
 		expect(container.firstChild).toHaveClass("badge_variant_success");
 	});
 
 	it("soft + accent variant uses accent_subtle bg via class", () => {
-		const { container } = render(
-			<Badge variant="accent" appearance="soft">
-				New
-			</Badge>,
-		);
+		const { container } = render(<Badge variant="accent" appearance="soft">New</Badge>);
 		expect(container.firstChild).toHaveClass("badge_appearance_soft");
 		expect(container.firstChild).toHaveClass("badge_variant_accent");
 	});

--- a/src/ui/display/badge/badge.stories.tsx
+++ b/src/ui/display/badge/badge.stories.tsx
@@ -7,10 +7,7 @@ const meta: Meta<typeof Badge> = {
 	tags: ["autodocs"],
 	argTypes: {
 		shape: { control: "select", options: ["dot", "count", "label"] },
-		variant: {
-			control: "select",
-			options: ["accent", "neutral", "info", "success", "warning", "error"],
-		},
+		variant: { control: "select", options: ["accent", "neutral", "info", "success", "warning", "error"] },
 		appearance: { control: "select", options: ["solid", "soft"] },
 		size: { control: "select", options: ["sm", "md", "lg"] },
 		count: { control: "number" },
@@ -79,60 +76,32 @@ export const SolidVsSoft: Story = {
 		docs: {
 			description: {
 				story:
-					'`appearance="solid"` (기본) - 강한 fill. 알림·상태 강조용. `appearance="soft"` - tint 배경 + 진한 글자. 정보 라벨용. 둘 다 WCAG AA (5~7:1) 를 통과한다.',
+					"`appearance=\"solid\"` (기본) - 강한 fill. 알림·상태 강조용. `appearance=\"soft\"` - tint 배경 + 진한 글자. 정보 라벨용. 둘 다 WCAG AA (5~7:1) 를 통과한다.",
 			},
 		},
 	},
 	render: () => (
 		<div style={{ display: "grid", gap: 24 }}>
 			<div>
-				<div style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 8 }}>
-					solid
-				</div>
+				<div style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 8 }}>solid</div>
 				<div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-					<Badge variant="accent" appearance="solid">
-						New
-					</Badge>
-					<Badge variant="neutral" appearance="solid">
-						Beta
-					</Badge>
-					<Badge variant="info" appearance="solid">
-						Info
-					</Badge>
-					<Badge variant="success" appearance="solid">
-						Active
-					</Badge>
-					<Badge variant="warning" appearance="solid">
-						Pending
-					</Badge>
-					<Badge variant="error" appearance="solid">
-						Error
-					</Badge>
+					<Badge variant="accent" appearance="solid">New</Badge>
+					<Badge variant="neutral" appearance="solid">Beta</Badge>
+					<Badge variant="info" appearance="solid">Info</Badge>
+					<Badge variant="success" appearance="solid">Active</Badge>
+					<Badge variant="warning" appearance="solid">Pending</Badge>
+					<Badge variant="error" appearance="solid">Error</Badge>
 				</div>
 			</div>
 			<div>
-				<div style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 8 }}>
-					soft
-				</div>
+				<div style={{ fontSize: 12, color: "var(--bt-color-text-caption)", marginBottom: 8 }}>soft</div>
 				<div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-					<Badge variant="accent" appearance="soft">
-						New
-					</Badge>
-					<Badge variant="neutral" appearance="soft">
-						Beta
-					</Badge>
-					<Badge variant="info" appearance="soft">
-						Info
-					</Badge>
-					<Badge variant="success" appearance="soft">
-						+5%
-					</Badge>
-					<Badge variant="warning" appearance="soft">
-						Review
-					</Badge>
-					<Badge variant="error" appearance="soft">
-						Failed
-					</Badge>
+					<Badge variant="accent" appearance="soft">New</Badge>
+					<Badge variant="neutral" appearance="soft">Beta</Badge>
+					<Badge variant="info" appearance="soft">Info</Badge>
+					<Badge variant="success" appearance="soft">+5%</Badge>
+					<Badge variant="warning" appearance="soft">Review</Badge>
+					<Badge variant="error" appearance="soft">Failed</Badge>
 				</div>
 			</div>
 		</div>

--- a/src/ui/display/badge/index.tsx
+++ b/src/ui/display/badge/index.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
-export type BadgeVariant = "accent" | "neutral" | "info" | "success" | "warning" | "error";
+export type BadgeVariant =
+	| "accent"
+	| "neutral"
+	| "info"
+	| "success"
+	| "warning"
+	| "error";
 export type BadgeShape = "dot" | "count" | "label";
 export type BadgeSize = "sm" | "md" | "lg";
 export type BadgeAppearance = "solid" | "soft";

--- a/src/ui/display/card/Card.test.tsx
+++ b/src/ui/display/card/Card.test.tsx
@@ -154,15 +154,8 @@ describe("Card", () => {
 
 	it("forwards ref to the root element", () => {
 		let node: HTMLDivElement | null = null;
-		render(
-			<Card
-				ref={(el) => {
-					node = el;
-				}}
-			>
-				X
-			</Card>,
-		);
+		render(<Card ref={(el) => { node = el; }}>X</Card>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});
+
 });

--- a/src/ui/display/card/card.stories.tsx
+++ b/src/ui/display/card/card.stories.tsx
@@ -128,7 +128,9 @@ export const WithFooter: Story = {
 				footerAlign="between"
 				footer={
 					<>
-						<span style={{ color: "var(--bt-color-text-caption)", fontSize: 13 }}>2026-06-16</span>
+						<span style={{ color: "var(--bt-color-text-caption)", fontSize: 13 }}>
+							2026-06-16
+						</span>
 						<Button size="sm" variant="outline">
 							자세히
 						</Button>

--- a/src/ui/display/chip/chip.stories.tsx
+++ b/src/ui/display/chip/chip.stories.tsx
@@ -8,10 +8,7 @@ const meta: Meta<typeof Chip> = {
 	tags: ["autodocs"],
 	argTypes: {
 		type: { control: "select", options: ["basic", "input", "filter", "static"] },
-		tone: {
-			control: "select",
-			options: ["default", "accent", "info", "success", "warning", "error"],
-		},
+		tone: { control: "select", options: ["default", "accent", "info", "success", "warning", "error"] },
 		size: { control: "select", options: [undefined, "sm", "md"] },
 		label: { control: "text" },
 		selected: { control: "boolean" },

--- a/src/ui/display/chip/index.tsx
+++ b/src/ui/display/chip/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { useState } from "react";
 import { cn } from "../../../utils";
 import "./style.scss";

--- a/src/ui/display/list-item/ListItem.test.tsx
+++ b/src/ui/display/list-item/ListItem.test.tsx
@@ -123,9 +123,7 @@ describe("ListItem", () => {
 			<ListItem label={<strong data-testid="rich-label">Rich</strong>} />,
 		);
 		expect(screen.getByTestId("rich-label")).toBeInTheDocument();
-		expect(
-			container.querySelector(".list_item_label")?.querySelector("strong"),
-		).toBeInTheDocument();
+		expect(container.querySelector(".list_item_label")?.querySelector("strong")).toBeInTheDocument();
 	});
 
 	it("renders ReactNode in overline / supportingText / metadata slots", () => {
@@ -133,11 +131,7 @@ describe("ListItem", () => {
 			<ListItem
 				overline={<span data-testid="ov">OV</span>}
 				label="Label"
-				supportingText={
-					<a href="#x" data-testid="sup-link">
-						link
-					</a>
-				}
+				supportingText={<a href="#x" data-testid="sup-link">link</a>}
 				metadata={<em data-testid="meta">meta</em>}
 			/>,
 		);

--- a/src/ui/display/list-item/list-item.stories.tsx
+++ b/src/ui/display/list-item/list-item.stories.tsx
@@ -55,13 +55,7 @@ const ChevronTrailing = (
 		onClick={(e) => e.stopPropagation()}
 	>
 		<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-			<path
-				d="M8 4L14 10L8 16"
-				stroke="#666"
-				strokeWidth="1.5"
-				strokeLinecap="round"
-				strokeLinejoin="round"
-			/>
+			<path d="M8 4L14 10L8 16" stroke="#666" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 		</svg>
 	</button>
 );
@@ -149,13 +143,7 @@ export const RichContent: Story = {
 		supportingText: (
 			<span>
 				자세한 내용은{" "}
-				<a
-					href="#changelog"
-					onClick={(e) => {
-						e.preventDefault();
-						e.stopPropagation();
-					}}
-				>
+				<a href="#changelog" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
 					체인지로그
 				</a>
 				를 확인하세요.

--- a/src/ui/display/media-card/MediaCard.test.tsx
+++ b/src/ui/display/media-card/MediaCard.test.tsx
@@ -42,7 +42,9 @@ describe("MediaCard", () => {
 	});
 
 	it("applies imagePosition class", () => {
-		const { container } = render(<MediaCard image={IMG} imagePosition="overlay" heading="제목" />);
+		const { container } = render(
+			<MediaCard image={IMG} imagePosition="overlay" heading="제목" />,
+		);
 		expect(container.firstChild).toHaveClass("media_card_image_overlay");
 	});
 
@@ -52,7 +54,9 @@ describe("MediaCard", () => {
 	});
 
 	it("applies aspectRatio inline style on image wrap", () => {
-		const { container } = render(<MediaCard image={IMG} heading="제목" aspectRatio="16/9" />);
+		const { container } = render(
+			<MediaCard image={IMG} heading="제목" aspectRatio="16/9" />,
+		);
 		const wrap = container.querySelector(".media_card_image_wrap") as HTMLElement;
 		expect(wrap.style.aspectRatio).toBe("16/9");
 	});

--- a/src/ui/display/table/Table.test.tsx
+++ b/src/ui/display/table/Table.test.tsx
@@ -71,9 +71,7 @@ describe("Table", () => {
 
 	it("renders dash for null/undefined/empty values", () => {
 		const data = [{ id: 1, name: "", score: 0 }] as Row[];
-		const { container } = render(
-			<Table columns={columns} data={data} keyExtractor={(r) => r.id} />,
-		);
+		const { container } = render(<Table columns={columns} data={data} keyExtractor={(r) => r.id} />);
 		// First td (name) is empty string → "-"
 		const tds = container.querySelectorAll("td");
 		expect(tds[0].textContent).toBe("-");
@@ -84,7 +82,12 @@ describe("Table", () => {
 	it("calls onRowClick with item and index", () => {
 		const onRowClick = vi.fn();
 		render(
-			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} onRowClick={onRowClick} />,
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				onRowClick={onRowClick}
+			/>,
 		);
 		fireEvent.click(screen.getByText("Alpha"));
 		expect(onRowClick).toHaveBeenCalledWith(rows[0], 0);
@@ -106,7 +109,12 @@ describe("Table", () => {
 
 	it("applies aria-label on table", () => {
 		render(
-			<Table columns={columns} data={rows} keyExtractor={(r) => r.id} ariaLabel="결과 목록" />,
+			<Table
+				columns={columns}
+				data={rows}
+				keyExtractor={(r) => r.id}
+				ariaLabel="결과 목록"
+			/>,
 		);
 		expect(screen.getByRole("table")).toHaveAttribute("aria-label", "결과 목록");
 	});
@@ -120,7 +128,10 @@ describe("Table sort", () => {
 
 	it("renders aria-sort='none' on sortable headers when unsorted", () => {
 		render(<Table columns={sortableColumns} data={rows} keyExtractor={(r) => r.id} />);
-		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute("aria-sort", "none");
+		expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+			"aria-sort",
+			"none",
+		);
 		expect(screen.getByRole("columnheader", { name: "Score" })).toHaveAttribute(
 			"aria-sort",
 			"none",
@@ -416,7 +427,9 @@ describe("Table isLoading guards", () => {
 	const sortableColumns: TableColumn<Row>[] = [{ key: "name", header: "Name", sortable: true }];
 
 	it("disables sortable header buttons while isLoading", () => {
-		render(<Table columns={sortableColumns} data={rows} keyExtractor={(r) => r.id} isLoading />);
+		render(
+			<Table columns={sortableColumns} data={rows} keyExtractor={(r) => r.id} isLoading />,
+		);
 		expect(screen.getByRole("button", { name: "Name" })).toBeDisabled();
 	});
 

--- a/src/ui/feedback/empty-state/index.tsx
+++ b/src/ui/feedback/empty-state/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 

--- a/src/ui/feedback/error-state/error-state.stories.tsx
+++ b/src/ui/feedback/error-state/error-state.stories.tsx
@@ -60,11 +60,7 @@ export const Widget: Story = {
 				<ErrorState
 					variant="widget"
 					title="데이터를 불러오지 못했어요"
-					action={
-						<Button variant="outline" size="sm">
-							재시도
-						</Button>
-					}
+					action={<Button variant="outline" size="sm">재시도</Button>}
 				/>
 			</div>
 		</div>

--- a/src/ui/feedback/error-state/index.tsx
+++ b/src/ui/feedback/error-state/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TriangleAlert } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -62,9 +62,7 @@ export const ErrorState = ({
 }: ErrorStateProps) => {
 	// icon === null → 숨김, undefined → 기본 아이콘
 	const resolvedIcon =
-		icon === null
-			? null
-			: (icon ?? <TriangleAlert size={DEFAULT_ICON_SIZE[variant]} strokeWidth={1.5} />);
+		icon === null ? null : (icon ?? <TriangleAlert size={DEFAULT_ICON_SIZE[variant]} strokeWidth={1.5} />);
 
 	return (
 		<div

--- a/src/ui/feedback/linear-progress/index.tsx
+++ b/src/ui/feedback/linear-progress/index.tsx
@@ -42,7 +42,10 @@ export const LinearProgress = ({
 			{Array.from({ length: dotCount }, (_, i) => (
 				<span
 					key={i}
-					className={cn("linear_progress_step", i <= clampedStep && "linear_progress_step_done")}
+					className={cn(
+						"linear_progress_step",
+						i <= clampedStep && "linear_progress_step_done",
+					)}
 					aria-hidden="true"
 				/>
 			))}

--- a/src/ui/feedback/skeleton/index.tsx
+++ b/src/ui/feedback/skeleton/index.tsx
@@ -50,5 +50,7 @@ export const Skeleton = ({
 		inlineStyle.height = inlineStyle.width;
 	}
 
-	return <div className={skeletonClassName} style={inlineStyle} aria-hidden="true" {...props} />;
+	return (
+		<div className={skeletonClassName} style={inlineStyle} aria-hidden="true" {...props} />
+	);
 };

--- a/src/ui/feedback/toast/Toast.test.tsx
+++ b/src/ui/feedback/toast/Toast.test.tsx
@@ -254,7 +254,9 @@ describe("useToast error message", () => {
 	it("throws with the full Korean guidance message when used outside ToastProvider", () => {
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-		expect(() => renderHook(() => useToast())).toThrow("[Bigtablet DS] useToast는 <ToastProvider>");
+		expect(() => renderHook(() => useToast())).toThrow(
+			"[Bigtablet DS] useToast는 <ToastProvider>",
+		);
 
 		spy.mockRestore();
 	});

--- a/src/ui/feedback/toast/toast.stories.tsx
+++ b/src/ui/feedback/toast/toast.stories.tsx
@@ -31,18 +31,10 @@ function ToastDemoButtons() {
 			<button type="button" style={demo_btn_style} onClick={() => t.message("기본 메시지입니다.")}>
 				Default
 			</button>
-			<button
-				type="button"
-				style={demo_btn_style}
-				onClick={() => t.success("성공적으로 완료되었습니다.")}
-			>
+			<button type="button" style={demo_btn_style} onClick={() => t.success("성공적으로 완료되었습니다.")}>
 				Success
 			</button>
-			<button
-				type="button"
-				style={demo_btn_style}
-				onClick={() => t.warning("주의가 필요한 상황입니다.")}
-			>
+			<button type="button" style={demo_btn_style} onClick={() => t.warning("주의가 필요한 상황입니다.")}>
 				Warning
 			</button>
 			<button
@@ -52,11 +44,7 @@ function ToastDemoButtons() {
 			>
 				Error
 			</button>
-			<button
-				type="button"
-				style={demo_btn_style}
-				onClick={() => t.info("참고용 안내 메시지입니다.")}
-			>
+			<button type="button" style={demo_btn_style} onClick={() => t.info("참고용 안내 메시지입니다.")}>
 				Info
 			</button>
 		</div>

--- a/src/ui/forms/date-picker/DatePicker.test.tsx
+++ b/src/ui/forms/date-picker/DatePicker.test.tsx
@@ -173,14 +173,7 @@ describe("DatePicker", () => {
 
 	it("calls onValueChange (canonical) when year is selected", () => {
 		const onValueChange = vi.fn();
-		render(
-			<DatePicker
-				mode="year-month"
-				startYear={2020}
-				endYear={2025}
-				onValueChange={onValueChange}
-			/>,
-		);
+		render(<DatePicker mode="year-month" startYear={2020} endYear={2025} onValueChange={onValueChange} />);
 		const buttons = screen.getAllByRole("button");
 		fireEvent.click(buttons[0]);
 		fireEvent.click(screen.getByText("2024"));
@@ -208,4 +201,5 @@ describe("DatePicker", () => {
 		expect(onValueChange).toHaveBeenCalledWith("2024-01");
 		expect(onChange).not.toHaveBeenCalled();
 	});
+
 });

--- a/src/ui/forms/file/file.stories.tsx
+++ b/src/ui/forms/file/file.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof FileInput> = {
 		},
 		previewSize: {
 			control: { type: "number", min: 80, max: 400, step: 8 },
-			description: 'variant="preview" 박스 크기 (px).',
+			description: "variant=\"preview\" 박스 크기 (px).",
 		},
 		multiple: {
 			control: "boolean",
@@ -100,7 +100,9 @@ export const Multiple: Story = {
 						setFileNames(names);
 					}}
 				/>
-				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>{fileNames}</p>
+				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>
+					{fileNames}
+				</p>
 			</div>
 		);
 	},

--- a/src/ui/forms/file/index.tsx
+++ b/src/ui/forms/file/index.tsx
@@ -144,7 +144,11 @@ export const FileInput = ({
 				>
 					{hasImage ? (
 						// biome-ignore lint/performance/noImgElement: framework-agnostic DS - host app should swap with next/image if needed
-						<img src={previewUrls[0]} alt="" className="file_input_preview_image" />
+						<img
+							src={previewUrls[0]}
+							alt=""
+							className="file_input_preview_image"
+						/>
 					) : (
 						<span className="file_input_preview_empty">
 							<ImageIcon size={iconSize.xl} aria-hidden="true" />
@@ -180,7 +184,12 @@ export const FileInput = ({
 				<div className="file_input_preview">
 					{previewUrls.map((url) => (
 						// biome-ignore lint/performance/noImgElement: framework-agnostic DS - host app should swap with next/image if needed
-						<img key={url} src={url} alt="" className="file_input_preview_img" />
+						<img
+							key={url}
+							src={url}
+							alt=""
+							className="file_input_preview_img"
+						/>
 					))}
 				</div>
 			)}

--- a/src/ui/forms/otp-input/OtpInput.test.tsx
+++ b/src/ui/forms/otp-input/OtpInput.test.tsx
@@ -356,7 +356,9 @@ describe("OtpInput", () => {
 
 	describe("Supporting text", () => {
 		it("applies error class to supporting text when error is true", () => {
-			render(<OtpInput length={6} error supportingText="잘못된 코드입니다" ariaLabel="OTP" />);
+			render(
+				<OtpInput length={6} error supportingText="잘못된 코드입니다" ariaLabel="OTP" />,
+			);
 			const helper = screen.getByText("잘못된 코드입니다");
 			expect(helper.className).toContain("otp_input_supporting_error");
 		});
@@ -369,7 +371,9 @@ describe("OtpInput", () => {
 
 	describe("Class names", () => {
 		it("applies custom className to root", () => {
-			const { container } = render(<OtpInput length={6} className="custom-otp" ariaLabel="OTP" />);
+			const { container } = render(
+				<OtpInput length={6} className="custom-otp" ariaLabel="OTP" />,
+			);
 			expect((container.firstChild as HTMLElement).className).toContain("custom-otp");
 		});
 
@@ -433,4 +437,5 @@ describe("OtpInput", () => {
 		fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "5" } });
 		expect(onValueChange).toHaveBeenCalledWith("5");
 	});
+
 });

--- a/src/ui/forms/otp-input/otp-input.stories.tsx
+++ b/src/ui/forms/otp-input/otp-input.stories.tsx
@@ -65,9 +65,7 @@ export const Controlled: Story = {
 					supportingText="인증 코드를 입력하세요"
 					autoFocus
 				/>
-				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>
-					입력된 값: "{val}"
-				</p>
+				<p style={{ margin: 0, fontSize: 13, color: "var(--bt-color-text-body)" }}>입력된 값: "{val}"</p>
 			</div>
 		);
 	},
@@ -84,15 +82,11 @@ export const Lengths: Story = {
 		return (
 			<div style={{ display: "grid", gap: 24, padding: 20 }}>
 				<div>
-					<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>
-						4자리
-					</p>
+					<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>4자리</p>
 					<OtpInput length={4} value={val4} onChange={setVal4} supportingText="4자리 코드" />
 				</div>
 				<div>
-					<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>
-						6자리
-					</p>
+					<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>6자리</p>
 					<OtpInput length={6} value={val6} onChange={setVal6} supportingText="6자리 코드" />
 				</div>
 			</div>
@@ -115,9 +109,7 @@ export const States: Story = {
 				<OtpInput length={6} value="123456" error supportingText="인증 코드가 올바르지 않습니다" />
 			</div>
 			<div>
-				<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>
-					비활성화
-				</p>
+				<p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--bt-color-text-body)" }}>비활성화</p>
 				<OtpInput length={6} disabled supportingText="Supporting text" />
 			</div>
 		</div>

--- a/src/ui/forms/radio-group/RadioGroup.test.tsx
+++ b/src/ui/forms/radio-group/RadioGroup.test.tsx
@@ -174,7 +174,7 @@ describe("Radio standalone (no RadioGroup) — 기존 동작 보존", () => {
 		expect(screen.getByRole("radio", { name: "Two" })).not.toBeChecked();
 	});
 
-	it('does not check a value="null" radio when the group value is null', () => {
+	it("does not check a value=\"null\" radio when the group value is null", () => {
 		// 회귀: group.value 가 null 이면 String(null)==="null" 이라 value=\"null\" Radio 가 선택되던
 		// 문제 - group.value != null 로 null/undefined 모두 방어
 		render(

--- a/src/ui/forms/textarea/Textarea.test.tsx
+++ b/src/ui/forms/textarea/Textarea.test.tsx
@@ -82,7 +82,11 @@ describe("Textarea", () => {
 	it("transformValue applied (non-composition)", () => {
 		const onChange = vi.fn();
 		render(
-			<Textarea label="내용" transformValue={(v) => v.toUpperCase()} onChangeAction={onChange} />,
+			<Textarea
+				label="내용"
+				transformValue={(v) => v.toUpperCase()}
+				onChangeAction={onChange}
+			/>,
 		);
 		fireEvent.change(screen.getByRole("textbox"), { target: { value: "abc" } });
 		expect(onChange).toHaveBeenCalledWith("ABC");
@@ -117,6 +121,7 @@ describe("Textarea", () => {
 		expect(onChange).toHaveBeenLastCalledWith("한");
 	});
 
+
 	it("calls onValueChange (canonical) on input", () => {
 		const onValueChange = vi.fn();
 		render(<Textarea label="내용" onValueChange={onValueChange} />);
@@ -127,7 +132,9 @@ describe("Textarea", () => {
 	it("prefers onValueChange over the deprecated onChangeAction when both are given", () => {
 		const onValueChange = vi.fn();
 		const onChangeAction = vi.fn();
-		render(<Textarea label="내용" onValueChange={onValueChange} onChangeAction={onChangeAction} />);
+		render(
+			<Textarea label="내용" onValueChange={onValueChange} onChangeAction={onChangeAction} />,
+		);
 
 		fireEvent.change(screen.getByRole("textbox"), { target: { value: "hello" } });
 
@@ -157,4 +164,5 @@ describe("Textarea", () => {
 		expect(onValueChange).toHaveBeenCalledWith("ㅎ");
 		expect(onChangeAction).not.toHaveBeenCalled();
 	});
+
 });

--- a/src/ui/forms/textarea/index.tsx
+++ b/src/ui/forms/textarea/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { useCallback, useId, useRef, useState } from "react";
 import { cn, useSafeLayoutEffect } from "../../../utils";
 import type { ImeStrategy, TextFieldSize } from "../textfield";
@@ -106,7 +106,9 @@ export const Textarea = ({
 	const applyTransform = (nextValue: string) =>
 		transformValue ? transformValue(nextValue) : nextValue;
 
-	const [innerValue, setInnerValue] = useState(() => applyTransform(value ?? defaultValue ?? ""));
+	const [innerValue, setInnerValue] = useState(() =>
+		applyTransform(value ?? defaultValue ?? ""),
+	);
 
 	const isComposingRef = useRef(false);
 	const innerRef = useRef<HTMLTextAreaElement | null>(null);

--- a/src/ui/forms/textarea/textarea.stories.tsx
+++ b/src/ui/forms/textarea/textarea.stories.tsx
@@ -48,11 +48,7 @@ type Story = StoryObj<typeof Textarea>;
 export const Default: Story = {
 	render: (args) => {
 		const [v, setV] = React.useState("");
-		return (
-			<div style={{ width: 420 }}>
-				<Textarea {...args} value={v} onChangeAction={setV} />
-			</div>
-		);
+		return <div style={{ width: 420 }}><Textarea {...args} value={v} onChangeAction={setV} /></div>;
 	},
 };
 
@@ -61,8 +57,7 @@ export const AutoGrow: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story:
-					"`minRows={2}` `maxRows={6}` - 입력할수록 늘어나다 6행 초과 시 스크롤. resize 핸들 자동 비활성.",
+				story: "`minRows={2}` `maxRows={6}` - 입력할수록 늘어나다 6행 초과 시 스크롤. resize 핸들 자동 비활성.",
 			},
 		},
 	},

--- a/src/ui/general/button/Button.test.tsx
+++ b/src/ui/general/button/Button.test.tsx
@@ -80,15 +80,7 @@ describe("Button", () => {
 
 	it("forwards ref to the root element", () => {
 		let node: HTMLButtonElement | null = null;
-		render(
-			<Button
-				ref={(el) => {
-					node = el;
-				}}
-			>
-				X
-			</Button>,
-		);
+		render(<Button ref={(el) => { node = el; }}>X</Button>);
 		expect(node).toBeInstanceOf(HTMLButtonElement);
 	});
 

--- a/src/ui/general/button/index.tsx
+++ b/src/ui/general/button/index.tsx
@@ -132,7 +132,9 @@ export const Button = (props: ButtonProps) => {
 				aria-disabled={disabled || undefined}
 				tabIndex={disabled ? -1 : tabIndex}
 				onClick={
-					disabled ? (e: React.MouseEvent<HTMLAnchorElement>) => e.preventDefault() : onClick
+					disabled
+						? (e: React.MouseEvent<HTMLAnchorElement>) => e.preventDefault()
+						: onClick
 				}
 			>
 				{content}

--- a/src/ui/general/icon-button/IconButton.test.tsx
+++ b/src/ui/general/icon-button/IconButton.test.tsx
@@ -71,15 +71,7 @@ describe("IconButton", () => {
 
 	it("forwards ref to the root element", () => {
 		let node: HTMLButtonElement | null = null;
-		render(
-			<IconButton
-				icon={<i />}
-				aria-label="x"
-				ref={(el) => {
-					node = el;
-				}}
-			/>,
-		);
+		render(<IconButton icon={<i />} aria-label="x" ref={(el) => { node = el; }} />);
 		expect(node).toBeInstanceOf(HTMLButtonElement);
 	});
 

--- a/src/ui/layout/container/Container.test.tsx
+++ b/src/ui/layout/container/Container.test.tsx
@@ -35,15 +35,8 @@ describe("Container", () => {
 
 	it("forwards ref to the root element", () => {
 		let node: HTMLElement | null = null;
-		render(
-			<Container
-				ref={(el) => {
-					node = el;
-				}}
-			>
-				X
-			</Container>,
-		);
+		render(<Container ref={(el) => { node = el; }}>X</Container>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});
+
 });

--- a/src/ui/layout/container/index.tsx
+++ b/src/ui/layout/container/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 

--- a/src/ui/layout/grid/Grid.test.tsx
+++ b/src/ui/layout/grid/Grid.test.tsx
@@ -27,7 +27,9 @@ describe("Grid", () => {
 	it("sets auto-fill template for cols=auto", () => {
 		const { container } = render(<Grid cols="auto" minColWidth="200px" />);
 		const el = container.firstChild as HTMLElement;
-		expect(el.style.getPropertyValue("--grid-cols")).toBe("repeat(auto-fill, minmax(200px, 1fr))");
+		expect(el.style.getPropertyValue("--grid-cols")).toBe(
+			"repeat(auto-fill, minmax(200px, 1fr))",
+		);
 	});
 
 	it("sets gap as CSS variable", () => {
@@ -55,15 +57,8 @@ describe("Grid", () => {
 
 	it("forwards ref to the root element", () => {
 		let node: HTMLElement | null = null;
-		render(
-			<Grid
-				ref={(el) => {
-					node = el;
-				}}
-			>
-				X
-			</Grid>,
-		);
+		render(<Grid ref={(el) => { node = el; }}>X</Grid>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});
+
 });

--- a/src/ui/layout/grid/grid.stories.tsx
+++ b/src/ui/layout/grid/grid.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Grid> = {
 				component: [
 					"**Grid** - CSS Grid 2D 레이아웃. 1D 흐름은 `Stack`.",
 					"",
-					'주요 prop: `cols` (1~6 또는 `"auto"` = minmax auto-fill), `gap`/`rowGap`/`colGap`, `singleColOnMobile` (<600 1열 축소, 기본 true).',
+					"주요 prop: `cols` (1~6 또는 `\"auto\"` = minmax auto-fill), `gap`/`rowGap`/`colGap`, `singleColOnMobile` (<600 1열 축소, 기본 true).",
 				].join("\n"),
 			},
 		},
@@ -66,14 +66,7 @@ export const ColVariants: Story = {
 		<div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
 			{([1, 2, 3, 4] as const).map((cols) => (
 				<div key={cols}>
-					<p
-						style={{
-							margin: "0 0 8px",
-							fontSize: 12,
-							color: "var(--bt-color-text-caption)",
-							fontWeight: 600,
-						}}
-					>
+					<p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--bt-color-text-caption)", fontWeight: 600 }}>
 						cols={cols}
 					</p>
 					<Grid cols={cols} gap={12}>

--- a/src/ui/layout/grid/index.tsx
+++ b/src/ui/layout/grid/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -67,7 +67,9 @@ export const Grid = ({
 	...props
 }: GridProps) => {
 	const gridTemplateColumns =
-		cols === "auto" ? `repeat(auto-fill, minmax(${minColWidth}, 1fr))` : `repeat(${cols}, 1fr)`;
+		cols === "auto"
+			? `repeat(auto-fill, minmax(${minColWidth}, 1fr))`
+			: `repeat(${cols}, 1fr)`;
 
 	return (
 		<Tag

--- a/src/ui/layout/section/Section.test.tsx
+++ b/src/ui/layout/section/Section.test.tsx
@@ -10,7 +10,11 @@ describe("Section", () => {
 
 	it("applies default classes (md spacing, default bg)", () => {
 		const { container } = render(<Section />);
-		expect(container.firstChild).toHaveClass("section", "section_spacing_md", "section_bg_default");
+		expect(container.firstChild).toHaveClass(
+			"section",
+			"section_spacing_md",
+			"section_bg_default",
+		);
 	});
 
 	it("applies spacing class", () => {
@@ -36,15 +40,8 @@ describe("Section", () => {
 
 	it("forwards ref to the root element", () => {
 		let node: HTMLElement | null = null;
-		render(
-			<Section
-				ref={(el) => {
-					node = el;
-				}}
-			>
-				X
-			</Section>,
-		);
+		render(<Section ref={(el) => { node = el; }}>X</Section>);
 		expect(node).toBeInstanceOf(HTMLElement);
 	});
+
 });

--- a/src/ui/layout/section/index.tsx
+++ b/src/ui/layout/section/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 
@@ -51,7 +51,12 @@ export const Section = ({
 	return (
 		<Tag
 			ref={ref}
-			className={cn("section", `section_spacing_${spacing}`, `section_bg_${bg}`, className)}
+			className={cn(
+				"section",
+				`section_spacing_${spacing}`,
+				`section_bg_${bg}`,
+				className,
+			)}
 			{...props}
 		>
 			{children}

--- a/src/ui/layout/stack/Stack.test.tsx
+++ b/src/ui/layout/stack/Stack.test.tsx
@@ -52,15 +52,8 @@ describe("Stack", () => {
 
 	it("forwards ref to the root element", () => {
 		let node: HTMLElement | null = null;
-		render(
-			<Stack
-				ref={(el) => {
-					node = el;
-				}}
-			>
-				X
-			</Stack>,
-		);
+		render(<Stack ref={(el) => { node = el; }}>X</Stack>);
 		expect(node).toBeInstanceOf(HTMLDivElement);
 	});
+
 });

--- a/src/ui/layout/stack/index.tsx
+++ b/src/ui/layout/stack/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../../../utils";
 import "./style.scss";
 

--- a/src/ui/layout/stack/stack.stories.tsx
+++ b/src/ui/layout/stack/stack.stories.tsx
@@ -69,9 +69,7 @@ export const GapScale: Story = {
 		<Stack gap={32}>
 			{([4, 8, 16, 24, 32] as const).map((gap) => (
 				<div key={gap}>
-					<p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--bt-color-text-caption)" }}>
-						gap={gap}
-					</p>
+					<p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--bt-color-text-caption)" }}>gap={gap}</p>
 					<Stack direction="horizontal" gap={gap} align="center">
 						<Item label="1" />
 						<Item label="2" />

--- a/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
+++ b/src/ui/navigation/bottom-nav/bottom-nav.stories.tsx
@@ -87,8 +87,7 @@ export const WithBadge: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story:
-					"아이콘 우상단에 `badge` prop 으로 알림 dot 이나 카운트를 표시한다. `<Badge>` 컴포넌트를 쓴다.",
+				story: "아이콘 우상단에 `badge` prop 으로 알림 dot 이나 카운트를 표시한다. `<Badge>` 컴포넌트를 쓴다.",
 			},
 		},
 	},
@@ -97,9 +96,7 @@ export const WithBadge: Story = {
 		return (
 			<PageShell>
 				<main style={{ flex: 1, padding: 24 }}>
-					<p style={{ color: "var(--bt-color-text-body)", margin: 0 }}>
-						알림 매장 - badge 표시 예.
-					</p>
+					<p style={{ color: "var(--bt-color-text-body)", margin: 0 }}>알림 매장 - badge 표시 예.</p>
 				</main>
 				<BottomNavSpacer />
 				<BottomNav>

--- a/src/ui/navigation/breadcrumb/Breadcrumb.test.tsx
+++ b/src/ui/navigation/breadcrumb/Breadcrumb.test.tsx
@@ -19,19 +19,40 @@ describe("Breadcrumb", () => {
 	});
 
 	it("marks last item with aria-current=page", () => {
-		render(<Breadcrumb items={[{ label: "홈", href: "/" }, { label: "현재" }]} />);
+		render(
+			<Breadcrumb
+				items={[
+					{ label: "홈", href: "/" },
+					{ label: "현재" },
+				]}
+			/>,
+		);
 		expect(screen.getByText("현재")).toHaveAttribute("aria-current", "page");
 	});
 
 	it("renders link for non-last items with href", () => {
-		render(<Breadcrumb items={[{ label: "홈", href: "/home" }, { label: "current" }]} />);
+		render(
+			<Breadcrumb
+				items={[
+					{ label: "홈", href: "/home" },
+					{ label: "current" },
+				]}
+			/>,
+		);
 		const link = screen.getByText("홈").closest("a");
 		expect(link).toHaveAttribute("href", "/home");
 	});
 
 	it("calls onClick", () => {
 		const onClick = vi.fn();
-		render(<Breadcrumb items={[{ label: "Click me", onClick }, { label: "current" }]} />);
+		render(
+			<Breadcrumb
+				items={[
+					{ label: "Click me", onClick },
+					{ label: "current" },
+				]}
+			/>,
+		);
 		fireEvent.click(screen.getByText("Click me"));
 		expect(onClick).toHaveBeenCalled();
 	});
@@ -43,9 +64,7 @@ describe("Breadcrumb", () => {
 
 	// <nav> 랜드마크 이름은 스크린리더의 리전 목록에 그대로 뜬다. 이전엔 영문 하드코딩이었다.
 	it("lets the app override the nav landmark name", () => {
-		render(
-			<Breadcrumb items={[{ label: "홈", href: "/" }, { label: "상세" }]} navLabel="Breadcrumb" />,
-		);
+		render(<Breadcrumb items={[{ label: "홈", href: "/" }, { label: "상세" }]} navLabel="Breadcrumb" />);
 		expect(screen.getByRole("navigation")).toHaveAttribute("aria-label", "Breadcrumb");
 	});
 });

--- a/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
+++ b/src/ui/navigation/breadcrumb/breadcrumb.stories.tsx
@@ -38,7 +38,12 @@ export const Default: Story = {
 export const ShortPath: Story = {
 	name: "2단계",
 	render: () => (
-		<Breadcrumb items={[{ label: "Settings", href: "/settings" }, { label: "Profile" }]} />
+		<Breadcrumb
+			items={[
+				{ label: "Settings", href: "/settings" },
+				{ label: "Profile" },
+			]}
+		/>
 	),
 };
 

--- a/src/ui/navigation/menu/Menu.test.tsx
+++ b/src/ui/navigation/menu/Menu.test.tsx
@@ -5,7 +5,10 @@ import { Menu } from "./index";
 describe("Menu", () => {
 	it("does not render menu items initially", () => {
 		render(
-			<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />,
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
 		);
 		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 	});
@@ -65,7 +68,10 @@ describe("Menu", () => {
 
 	it("aria-haspopup and aria-expanded on trigger", () => {
 		render(
-			<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />,
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
 		);
 		const trigger = screen.getByRole("button", { name: "Open" });
 		expect(trigger).toHaveAttribute("aria-haspopup", "menu");
@@ -142,7 +148,10 @@ describe("Menu", () => {
 
 	it("applies align=start class by default", () => {
 		render(
-			<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />,
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Open" }));
 		expect(screen.getByRole("menu")).toHaveClass("menu_align_start");
@@ -162,7 +171,10 @@ describe("Menu", () => {
 
 	it("sets aria-controls on trigger when open and clears when closed", () => {
 		render(
-			<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />,
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
 		);
 		const trigger = screen.getByRole("button", { name: "Open" });
 		expect(trigger).not.toHaveAttribute("aria-controls");
@@ -196,7 +208,9 @@ describe("Menu", () => {
 		render(
 			<Menu
 				trigger={<button type="button">Open</button>}
-				items={[{ key: "a", label: "A", icon: <svg data-testid="ic" /> }]}
+				items={[
+					{ key: "a", label: "A", icon: <svg data-testid="ic" /> },
+				]}
 			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Open" }));
@@ -221,10 +235,15 @@ describe("Menu", () => {
 
 	it("does not apply destructive class on regular items", () => {
 		render(
-			<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />,
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Open" }));
-		expect(screen.getByRole("menuitem", { name: "A" })).not.toHaveClass("menu_item_destructive");
+		expect(screen.getByRole("menuitem", { name: "A" })).not.toHaveClass(
+			"menu_item_destructive",
+		);
 	});
 
 	it("calls correct onSelect when multiple items exist", () => {
@@ -275,7 +294,10 @@ describe("Menu", () => {
 
 	it("Escape only triggers close while open (no listener leak)", () => {
 		const { unmount } = render(
-			<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />,
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
 		);
 		// 닫힌 상태에서 Escape를 눌러도 throw 없이 동작
 		expect(() => fireEvent.keyDown(document, { key: "Escape" })).not.toThrow();
@@ -360,7 +382,10 @@ describe("Menu", () => {
 
 	it("Escape closes and returns focus to the trigger", () => {
 		render(
-			<Menu trigger={<button type="button">Open</button>} items={[{ key: "a", label: "A" }]} />,
+			<Menu
+				trigger={<button type="button">Open</button>}
+				items={[{ key: "a", label: "A" }]}
+			/>,
 		);
 		const trigger = screen.getByRole("button", { name: "Open" });
 		fireEvent.click(trigger);
@@ -368,6 +393,7 @@ describe("Menu", () => {
 		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 		expect(trigger).toHaveFocus();
 	});
+
 
 	it("does not bubble handled keys to parent (stopPropagation)", () => {
 		const parentKeyDown = vi.fn();
@@ -381,6 +407,7 @@ describe("Menu", () => {
 		expect(parentKeyDown).not.toHaveBeenCalled();
 	});
 
+
 	it("lets Tab bubble to parent (focus-trap compatibility)", () => {
 		const parentKeyDown = vi.fn();
 		render(
@@ -392,6 +419,7 @@ describe("Menu", () => {
 		fireEvent.keyDown(screen.getByRole("menu"), { key: "Tab" });
 		expect(parentKeyDown).toHaveBeenCalled();
 	});
+
 
 	it("focuses first item even when the trigger had focus before opening", () => {
 		render(
@@ -409,4 +437,5 @@ describe("Menu", () => {
 		fireEvent.click(trigger);
 		expect(screen.getAllByRole("menuitem")[0]).toHaveFocus();
 	});
+
 });

--- a/src/ui/navigation/menu/index.tsx
+++ b/src/ui/navigation/menu/index.tsx
@@ -84,11 +84,7 @@ export const Menu = ({ items, trigger, align = "start" }: MenuProps) => {
 		if (dir === "last") return void itemRefs.current[enabled[enabled.length - 1]]?.focus();
 		const pos = enabled.findIndex((i) => itemRefs.current[i] === document.activeElement);
 		const next =
-			pos < 0
-				? dir === 1
-					? 0
-					: enabled.length - 1
-				: (pos + dir + enabled.length) % enabled.length;
+			pos < 0 ? (dir === 1 ? 0 : enabled.length - 1) : (pos + dir + enabled.length) % enabled.length;
 		itemRefs.current[enabled[next]]?.focus();
 	};
 

--- a/src/ui/navigation/nav-bar/NavBar.test.tsx
+++ b/src/ui/navigation/nav-bar/NavBar.test.tsx
@@ -105,6 +105,7 @@ describe("NavBar", () => {
 		});
 	});
 
+
 	it("LocaleSwitcher calls onValueChange (canonical) on select", () => {
 		const onValueChange = vi.fn();
 		render(
@@ -148,4 +149,5 @@ describe("NavBar", () => {
 		expect(onValueChange).toHaveBeenCalledWith("en");
 		expect(onChange).not.toHaveBeenCalled();
 	});
+
 });

--- a/src/ui/navigation/nav-bar/nav-bar.stories.tsx
+++ b/src/ui/navigation/nav-bar/nav-bar.stories.tsx
@@ -80,11 +80,7 @@ export const Transparent: Story = {
 				color: "#fff",
 			}}
 		>
-			<NavBar
-				variant="transparent"
-				brand={<Brand invert />}
-				actions={<Button size="sm">시작</Button>}
-			>
+			<NavBar variant="transparent" brand={<Brand invert />} actions={<Button size="sm">시작</Button>}>
 				<NavLink href="#" active>
 					소개
 				</NavLink>

--- a/src/ui/navigation/pagination/Pagination.test.tsx
+++ b/src/ui/navigation/pagination/Pagination.test.tsx
@@ -88,7 +88,9 @@ describe("Pagination", () => {
 	it("prefers onPageChange over the deprecated onChange when both are given", () => {
 		const onPageChange = vi.fn();
 		const onChange = vi.fn();
-		render(<Pagination page={5} totalPages={10} onPageChange={onPageChange} onChange={onChange} />);
+		render(
+			<Pagination page={5} totalPages={10} onPageChange={onPageChange} onChange={onChange} />,
+		);
 
 		fireEvent.click(screen.getByLabelText("이전 페이지"));
 
@@ -96,6 +98,7 @@ describe("Pagination", () => {
 		expect(onPageChange).toHaveBeenCalledWith(4);
 		expect(onChange).not.toHaveBeenCalled();
 	});
+
 
 	// <nav> 랜드마크 이름은 스크린리더의 리전 목록에 그대로 뜬다. 이전엔 영문 하드코딩이었다.
 	it("lets the app override the nav landmark name", () => {

--- a/src/ui/navigation/sidebar/sidebar.stories.tsx
+++ b/src/ui/navigation/sidebar/sidebar.stories.tsx
@@ -37,7 +37,12 @@ function BrandHeader() {
 	return (
 		// GH Pages 는 `/bigtablet-design-system/` 하위에 배포되므로 절대경로(`/images/…`)는
 		// 그 접두사를 건너뛰어 404 가 난다. iframe 기준 상대경로여야 로컬·배포 양쪽에서 맞는다.
-		<img src="images/logo/bigtablet.png" alt="Bigtablet" height={28} style={{ display: "block" }} />
+		<img
+			src="images/logo/bigtablet.png"
+			alt="Bigtablet"
+			height={28}
+			style={{ display: "block" }}
+		/>
 	);
 }
 
@@ -84,9 +89,7 @@ function ProfileFooter({ collapsed = false }: { collapsed?: boolean }) {
 			{!collapsed && (
 				<div style={{ display: "grid", gap: 2, fontSize: 13, minWidth: 0 }}>
 					<strong>sangmin</strong>
-					<span style={{ color: "var(--bt-color-text-body)", fontSize: 11 }}>
-						sangmin@bigtablet.com
-					</span>
+					<span style={{ color: "var(--bt-color-text-body)", fontSize: 11 }}>sangmin@bigtablet.com</span>
 				</div>
 			)}
 		</div>

--- a/src/ui/navigation/tabs/index.tsx
+++ b/src/ui/navigation/tabs/index.tsx
@@ -102,10 +102,7 @@ export const Tabs = ({
 	);
 	return (
 		<TabsContext.Provider value={ctx}>
-			<div
-				className={cn("tabs", `tabs_variant_${variant}`, `tabs_size_${size}`, className)}
-				{...props}
-			>
+			<div className={cn("tabs", `tabs_variant_${variant}`, `tabs_size_${size}`, className)} {...props}>
 				{children}
 			</div>
 		</TabsContext.Provider>
@@ -147,7 +144,8 @@ export const TabList = ({ ariaLabel, className, children, ...props }: TabListPro
 			attributeFilter: ["aria-selected"],
 		});
 
-		const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+		const ro =
+			typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
 		ro?.observe(list);
 		const handleResize = () => update();
 		window.addEventListener("resize", handleResize);
@@ -209,13 +207,10 @@ export const Tab = ({ value, className, children, onClick, onKeyDown, ...props }
 		// ({...props} 로 넘어온 onKeyDown 이 내비게이션을 통째로 제거하지 않도록 합성).
 		onKeyDown?.(e);
 		if (e.defaultPrevented) return;
-		if (e.key !== "ArrowLeft" && e.key !== "ArrowRight" && e.key !== "Home" && e.key !== "End")
-			return;
+		if (e.key !== "ArrowLeft" && e.key !== "ArrowRight" && e.key !== "Home" && e.key !== "End") return;
 		const list = (e.currentTarget as HTMLElement).closest('[role="tablist"]');
 		if (!list) return;
-		const tabs = Array.from(
-			list.querySelectorAll<HTMLButtonElement>('[role="tab"]:not([disabled])'),
-		);
+		const tabs = Array.from(list.querySelectorAll<HTMLButtonElement>('[role="tab"]:not([disabled])'));
 		const currentIndex = tabs.indexOf(e.currentTarget);
 		if (currentIndex < 0) return;
 		e.preventDefault();

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -579,12 +579,7 @@ describe("Drawer", () => {
 
 	it("freezes title and footer along with children", () => {
 		const { rerender } = render(
-			<Drawer
-				open
-				onClose={() => {}}
-				title="항목 제목"
-				footer={<button type="button">삭제</button>}
-			>
+			<Drawer open onClose={() => {}} title="항목 제목" footer={<button type="button">삭제</button>}>
 				<p>항목 본문</p>
 			</Drawer>,
 		);

--- a/src/ui/overlay/drawer/drawer.stories.tsx
+++ b/src/ui/overlay/drawer/drawer.stories.tsx
@@ -53,7 +53,8 @@ export const Right: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "우측에서 들어오는 기본 드로어 - 필터·상세·설정에 가장 흔한 사이드 패널 패턴.",
+				story:
+					"우측에서 들어오는 기본 드로어 - 필터·상세·설정에 가장 흔한 사이드 패널 패턴.",
 			},
 		},
 	},
@@ -64,8 +65,7 @@ export const Right: Story = {
 				<Button onClick={() => setOpen(true)}>드로어 열기</Button>
 				<Drawer {...args} open={open} onClose={() => setOpen(false)} title="설정 / Settings">
 					<p style={{ margin: 0 }}>
-						오른쪽에서 미끄러져 들어오는 패널입니다. 폼, 목록, 상세 정보를 자유롭게 배치할 수
-						있습니다.
+						오른쪽에서 미끄러져 들어오는 패널입니다. 폼, 목록, 상세 정보를 자유롭게 배치할 수 있습니다.
 					</p>
 				</Drawer>
 			</div>
@@ -79,7 +79,8 @@ export const Left: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "좌측 드로어 - 모바일 내비게이션 메뉴에 자주 쓰인다.",
+				story:
+					"좌측 드로어 - 모바일 내비게이션 메뉴에 자주 쓰인다.",
 			},
 		},
 	},
@@ -106,7 +107,8 @@ export const Bottom: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "하단 시트 - 아래에서 위로 올라오며 터치 기기에서 흔하다.",
+				story:
+					"하단 시트 - 아래에서 위로 올라오며 터치 기기에서 흔하다.",
 			},
 		},
 	},
@@ -130,7 +132,8 @@ export const WithFooter: Story = {
 	parameters: {
 		docs: {
 			description: {
-				story: "footer 액션 영역이 있는 드로어 - 확인·취소 또는 저장 패턴.",
+				story:
+					"footer 액션 영역이 있는 드로어 - 확인·취소 또는 저장 패턴.",
 			},
 		},
 	},

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -225,7 +225,12 @@ export const Drawer = ({
 				}}
 			>
 				{showCloseIcon && onClose && (
-					<button type="button" className="drawer_close" onClick={onClose} aria-label={closeLabel}>
+					<button
+						type="button"
+						className="drawer_close"
+						onClick={onClose}
+						aria-label={closeLabel}
+					>
 						<X size={iconSize.md} aria-hidden="true" />
 					</button>
 				)}


### PR DESCRIPTION
## 작업 개요

#534 에 섞여 들어간 **포맷 커밋 `bffda4e` 만** 되돌린다. 68파일 리플로우가 실제 수정과 한 PR 에 묶여 있어 리뷰가 어려웠고, 별도 PR(후속)로 다시 올린다.

**"포맷" 이 whitespace 만은 아니다.** `bffda4e` 가 담고 있던 변경은 세 종류이고, revert 는 그 셋을 모두 되돌린다.

- 줄폭 리플로우 (여러 줄 ↔ 한 줄)
- `import` 정렬 및 `import * as React` → `import type * as React` — **약 10개 파일**(`stack` · `container` · `grid` · `section` · `chip` · `badge` · `empty-state` · `error-state` · `textarea` 등). 이건 lint 성격 변경이지 공백 정렬이 아니다
- 유니온 타입의 선두 `|` (여러 줄) ↔ 인라인

`import type` 되돌림은 타입 전용 import 가 값 import 로 돌아간다는 뜻이다. 런타임 동작은 같고(둘 다 `react` 를 불러오지만 이 파일들은 `React.*` 를 타입 위치에서만 쓴다), 번들에는 `verbatimModuleSyntax` 를 쓰지 않는 한 차이가 없다. #536 이 그대로 다시 넣는다.

**되돌리지 않는 것** — #534 의 나머지 세 커밋은 실제 수정이라 develop 에 남긴다.

- `ff7303a` 죽은 import 2건 + `forEach` 반환값
- `8b75f08` 아무것도 억제하지 않는 suppression 7건 제거 + stories `noImgElement` 해제
- `152c1de` vanilla label 연결 (`for`/`id`, `role="group"`)

## 작업한 내용

- [x] `bffda4e` revert — 68파일, 424 insertions / 655 deletions (위 세 종류 전부)
- [x] 포맷 대상 68파일이 **머지 직전 상태와 바이트 단위로 동일**한지 확인 (다른 파일 0건)
- [x] 의미 커밋 3건이 그대로 남아 있는지 확인 — `toast` 의 `cn` 제거 유지, vanilla `for="demo-field-basic"` 유지, `nav-bar` 의 죽은 `useValidAnchor` suppression 제거 유지

## 검증

- 단위 **927 passed** / 9 skipped, `tsc --noEmit` 0, `build` 통과
- `biome check src` 는 포맷 부채가 되살아나 다시 실패한다 — **의도한 상태다.** biome 은 CI 게이트가 아니고, 게이트 전제 조건은 #533 이다

## 전달할 추가 이슈

- 포맷 스윕은 별도 PR 로 다시 올린다. 68파일이 다른 브랜치와 충돌하기 쉬워 **다른 PR 을 다 머지한 뒤 마지막에** 넣는 것이 맞다
- 열려 있는 #530 은 `.scss` · `scripts` · `ci.yml` · `package.json` 만 건드려 이 revert 와 겹치는 파일이 없다
