### PR TITLE
merge: release v3.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.15.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.15.2) - 2026-08-25
+- 오버레이가 닫히는 동안 스크롤 잠금이 먼저 풀려, `scrollbar-gutter: stable` 환경에서 오른쪽에 빈 띠가 보이고 배경 콘텐츠가 튀던 문제를 고쳤습니다 (`Modal`·`Drawer`)
+- Vanilla 모달이 좁은 화면에서 잘리던 문제를 고쳤습니다 (375px 에서 우측 89px 잘림 — React 는 3.15.0 에서 이미 수정)
+
 ## [3.15.1](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.15.1) - 2026-08-25
 - `scrollbar-gutter: stable` 을 쓰는 앱에서 오버레이(Modal·Alert·Drawer) 오른쪽에 배경색 띠가 남던 문제를 고쳤습니다. 스크롤 잠금이 예약된 거터를 재지 못해 보정이 걸리지 않았습니다 — React 와 Vanilla 양쪽 다 적용됩니다
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.15.1",
+	"version": "3.15.2",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/scripts/check-overlay-geometry.py
+++ b/scripts/check-overlay-geometry.py
@@ -110,25 +110,34 @@ def shorthand_side(value: str | None, side: str) -> str | None:
 
 # ── 스크롤 잠금 수명 (소스) ───────────────────────────────────────────────────
 
-LOCK_OWNERS = [
-    Path("src/ui/overlay/modal/index.tsx"),
-    Path("src/ui/overlay/drawer/index.tsx"),
-    Path("src/ui/feedback/alert/index.tsx"),
-]
+# 잠금 소비처는 하드코딩하지 않고 소스에서 찾는다. 목록으로 두면 새 오버레이가 같은 패턴을
+# 쓰기 시작했을 때 검사가 조용히 놓친다 - 이 검사가 막으려는 바로 그 재발이 검사 자체에 남는다.
+UI = Path("src/ui")
+LOCK_CALL = "lockBodyScroll()"
+# 소비처가 이 수 아래로 떨어지면 탐색이 깨진 것으로 본다 (현재 Modal·Drawer·AlertModal).
+MIN_LOCK_OWNERS = 3
 
-# `lockBodyScroll()` 을 부르는 effect 의 deps 배열
+
+# `lockBodyScroll()` 을 부르는 effect 의 본문과 deps 배열
 LOCK_EFFECT = re.compile(
     r"useEffect\(\(\)\s*=>\s*\{(?P<body>[^}]*?lockBodyScroll\(\)[^}]*?)\}\s*,\s*\[(?P<deps>[^\]]*)\]\)",
     re.DOTALL,
 )
 
 
-def check_lock_lifecycle() -> list[str]:
+def lock_owners() -> list[Path]:
+    return sorted(p for p in UI.rglob("index.tsx") if LOCK_CALL in p.read_text(encoding="utf-8"))
+
+
+def check_lock_lifecycle() -> tuple[list[str], int]:
     problems: list[str] = []
-    for path in LOCK_OWNERS:
-        if not path.exists():
-            problems.append(f"{path} 가 없다 - LOCK_OWNERS 목록이 소스와 어긋났다")
-            continue
+    owners = lock_owners()
+    if len(owners) < MIN_LOCK_OWNERS:
+        problems.append(
+            f"잠금 소비처를 {len(owners)}개만 찾았다 (최소 {MIN_LOCK_OWNERS}) -"
+            f" `{LOCK_CALL}` 탐색이 소스와 어긋났는지 보라"
+        )
+    for path in owners:
         source = path.read_text(encoding="utf-8")
         matches = LOCK_EFFECT.findall(source)
         if len(matches) != 1:
@@ -144,10 +153,13 @@ def check_lock_lifecycle() -> list[str]:
                 " open/isOpen 에 묶으면 퇴출 애니메이션 동안 보정이 풀려 거터에 빈 띠가 보인다"
             )
         if "if (!shouldRender) return" not in body:
+            problems.append(f"{path}: 잠금 effect 의 가드가 shouldRender 기준이 아니다")
+        # cleanup 이 없으면 unmount·shouldRender=false 후에도 잠금이 남아 페이지가 잠긴다.
+        if not re.search(r"\breturn\s+unlockBodyScroll\s*;", body):
             problems.append(
-                f"{path}: 잠금 effect 의 가드가 shouldRender 기준이 아니다"
+                f"{path}: 잠금 effect 가 unlockBodyScroll cleanup 을 반환하지 않는다"
             )
-    return problems
+    return problems, len(owners)
 
 
 def main() -> int:
@@ -206,8 +218,9 @@ def main() -> int:
                 f"(inset {inset} + 박스 {box}) 기준이면 {expected}px 이어야 한다"
             )
 
-    problems += check_lock_lifecycle()
-    checked += 3
+    lock_problems, owner_count = check_lock_lifecycle()
+    problems += lock_problems
+    checked += owner_count
 
     # 오버플로 가드 - 암묵 grid 트랙(auto)이면 패널의 max-width 백분율이 뷰포트가 아니라
     # 패널 자신의 max-content 로 풀려 clamp 가 전혀 걸리지 않는다(기본 width=480 이 375 화면에서
@@ -240,8 +253,8 @@ def main() -> int:
             print(f"  {p}", file=sys.stderr)
         return 1
 
-    print(f"오버레이 close 기하 {checked - 3}건 - 전부 패널 패딩에서 파생됩니다.")
-    print(f"스크롤 잠금 수명 {len(LOCK_OWNERS)}건 - 전부 shouldRender 에 묶여 있습니다.")
+    print(f"오버레이 close 기하 {checked - owner_count}건 - 전부 패널 패딩에서 파생됩니다.")
+    print(f"스크롤 잠금 수명 {owner_count}건 - shouldRender 에 묶이고 cleanup 을 반환합니다.")
     return 0
 
 

--- a/scripts/check-overlay-geometry.py
+++ b/scripts/check-overlay-geometry.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""오버레이(Modal·Drawer)의 close 버튼 기하가 패널 패딩에서 파생되는지 빌드 CSS 로 검사한다.
+"""오버레이(Modal·Drawer·AlertModal)의 두 가지 불변식을 검사한다.
+
+## 1. close 버튼 기하 (빌드 CSS)
 
 close 버튼은 `position: absolute` 로 패널 모서리에 붙는데, 그 inset 은 패널 패딩과 **합의해야
 하는 값**이다. 손으로 고정하면 패딩만 바뀌었을 때(Modal 은 `from_medium` 에서 24 -> 32) close 가
@@ -11,6 +13,14 @@ close 버튼은 `position: absolute` 로 패널 모서리에 붙는데, 그 inse
 
 jsdom 은 스타일시트를 계산하지 않아 단위 테스트로는 잡을 수 없다. 그래서 빌드 산출물을 읽는다.
 
+## 2. 스크롤 잠금 수명 (소스)
+
+잠금 effect 는 **마운트 게이트와 같은 값**(`shouldRender`)에 묶여야 한다. `open` / `isOpen` 에
+묶으면 닫기 시작 즉시 cleanup 이 돌아 `scrollbar-gutter` 와 `padding-right` 보정이 풀리는데,
+오버레이는 퇴출 애니메이션이 끝날 때까지 계속 렌더된다 - 그 구간에 거터가 빈 띠로 보이고 배경이
+튄다. AlertModal 만 처음부터 `shouldRender` 를 썼고 Modal·Drawer 가 `open` 을 써서 같은 증상이
+두 번 재발했다.
+
 exit 1 이면 위반이 있다.
 """
 
@@ -21,6 +31,7 @@ import sys
 from pathlib import Path
 
 CSS = Path("dist/index.css")
+VANILLA_CSS = Path("dist/vanilla/bigtablet.css")
 ICON_INSET = 8  # (32 - 18) / 2 = 7 이지만 토큰 스케일에 맞춰 8 을 뺀다
 
 
@@ -97,6 +108,48 @@ def shorthand_side(value: str | None, side: str) -> str | None:
     return None
 
 
+# ── 스크롤 잠금 수명 (소스) ───────────────────────────────────────────────────
+
+LOCK_OWNERS = [
+    Path("src/ui/overlay/modal/index.tsx"),
+    Path("src/ui/overlay/drawer/index.tsx"),
+    Path("src/ui/feedback/alert/index.tsx"),
+]
+
+# `lockBodyScroll()` 을 부르는 effect 의 deps 배열
+LOCK_EFFECT = re.compile(
+    r"useEffect\(\(\)\s*=>\s*\{(?P<body>[^}]*?lockBodyScroll\(\)[^}]*?)\}\s*,\s*\[(?P<deps>[^\]]*)\]\)",
+    re.DOTALL,
+)
+
+
+def check_lock_lifecycle() -> list[str]:
+    problems: list[str] = []
+    for path in LOCK_OWNERS:
+        if not path.exists():
+            problems.append(f"{path} 가 없다 - LOCK_OWNERS 목록이 소스와 어긋났다")
+            continue
+        source = path.read_text(encoding="utf-8")
+        matches = LOCK_EFFECT.findall(source)
+        if len(matches) != 1:
+            problems.append(
+                f"{path}: lockBodyScroll effect 를 {len(matches)}개 찾았다 - 1개여야 한다"
+            )
+            continue
+        body, deps = matches[0]
+        deps = deps.strip()
+        if deps != "shouldRender":
+            problems.append(
+                f"{path}: 잠금 effect 의 deps 가 [{deps}] 다 - [shouldRender] 여야 한다."
+                " open/isOpen 에 묶으면 퇴출 애니메이션 동안 보정이 풀려 거터에 빈 띠가 보인다"
+            )
+        if "if (!shouldRender) return" not in body:
+            problems.append(
+                f"{path}: 잠금 effect 의 가드가 shouldRender 기준이 아니다"
+            )
+    return problems
+
+
 def main() -> int:
     if not CSS.exists():
         print(f"{CSS} 가 없다 - `pnpm build` 를 먼저 실행하라", file=sys.stderr)
@@ -153,18 +206,28 @@ def main() -> int:
                 f"(inset {inset} + 박스 {box}) 기준이면 {expected}px 이어야 한다"
             )
 
+    problems += check_lock_lifecycle()
+    checked += 3
+
     # 오버플로 가드 - 암묵 grid 트랙(auto)이면 패널의 max-width 백분율이 뷰포트가 아니라
     # 패널 자신의 max-content 로 풀려 clamp 가 전혀 걸리지 않는다(기본 width=480 이 375 화면에서
     # 잘리고 close 가 화면 밖으로 나갔다).
-    track = find(parsed, ".modal", "grid-template-columns")
-    checked += 1
-    if track is None or "minmax(0" not in track:
-        problems.append(
-            f".modal 의 grid-template-columns 가 {track!r} - minmax(0, ...) 로 트랙을"
-            " 컨테이너에 묶어야 패널 max-width 의 100% 가 뷰포트 폭이 된다"
-        )
+    for label, css_path, selector in (
+        ("React", CSS, ".modal"),
+        ("Vanilla", VANILLA_CSS, ".bt-modal.is-open"),
+    ):
+        checked += 1
+        if not css_path.exists():
+            problems.append(f"{label}: {css_path} 가 없다 - `pnpm build` 를 먼저 실행하라")
+            continue
+        track = find(rules(css_path.read_text(encoding="utf-8")), selector, "grid-template-columns")
+        if track is None or "minmax(0" not in track:
+            problems.append(
+                f"{label}: {selector} 의 grid-template-columns 가 {track!r} - minmax(0, ...) 로"
+                " 트랙을 컨테이너에 묶어야 패널 max-width 의 100% 가 뷰포트 폭이 된다"
+            )
 
-    if checked < 8:
+    if checked < 9:
         print(
             f"검사 대상이 사라졌다 (확인 {checked}건) - 선택자나 빌드 구조가 바뀌었는지 보라",
             file=sys.stderr,
@@ -177,7 +240,8 @@ def main() -> int:
             print(f"  {p}", file=sys.stderr)
         return 1
 
-    print(f"오버레이 close 기하 {checked}건 - 전부 패널 패딩에서 파생됩니다.")
+    print(f"오버레이 close 기하 {checked - 3}건 - 전부 패널 패딩에서 파생됩니다.")
+    print(f"스크롤 잠금 수명 {len(LOCK_OWNERS)}건 - 전부 shouldRender 에 묶여 있습니다.")
     return 0
 
 

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -2,6 +2,21 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Drawer } from "./index";
 
+const stubReducedMotion = () => {
+	vi.stubGlobal(
+		"matchMedia",
+		vi.fn().mockImplementation((query: string) => ({
+			matches: query.includes("prefers-reduced-motion"),
+			media: query,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	);
+};
+
 describe("Drawer", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
@@ -322,7 +337,7 @@ describe("Drawer", () => {
 
 	// ── Body scroll lock ───────────────────────────────────────────────────
 
-	it("locks body scroll while open and restores on close", () => {
+	it("locks body scroll while open and restores after the exit finishes", async () => {
 		const { rerender } = render(
 			<Drawer open onClose={() => {}}>
 				Content
@@ -335,10 +350,38 @@ describe("Drawer", () => {
 				Content
 			</Drawer>,
 		);
-		expect(document.body.style.overflow).not.toBe("hidden");
+		// 닫기 시작 시점에는 아직 잠겨 있어야 한다 - 퇴출 애니메이션 동안 오버레이가 계속
+		// 렌더되므로, 여기서 풀면 `scrollbar-gutter` 보정이 사라져 거터에 빈 띠가 보이고
+		// 배경 콘텐츠가 그만큼 튄다.
+		expect(document.body.style.overflow).toBe("hidden");
+
+		// 퇴출이 끝나(shouldRender false) 완전히 unmount 되면 풀린다.
+		await waitFor(() => expect(document.body.style.overflow).not.toBe("hidden"));
 	});
 
-	it("keeps body scroll locked until the last overlay closes (shared counter)", () => {
+	it("releases the scroll lock under reduced motion", async () => {
+		// Drawer 는 useSpringPresence 의 onExitComplete 로 shouldRender 를 내린다.
+		// reduced-motion(`immediate: true`)에서도 그 콜백이 도는지 확인한다 - 안 돌면
+		// 잠금이 영구히 남는다.
+		stubReducedMotion();
+		const { rerender } = render(
+			<Drawer open onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		rerender(
+			<Drawer open={false} onClose={() => {}}>
+				Content
+			</Drawer>,
+		);
+
+		await waitFor(() => expect(document.body.style.overflow).not.toBe("hidden"));
+		expect(document.body.dataset.openModals).toBeUndefined();
+	});
+
+	it("keeps body scroll locked until the last overlay closes (shared counter)", async () => {
 		const { rerender } = render(
 			<>
 				<Drawer open onClose={() => {}}>
@@ -375,7 +418,7 @@ describe("Drawer", () => {
 				</Drawer>
 			</>,
 		);
-		expect(document.body.style.overflow).not.toBe("hidden");
+		await waitFor(() => expect(document.body.style.overflow).not.toBe("hidden"));
 	});
 
 	// ── Reduced motion ───────────────────────────────────────────────────────

--- a/src/ui/overlay/drawer/Drawer.test.tsx
+++ b/src/ui/overlay/drawer/Drawer.test.tsx
@@ -1,3 +1,4 @@
+import { Globals } from "@react-spring/web";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Drawer } from "./index";
@@ -363,6 +364,11 @@ describe("Drawer", () => {
 		// Drawer 는 useSpringPresence 의 onExitComplete 로 shouldRender 를 내린다.
 		// reduced-motion(`immediate: true`)에서도 그 콜백이 도는지 확인한다 - 안 돌면
 		// 잠금이 영구히 남는다.
+		// setup.ts 가 스위트 전체에 skipAnimation 을 걸어 두면 어떤 스프링이든 즉시 끝나
+		// 일반 종료 테스트와 같은 경로가 된다. 여기서만 끄고 `immediate: reduced` 가 실제로
+		// 도는 경로를 태운다. (그 플래그를 지우는 뮤테이션까지 잡지는 못한다 - 스프링이
+		// 애니메이션으로 끝나도 waitFor 안에 들어오기 때문이다.)
+		Globals.assign({ skipAnimation: false });
 		stubReducedMotion();
 		const { rerender } = render(
 			<Drawer open onClose={() => {}}>
@@ -379,6 +385,8 @@ describe("Drawer", () => {
 
 		await waitFor(() => expect(document.body.style.overflow).not.toBe("hidden"));
 		expect(document.body.dataset.openModals).toBeUndefined();
+
+		Globals.assign({ skipAnimation: true });
 	});
 
 	it("keeps body scroll locked until the last overlay closes (shared counter)", async () => {

--- a/src/ui/overlay/drawer/index.tsx
+++ b/src/ui/overlay/drawer/index.tsx
@@ -167,11 +167,15 @@ export const Drawer = ({
 	// Modal/Drawer 를 동시에 열거나 중첩해도 카운터가 0 이 될 때만 원래 overflow 를 복원해
 	// 스크롤 잠금 오작동/원래 스타일 유실을 막는다.
 	React.useEffect(() => {
-		if (!open) return;
+		// `open` 이 아니라 `shouldRender` 에 묶는다. `open` 기준이면 닫기 시작 즉시 cleanup 이
+		// 돌아 `scrollbar-gutter` 와 `padding-right` 보정이 풀리는데, 오버레이는 퇴출
+		// 애니메이션이 끝날 때까지(= shouldRender false) 계속 렌더된다. 그 구간에서 ICB 가
+		// 거터만큼 줄어 오버레이가 거터를 못 덮고(빈 띠) 배경 콘텐츠가 그만큼 튄다.
+		if (!shouldRender) return;
 
 		lockBodyScroll();
 		return unlockBodyScroll;
-	}, [open]);
+	}, [shouldRender]);
 
 	// open 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
 	// panelRef.current 가 이미 붙어 있어 포커스 트랩이 정상 활성화된다. shouldRender 만 보면

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -3,6 +3,21 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Modal } from "./index";
 
+const stubReducedMotion = () => {
+	vi.stubGlobal(
+		"matchMedia",
+		vi.fn().mockImplementation((query: string) => ({
+			matches: query.includes("prefers-reduced-motion"),
+			media: query,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	);
+};
+
 describe("Modal", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
@@ -147,7 +162,7 @@ describe("Modal", () => {
 		expect(panel).toHaveClass("custom-modal");
 	});
 
-	it("keeps scroll locked when one of multiple open modals is closed", () => {
+	it("keeps scroll locked when one of multiple open modals is closed", async () => {
 		const { rerender } = render(
 			<>
 				<Modal open onClose={() => {}}>
@@ -176,7 +191,51 @@ describe("Modal", () => {
 
 		// First modal still open - scroll must remain locked
 		expect(document.body.style.overflow).toBe("hidden");
-		expect(document.body.dataset.openModals).toBe("1");
+		// 닫힌 모달도 퇴출 애니메이션 동안 계속 렌더되므로 그 잠금이 아직 살아 있다.
+		// 닫기 시작 즉시 풀면 `scrollbar-gutter` 보정이 사라져 거터에 빈 띠가 보인다.
+		expect(document.body.dataset.openModals).toBe("2");
+
+		// 두 번째의 퇴출이 끝나면 카운터가 내려가고, 첫 번째 잠금은 그대로 남는다.
+		await waitFor(() => expect(document.body.dataset.openModals).toBe("1"));
+		expect(document.body.style.overflow).toBe("hidden");
+	});
+
+	it("releases the scroll lock when unmounted while still open", () => {
+		// 전역 스택은 `{mounted && <Modal open />}` 로 붙였다 떼는 경우가 있다. 잠금이
+		// `shouldRender` 에 묶여 있어도 unmount 시 effect cleanup 이 돌아야 풀린다.
+		const { unmount } = render(
+			<Modal open onClose={() => {}}>
+				Body
+			</Modal>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		unmount();
+
+		expect(document.body.style.overflow).not.toBe("hidden");
+		expect(document.body.dataset.openModals).toBeUndefined();
+	});
+
+	it("releases the scroll lock under reduced motion", async () => {
+		// 잠금이 `shouldRender` 에 묶여 있으므로, 퇴출 완료 콜백이 발화하지 않으면 페이지가
+		// 영구히 잠긴다. reduced-motion 은 `immediate: true` 로 스프링을 점프시키는 경로라
+		// onRest 가 도는지 따로 확인한다.
+		stubReducedMotion();
+		const { rerender } = render(
+			<Modal open onClose={() => {}}>
+				Body
+			</Modal>,
+		);
+		expect(document.body.style.overflow).toBe("hidden");
+
+		rerender(
+			<Modal open={false} onClose={() => {}}>
+				Body
+			</Modal>,
+		);
+
+		await waitFor(() => expect(document.body.style.overflow).not.toBe("hidden"));
+		expect(document.body.dataset.openModals).toBeUndefined();
 	});
 
 	it("activates the focus trap when toggled open after mounting closed", () => {

--- a/src/ui/overlay/modal/Modal.test.tsx
+++ b/src/ui/overlay/modal/Modal.test.tsx
@@ -220,6 +220,11 @@ describe("Modal", () => {
 		// 잠금이 `shouldRender` 에 묶여 있으므로, 퇴출 완료 콜백이 발화하지 않으면 페이지가
 		// 영구히 잠긴다. reduced-motion 은 `immediate: true` 로 스프링을 점프시키는 경로라
 		// onRest 가 도는지 따로 확인한다.
+		// setup.ts 가 스위트 전체에 skipAnimation 을 걸어 두면 어떤 스프링이든 즉시 끝나
+		// 일반 종료 테스트와 같은 경로가 된다. 여기서만 끄고 `immediate: reduced` 가 실제로
+		// 도는 경로를 태운다. (그 플래그를 지우는 뮤테이션까지 잡지는 못한다 - 스프링이
+		// 애니메이션으로 끝나도 waitFor 안에 들어오기 때문이다.)
+		Globals.assign({ skipAnimation: false });
 		stubReducedMotion();
 		const { rerender } = render(
 			<Modal open onClose={() => {}}>
@@ -236,6 +241,8 @@ describe("Modal", () => {
 
 		await waitFor(() => expect(document.body.style.overflow).not.toBe("hidden"));
 		expect(document.body.dataset.openModals).toBeUndefined();
+
+		Globals.assign({ skipAnimation: true });
 	});
 
 	it("activates the focus trap when toggled open after mounting closed", () => {

--- a/src/ui/overlay/modal/index.tsx
+++ b/src/ui/overlay/modal/index.tsx
@@ -175,11 +175,15 @@ export const Modal = ({
 
 	// 바디 스크롤 잠금(중첩 모달 지원)
 	React.useEffect(() => {
-		if (!open) return;
+		// `open` 이 아니라 `shouldRender` 에 묶는다. `open` 기준이면 닫기 시작 즉시 cleanup 이
+		// 돌아 `scrollbar-gutter` 와 `padding-right` 보정이 풀리는데, 오버레이는 퇴출
+		// 애니메이션이 끝날 때까지(= shouldRender false) 계속 렌더된다. 그 구간에서 ICB 가
+		// 거터만큼 줄어 오버레이가 거터를 못 덮고(빈 띠) 배경 콘텐츠가 그만큼 튄다.
+		if (!shouldRender) return;
 
 		lockBodyScroll();
 		return unlockBodyScroll;
-	}, [open]);
+	}, [shouldRender]);
 
 	// open 이 true 로 바뀌는 렌더에서 패널을 즉시 마운트해야 useFocusTrap effect 실행 시점에
 	// panelRef.current 가 이미 붙어 있어 포커스 트랩이 정상 활성화된다. shouldRender 만 보면

--- a/src/vanilla/bigtablet.scss
+++ b/src/vanilla/bigtablet.scss
@@ -1020,6 +1020,11 @@
 
   &.is-open {
     display: grid;
+    // 암묵 트랙은 auto - 즉 패널의 max-content 로 커진다. 그러면 패널의
+    // `max-width: calc(100% - 32px)` 가 뷰포트가 아니라 그 트랙 기준으로 풀려 전혀 clamp 되지
+    // 않는다. 실측 - 375px 화면에서 `width: 480px` 를 준 패널이 우측으로 89px 잘렸다.
+    // React 쪽 `.modal` 과 같은 수정이다.
+    grid-template-columns: minmax(0, 1fr);
   }
 
   &__panel {


### PR DESCRIPTION
## 작업 개요

3.15.2 패치 릴리즈. `merge: release v3.15.2`.

Closes #541.

**patch 인 이유** — `git diff v3.15.1..develop -- src/index.ts src/styles` 가 비어 있다. 바뀐 것은 컴포넌트 내부 effect deps, Vanilla SCSS 한 줄, 검사 스크립트뿐이다.

## 작업한 내용

- [x] #541 — 오버레이가 닫히는 동안 스크롤 잠금이 먼저 풀리던 버그 (PR #542). `Modal`·`Drawer` 의 잠금 effect 가 `[open]` 에 묶여 있어 퇴출 애니메이션 구간에서 `scrollbar-gutter` 보정과 `padding-right` 가 사라졌다. `AlertModal` 과 같은 `[shouldRender]` 로 맞췄다
- [x] #541 — Vanilla `.bt-modal` 트랙 제약. #529 를 React 에만 적용했던 것의 형제 수정
- [x] 재발 방지 — `check:geometry` 가 잠금 effect 의 deps·cleanup(소비처는 소스에서 탐색)과 두 번들의 grid 트랙을 검사한다
- [x] `package.json` 3.15.1 → 3.15.2
- [x] `CHANGELOG.md` 3.15.2 항목 추가

## 검증

develop 최신에서 전 게이트를 직접 돌렸다.

- 단위 **933 passed** / 9 skipped, storybook a11y **299 passed**
- `tsc --noEmit` 0, `build` 통과, `lint:css` 0
- `check:prose` · `check:css-vars` · `check:defaults` · `check:geometry` 전부 통과

### Chromium end-to-end (1600x900, 거터 15px, `scrollbar-gutter: stable`)

퇴출 애니메이션 중(`open=false`, panel opacity 0)에도 gutter `auto` · `padding-right: 31px` · 오버레이 폭 **1600**(= `innerWidth`) 유지. 수정 전에는 이 구간에서 gutter 가 `stable` 로 복원되고 오버레이가 1585 로 줄었다.

### Vanilla 오버플로 (375px)

트랙 `480px` → `375px`, 패널 448 → 343, 우측 잘림 **89px → 없음**.

### 뮤테이션 6/6 사망

Modal·Drawer deps 되돌림, 소비처 탐색 축소(canary), Vanilla 트랙 제거, cleanup 반환 제거, 잠금 소비처 목록 하드코딩 회귀.
