### PR TITLE
merge: release v3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.15.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.15.1) - 2026-08-25
+- `scrollbar-gutter: stable` 을 쓰는 앱에서 오버레이(Modal·Alert·Drawer) 오른쪽에 배경색 띠가 남던 문제를 고쳤습니다. 스크롤 잠금이 예약된 거터를 재지 못해 보정이 걸리지 않았습니다 — React 와 Vanilla 양쪽 다 적용됩니다
+
 ## [3.15.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.15.0) - 2026-08-24
 - `Modal` 이 좁은 화면에서 잘리고 우상단 닫기 버튼이 화면 밖으로 나가던 문제를 고쳤습니다 (기본 `width` 만으로도 375px 화면에서 재현됐습니다)
 - `Modal`·`Drawer` 닫기 버튼 여백이 패널 패딩에서 파생됩니다 - 데스크톱에서 X 가 내용 열 밖으로 20px 튀어나가던 어긋남이 사라집니다

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.15.0",
+	"version": "3.15.1",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/src/utils/scroll-lock.test.ts
+++ b/src/utils/scroll-lock.test.ts
@@ -55,17 +55,20 @@ describe("scroll-lock", () => {
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("15px");
 	});
 
-	it("releases a reserved gutter even when clientWidth hides it", () => {
+	it("measures the gutter from the ICB, not from clientWidth", () => {
 		// `scrollbar-gutter: stable` 의 정의가 이 상황이다 - 거터 15px 이 예약돼 있는데
-		// clientWidth 는 innerWidth 와 같게 보고한다(Chromium 실측). 이전 구현은
-		// `innerWidth - clientWidth` 를 써서 0 을 얻고 거터를 놓지 못했고, 그래서 오버레이
-		// 옆에 거터 폭만큼 배경색 띠가 남았다.
+		// clientWidth 는 innerWidth 와 같게 보고한다(Chromium 실측).
 		document.documentElement.style.scrollbarGutter = "stable";
 		setViewportInset(15);
 		vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280);
 
+		// 옛 측정식은 이 상황에서 0 을 낸다 - 그래서 보정이 한 번도 걸리지 않았다.
+		// 이 단정이 위 clientWidth 스텁을 의미 있게 만든다.
+		expect(window.innerWidth - document.documentElement.clientWidth).toBe(0);
+
 		lockBodyScroll();
 
+		// 그런데도 거터를 놓고 그 폭을 보정한다 - 측정이 clientWidth 와 무관하다는 뜻이다.
 		expect(document.documentElement.style.scrollbarGutter).toBe("auto");
 		expect(document.body.style.paddingRight).toBe("15px");
 	});

--- a/src/utils/scroll-lock.test.ts
+++ b/src/utils/scroll-lock.test.ts
@@ -2,12 +2,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { lockBodyScroll, unlockBodyScroll } from "./scroll-lock";
 
 /**
- * jsdom 은 레이아웃을 하지 않아 `innerWidth - documentElement.clientWidth` 가 항상 0 이다.
- * 스크롤바가 있는 상황을 만들려면 그 두 값을 직접 세워야 한다.
+ * jsdom 은 레이아웃을 하지 않아 fixed 프로브의 `getBoundingClientRect().width` 가 0 이다.
+ * 스크롤바나 예약된 거터가 있는 상황을 만들려면 프로브가 재는 ICB 폭을 직접 세워야 한다.
+ *
+ * 이 스텁이 `clientWidth` 가 아니라 프로브를 세우는 것이 핵심이다 - `scrollbar-gutter: stable`
+ * 에서는 `clientWidth` 가 거터를 포함해 보고하므로(Chromium 실측) 거기서는 잴 수 없다.
  */
-const setScrollbarWidth = (width: number) => {
+const setViewportInset = (inset: number) => {
 	Object.defineProperty(window, "innerWidth", { value: 1280, configurable: true, writable: true });
-	vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280 - width);
+	vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+		width: 1280 - inset,
+		height: 0,
+		top: 0,
+		left: 0,
+		right: 1280 - inset,
+		bottom: 0,
+		x: 0,
+		y: 0,
+		toJSON: () => ({}),
+	} as DOMRect);
 };
 
 describe("scroll-lock", () => {
@@ -21,7 +34,7 @@ describe("scroll-lock", () => {
 	});
 
 	it("locks overflow and counts one open overlay", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		lockBodyScroll();
 
 		expect(document.body.style.overflow).toBe("hidden");
@@ -30,7 +43,7 @@ describe("scroll-lock", () => {
 
 	it("compensates the scrollbar width and releases the stable gutter", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 
@@ -42,9 +55,39 @@ describe("scroll-lock", () => {
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("15px");
 	});
 
+	it("releases a reserved gutter even when clientWidth hides it", () => {
+		// `scrollbar-gutter: stable` 의 정의가 이 상황이다 - 거터 15px 이 예약돼 있는데
+		// clientWidth 는 innerWidth 와 같게 보고한다(Chromium 실측). 이전 구현은
+		// `innerWidth - clientWidth` 를 써서 0 을 얻고 거터를 놓지 못했고, 그래서 오버레이
+		// 옆에 거터 폭만큼 배경색 띠가 남았다.
+		document.documentElement.style.scrollbarGutter = "stable";
+		setViewportInset(15);
+		vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280);
+
+		lockBodyScroll();
+
+		expect(document.documentElement.style.scrollbarGutter).toBe("auto");
+		expect(document.body.style.paddingRight).toBe("15px");
+	});
+
+	it("skips compensation when the environment does not lay out", () => {
+		// jsdom 처럼 레이아웃이 없으면 프로브 폭이 0 이다. innerWidth 를 그대로 쓰면
+		// body 에 뷰포트 폭(1280px)만큼 padding 이 붙는다.
+		Object.defineProperty(window, "innerWidth", {
+			value: 1280,
+			configurable: true,
+			writable: true,
+		});
+
+		lockBodyScroll();
+
+		expect(document.body.style.paddingRight).toBe("");
+		expect(document.documentElement.style.scrollbarGutter).toBe("");
+	});
+
 	it("adds to the consumer's existing body padding instead of replacing it", () => {
 		document.body.style.paddingRight = "20px";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 
@@ -52,7 +95,7 @@ describe("scroll-lock", () => {
 	});
 
 	it("skips compensation when there is no scrollbar to hide", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 
 		lockBodyScroll();
 
@@ -64,7 +107,7 @@ describe("scroll-lock", () => {
 	it("restores every touched property on the last unlock", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
 		document.body.style.paddingRight = "20px";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 		unlockBodyScroll();
@@ -78,7 +121,7 @@ describe("scroll-lock", () => {
 
 	it("keeps the lock while a nested overlay is still open", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll(); // Modal
 		lockBodyScroll(); // Modal 위 Alert
@@ -96,18 +139,18 @@ describe("scroll-lock", () => {
 	});
 
 	it("measures only once so a nested lock cannot double the padding", () => {
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 		// 첫 잠금 뒤에는 스크롤바가 사라져 실제 브라우저에서도 0 이 잰다.
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		lockBodyScroll();
 
 		expect(document.body.style.paddingRight).toBe("15px");
 	});
 
 	it("does not drive the counter negative on a repeated unlock", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		lockBodyScroll();
 		unlockBodyScroll();
 		unlockBodyScroll();
@@ -119,7 +162,7 @@ describe("scroll-lock", () => {
 	it("restores an inline --bt-scrollbar-width the consumer had set", () => {
 		// 소비자가 이 변수를 직접 잡아둔 경우 - 오버레이 한 번 열고 닫았다고 지워지면 안 된다.
 		document.documentElement.style.setProperty("--bt-scrollbar-width", "10px");
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		lockBodyScroll();
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("15px");
@@ -130,7 +173,7 @@ describe("scroll-lock", () => {
 
 	it("restores an inline overflow the consumer had set", () => {
 		document.body.style.overflow = "auto";
-		setScrollbarWidth(0);
+		setViewportInset(0);
 
 		lockBodyScroll();
 		expect(document.body.style.overflow).toBe("hidden");

--- a/src/utils/scroll-lock.ts
+++ b/src/utils/scroll-lock.ts
@@ -36,8 +36,34 @@ const PREV_SCROLLBAR_WIDTH_VAR = "originalScrollbarWidthVar";
 
 const SCROLLBAR_WIDTH_VAR = "--bt-scrollbar-width";
 
-/** 잠금으로 사라질 스크롤바의 폭(px). 오버레이 스크롤바(macOS 기본)나 스크롤 없는 페이지는 0. */
-const measureScrollbarWidth = () => window.innerWidth - document.documentElement.clientWidth;
+/**
+ * 잠금으로 회수되는 오른쪽 폭(px). 오버레이 스크롤바(macOS 기본)에서는 0.
+ *
+ * `window.innerWidth - documentElement.clientWidth` 로는 안 된다. 그 값은 "지금 스크롤바가
+ * 떠 있는가" 만 재고, `scrollbar-gutter: stable` 이 **예약해 둔** 거터는 잡지 못한다. Chromium
+ * 실측 - 거터 15px 이 예약된 상태에서 `innerWidth` 와 `clientWidth` 가 똑같이 1600 을 보고하고
+ * (스크롤이 있든 없든), 같은 상황에서 `position: fixed` 박스는 1585px 로 잡힌다. 그래서 잠금이
+ * 거터를 놓지 못하고 오버레이 옆에 거터 폭만큼 빈 띠가 남았다.
+ *
+ * 필요한 값은 "ICB 가 뷰포트보다 몇 px 좁은가" 다. fixed 박스를 하나 띄워 직접 잰다 - 클래식
+ * 스크롤바든 예약된 거터든 같은 값으로 잡히므로 기존 `> 0` 분기는 그대로 쓸 수 있다.
+ */
+const measureViewportInset = () => {
+	const probe = document.createElement("div");
+	probe.style.cssText =
+		"position:fixed;top:0;left:0;right:0;height:0;visibility:hidden;pointer-events:none";
+	// body 가 아니라 html 에 붙인다 - 소비자가 body 에 transform/filter/contain 을 걸어두면
+	// 그것이 fixed 의 컨테이닝 블록이 되어 뷰포트가 아닌 값을 재게 된다.
+	document.documentElement.appendChild(probe);
+	const width = probe.getBoundingClientRect().width;
+	probe.remove();
+
+	// 레이아웃하지 않는 환경(jsdom)에서는 0 이 나온다. 그때 innerWidth 를 그대로 보정폭으로
+	// 쓰면 body 에 뷰포트 폭만큼 padding 이 붙는다 - 보정하지 않는 쪽이 맞다.
+	if (width <= 0) return 0;
+
+	return Math.max(0, window.innerWidth - width);
+};
 
 /** 오버레이 하나가 열릴 때 호출. 중첩되면 카운터만 올린다. */
 export function lockBodyScroll(): void {
@@ -48,8 +74,8 @@ export function lockBodyScroll(): void {
 	const open = Number.parseInt(body.dataset[COUNTER] || "0", 10);
 
 	if (open === 0) {
-		// overflow 를 건드리기 전에 재야 한다 - 잠근 뒤엔 clientWidth 가 이미 넓어져 0 이 나온다.
-		const scrollbarWidth = measureScrollbarWidth();
+		// overflow 를 건드리기 전에 재야 한다 - 잠근 뒤엔 스크롤바가 사라져 0 이 나온다.
+		const scrollbarWidth = measureViewportInset();
 
 		body.dataset[PREV_OVERFLOW] = body.style.overflow;
 		body.dataset[PREV_GUTTER] = html.style.scrollbarGutter;

--- a/src/vanilla/bigtablet.js
+++ b/src/vanilla/bigtablet.js
@@ -73,6 +73,33 @@
 	].join(", ");
 
 	/**
+	 * 잠금으로 회수되는 오른쪽 폭(px). 오버레이 스크롤바(macOS 기본)에서는 0.
+	 *
+	 * `window.innerWidth - html.clientWidth` 로는 안 된다. 그 값은 "지금 스크롤바가 떠 있는가"
+	 * 만 재고 `scrollbar-gutter: stable` 이 **예약해 둔** 거터는 잡지 못한다. Chromium 실측 -
+	 * 거터 15px 이 예약된 상태에서 `innerWidth` 와 `clientWidth` 가 똑같이 1600 을 보고하고
+	 * (스크롤이 있든 없든), 같은 상황에서 `position: fixed` 박스는 1585px 로 잡힌다.
+	 *
+	 * 필요한 값은 "ICB 가 뷰포트보다 몇 px 좁은가" 다. fixed 박스를 하나 띄워 직접 잰다 -
+	 * 클래식 스크롤바든 예약된 거터든 같은 값으로 잡힌다.
+	 * (React 쪽 `utils/scroll-lock.ts` 의 `measureViewportInset` 과 동일 동작.)
+	 */
+	function measureViewportInset() {
+		const probe = document.createElement("div");
+		probe.style.cssText =
+			"position:fixed;top:0;left:0;right:0;height:0;visibility:hidden;pointer-events:none";
+		// body 가 아니라 html 에 붙인다 - 소비자가 body 에 transform/filter/contain 을 걸면
+		// 그것이 fixed 의 컨테이닝 블록이 되어 뷰포트가 아닌 값을 재게 된다.
+		document.documentElement.appendChild(probe);
+		const width = probe.getBoundingClientRect().width;
+		probe.remove();
+
+		if (width <= 0) return 0;
+
+		return Math.max(0, window.innerWidth - width);
+	}
+
+	/**
 	 * 바디 스크롤 잠금 카운터 - Modal 위 Alert 처럼 오버레이가 겹칠 때
 	 * 하나만 닫혀도 배경 스크롤이 풀리던 문제 방지 (React 쪽 data-open-modals 와 동일 패턴)
 	 */
@@ -81,8 +108,8 @@
 		const html = document.documentElement;
 		const n = parseInt(body.dataset.btOpenModals || "0", 10);
 		if (n === 0) {
-			// overflow 를 건드리기 전에 스크롤바 폭을 잰다 - 잠근 뒤엔 clientWidth 가 이미 넓어져 0 이 된다.
-			const scrollbarWidth = window.innerWidth - html.clientWidth;
+			// overflow 를 건드리기 전에 재야 한다 - 잠근 뒤엔 스크롤바가 사라져 0 이 나온다.
+			const scrollbarWidth = measureViewportInset();
 
 			// 소비자가 인라인으로 지정해둔 값들을 저장했다가 마지막 unlock 때 복원
 			// (React 쪽 utils/scroll-lock.ts 와 동일 동작).

--- a/src/vanilla/bigtablet.test.ts
+++ b/src/vanilla/bigtablet.test.ts
@@ -4,10 +4,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // 로직은 동일하다. 빌드 산출물이 아니라 소스를 import 해서, 소스 변경이 곧 테스트에 걸린다.
 import { Alert, Dropdown, Modal, Toggle } from "./bigtablet.js";
 
-/** jsdom 은 레이아웃을 하지 않아 스크롤바 폭이 항상 0 이다. 있는 상황을 직접 세운다. */
-const setScrollbarWidth = (width: number) => {
+/**
+ * jsdom 은 레이아웃을 하지 않아 fixed 프로브의 폭이 0 이다. 스크롤바나 예약된 거터가 있는
+ * 상황을 만들려면 프로브가 재는 ICB 폭을 직접 세운다. `clientWidth` 가 아니라 프로브를 세우는
+ * 것이 핵심 - `scrollbar-gutter: stable` 에서는 `clientWidth` 가 거터를 포함해 보고한다.
+ */
+const setViewportInset = (inset: number) => {
 	Object.defineProperty(window, "innerWidth", { value: 1280, configurable: true, writable: true });
-	vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280 - width);
+	vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+		width: 1280 - inset,
+		height: 0,
+		top: 0,
+		left: 0,
+		right: 1280 - inset,
+		bottom: 0,
+		x: 0,
+		y: 0,
+		toJSON: () => ({}),
+	} as DOMRect);
 };
 
 const pressEscape = () =>
@@ -262,7 +276,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 	};
 
 	it("열면 잠그고 닫으면 푼다", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		const m = Modal(modalMarkup());
 
 		m?.open();
@@ -276,7 +290,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 
 	it("스크롤바 폭을 보정하고 stable 거터를 놓는다", () => {
 		document.documentElement.style.scrollbarGutter = "stable";
-		setScrollbarWidth(15);
+		setViewportInset(15);
 
 		const m = Modal(modalMarkup());
 		m?.open();
@@ -292,8 +306,25 @@ describe("Modal - 바디 스크롤 잠금", () => {
 		expect(document.documentElement.style.getPropertyValue("--bt-scrollbar-width")).toBe("");
 	});
 
+	it("clientWidth 가 거터를 감춰도 거터를 놓는다", () => {
+		// `scrollbar-gutter: stable` 에서 Chromium 은 clientWidth 를 innerWidth 와 같게 보고한다.
+		// React 쪽과 같은 회귀 - 옛 측정식은 0 을 내고 보정이 한 번도 걸리지 않았다.
+		document.documentElement.style.scrollbarGutter = "stable";
+		setViewportInset(15);
+		vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(1280);
+		expect(window.innerWidth - document.documentElement.clientWidth).toBe(0);
+
+		const m = Modal(modalMarkup());
+		m?.open();
+
+		expect(document.documentElement.style.scrollbarGutter).toBe("auto");
+		expect(document.body.style.paddingRight).toBe("15px");
+
+		m?.close();
+	});
+
 	it("중첩 오버레이는 마지막 해제까지 잠금을 유지한다", () => {
-		setScrollbarWidth(15);
+		setViewportInset(15);
 		const a = Modal(modalMarkup("m1"));
 		const b = Modal(modalMarkup("m2"));
 
@@ -310,7 +341,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 	});
 
 	it("이미 열린 모달을 다시 열어도 카운터가 중복 증가하지 않는다", () => {
-		setScrollbarWidth(0);
+		setViewportInset(0);
 		const m = Modal(modalMarkup());
 
 		m?.open();
@@ -331,7 +362,7 @@ describe("Modal - 바디 스크롤 잠금", () => {
 describe("Alert", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
-		setScrollbarWidth(0);
+		setViewportInset(0);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## 작업 개요

3.15.1 패치 릴리즈. `merge: release v3.15.1`.

Closes #538.

**patch 인 이유** — 공개 표면 변화가 없다. `git diff v3.15.0..develop -- src/index.ts src/styles` 가 비어 있고, 바뀐 것은 내부 유틸(`src/utils/scroll-lock.ts`)과 Vanilla 번들 내부 함수뿐이다. export·토큰·prop 추가나 제거가 없다.

## 작업한 내용

- [x] #538 — `scrollbar-gutter: stable` 환경에서 오버레이가 예약된 거터를 덮지 못하던 버그 (PR #539). 스크롤 잠금의 측정값이 "지금 스크롤바가 떠 있는가"였는데 필요한 값은 "거터가 예약돼 있는가"였다. fixed 프로브로 ICB 폭을 직접 재는 방식으로 교체
- [x] Vanilla 번들(`/vanilla`)에도 같은 수정 적용 — 같은 측정식을 쓰고 있어 그대로면 같은 버전에서 React 만 고쳐지고 Vanilla 는 버그가 남았다
- [x] `package.json` 3.15.0 → 3.15.1
- [x] `CHANGELOG.md` 3.15.1 항목 추가

## 검증

develop 최신에서 전 게이트를 직접 돌렸다.

- 단위 **930 passed** / 9 skipped, storybook a11y **299 passed**
- `tsc --noEmit` 0, `build` 통과, `check:prose` · `check:css-vars` · `check:defaults` · `check:geometry` 전부 통과

### Chromium 실측 (1600x900, 거터 15px)

| | 수정 전 | 수정 후 |
| --- | --- | --- |
| 오버레이(`position: fixed; inset: 0`) 폭 | 1585 | **1600** (= `innerWidth`) |
| 잠금 중 body 콘텐츠 폭 | 1585 | 1600 (`padding-right: 15px` 로 유지) |
| 측정값 | 0 (보정 안 걸림) | 15 |

### 뮤테이션

- 옛 측정식(`innerWidth - clientWidth`) 복귀 → React·Vanilla 테스트 양쪽 실패
- 레이아웃 없음 가드 제거 → 실패 (없으면 jsdom 에서 body 에 1280px padding 이 붙는다)
- 프로브를 `body` 에 붙이기 → jsdom 이 컨테이닝 블록 차이를 표현하지 못해 단위 테스트로는 못 잡는다. 브라우저 실측으로 확인했다 (transform 걸린 800px body 에서 `body` 프로브는 800, `html` 프로브는 15)
