### PR TITLE
docs/release-convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,8 +297,10 @@ label/domain
 
 1. **dev→main 릴리즈 PR(`merge: release`)에 아래 셋을 반드시 함께 포함** (별도 커밋으로 미루지 말 것):
    - `package.json` `version` bump (SemVer). 공개 API 기준은 `package.json` `exports`의 모든 표면 - React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
-     - **렌더 결과가 바뀌면 API 변화가 없어도 minor** - 기존 컴포넌트의 굵기·간격·위치·기본 크기가 달라지는 변경. 버그 수정이라도 소비자 화면이 바뀌면 patch 로 내보내지 않는다(`~3.14.0` 같은 범위로 받는 앱이 자동으로 끌어간다). CHANGELOG 항목 앞에 `(렌더 변경)` 을 붙인다.
-       예 - Prose 제목 굵기 400→700(3.14.1), Modal close 버튼 위치 20px 이동(3.15.0), Vanilla 모달 폭 clamp(3.15.2). 셋 다 API 는 그대로였다.
+     - **렌더 결과가 바뀌는 변경은 의도로 가른다.** API 가 그대로여도 소비자 화면은 바뀌므로 CHANGELOG 항목 앞에 **`(렌더 변경)` 을 반드시 붙인다** - 버전과 무관하게.
+       - **결함 수정**(지금 렌더가 틀렸다) → **patch**. `~3.16.0` 처럼 patch 만 받는 앱에도 수정이 닿아야 한다. minor 로 올리면 가장 보수적으로 고정한 소비자가 그 수정을 못 받는다.
+         예 - Prose `h1` 이 `h3` 보다 가늘던 것(3.14.1), close 버튼이 내용 열 밖 20px(3.15.0), Vanilla 모달이 375px 에서 잘림(3.15.2).
+       - **의도적 디자인 변경**(지금도 틀리지 않았는데 다르게 바꾼다) → **minor**. 기본 size·간격 스케일·컴포넌트 재디자인 등. 받을지를 소비자가 고르게 한다.
    - `CHANGELOG.md` 맨 위에 새 버전 섹션 추가 (아래 양식, semver 내림차순 유지).
    - **이번 릴리즈에 담긴 모든 이슈의 `Closes #NNN`** 을 `## 작업 개요` 에 나열. `Closes #` 는 기본 브랜치(main) 머지에서만 발동하는데 feature PR 은 전부 `develop` 대상이라, feature PR 본문에 써 둔 것은 이슈를 닫지 못한다. 배포 후 `gh issue list --state open` 으로 실제로 닫혔는지 확인한다.
 2. 리뷰어 approve 후 머지.
@@ -312,7 +314,7 @@ label/domain
 - 핵심 변경 2
 ```
 - 주요 업데이트 불릿만 - 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
-- 렌더 결과가 바뀐 항목은 `- (렌더 변경) ...` 로 시작한다 - 소비자가 화면 확인이 필요한 줄을 한눈에 찾게.
+- 렌더 결과가 바뀐 항목은 `- (렌더 변경) ...` 로 시작한다 - 결함 수정이든 의도적 변경이든, 소비자가 화면 확인이 필요한 줄을 한눈에 찾게.
 - 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
 **GitHub Release 노트는 조직 공통 양식 필수** - 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG의 해당 버전 주요 업데이트를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (제목 = `Design System of Bigtablet, Inc.`, `##` 제목과 `####` 사이 빈 줄 없음):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,9 +295,12 @@ label/domain
 ### Release & Changelog
 **태그 기반 배포** - semantic-release / changeset 미사용. 절차:
 
-1. **dev→main 릴리즈 PR(`merge: release`)에 아래 둘을 반드시 함께 포함** (별도 커밋으로 미루지 말 것):
+1. **dev→main 릴리즈 PR(`merge: release`)에 아래 셋을 반드시 함께 포함** (별도 커밋으로 미루지 말 것):
    - `package.json` `version` bump (SemVer). 공개 API 기준은 `package.json` `exports`의 모든 표면 - React export(`src/index.ts`), Vanilla JS/CSS(`/vanilla`), SCSS 토큰·CSS 변수(`/scss/token`, `style.css`). 하위 호환이 깨지는 변경(export·토큰·CSS 변수 제거, 이름·시그니처 변경, prop 제거 등)은 major, 새 export·prop·토큰 추가는 minor, 버그/문서/내부 전용(미export) 변경은 patch.
+     - **렌더 결과가 바뀌면 API 변화가 없어도 minor** - 기존 컴포넌트의 굵기·간격·위치·기본 크기가 달라지는 변경. 버그 수정이라도 소비자 화면이 바뀌면 patch 로 내보내지 않는다(`~3.14.0` 같은 범위로 받는 앱이 자동으로 끌어간다). CHANGELOG 항목 앞에 `(렌더 변경)` 을 붙인다.
+       예 - Prose 제목 굵기 400→700(3.14.1), Modal close 버튼 위치 20px 이동(3.15.0), Vanilla 모달 폭 clamp(3.15.2). 셋 다 API 는 그대로였다.
    - `CHANGELOG.md` 맨 위에 새 버전 섹션 추가 (아래 양식, semver 내림차순 유지).
+   - **이번 릴리즈에 담긴 모든 이슈의 `Closes #NNN`** 을 `## 작업 개요` 에 나열. `Closes #` 는 기본 브랜치(main) 머지에서만 발동하는데 feature PR 은 전부 `develop` 대상이라, feature PR 본문에 써 둔 것은 이슈를 닫지 못한다. 배포 후 `gh issue list --state open` 으로 실제로 닫혔는지 확인한다.
 2. 리뷰어 approve 후 머지.
 3. main 에서 `git tag -a vX.Y.Z -m "vX.Y.Z"` → `git push origin vX.Y.Z`.
 4. `release.yml`(GitHub Actions)이 `npm publish --provenance` + GitHub Release 자동 생성.
@@ -309,6 +312,7 @@ label/domain
 - 핵심 변경 2
 ```
 - 주요 업데이트 불릿만 - 커밋 본문/Co-Authored-By/이슈 링크 덤프 금지.
+- 렌더 결과가 바뀐 항목은 `- (렌더 변경) ...` 로 시작한다 - 소비자가 화면 확인이 필요한 줄을 한눈에 찾게.
 - 롤백한 버전은 CHANGELOG·Release 양쪽에서 제외.
 
 **GitHub Release 노트는 조직 공통 양식 필수** - 모든 릴리즈 노트는 한글 작성, title = 버전명만(예: `v3.3.0`). CHANGELOG의 해당 버전 주요 업데이트를 그대로 사용. `--generate-notes` 자동 PR 목록은 양식에 안 맞으니 아래로 교체 (제목 = `Design System of Bigtablet, Inc.`, `##` 제목과 `####` 사이 빈 줄 없음):


### PR DESCRIPTION
## 작업 개요

릴리즈 규칙 두 줄을 보강한다. 둘 다 이번 사이클에 실제로 걸린 것이다.

> **초안 수정됨** — 처음에는 "렌더 결과가 바뀌면 무조건 minor" 로 썼는데 자기 리뷰에서 반대로 작동하는 것을 찾았다. `~3.16.0` 은 patch 만 받으므로, 렌더를 바꾸는 **결함 수정**을 minor 로 올리면 가장 보수적으로 고정한 소비자가 그 수정을 못 받는다. 의도로 가르도록 고쳤다(`bbddcb7`).

## 작업한 내용

- [x] **렌더 변경은 의도로 가른다**
  - 결함 수정(지금 렌더가 틀렸다) → **patch**. 고정 범위가 좁은 앱에도 닿아야 한다
  - 의도적 디자인 변경(틀리지 않았는데 다르게 바꾼다) → **minor**. 받을지를 소비자가 고른다
  - 둘 다 CHANGELOG 항목 앞에 **`(렌더 변경)`** 을 붙인다 — 버전과 무관하게. 화면 확인이 필요한 줄을 소비자가 찾는 수단은 라벨이지 버전이 아니다
- [x] **`Closes #` 는 릴리즈 PR 에 모아 쓴다** — 기본 브랜치 머지에서만 발동하므로 develop 대상 feature PR 에 써 둔 것은 이슈를 닫지 못한다. 배포 후 `gh issue list --state open` 으로 확인
- [x] 도입부 "아래 둘" → "아래 셋"
- [x] CHANGELOG 양식 절에도 `(렌더 변경)` 표기 규칙 추가

## 검증

문서만 바뀌므로 코드 검증 대상이 없다. 근거는 이번 사이클 실적이다.

### 렌더가 바뀌었는데 라벨이 없던 사례 — 전부 결함 수정이라 patch 가 맞았다

| 릴리즈 | 변경 | 실제 버전 | 새 규칙 |
| --- | --- | --- | --- |
| 3.14.1 | Prose `h1` 이 `h3` 보다 가늘던 것 | patch | patch + `(렌더 변경)` |
| 3.15.0 | close 버튼이 내용 열 밖 20px | minor (토큰 추가 덕에 우연히) | patch + `(렌더 변경)` |
| 3.15.2 | Vanilla 모달이 375px 에서 잘림 | patch | patch + `(렌더 변경)` |

즉 새 규칙이 바꾸는 것은 **버전이 아니라 라벨**이다. 버전은 이미 맞게 나가고 있었다.

### 이슈가 안 닫힌 사례

- v3.14.1 — #518 이 열린 채 남아 수동으로 닫음
- v3.15.0 — #529 · #531 이 열린 채 남아 수동으로 닫음. 그때 "자동 종료됐다"고 잘못 보고까지 했다

이후 릴리즈(3.15.1 · 3.15.2 · 3.16.0)는 릴리즈 PR 에 `Closes #` 를 넣어 정상 종료됐다.

## 전달할 추가 이슈

- **조직 [버저닝 원칙](https://app.notion.com/p/Version-Convention-25eef4b5605c805aa8a6fc929b5ec848?pvs=21) 문서와의 정합성은 확인하지 못했다.** CLAUDE.md 가 그 문서를 따른다고 명시하는데 접근할 수 없었다. 조직 규칙이 렌더 변경을 다르게 정의하고 있으면 이 PR 이 어긋난다 — 확인 부탁한다
- prerelease(`next` dist-tag) 단계는 넣지 않았다. 이번 3연속 배포는 전부 소비자 앱 환경에서만 재현되는 것들이라(`scrollbar-gutter: stable`, 소비자 지정 패널 폭) 단계를 늘려도 잡혔을지 불확실하고 절차 비용만 확실히 는다
