### PR TITLE
bug/scrollbar-gutter

### DIFF
--- a/src/utils/scroll-lock.test.ts
+++ b/src/utils/scroll-lock.test.ts
@@ -55,17 +55,20 @@ describe("scroll-lock", () => {
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("15px");
 	});
 
-	it("releases a reserved gutter even when clientWidth hides it", () => {
+	it("measures the gutter from the ICB, not from clientWidth", () => {
 		// `scrollbar-gutter: stable` 의 정의가 이 상황이다 - 거터 15px 이 예약돼 있는데
-		// clientWidth 는 innerWidth 와 같게 보고한다(Chromium 실측). 이전 구현은
-		// `innerWidth - clientWidth` 를 써서 0 을 얻고 거터를 놓지 못했고, 그래서 오버레이
-		// 옆에 거터 폭만큼 배경색 띠가 남았다.
+		// clientWidth 는 innerWidth 와 같게 보고한다(Chromium 실측).
 		document.documentElement.style.scrollbarGutter = "stable";
 		setViewportInset(15);
 		vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280);
 
+		// 옛 측정식은 이 상황에서 0 을 낸다 - 그래서 보정이 한 번도 걸리지 않았다.
+		// 이 단정이 위 clientWidth 스텁을 의미 있게 만든다.
+		expect(window.innerWidth - document.documentElement.clientWidth).toBe(0);
+
 		lockBodyScroll();
 
+		// 그런데도 거터를 놓고 그 폭을 보정한다 - 측정이 clientWidth 와 무관하다는 뜻이다.
 		expect(document.documentElement.style.scrollbarGutter).toBe("auto");
 		expect(document.body.style.paddingRight).toBe("15px");
 	});

--- a/src/utils/scroll-lock.test.ts
+++ b/src/utils/scroll-lock.test.ts
@@ -2,12 +2,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { lockBodyScroll, unlockBodyScroll } from "./scroll-lock";
 
 /**
- * jsdom 은 레이아웃을 하지 않아 `innerWidth - documentElement.clientWidth` 가 항상 0 이다.
- * 스크롤바가 있는 상황을 만들려면 그 두 값을 직접 세워야 한다.
+ * jsdom 은 레이아웃을 하지 않아 fixed 프로브의 `getBoundingClientRect().width` 가 0 이다.
+ * 스크롤바나 예약된 거터가 있는 상황을 만들려면 프로브가 재는 ICB 폭을 직접 세워야 한다.
+ *
+ * 이 스텁이 `clientWidth` 가 아니라 프로브를 세우는 것이 핵심이다 - `scrollbar-gutter: stable`
+ * 에서는 `clientWidth` 가 거터를 포함해 보고하므로(Chromium 실측) 거기서는 잴 수 없다.
  */
-const setScrollbarWidth = (width: number) => {
+const setViewportInset = (inset: number) => {
 	Object.defineProperty(window, "innerWidth", { value: 1280, configurable: true, writable: true });
-	vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280 - width);
+	vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+		width: 1280 - inset,
+		height: 0,
+		top: 0,
+		left: 0,
+		right: 1280 - inset,
+		bottom: 0,
+		x: 0,
+		y: 0,
+		toJSON: () => ({}),
+	} as DOMRect);
 };
 
 describe("scroll-lock", () => {
@@ -21,7 +34,7 @@ describe("scroll-lock", () => {
 	});
 
 	it("locks overflow and counts one open overlay", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		lockBodyScroll();
 
 		expect(document.body.style.overflow).toBe("hidden");
@@ -30,7 +43,7 @@ describe("scroll-lock", () => {
 
 	it("compensates the scrollbar width and releases the stable gutter", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 
@@ -42,9 +55,39 @@ describe("scroll-lock", () => {
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("15px");
 	});
 
+	it("releases a reserved gutter even when clientWidth hides it", () => {
+		// `scrollbar-gutter: stable` 의 정의가 이 상황이다 - 거터 15px 이 예약돼 있는데
+		// clientWidth 는 innerWidth 와 같게 보고한다(Chromium 실측). 이전 구현은
+		// `innerWidth - clientWidth` 를 써서 0 을 얻고 거터를 놓지 못했고, 그래서 오버레이
+		// 옆에 거터 폭만큼 배경색 띠가 남았다.
+		document.documentElement.style.scrollbarGutter = "stable";
+		setViewportInset(15);
+		vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280);
+
+		lockBodyScroll();
+
+		expect(document.documentElement.style.scrollbarGutter).toBe("auto");
+		expect(document.body.style.paddingRight).toBe("15px");
+	});
+
+	it("skips compensation when the environment does not lay out", () => {
+		// jsdom 처럼 레이아웃이 없으면 프로브 폭이 0 이다. innerWidth 를 그대로 쓰면
+		// body 에 뷰포트 폭(1280px)만큼 padding 이 붙는다.
+		Object.defineProperty(window, "innerWidth", {
+			value: 1280,
+			configurable: true,
+			writable: true,
+		});
+
+		lockBodyScroll();
+
+		expect(document.body.style.paddingRight).toBe("");
+		expect(document.documentElement.style.scrollbarGutter).toBe("");
+	});
+
 	it("adds to the consumer's existing body padding instead of replacing it", () => {
 		document.body.style.paddingRight = "20px";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 
@@ -52,7 +95,7 @@ describe("scroll-lock", () => {
 	});
 
 	it("skips compensation when there is no scrollbar to hide", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 
 		lockBodyScroll();
 
@@ -64,7 +107,7 @@ describe("scroll-lock", () => {
 	it("restores every touched property on the last unlock", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
 		document.body.style.paddingRight = "20px";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 		unlockBodyScroll();
@@ -78,7 +121,7 @@ describe("scroll-lock", () => {
 
 	it("keeps the lock while a nested overlay is still open", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll(); // Modal
 		lockBodyScroll(); // Modal 위 Alert
@@ -96,18 +139,18 @@ describe("scroll-lock", () => {
 	});
 
 	it("measures only once so a nested lock cannot double the padding", () => {
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 		// 첫 잠금 뒤에는 스크롤바가 사라져 실제 브라우저에서도 0 이 잰다.
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		lockBodyScroll();
 
 		expect(document.body.style.paddingRight).toBe("15px");
 	});
 
 	it("does not drive the counter negative on a repeated unlock", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		lockBodyScroll();
 		unlockBodyScroll();
 		unlockBodyScroll();
@@ -119,7 +162,7 @@ describe("scroll-lock", () => {
 	it("restores an inline --bt-scrollbar-width the consumer had set", () => {
 		// 소비자가 이 변수를 직접 잡아둔 경우 - 오버레이 한 번 열고 닫았다고 지워지면 안 된다.
 		document.documentElement.style.setProperty("--bt-scrollbar-width", "10px");
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("15px");
@@ -130,7 +173,7 @@ describe("scroll-lock", () => {
 
 	it("restores an inline overflow the consumer had set", () => {
 		document.body.style.overflow = "auto";
-		setScrollbarWidth(0);
+		setViewportInset(0);
 
 		lockBodyScroll();
 		expect(document.body.style.overflow).toBe("hidden");

--- a/src/utils/scroll-lock.ts
+++ b/src/utils/scroll-lock.ts
@@ -36,8 +36,34 @@ const PREV_SCROLLBAR_WIDTH_VAR = "originalScrollbarWidthVar";
 
 const SCROLLBAR_WIDTH_VAR = "--bt-scrollbar-width";
 
-/** 잠금으로 사라질 스크롤바의 폭(px). 오버레이 스크롤바(macOS 기본)나 스크롤 없는 페이지는 0. */
-const measureScrollbarWidth = () => window.innerWidth - document.documentElement.clientWidth;
+/**
+ * 잠금으로 회수되는 오른쪽 폭(px). 오버레이 스크롤바(macOS 기본)에서는 0.
+ *
+ * `window.innerWidth - documentElement.clientWidth` 로는 안 된다. 그 값은 "지금 스크롤바가
+ * 떠 있는가" 만 재고, `scrollbar-gutter: stable` 이 **예약해 둔** 거터는 잡지 못한다. Chromium
+ * 실측 - 거터 15px 이 예약된 상태에서 `innerWidth` 와 `clientWidth` 가 똑같이 1600 을 보고하고
+ * (스크롤이 있든 없든), 같은 상황에서 `position: fixed` 박스는 1585px 로 잡힌다. 그래서 잠금이
+ * 거터를 놓지 못하고 오버레이 옆에 거터 폭만큼 빈 띠가 남았다.
+ *
+ * 필요한 값은 "ICB 가 뷰포트보다 몇 px 좁은가" 다. fixed 박스를 하나 띄워 직접 잰다 - 클래식
+ * 스크롤바든 예약된 거터든 같은 값으로 잡히므로 기존 `> 0` 분기는 그대로 쓸 수 있다.
+ */
+const measureViewportInset = () => {
+	const probe = document.createElement("div");
+	probe.style.cssText =
+		"position:fixed;top:0;left:0;right:0;height:0;visibility:hidden;pointer-events:none";
+	// body 가 아니라 html 에 붙인다 - 소비자가 body 에 transform/filter/contain 을 걸어두면
+	// 그것이 fixed 의 컨테이닝 블록이 되어 뷰포트가 아닌 값을 재게 된다.
+	document.documentElement.appendChild(probe);
+	const width = probe.getBoundingClientRect().width;
+	probe.remove();
+
+	// 레이아웃하지 않는 환경(jsdom)에서는 0 이 나온다. 그때 innerWidth 를 그대로 보정폭으로
+	// 쓰면 body 에 뷰포트 폭만큼 padding 이 붙는다 - 보정하지 않는 쪽이 맞다.
+	if (width <= 0) return 0;
+
+	return Math.max(0, window.innerWidth - width);
+};
 
 /** 오버레이 하나가 열릴 때 호출. 중첩되면 카운터만 올린다. */
 export function lockBodyScroll(): void {
@@ -48,8 +74,8 @@ export function lockBodyScroll(): void {
 	const open = Number.parseInt(body.dataset[COUNTER] || "0", 10);
 
 	if (open === 0) {
-		// overflow 를 건드리기 전에 재야 한다 - 잠근 뒤엔 clientWidth 가 이미 넓어져 0 이 나온다.
-		const scrollbarWidth = measureScrollbarWidth();
+		// overflow 를 건드리기 전에 재야 한다 - 잠근 뒤엔 스크롤바가 사라져 0 이 나온다.
+		const scrollbarWidth = measureViewportInset();
 
 		body.dataset[PREV_OVERFLOW] = body.style.overflow;
 		body.dataset[PREV_GUTTER] = html.style.scrollbarGutter;

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -73,6 +73,33 @@
 	].join(", ");
 
 	/**
+	 * 잠금으로 회수되는 오른쪽 폭(px). 오버레이 스크롤바(macOS 기본)에서는 0.
+	 *
+	 * `window.innerWidth - html.clientWidth` 로는 안 된다. 그 값은 "지금 스크롤바가 떠 있는가"
+	 * 만 재고 `scrollbar-gutter: stable` 이 **예약해 둔** 거터는 잡지 못한다. Chromium 실측 -
+	 * 거터 15px 이 예약된 상태에서 `innerWidth` 와 `clientWidth` 가 똑같이 1600 을 보고하고
+	 * (스크롤이 있든 없든), 같은 상황에서 `position: fixed` 박스는 1585px 로 잡힌다.
+	 *
+	 * 필요한 값은 "ICB 가 뷰포트보다 몇 px 좁은가" 다. fixed 박스를 하나 띄워 직접 잰다 -
+	 * 클래식 스크롤바든 예약된 거터든 같은 값으로 잡힌다.
+	 * (React 쪽 `utils/scroll-lock.ts` 의 `measureViewportInset` 과 동일 동작.)
+	 */
+	function measureViewportInset() {
+		const probe = document.createElement("div");
+		probe.style.cssText =
+			"position:fixed;top:0;left:0;right:0;height:0;visibility:hidden;pointer-events:none";
+		// body 가 아니라 html 에 붙인다 - 소비자가 body 에 transform/filter/contain 을 걸면
+		// 그것이 fixed 의 컨테이닝 블록이 되어 뷰포트가 아닌 값을 재게 된다.
+		document.documentElement.appendChild(probe);
+		const width = probe.getBoundingClientRect().width;
+		probe.remove();
+
+		if (width <= 0) return 0;
+
+		return Math.max(0, window.innerWidth - width);
+	}
+
+	/**
 	 * 바디 스크롤 잠금 카운터 - Modal 위 Alert 처럼 오버레이가 겹칠 때
 	 * 하나만 닫혀도 배경 스크롤이 풀리던 문제 방지 (React 쪽 data-open-modals 와 동일 패턴)
 	 */
@@ -81,8 +108,8 @@
 		const html = document.documentElement;
 		const n = parseInt(body.dataset.btOpenModals || "0", 10);
 		if (n === 0) {
-			// overflow 를 건드리기 전에 스크롤바 폭을 잰다 - 잠근 뒤엔 clientWidth 가 이미 넓어져 0 이 된다.
-			const scrollbarWidth = window.innerWidth - html.clientWidth;
+			// overflow 를 건드리기 전에 재야 한다 - 잠근 뒤엔 스크롤바가 사라져 0 이 나온다.
+			const scrollbarWidth = measureViewportInset();
 
 			// 소비자가 인라인으로 지정해둔 값들을 저장했다가 마지막 unlock 때 복원
 			// (React 쪽 utils/scroll-lock.ts 와 동일 동작).

--- a/src/vanilla/bigtablet.test.ts
+++ b/src/vanilla/bigtablet.test.ts
@@ -4,10 +4,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // 로직은 동일하다. 빌드 산출물이 아니라 소스를 import 해서, 소스 변경이 곧 테스트에 걸린다.
 import { Alert, Dropdown, Modal, Toggle } from "./bigtablet.js";
 
-/** jsdom 은 레이아웃을 하지 않아 스크롤바 폭이 항상 0 이다. 있는 상황을 직접 세운다. */
-const setScrollbarWidth = (width: number) => {
+/**
+ * jsdom 은 레이아웃을 하지 않아 fixed 프로브의 폭이 0 이다. 스크롤바나 예약된 거터가 있는
+ * 상황을 만들려면 프로브가 재는 ICB 폭을 직접 세운다. `clientWidth` 가 아니라 프로브를 세우는
+ * 것이 핵심 - `scrollbar-gutter: stable` 에서는 `clientWidth` 가 거터를 포함해 보고한다.
+ */
+const setViewportInset = (inset: number) => {
 	Object.defineProperty(window, "innerWidth", { value: 1280, configurable: true, writable: true });
-	vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280 - width);
+	vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+		width: 1280 - inset,
+		height: 0,
+		top: 0,
+		left: 0,
+		right: 1280 - inset,
+		bottom: 0,
+		x: 0,
+		y: 0,
+		toJSON: () => ({}),
+	} as DOMRect);
 };
 
 const pressEscape = () =>
@@ -262,7 +276,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 	};
 
 	it("열면 잠그고 닫으면 푼다", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		const m = Modal(modalMarkup());
 
 		m?.open();
@@ -276,7 +290,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 
 	it("스크롤바 폭을 보정하고 stable 거터를 놓는다", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		const m = Modal(modalMarkup());
 		m?.open();
@@ -292,8 +306,25 @@ describe("Modal - 바디 스크롤 잠금", () => {
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("");
 	});
 
+	it("clientWidth 가 거터를 감춰도 거터를 놓는다", () => {
+		// `scrollbar-gutter: stable` 에서 Chromium 은 clientWidth 를 innerWidth 와 같게 보고한다.
+		// React 쪽과 같은 회귀 - 옛 측정식은 0 을 내고 보정이 한 번도 걸리지 않았다.
+		document.documentElement.style.scrollbarGutter = "stable";
+		setViewportInset(15);
+		vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280);
+		expect(window.innerWidth - document.documentElement.clientWidth).toBe(0);
+
+		const m = Modal(modalMarkup());
+		m?.open();
+
+		expect(document.documentElement.style.scrollbarGutter).toBe("auto");
+		expect(document.body.style.paddingRight).toBe("15px");
+
+		m?.close();
+	});
+
 	it("중첩 오버레이는 마지막 해제까지 잠금을 유지한다", () => {
-		setScrollbarWidth(15);
+		setViewportInset(15);
 		const a = Modal(modalMarkup("m1"));
 		const b = Modal(modalMarkup("m2"));
 
@@ -310,7 +341,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 	});
 
 	it("이미 열린 모달을 다시 열어도 카운터가 중복 증가하지 않는다", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		const m = Modal(modalMarkup());
 
 		m?.open();
@@ -331,7 +362,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 describe("Alert", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
-		setScrollbarWidth(0);
+		setViewportInset(0);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## 작업 개요

Closes #538.

리포트의 진단이 정확했다. 한 가지만 다르다 — **"스크롤이 있는 페이지에서는 15가 나와 보정이 정상 동작한다"는 부분은 사실이 아니다.** `scrollbar-gutter: stable` 이 걸려 있으면 스크롤 유무와 무관하게 `innerWidth - clientWidth` 가 0 이다. 즉 보정이 **한 번도** 걸리지 않았고, 화면마다 재현 여부가 달라 보인 것은 거터가 예약된 라우트와 그렇지 않은 라우트의 차이였을 가능성이 크다.

제안한 fixed 프로브 방식을 그대로 채택했다. 부모만 `document.body` → `document.documentElement` 로 바꿨다(이유는 아래 실측).

## 작업한 내용

- [x] `measureScrollbarWidth` → `measureViewportInset` — fixed 프로브로 "ICB 가 뷰포트보다 몇 px 좁은가" 를 잰다. 기존 `> 0` 분기와 `padding-right` 보정, `--bt-scrollbar-width` 노출은 그대로다
- [x] 프로브를 `documentElement` 에 붙인다 — 소비자가 `body` 에 transform/filter/contain 을 걸면 그것이 fixed 의 컨테이닝 블록이 되어 뷰포트가 아닌 값을 잰다
- [x] 레이아웃 없는 환경 가드 — 프로브 폭이 0 이면 보정하지 않는다. 없으면 jsdom 에서 `innerWidth` 가 그대로 보정폭이 되어 body 에 1280px padding 이 붙는다
- [x] 회귀 테스트 2건 + 기존 테스트 스텁 교체 (`clientWidth` → 프로브 폭)

## 검증

### Chromium 실측 (1600x900, 클래식 스크롤바 15px)

| 상태 | `innerWidth - clientWidth` (기존) | 프로브 (신규) | 실제 거터 |
| --- | --- | --- | --- |
| `gutter: auto` | 0 | 0 | 0 |
| `gutter: stable` + 스크롤 있음 | **0** | **15** | 15 |
| `gutter: stable` + 짧은 페이지 | **0** | **15** | 15 |

기존 측정은 `stable` 에서 항상 0 이다 — 리포트가 말한 "짧은 페이지에서만" 이 아니다.

### 수정 후 오버레이가 뷰포트를 덮는가

`gutter: stable` 에서 새 로직을 적용하고 `position: fixed; inset: 0` 요소의 폭을 쟀다.

| | 전 | 후 |
| --- | --- | --- |
| 오버레이 폭 | **1585** | **1600** (= `innerWidth`) |
| body 콘텐츠 폭 | 1585 | 1600 (padding-right 15px 로 유지) |

### 프로브 부모를 `documentElement` 로 둔 이유 — 실측

소비자가 `body` 를 좁히고 transform 을 걸면 `body` 에 붙인 프로브는 쓰레기값을 낸다.

| `body` 상태 | `body` 에 붙인 프로브 | `html` 에 붙인 프로브 |
| --- | --- | --- |
| 기본 | 15 | 15 |
| `width: 800px` | 15 | 15 |
| `width: 800px` + `translateZ(0)` | **800** | **15** |

`body` 였다면 그 경우 `padding-right: 800px` 이 붙었다.

### 뮤테이션 2/3 사망

| 심은 위반 | 결과 |
| --- | --- |
| 옛 측정(`innerWidth - clientWidth`) 복귀 | killed |
| 레이아웃 없음 가드 제거 | killed |
| 프로브를 `body` 에 붙임 | **SURVIVED** |

마지막 것은 jsdom 이 레이아웃을 하지 않아 컨테이닝 블록 차이를 표현할 수 없다 — 단위 테스트로 덮을 수 없는 종류다. 대신 위 브라우저 실측으로 확인했다.

### 그 밖에

- 단위 **930 passed** / 9 skipped (+3), storybook a11y **299 passed**
- `tsc --noEmit` 0, `build` 통과, `lint:css` 0, `check:prose` · `check:css-vars` · `check:defaults` · `check:geometry` 통과
- `biome check` 대상 2파일 클린

## 리뷰 반영 (`59f4847`)

- **Vanilla 번들에도 같은 버그가 있었다** — `src/vanilla/bigtablet.js` 가 같은 `innerWidth - html.clientWidth` 를 쓰고 주석까지 같았다. 그대로면 같은 버전에서 `/vanilla` 진입점만 버그가 남는다. 같은 `measureViewportInset()` 적용 + 테스트 스텁 교체 + 회귀 테스트 1건. 옛 측정식 복귀 뮤테이션으로 vanilla 테스트도 실패 확인
- **React 테스트의 `clientWidth` 스텁이 죽은 코드였다** — `measureViewportInset` 은 `clientWidth` 를 읽지 않는다. 지우는 대신 테스트 안에서 `expect(innerWidth - clientWidth).toBe(0)` 를 먼저 단정해 load-bearing 으로 만들었다. 이름도 `measures the gutter from the ICB, not from clientWidth` 로 바꿨다

## 전달할 추가 이슈

- **오버레이 스크롤바(macOS 기본) 환경은 이 세션에서 재현할 수 없었다.** 이 Chromium 은 스크롤이 필요한 페이지에서도 `innerWidth - clientWidth` 가 0 이라 클래식 스크롤바 분기를 실측하지 못했다. 프로브는 그 경우 `innerWidth - innerWidth = 0` 을 돌려 보정을 건너뛰므로 기존 동작과 같다고 판단했지만, 실물 확인은 못 했다
