### PR TITLE
merge: release v3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 이 문서는 [GitHub Releases](https://github.com/Bigtablet/bigtablet-design-system/releases) 를 기준으로 정리됩니다. 릴리즈는 `v*` 태그 푸시로 배포됩니다.
 
+## [3.16.0](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.16.0) - 2026-08-25
+- `Textarea` 에 `toolbar` 슬롯을 추가했습니다. 서식 툴바를 테두리 안쪽에 넣어 포커스 표시·모서리·구분선을 DS 가 처리합니다 — 소비자가 내부 클래스를 건드리던 3곳이 사라집니다
+- 비활성 `Textarea` 의 툴바는 흐려질 뿐 아니라 상호작용도 막힙니다
+
 ## [3.15.2](https://github.com/Bigtablet/bigtablet-design-system/releases/tag/v3.15.2) - 2026-08-25
 - 오버레이가 닫히는 동안 스크롤 잠금이 먼저 풀려, `scrollbar-gutter: stable` 환경에서 오른쪽에 빈 띠가 보이고 배경 콘텐츠가 튀던 문제를 고쳤습니다 (`Modal`·`Drawer`)
 - Vanilla 모달이 좁은 화면에서 잘리던 문제를 고쳤습니다 (375px 에서 우측 89px 잘림 — React 는 3.15.0 에서 이미 수정)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,8 +297,10 @@ label/domain
 
 1. **dev→main 릴리즈 PR(`merge: release`)에 아래 셋을 반드시 함께 포함** (별도 커밋으로 미루지 말 것):
    - `package.json` `version` bump (SemVer). 공개 API 기준은 `package.json` `exports`의 모든 표면 - React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
-     - **렌더 결과가 바뀌면 API 변화가 없어도 minor** - 기존 컴포넌트의 굵기·간격·위치·기본 크기가 달라지는 변경. 버그 수정이라도 소비자 화면이 바뀌면 patch 로 내보내지 않는다(`~3.14.0` 같은 범위로 받는 앱이 자동으로 끌어간다). CHANGELOG 항목 앞에 `(렌더 변경)` 을 붙인다.
-       예 - Prose 제목 굵기 400→700(3.14.1), Modal close 버튼 위치 20px 이동(3.15.0), Vanilla 모달 폭 clamp(3.15.2). 셋 다 API 는 그대로였다.
+     - **렌더 결과가 바뀌는 변경은 의도로 가른다.** API 가 그대로여도 소비자 화면은 바뀌므로 CHANGELOG 항목 앞에 **`(렌더 변경)` 을 반드시 붙인다** - 버전과 무관하게.
+       - **결함 수정**(지금 렌더가 틀렸다) → **patch**. `~3.16.0` 처럼 patch 만 받는 앱에도 수정이 닿아야 한다. minor 로 올리면 가장 보수적으로 고정한 소비자가 그 수정을 못 받는다.
+         예 - Prose `h1` 이 `h3` 보다 가늘던 것(3.14.1), close 버튼이 내용 열 밖 20px(3.15.0), Vanilla 모달이 375px 에서 잘림(3.15.2).
+       - **의도적 디자인 변경**(지금도 틀리지 않았는데 다르게 바꾼다) → **minor**. 기본 size·간격 스케일·컴포넌트 재디자인 등. 받을지를 소비자가 고르게 한다.
    - `CHANGELOG.md` 맨 위에 새 버전 섹션 추가 (아래 양식, semver 내림차순 유지).
    - **이번 릴리즈에 담긴 모든 이슈의 `Closes #NNN`** 을 `## 작업 개요` 에 나열. `Closes #` 는 기본 브랜치(main) 머지에서만 발동하는데 feature PR 은 전부 `develop` 대상이라, feature PR 본문에 써 둔 것은 이슈를 닫지 못한다. 배포 후 `gh issue list --state open` 으로 실제로 닫혔는지 확인한다.
 2. 리뷰어 approve 후 머지.
@@ -312,7 +314,7 @@ label/domain
 - 핵심 변경 2
 ```
 - 주요 업데이트 불릿만 - 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
-- 렌더 결과가 바뀐 항목은 `- (렌더 변경) ...` 로 시작한다 - 소비자가 화면 확인이 필요한 줄을 한눈에 찾게.
+- 렌더 결과가 바뀐 항목은 `- (렌더 변경) ...` 로 시작한다 - 결함 수정이든 의도적 변경이든, 소비자가 화면 확인이 필요한 줄을 한눈에 찾게.
 - 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
 **GitHub Release 노트는 조직 공통 양식 필수** - 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG의 해당 버전 주요 업데이트를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (제목 = `Design System of Bigtablet, Inc.`, `##` 제목과 `####` 사이 빈 줄 없음):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,9 +295,12 @@ label/domain
 ### Release & Changelog
 **태그 기반 배포** - semantic-release / changeset 미사용. 절차:
 
-1. **dev→main 릴리즈 PR(`merge: release`)에 아래 둘을 반드시 함께 포함** (별도 커밋으로 미루지 말 것):
+1. **dev→main 릴리즈 PR(`merge: release`)에 아래 셋을 반드시 함께 포함** (별도 커밋으로 미루지 말 것):
    - `package.json` `version` bump (SemVer). 공개 API 기준은 `package.json` `exports`의 모든 표면 - React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+     - **렌더 결과가 바뀌면 API 변화가 없어도 minor** - 기존 컴포넌트의 굵기·간격·위치·기본 크기가 달라지는 변경. 버그 수정이라도 소비자 화면이 바뀌면 patch 로 내보내지 않는다(`~3.14.0` 같은 범위로 받는 앱이 자동으로 끌어간다). CHANGELOG 항목 앞에 `(렌더 변경)` 을 붙인다.
+       예 - Prose 제목 굵기 400→700(3.14.1), Modal close 버튼 위치 20px 이동(3.15.0), Vanilla 모달 폭 clamp(3.15.2). 셋 다 API 는 그대로였다.
    - `CHANGELOG.md` 맨 위에 새 버전 섹션 추가 (아래 양식, semver 내림차순 유지).
+   - **이번 릴리즈에 담긴 모든 이슈의 `Closes #NNN`** 을 `## 작업 개요` 에 나열. `Closes #` 는 기본 브랜치(main) 머지에서만 발동하는데 feature PR 은 전부 `develop` 대상이라, feature PR 본문에 써 둔 것은 이슈를 닫지 못한다. 배포 후 `gh issue list --state open` 으로 실제로 닫혔는지 확인한다.
 2. 리뷰어 approve 후 머지.
 3. main 에서 `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`.
 4. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성.
@@ -309,6 +312,7 @@ label/domain
 - 핵심 변경 2
 ```
 - 주요 업데이트 불릿만 - 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
+- 렌더 결과가 바뀐 항목은 `- (렌더 변경) ...` 로 시작한다 - 소비자가 화면 확인이 필요한 줄을 한눈에 찾게.
 - 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
 **GitHub Release 노트는 조직 공통 양식 필수** - 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG의 해당 버전 주요 업데이트를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (제목 = `Design System of Bigtablet, Inc.`, `##` 제목과 `####` 사이 빈 줄 없음):

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -524,6 +524,7 @@ Pretendard 의 `cv05`(l 에 꼬리) · `cv08`(I 에 세리프) 와 `slashed-zero
 | `maxLength` | `number` | - | 최대 글자 수 |
 | `showCounter` | `boolean` | `false` | 글자 수 카운터 표시 (`maxLength` 와 함께 권장) |
 | `resize` | `'none' \| 'vertical' \| 'both'` | `'vertical'` | resize 핸들 (auto-grow 시 무시) |
+| `toolbar` | `ReactNode` | - | 입력 위, **테두리 안쪽** 슬롯. 서식 툴바처럼 입력과 한 박스로 보여야 하는 컨트롤용. 포커스 테두리가 툴바까지 감싸고 하단 구분선은 DS 가 긋는다 |
 | `fullWidth` | `boolean` | `false` | 전체 너비 |
 | `onValueChange` | `(value: string) => void` | - | 값 변경 콜백 |
 | `imeStrategy` | `'delayed' \| 'immediate'` | `'delayed'` | IME 조합 중 콜백 전략 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bigtablet/design-system",
-	"version": "3.15.2",
+	"version": "3.16.0",
 	"description": "Bigtablet Design System UI Components",
 	"type": "module",
 	"types": "dist/index.d.ts",

--- a/src/ui/forms/textarea/Textarea.test.tsx
+++ b/src/ui/forms/textarea/Textarea.test.tsx
@@ -157,4 +157,44 @@ describe("Textarea", () => {
 		expect(onValueChange).toHaveBeenCalledWith("ㅎ");
 		expect(onChangeAction).not.toHaveBeenCalled();
 	});
+
+	// ── toolbar 슬롯 ────────────────────────────────────────────────────────
+
+	describe("toolbar", () => {
+		it("renders nothing extra when no toolbar is given", () => {
+			const { container } = render(<Textarea label="설명" />);
+
+			expect(container.querySelector(".textarea_toolbar")).toBeNull();
+			// 컨테이너의 자식은 입력 wrap 하나뿐 - 기존 DOM 과 동일하다.
+			const box = container.querySelector(".textarea_container");
+			expect(box?.children).toHaveLength(1);
+			expect(box?.firstElementChild).toHaveClass("textarea_input_wrap");
+		});
+
+		it("puts the toolbar inside the container, above the input", () => {
+			// 컨테이너가 품어야 :focus-within 테두리가 툴바까지 감싼다. 밖에 두면 소비자가
+			// 모서리와 포커스 링을 직접 맞춰야 했다.
+			const { container } = render(
+				<Textarea label="설명" toolbar={<button type="button">굵게</button>} />,
+			);
+
+			const box = container.querySelector(".textarea_container");
+			expect(box?.children).toHaveLength(2);
+			expect(box?.firstElementChild).toHaveClass("textarea_toolbar");
+			expect(box?.lastElementChild).toHaveClass("textarea_input_wrap");
+			expect(screen.getByRole("button", { name: "굵게" })).toBeInTheDocument();
+		});
+
+		it("keeps the toolbar inside the disabled dimming", () => {
+			// `.textarea_disabled .textarea_container > *` 가 직접 자식만 흐리게 한다.
+			// 툴바가 컨테이너 직계여야 입력과 같이 흐려진다.
+			const { container } = render(
+				<Textarea label="설명" disabled toolbar={<button type="button">굵게</button>} />,
+			);
+
+			const toolbar = container.querySelector(".textarea_toolbar");
+			expect(toolbar?.parentElement).toHaveClass("textarea_container");
+			expect(container.querySelector(".textarea")).toHaveClass("textarea_disabled");
+		});
+	});
 });

--- a/src/ui/forms/textarea/Textarea.test.tsx
+++ b/src/ui/forms/textarea/Textarea.test.tsx
@@ -185,6 +185,20 @@ describe("Textarea", () => {
 			expect(screen.getByRole("button", { name: "굵게" })).toBeInTheDocument();
 		});
 
+		it("blocks interaction with the toolbar while disabled", () => {
+			// `_disabled` 스타일은 opacity 만 걸고 pointer-events 는 건드리지 않는다. inert 가
+			// 없으면 비활성 필드의 툴바 버튼이 계속 포커스·클릭된다.
+			// (jsdom 은 inert 의 포커스 차단을 구현하지 않아 속성 존재로 고정한다 - 실제 차단은
+			//  Chromium 실측으로 확인했다.)
+			const { container, rerender } = render(
+				<Textarea label="설명" disabled toolbar={<button type="button">굵게</button>} />,
+			);
+			expect(container.querySelector(".textarea_toolbar")).toHaveAttribute("inert");
+
+			rerender(<Textarea label="설명" toolbar={<button type="button">굵게</button>} />);
+			expect(container.querySelector(".textarea_toolbar")).not.toHaveAttribute("inert");
+		});
+
 		it("keeps the toolbar inside the disabled dimming", () => {
 			// `.textarea_disabled .textarea_container > *` 가 직접 자식만 흐리게 한다.
 			// 툴바가 컨테이너 직계여야 입력과 같이 흐려진다.

--- a/src/ui/forms/textarea/index.tsx
+++ b/src/ui/forms/textarea/index.tsx
@@ -54,6 +54,12 @@ export interface TextareaProps
 	showCounter?: boolean;
 	/** resize 핸들 제어 (기본 "vertical") */
 	resize?: TextareaResize;
+	/**
+	 * 입력 영역 위, **테두리 안쪽**에 붙는 슬롯. 서식 툴바처럼 입력과 한 박스로 보여야 하는
+	 * 컨트롤을 넣는다. 컨테이너가 품으므로 `:focus-within` 테두리가 툴바까지 감싸고, 모서리와
+	 * 구분선을 DS 가 처리한다. 미지정 시 DOM·스타일이 이전과 동일하다.
+	 */
+	toolbar?: React.ReactNode;
 	/** textarea 요소 참조 */
 	ref?: React.Ref<HTMLTextAreaElement>;
 }
@@ -94,6 +100,7 @@ export const Textarea = ({
 	maxRows,
 	showCounter,
 	resize = "vertical",
+	toolbar,
 	maxLength,
 	ref,
 	...props
@@ -188,6 +195,7 @@ export const Textarea = ({
 			)}
 
 			<div className="textarea_container">
+				{toolbar && <div className="textarea_toolbar">{toolbar}</div>}
 				<div className="textarea_input_wrap">
 					<textarea
 						id={inputId}

--- a/src/ui/forms/textarea/index.tsx
+++ b/src/ui/forms/textarea/index.tsx
@@ -195,7 +195,15 @@ export const Textarea = ({
 			)}
 
 			<div className="textarea_container">
-				{toolbar && <div className="textarea_toolbar">{toolbar}</div>}
+				{/* 비활성 필드의 툴바는 상호작용도 막는다 - `_disabled` 스타일은 컨테이너 자식에
+				    opacity 만 걸고 pointer-events 는 건드리지 않아(TextField 와 동일), 없으면
+				    비활성 상태에서도 툴바 버튼이 포커스·클릭된다. `toolbar` 는 임의 ReactNode 라
+				    개별 컨트롤에 disabled 를 주입할 수 없으므로 서브트리를 inert 로 막는다. */}
+				{toolbar && (
+					<div className="textarea_toolbar" inert={props.disabled || undefined}>
+						{toolbar}
+					</div>
+				)}
 				<div className="textarea_input_wrap">
 					<textarea
 						id={inputId}

--- a/src/ui/forms/textarea/style.scss
+++ b/src/ui/forms/textarea/style.scss
@@ -46,6 +46,22 @@
     }
   }
 
+  // ── Toolbar (toolbar prop 이 있을 때만) ────────────────────────────────
+  //
+  // 컨테이너 **안**, 입력 위에 놓인다. 그래야 `:focus-within` 테두리가 툴바까지 감싸고
+  // 소비자가 모서리를 손으로 맞출 필요가 없다.
+  //
+  // 배경을 주지 않는다. 배경을 주면 컨테이너의 12px 모서리를 사각으로 덮어 `overflow: hidden`
+  // 이 필요해지는데, 그러면 textarea 의 resize 핸들이 잘린다. 구분선 하나로 충분하다.
+  &_toolbar {
+    display: flex;
+    align-items: center;
+    gap: token.$spacing_4;
+    flex-wrap: wrap;
+    padding: token.$spacing_8 token.$spacing_16; // md 기본 - input wrap 과 좌우를 맞춘다
+    @include token.hairline(bottom);
+  }
+
   // ── Input wrap ─────────────────────────────────────────────────────────
 
   &_input_wrap {
@@ -79,7 +95,8 @@
 
   // ── Size variants ──────────────────────────────────────────────────────
 
-  &_size_sm &_input_wrap {
+  &_size_sm &_input_wrap,
+  &_size_sm &_toolbar {
     padding: token.$spacing_8 token.$spacing_16;
   }
 
@@ -88,7 +105,8 @@
     line-height: token.$line_height_20;
   }
 
-  &_size_lg &_input_wrap {
+  &_size_lg &_input_wrap,
+  &_size_lg &_toolbar {
     padding: token.$spacing_12 token.$spacing_20;
   }
 

--- a/src/ui/forms/textarea/textarea.stories.tsx
+++ b/src/ui/forms/textarea/textarea.stories.tsx
@@ -135,6 +135,37 @@ export const Sizes: Story = {
 	),
 };
 
+export const ToolbarDisabled: Story = {
+	name: "서식 툴바 - 비활성",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"필드가 `disabled` 면 툴바도 흐려지고 **상호작용이 막힌다**(`inert`). 흐려지기만 하면 비활성 필드에서도 버튼이 포커스·클릭돼 보이는 상태와 동작이 어긋난다.",
+			},
+		},
+	},
+	render: () => (
+		<div style={{ width: 420 }}>
+			<Textarea
+				label="공지 내용"
+				fullWidth
+				disabled
+				rows={3}
+				placeholder="비활성"
+				toolbar={
+					<IconButton
+						aria-label="굵게"
+						size="sm"
+						variant="standard"
+						icon={<Bold size={iconSize.sm} />}
+					/>
+				}
+			/>
+		</div>
+	),
+};
+
 export const WithToolbar: Story = {
 	name: "서식 툴바 (toolbar 슬롯)",
 	parameters: {

--- a/src/ui/forms/textarea/textarea.stories.tsx
+++ b/src/ui/forms/textarea/textarea.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Bold, Italic, Underline } from "lucide-react";
 import * as React from "react";
+import { iconSize } from "../../../styles/icon";
+import { IconButton } from "../../general/icon-button";
 import { Textarea } from ".";
 
 const meta: Meta<typeof Textarea> = {
@@ -128,6 +131,51 @@ export const Sizes: Story = {
 			<Textarea label="Small" size="sm" rows={2} fullWidth placeholder="sm" />
 			<Textarea label="Medium" size="md" rows={2} fullWidth placeholder="md" />
 			<Textarea label="Large" size="lg" rows={2} fullWidth placeholder="lg" />
+		</div>
+	),
+};
+
+export const WithToolbar: Story = {
+	name: "서식 툴바 (toolbar 슬롯)",
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"`toolbar` 는 테두리 **안쪽**, 입력 위에 렌더된다. 컨테이너가 품으므로 포커스 테두리가 툴바까지 감싸고 모서리·구분선을 DS 가 처리한다. 밖에 두면 소비자가 컨테이너 모서리를 깎고 포커스 링을 따로 걸어야 했다.",
+			},
+		},
+	},
+	render: () => (
+		<div style={{ width: 420 }}>
+			<Textarea
+				label="공지 내용"
+				fullWidth
+				minRows={4}
+				maxRows={10}
+				placeholder="내용을 입력하세요"
+				toolbar={
+					<>
+						<IconButton
+							aria-label="굵게"
+							size="sm"
+							variant="standard"
+							icon={<Bold size={iconSize.sm} />}
+						/>
+						<IconButton
+							aria-label="기울임"
+							size="sm"
+							variant="standard"
+							icon={<Italic size={iconSize.sm} />}
+						/>
+						<IconButton
+							aria-label="밑줄"
+							size="sm"
+							variant="standard"
+							icon={<Underline size={iconSize.sm} />}
+						/>
+					</>
+				}
+			/>
 		</div>
 	),
 };


### PR DESCRIPTION
## 작업 개요

3.16.0 마이너 릴리즈. `merge: release v3.16.0`.

Closes #544.

**minor 인 이유** — 공개 API 가 늘었다. `TextareaProps` 에 `toolbar?: ReactNode` 가 추가됐다. 제거·이름 변경·기본값 변경은 없고, `toolbar` 미지정 시 DOM·스타일이 3.15.2 와 동일하다.

## 작업한 내용

- [x] #544 — `Textarea` `toolbar` 슬롯 (PR #545). `.textarea_container` 안, 입력 위에 렌더해 포커스 테두리가 툴바까지 감싼다. 소비자가 내부 클래스에 기대던 3곳(컨테이너 모서리 깎기, `radius_lg` 손으로 맞추기, 앱 wrapper 의 `:focus-within` 링)이 사라진다
- [x] 비활성 필드의 툴바에 `inert` — `_disabled` 스타일이 opacity 만 걸어 비활성 상태에서도 툴바 버튼이 포커스·클릭되던 것을 막는다
- [x] `package.json` 3.15.2 → 3.16.0
- [x] `CHANGELOG.md` 3.16.0 항목 추가

## 검증

develop 최신에서 전 게이트를 직접 돌렸다.

- 단위 **937 passed** / 9 skipped, storybook a11y **301 passed**
- `tsc --noEmit` 0, `build` 통과, `lint:css` 0
- `check:prose` · `check:css-vars` · `check:defaults` · `check:geometry` 전부 통과

### Chromium 실측

| 항목 | 값 |
| --- | --- |
| 툴바가 컨테이너 직계 | true |
| 컨테이너 좌우 대비 툴바 inset | 1px / 1px (= border 두께) |
| 툴바 / 입력 패딩 | `8px 16px` / `8px 16px` |
| 비활성 시 `focus()` 후 `activeElement` | `BODY` (차단) |
| 비활성 시 버튼 중심 `elementFromPoint` | `DIV.textarea_container` (히트 테스트 건너뜀) |
| 활성 시 | 포커스·히트 테스트 정상 |

### 뮤테이션 4/4 사망

툴바를 `input_wrap` 안으로, `toolbar` 없어도 항상 렌더, `inert` 제거, 항상 `inert`.
