### PR TITLE
feat/textarea-toolbar

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -524,6 +524,7 @@ Pretendard 의 `cv05`(l 에 꼬리) · `cv08`(I 에 세리프) 와 `slashed-zero
 | `maxLength` | `number` | - | 최대 글자 수 |
 | `showCounter` | `boolean` | `false` | 글자 수 카운터 표시 (`maxLength` 와 함께 권장) |
 | `resize` | `'none' \| 'vertical' \| 'both'` | `'vertical'` | resize 핸들 (auto-grow 시 무시) |
+| `toolbar` | `ReactNode` | - | 입력 위, **테두리 안쪽** 슬롯. 서식 툴바처럼 입력과 한 박스로 보여야 하는 컨트롤용. 포커스 테두리가 툴바까지 감싸고 하단 구분선은 DS 가 긋는다 |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
 | `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 |
 | `imeStrategy` | `'delayed' \| 'immediate'` | `'delayed'` | IME 조합 중 콜백 전략 |

--- a/src/ui/forms/textarea/Textarea.test.tsx
+++ b/src/ui/forms/textarea/Textarea.test.tsx
@@ -157,4 +157,44 @@ describe("Textarea", () => {
 		expect(onValueChange).toHaveBeenCalledWith("ㅎ");
 		expect(onChangeAction).not.toHaveBeenCalled();
 	});
+
+	// ── toolbar 슬롯 ────────────────────────────────────────────────────────
+
+	describe("toolbar", () => {
+		it("renders nothing extra when no toolbar is given", () => {
+			const { container } = render(<Textarea label="설명" />);
+
+			expect(container.querySelector(".textarea_toolbar")).toBeNull();
+			// 컨테이너의 자식은 입력 wrap 하나뿐 - 기존 DOM 과 동일하다.
+			const box = container.querySelector(".textarea_container");
+			expect(box?.children).toHaveLength(1);
+			expect(box?.firstElementChild).toHaveClass("textarea_input_wrap");
+		});
+
+		it("puts the toolbar inside the container, above the input", () => {
+			// 컨테이너가 품어야 :focus-within 테두리가 툴바까지 감싼다. 밖에 두면 소비자가
+			// 모서리와 포커스 링을 직접 맞춰야 했다.
+			const { container } = render(
+				<Textarea label="설명" toolbar={<button type="button">굵게</button>} />,
+			);
+
+			const box = container.querySelector(".textarea_container");
+			expect(box?.children).toHaveLength(2);
+			expect(box?.firstElementChild).toHaveClass("textarea_toolbar");
+			expect(box?.lastElementChild).toHaveClass("textarea_input_wrap");
+			expect(screen.getByRole("button", { name: "굵게" })).toBeInTheDocument();
+		});
+
+		it("keeps the toolbar inside the disabled dimming", () => {
+			// `.textarea_disabled .textarea_container > *` 가 직접 자식만 흐리게 한다.
+			// 툴바가 컨테이너 직계여야 입력과 같이 흐려진다.
+			const { container } = render(
+				<Textarea label="설명" disabled toolbar={<button type="button">굵게</button>} />,
+			);
+
+			const toolbar = container.querySelector(".textarea_toolbar");
+			expect(toolbar?.parentElement).toHaveClass("textarea_container");
+			expect(container.querySelector(".textarea")).toHaveClass("textarea_disabled");
+		});
+	});
 });

--- a/src/ui/forms/textarea/Textarea.test.tsx
+++ b/src/ui/forms/textarea/Textarea.test.tsx
@@ -185,6 +185,20 @@ describe("Textarea", () => {
 			expect(screen.getByRole("button", { name: "굵게" })).toBeInTheDocument();
 		});
 
+		it("blocks interaction with the toolbar while disabled", () => {
+			// `_disabled` 스타일은 opacity 만 걸고 pointer-events 는 건드리지 않는다. inert 가
+			// 없으면 비활성 필드의 툴바 버튼이 계속 포커스·클릭된다.
+			// (jsdom 은 inert 의 포커스 차단을 구현하지 않아 속성 존재로 고정한다 - 실제 차단은
+			//  Chromium 실측으로 확인했다.)
+			const { container, rerender } = render(
+				<Textarea label="설명" disabled toolbar={<button type="button">굵게</button>} />,
+			);
+			expect(container.querySelector(".textarea_toolbar")).toHaveAttribute("inert");
+
+			rerender(<Textarea label="설명" toolbar={<button type="button">굵게</button>} />);
+			expect(container.querySelector(".textarea_toolbar")).not.toHaveAttribute("inert");
+		});
+
 		it("keeps the toolbar inside the disabled dimming", () => {
 			// `.textarea_disabled .textarea_container > *` 가 직접 자식만 흐리게 한다.
 			// 툴바가 컨테이너 직계여야 입력과 같이 흐려진다.

--- a/src/ui/forms/textarea/index.tsx
+++ b/src/ui/forms/textarea/index.tsx
@@ -54,6 +54,12 @@ export interface TextareaProps
 	showCounter?: boolean;
 	/** resize 핸들 제어 (기본 "vertical") */
 	resize?: TextareaResize;
+	/**
+	 * 입력 영역 위, **테두리 안쪽**에 붙는 슬롯. 서식 툴바처럼 입력과 한 박스로 보여야 하는
+	 * 컨트롤을 넣는다. 컨테이너가 품으므로 `:focus-within` 테두리가 툴바까지 감싸고, 모서리와
+	 * 구분선을 DS 가 처리한다. 미지정 시 DOM·스타일이 이전과 동일하다.
+	 */
+	toolbar?: React.ReactNode;
 	/** textarea 요소 참조 */
 	ref?: React.Ref<HTMLTextAreaElement>;
 }
@@ -94,6 +100,7 @@ export const Textarea = ({
 	maxRows,
 	showCounter,
 	resize = "vertical",
+	toolbar,
 	maxLength,
 	ref,
 	...props
@@ -188,6 +195,7 @@ export const Textarea = ({
 			)}
 
 			<div className="textarea_container">
+				{toolbar && <div className="textarea_toolbar">{toolbar}</div>}
 				<div className="textarea_input_wrap">
 					<textarea
 						id={inputId}

--- a/src/ui/forms/textarea/index.tsx
+++ b/src/ui/forms/textarea/index.tsx
@@ -195,7 +195,15 @@ export const Textarea = ({
 			)}
 
 			<div className="textarea_container">
-				{toolbar && <div className="textarea_toolbar">{toolbar}</div>}
+				{/* 비활성 필드의 툴바는 상호작용도 막는다 - `_disabled` 스타일은 컨테이너 자식에
+				    opacity 만 걸고 pointer-events 는 건드리지 않아(TextField 와 동일), 없으면
+				    비활성 상태에서도 툴바 버튼이 포커스·클릭된다. `toolbar` 는 임의 ReactNode 라
+				    개별 컨트롤에 disabled 를 주입할 수 없으므로 서브트리를 inert 로 막는다. */}
+				{toolbar && (
+					<div className="textarea_toolbar" inert={props.disabled || undefined}>
+						{toolbar}
+					</div>
+				)}
 				<div className="textarea_input_wrap">
 					<textarea
 						id={inputId}

--- a/src/ui/forms/textarea/style.scss
+++ b/src/ui/forms/textarea/style.scss
@@ -46,6 +46,22 @@
     }
   }
 
+  // ── Toolbar (toolbar prop 이 있을 때만) ────────────────────────────────
+  //
+  // 컨테이너 **안**, 입력 위에 놓인다. 그래야 `:focus-within` 테두리가 툴바까지 감싸고
+  // 소비자가 모서리를 손으로 맞출 필요가 없다.
+  //
+  // 배경을 주지 않는다. 배경을 주면 컨테이너의 12px 모서리를 사각으로 덮어 `overflow: hidden`
+  // 이 필요해지는데, 그러면 textarea 의 resize 핸들이 잘린다. 구분선 하나로 충분하다.
+  &_toolbar {
+    display: flex;
+    align-items: center;
+    gap: token.$spacing_4;
+    flex-wrap: wrap;
+    padding: token.$spacing_8 token.$spacing_16; // md 기본 - input wrap 과 좌우를 맞춘다
+    @include token.hairline(bottom);
+  }
+
   // ── Input wrap ─────────────────────────────────────────────────────────
 
   &_input_wrap {
@@ -79,7 +95,8 @@
 
   // ── Size variants ──────────────────────────────────────────────────────
 
-  &_size_sm &_input_wrap {
+  &_size_sm &_input_wrap,
+  &_size_sm &_toolbar {
     padding: token.$spacing_8 token.$spacing_16;
   }
 
@@ -88,7 +105,8 @@
     line-height: token.$line_height_20;
   }
 
-  &_size_lg &_input_wrap {
+  &_size_lg &_input_wrap,
+  &_size_lg &_toolbar {
     padding: token.$spacing_12 token.$spacing_20;
   }
 

--- a/src/ui/forms/textarea/textarea.stories.tsx
+++ b/src/ui/forms/textarea/textarea.stories.tsx
@@ -135,6 +135,37 @@ export const Sizes: Story = {
 	),
 };
 
+export const ToolbarDisabled: Story = {
+	name: "서식 툴바 - 비활성",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"필드가 `disabled` 면 툴바도 흐려지고 **상호작용이 막힌다**(`inert`). 흐려지기만 하면 비활성 필드에서도 버튼이 포커스·클릭돼 보이는 상태와 동작이 어긋난다.",
+			},
+		},
+	},
+	render: () => (
+		<div style={{ width: 420 }}>
+			<Textarea
+				label="공지 내용"
+				fullWidth
+				disabled
+				rows={3}
+				placeholder="비활성"
+				toolbar={
+					<IconButton
+						aria-label="굵게"
+						size="sm"
+						variant="standard"
+						icon={<Bold size={iconSize.sm} />}
+					/>
+				}
+			/>
+		</div>
+	),
+};
+
 export const WithToolbar: Story = {
 	name: "서식 툴바 (toolbar 슬롯)",
 	parameters: {

--- a/src/ui/forms/textarea/textarea.stories.tsx
+++ b/src/ui/forms/textarea/textarea.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Bold, Italic, Underline } from "lucide-react";
 import * as React from "react";
+import { iconSize } from "../../../styles/icon";
+import { IconButton } from "../../general/icon-button";
 import { Textarea } from ".";
 
 const meta: Meta<typeof Textarea> = {
@@ -128,6 +131,51 @@ export const Sizes: Story = {
 			<Textarea label="Small" size="sm" rows={2} fullWidth placeholder="sm" />
 			<Textarea label="Medium" size="md" rows={2} fullWidth placeholder="md" />
 			<Textarea label="Large" size="lg" rows={2} fullWidth placeholder="lg" />
+		</div>
+	),
+};
+
+export const WithToolbar: Story = {
+	name: "서식 툴바 (toolbar 슬롯)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"`toolbar` 는 테두리 **안쪽**, 입력 위에 렌더된다. 컨테이너가 품으므로 포커스 테두리가 툴바까지 감싸고 모서리·구분선을 DS 가 처리한다. 밖에 두면 소비자가 컨테이너 모서리를 깎고 포커스 링을 따로 걸어야 했다.",
+			},
+		},
+	},
+	render: () => (
+		<div style={{ width: 420 }}>
+			<Textarea
+				label="공지 내용"
+				fullWidth
+				minRows={4}
+				maxRows={10}
+				placeholder="내용을 입력하세요"
+				toolbar={
+					<>
+						<IconButton
+							aria-label="굵게"
+							size="sm"
+							variant="standard"
+							icon={<Bold size={iconSize.sm} />}
+						/>
+						<IconButton
+							aria-label="기울임"
+							size="sm"
+							variant="standard"
+							icon={<Italic size={iconSize.sm} />}
+						/>
+						<IconButton
+							aria-label="밑줄"
+							size="sm"
+							variant="standard"
+							icon={<Underline size={iconSize.sm} />}
+						/>
+					</>
+				}
+			/>
 		</div>
 	),
 };


### PR DESCRIPTION
## 작업 개요

Closes #544.

`toolbar?: ReactNode` 슬롯을 추가한다. 이슈가 적은 내부 구조 의존 3곳이 전부 사라진다 — 컨테이너가 툴바를 품으므로 모서리·구분선·포커스 표시가 DS 쪽으로 넘어온다.

이슈의 구조 제안을 그대로 따랐다. 한 가지만 다르게 했다 — **툴바에 배경을 주지 않았다**(아래 근거).

## 작업한 내용

- [x] `TextareaProps` 에 `toolbar?: ReactNode`
- [x] `.textarea_container` 안, `.textarea_input_wrap` **위**에 렌더 (`toolbar` 가 있을 때만)
- [x] 하단 구분선은 `token.hairline(bottom)`
- [x] `size` 별 좌우 패딩을 `input_wrap` 과 공유 — `sm`/`md` 8·16, `lg` 12·20
- [x] `toolbar` 미지정 시 DOM 동일함을 테스트로 고정
- [x] `disabled` 전파 확인 — 툴바가 컨테이너 직계라 `.textarea_disabled .textarea_container > *` 의 `opacity: 0.38` 을 그대로 받는다
- [x] 스토리 + `docs/COMPONENTS.md` prop 표

## 검증

### 브라우저 실측 (Storybook)

| 항목 | 값 |
| --- | --- |
| 툴바가 컨테이너 직계인가 | true |
| 입력 wrap 이 툴바 아래인가 | true |
| 컨테이너 좌우 대비 툴바 inset | 1px / 1px (= border 두께, 정확히 안쪽) |
| 구분선 | `1px solid var(--bt-color-border-default)` |
| 툴바 패딩 / 입력 패딩 | `8px 16px` / `8px 16px` (일치) |
| 컨테이너 반경 | 12px (툴바가 덮지 않음) |

### 배경을 주지 않은 이유

배경을 주면 컨테이너의 12px 모서리를 사각으로 덮어 `overflow: hidden` 이 필요해진다. 그런데 컨테이너에 `overflow: hidden` 을 걸면 **textarea 의 resize 핸들이 잘린다**. 구분선만으로 충분하고 모서리 문제가 사라진다.

### 뮤테이션 2/2 사망

| 심은 위반 | 결과 |
| --- | --- |
| 툴바를 `input_wrap` 안으로 옮김 | killed |
| `toolbar` 없어도 항상 렌더 | killed |

### 그 밖에

- 단위 **936 passed** / 9 skipped (+3), storybook a11y **300 passed** (+1)
- `tsc --noEmit` 0, `build` 통과, `lint:css` 0, `check:prose` · `check:css-vars` · `check:defaults` · `check:geometry` 통과

## 전달할 추가 이슈

**같이 보고받은 `:focus-within` 미적용 건은 이 PR 에 넣지 않았다.** 빌드 CSS 를 전수 분석한 결과 DS 쪽은 정상이다 — `.textarea_container` 에 border 를 거는 규칙 7개 중 일반 상태에 적용되는 것은 3개뿐이고 `:focus-within`(0,2,0)이 마지막이라 이긴다. TextField 와 선택자 모양·순서가 같다.

브라우저 실측은 못 했다. 이 환경의 창이 OS 포커스를 못 잡아 `document.hasFocus()` 가 false 이고, 그 상태에서는 `:focus-within` 스타일이 평가되지 않는다(빨간 규칙을 직접 주입해도 안 먹는 것으로 확인).

소비자 쪽에서 **실제로 이긴 규칙**을 확인해야 한다. 이 PR 이 그 override 자체를 없애므로, 슬롯으로 옮기고 나서도 남으면 그때 DS 버그로 다시 보겠다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Textarea 상단에 서식 도구 모음을 표시할 수 있는 `toolbar` 슬롯을 추가했습니다.
  * 도구 모음이 입력 영역과 하나의 컴포넌트처럼 표시되며, 크기별 여백과 구분선을 지원합니다.
  * 굵게, 기울임, 밑줄 버튼을 활용한 사용 예시를 추가했습니다.

* **문서**
  * Textarea의 `toolbar` 속성 사용 방법과 동작을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->